### PR TITLE
Don't race on multitargeted project -> skipped compat check

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1688,9 +1688,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <!--
          Remove the items we've touched from _MSBuildProjectReferenceExistent. This will leave all projects where
-         SkipGetTargetFrameworkProperties was set. Then add all AnnotatedProjects back.
+         SkipGetTargetFrameworkProperties was set.
       -->
       <_MSBuildProjectReferenceExistent Remove="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'" />
+
+      <!-- If we skipped querying the other project, ensure we don't pollute it with the TargetFramework/RuntimeIdentifier
+           that may be set for this project as a global property (if we're in an inner build). -->
+      <_MSBuildProjectReferenceExistent>
+          <UndefineProperties>%(_MSBuildProjectReferenceExistent.UndefineProperties);TargetFramework;RuntimeIdentifier</UndefineProperties>
+      </_MSBuildProjectReferenceExistent>
+
+      <!-- Then add all AnnotatedProjects back. -->
       <_MSBuildProjectReferenceExistent Include="@(AnnotatedProjects)" />
     </ItemGroup>
   </Target>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1693,9 +1693,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_MSBuildProjectReferenceExistent Remove="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'" />
 
       <!-- If we skipped querying the other project, ensure we don't pollute it with the TargetFramework/RuntimeIdentifier
-           that may be set for this project as a global property (if we're in an inner build). -->
+           that may be set for this project as a global property (if we're in an inner build).
+
+           But allow setting TF explicitly. -->
+      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SetTargetFramework)' == ''">
+          <UndefineProperties>%(_MSBuildProjectReferenceExistent.UndefineProperties);TargetFramework</UndefineProperties>
+      </_MSBuildProjectReferenceExistent>
       <_MSBuildProjectReferenceExistent>
-          <UndefineProperties>%(_MSBuildProjectReferenceExistent.UndefineProperties);TargetFramework;RuntimeIdentifier</UndefineProperties>
+          <UndefineProperties>%(_MSBuildProjectReferenceExistent.UndefineProperties);RuntimeIdentifier</UndefineProperties>
       </_MSBuildProjectReferenceExistent>
 
       <!-- Then add all AnnotatedProjects back. -->


### PR DESCRIPTION
A multitargeted project referencing a non-SDK project had a race
condition. The inner builds each had `TargetFramework` set as a global
property, and each passed that global property along when building
referenced non-SDK projects. Since those projects aren't aware of TF,
they raced each other.

Fixes #2366 for vcxproj references by ensuring that referenced projects
which skipped TF checks also don't inherit TF/RID.