### PR TITLE
Fix NativeMethodsShared.GetLastWriteFileTimeUtc when the path is a

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -838,11 +838,16 @@ namespace Microsoft.Build.Shared
                 return success;
             }
 
-            DateTime lastWriteTime = Directory.GetLastWriteTimeUtc(fullPath);
-            bool directoryExists = lastWriteTime != MinFileDate;
-
-            fileModifiedTimeUtc = directoryExists ? lastWriteTime : DateTime.MinValue;
-            return directoryExists;
+            if (Directory.Exists(fullPath))
+            {
+                fileModifiedTimeUtc = Directory.GetLastWriteTimeUtc(fullPath);
+                return true;
+            }
+            else
+            {
+                fileModifiedTimeUtc = DateTime.MinValue;
+                return false;
+            }
         }
 
         /// <summary>
@@ -967,7 +972,7 @@ namespace Microsoft.Build.Shared
 
                 success = NativeMethodsShared.GetFileAttributesEx(fullPath, 0, ref data);
 
-                if (success)
+                if (success && (data.fileAttributes & NativeMethodsShared.FILE_ATTRIBUTE_DIRECTORY) == 0)
                 {
                     long dt = ((long)(data.ftLastWriteTimeHigh) << 32) | ((long)data.ftLastWriteTimeLow);
                     fileModifiedTime = DateTime.FromFileTimeUtc(dt);
@@ -978,16 +983,15 @@ namespace Microsoft.Build.Shared
                         fileModifiedTime = GetContentLastWriteFileUtcTime(fullPath);
                     }
                 }
+
+                return fileModifiedTime;
             }
             else
             {
-                DateTime lastWriteTime = File.GetLastWriteTimeUtc(fullPath);
-                bool fileExists = lastWriteTime != MinFileDate;
-
-                fileModifiedTime = fileExists ? lastWriteTime : DateTime.MinValue;
+                return File.Exists(fullPath)
+                        ? File.GetLastWriteTimeUtc(fullPath)
+                        : DateTime.MinValue;
             }
-
-            return fileModifiedTime;
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
+++ b/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
@@ -84,6 +84,34 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// Verifies that when NativeMethodsShared.GetLastWriteFileUtcTime() is called on a
+        /// *directory*, DateTime.MinValue is returned.
+        /// </summary>
+        [Fact]
+        public void GetLastWriteFileUtcTimeReturnsMinValueForDirectory()
+        {
+            string directory = FileUtilities.GetTemporaryDirectory(createDirectory: true);
+
+            DateTime directoryTime = NativeMethodsShared.GetLastWriteFileUtcTime(directory);
+            Assert.Equal(DateTime.MinValue, directoryTime);
+        }
+
+        /// <summary>
+        /// Verifies that when NativeMethodsShared.GetLastWriteDirectoryUtcTime() is called on a
+        /// *file*, it returns DateTime.MinValue
+        /// </summary>
+        [Fact]
+        public void GetLastWriteDirectoryUtcTimeReturnsMinValueForFile()
+        {
+            string file = FileUtilities.GetTemporaryFile();
+
+            DateTime directoryTime;
+            Assert.False(NativeMethodsShared.GetLastWriteDirectoryUtcTime(file, out directoryTime));
+            Assert.Equal(DateTime.MinValue, directoryTime);
+        }
+
+
+        /// <summary>
         /// Verifies that NativeMethodsShared.SetCurrentDirectory(), when called on a nonexistent
         /// directory, will not set the current directory to that location. 
         /// </summary>


### PR DESCRIPTION
.. directory.

`GetLastWriteFileTimeUtc` depends on the incorrect assumption[1] that
`File.GetLastWriteTimeUtc` will return `DateTime.FromFileTimeUtc(0)` if
the path is a directory.

The same thing applies for the `Directory` equivalent of the same
method.

This breaks File existence checks, for example in
`ResolveAssemblyReference` when we have a reference like:

`<Reference Include="FooBar" />`

.. where `FooBar` is a directory in the current(project) directory.
ResolveAssemblyReference ends up triyng to get assembly information from
the file, because it thinks that `FooBar` is a file and thus an assembly
path.