### PR TITLE
Rework SdkReference computation

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         /// <summary>
-        /// Used for unit tests only.  This is currently only called through reflection in Microsoft.Build.Engine.UnitTests.TransientSdkResolution.CallResetForTests
+        /// Used for unit tests only.
         /// </summary>
         /// <param name="resolverLoader">An <see cref="SdkResolverLoader"/> to use for loading SDK resolvers.</param>
         /// <param name="resolvers">Explicit set of SdkResolvers to use for all SDK resolution.</param>

--- a/src/Build/Construction/ISdkReferenceMutableSource.cs
+++ b/src/Build/Construction/ISdkReferenceMutableSource.cs
@@ -1,0 +1,15 @@
+#nullable enable
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    ///     Interface for the XML-element-backed <see cref="ISdkReferenceSource" />.
+    /// </summary>
+    internal interface ISdkReferenceMutableSource : ISdkReferenceSource
+    {
+        SdkReferenceSourceFullQuery SdkReferenceFullQuery { get; }
+        SdkReferenceSourceQuery SdkReferenceNameQuery { get; }
+        SdkReferenceSourceQuery SdkReferenceVersionQuery { get; }
+        SdkReferenceSourceQuery SdkReferenceMinimumVersionQuery { get; }
+    }
+}

--- a/src/Build/Construction/ISdkReferenceSource.cs
+++ b/src/Build/Construction/ISdkReferenceSource.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    ///     Represents a source of Microsoft Build SDK references data. Implementing this interface is not enough, you have to
+    ///     also make changes to <see cref="ProjectImportElement" />.
+    /// </summary>
+    internal interface ISdkReferenceSource
+    {
+    }
+}

--- a/src/Build/Construction/ProjectImportElement.cs
+++ b/src/Build/Construction/ProjectImportElement.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
+using System;
 using System.Diagnostics;
+using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
@@ -9,44 +13,75 @@ using Microsoft.Build.Shared;
 namespace Microsoft.Build.Construction
 {
     /// <summary>
-    /// Initializes a ProjectImportElement instance.
+    ///     Initializes a ProjectImportElement instance.
     /// </summary>
     [DebuggerDisplay("Project={Project} Condition={Condition}")]
-    public class ProjectImportElement : ProjectElement
+    public class ProjectImportElement : ProjectElement, ISdkReferenceMutableSource
     {
-        internal ProjectImportElementLink ImportLink => (ProjectImportElementLink)Link;
+        private static readonly SdkReferenceAttribute NameAttributeFactory =
+            new SdkReferenceAttribute(
+                XMakeAttributes.sdk, "Set Import Sdk {0}"
+            );
 
-        private ImplicitImportLocation _implicitImportLocation;
-        private ProjectElement _originalElement;
+        private static readonly SdkReferenceAttribute VersionAttributeFactory =
+            new SdkReferenceAttribute(
+                XMakeAttributes.sdkVersion, "Set Import Version {0}"
+            );
+
+        private static readonly SdkReferenceAttribute MinimumVersionAttributeFactory =
+            new SdkReferenceAttribute(
+                XMakeAttributes.sdkMinimumVersion, "Set Import Minimum Version {0}"
+            );
+
+        internal ProjectImportElementLink? ImportLink => (ProjectImportElementLink) Link;
+
+        private ImplicitImportLocation _implicitImportLocation = ImplicitImportLocation.None;
+        private ProjectElement? _originalElement;
+        private readonly ISdkReferenceSource _sdkReferenceSource;
 
         /// <summary>
-        /// External projects support
+        ///     External projects support
         /// </summary>
         internal ProjectImportElement(ProjectImportElementLink link)
-            : base(link)
-        {
-        }
+            : base(link) =>
+            _sdkReferenceSource = this;
 
         /// <summary>
-        /// Initialize a parented ProjectImportElement
+        ///     Initialize a parented ProjectImportElement
         /// </summary>
-        internal ProjectImportElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject, SdkReference sdkReference = null)
-            : base(xmlElement, parent, containingProject)
+        internal ProjectImportElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent,
+                                      ProjectRootElement containingProject)
+            : this(xmlElement, parent, containingProject, null)
         {
             ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
-            SdkReference = sdkReference;
         }
 
         /// <summary>
-        /// Initialize an unparented ProjectImportElement
+        ///     Initialize an unparented ProjectImportElement
         /// </summary>
         internal ProjectImportElement(XmlElementWithLocation xmlElement, ProjectRootElement containingProject)
-            : base(xmlElement, null, containingProject)
+            : this(xmlElement, null, containingProject, null)
         {
         }
 
+        private ProjectImportElement(XmlElement xmlElement, ProjectElementContainer? parent,
+                                     ProjectRootElement containingProject, ISdkReferenceSource? referenceSource)
+            : base(xmlElement, parent, containingProject)
+        {
+            _sdkReferenceSource = referenceSource ?? this;
+
+            if (referenceSource is SdkReferenceConstantSource source)
+            {
+                SetValue(this, NameAttributeFactory, source.SdkReference.Reference.Name);
+                SetValue(this, VersionAttributeFactory, source.SdkReference.Reference.Version);
+                SetValue(this, MinimumVersionAttributeFactory, source.SdkReference.Reference.MinimumVersion);
+            }
+        }
+
+#nullable restore
+
         /// <summary>
-        /// Gets or sets the Project value. 
+        ///     Gets or sets the Project value.
         /// </summary>
         public string Project
         {
@@ -60,144 +95,341 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Location of the project attribute
+        ///     Location of the project attribute
         /// </summary>
         public ElementLocation ProjectLocation => GetAttributeLocation(XMakeAttributes.project);
 
+#nullable enable
+
         /// <summary>
-        /// Gets or sets the SDK that contains the import.
+        ///     Gets or sets the SDK that contains the import.
         /// </summary>
-        public string Sdk
+        public string? Sdk
         {
-            get => FileUtilities.FixFilePath(GetAttributeValue(XMakeAttributes.sdk));
+            get
+            {
+                switch (_sdkReferenceSource)
+                {
+                    case ISdkReferenceMutableSource mutableSource:
+                        var query = mutableSource.SdkReferenceNameQuery;
+                        return GetValue(query.Element, query.Factory);
+                    case SdkReferenceConstantSource constantSource:
+                        return constantSource.SdkReference.Reference.Name;
+                    default:
+                        throw CreateUnknownSourceException();
+                }
+            }
             set
             {
-                ErrorUtilities.VerifyThrowArgumentLength(value, XMakeAttributes.sdk);
-                if (UpdateSdkReference(name: value, SdkReference?.Version, SdkReference?.MinimumVersion))
+                ErrorUtilities.VerifyThrowArgumentLength(value, nameof(value));
+
+                if (_sdkReferenceSource is ISdkReferenceMutableSource source)
                 {
-                    SetOrRemoveAttribute(XMakeAttributes.sdk, value, "Set Import Sdk {0}", value);
+                    var query = source.SdkReferenceNameQuery;
+                    Mutate(in query, NameAttributeFactory, value);
+                }
+                else
+                {
+                    PushValueFromImmutable(Sdk, value, NameAttributeFactory);
                 }
             }
         }
 
         /// <summary>
-        /// Gets or sets the version associated with this SDK import
+        ///     Gets or sets the version associated with this SDK import
         /// </summary>
-        public string Version
+        public string? Version
         {
-            get => GetAttributeValue(XMakeAttributes.sdkVersion);
+            get
+            {
+                switch (_sdkReferenceSource)
+                {
+                    case ISdkReferenceMutableSource mutableSource:
+                        var query = mutableSource.SdkReferenceVersionQuery;
+                        return GetValue(query.Element, query.Factory);
+                    case SdkReferenceConstantSource constantSource:
+                        return constantSource.SdkReference.Reference.Version;
+                    default:
+                        throw CreateUnknownSourceException();
+                }
+            }
             set
             {
-                if (UpdateSdkReference(SdkReference?.Name, version: value, SdkReference?.MinimumVersion))
+                if (_sdkReferenceSource is ISdkReferenceMutableSource source)
                 {
-                    SetOrRemoveAttribute(XMakeAttributes.sdkVersion, value, "Set Import Version {0}", value);
+                    var query = source.SdkReferenceVersionQuery;
+                    Mutate(in query, VersionAttributeFactory, value);
+                }
+                else
+                {
+                    PushValueFromImmutable(Version, value, VersionAttributeFactory);
                 }
             }
         }
 
         /// <summary>
-        /// Gets or sets the minimum SDK version required by this import.
+        ///     Gets or sets the minimum SDK version required by this import.
         /// </summary>
-        public string MinimumVersion
+        public string? MinimumVersion
         {
-            get => GetAttributeValue(XMakeAttributes.sdkMinimumVersion);
+            get
+            {
+                switch (_sdkReferenceSource)
+                {
+                    case ISdkReferenceMutableSource mutableSource:
+                        var query = mutableSource.SdkReferenceMinimumVersionQuery;
+                        return GetValue(query.Element, query.Factory);
+                    case SdkReferenceConstantSource constantSource:
+                        return constantSource.SdkReference.Reference.MinimumVersion;
+                    default:
+                        throw CreateUnknownSourceException();
+                }
+            }
             set
             {
-                if (UpdateSdkReference(SdkReference?.Name, SdkReference?.Version, minimumVersion: value))
+                if (_sdkReferenceSource is ISdkReferenceMutableSource source)
                 {
-                    SetOrRemoveAttribute(XMakeAttributes.sdkMinimumVersion, value, "Set Import Minimum Version {0}", value);
+                    var query = source.SdkReferenceMinimumVersionQuery;
+                    Mutate(in query, MinimumVersionAttributeFactory, value);
+                }
+                else
+                {
+                    PushValueFromImmutable(MinimumVersion, value, MinimumVersionAttributeFactory);
                 }
             }
         }
 
         /// <summary>
-        /// Location of the Sdk attribute
+        ///     Location of the Sdk attribute
         /// </summary>
-        public ElementLocation SdkLocation => GetAttributeLocation(XMakeAttributes.sdk);
+        public ElementLocation? SdkLocation => SdkReferenceOrigin?.Name as ElementLocation;
 
         /// <summary>
-        /// Gets the <see cref="ImplicitImportLocation"/> of the import.  This indicates if the import was implicitly
-        /// added because of the <see cref="ProjectRootElement.Sdk"/> attribute and the location where the project was
-        /// imported.
+        ///     Gets the <see cref="ImplicitImportLocation" /> of the import.  This indicates if the import was implicitly
+        ///     added because of the <see cref="ProjectRootElement.Sdk" /> attribute and the location where the project was
+        ///     imported.
         /// </summary>
-        public ImplicitImportLocation ImplicitImportLocation { get => Link != null ? ImportLink.ImplicitImportLocation : _implicitImportLocation; internal set => _implicitImportLocation = value; }
+        public ImplicitImportLocation ImplicitImportLocation
+        {
+            get => ImportLink?.ImplicitImportLocation ?? _implicitImportLocation;
+            internal set => _implicitImportLocation = value;
+        }
 
         /// <summary>
-        /// If the import is an implicit one (<see cref="ImplicitImportLocation"/> != None) then this element points
-        /// to the original element which generated this implicit import.
+        ///     If the import is an implicit one (<see cref="ImplicitImportLocation" /> != None) then this element points
+        ///     to the original element which generated this implicit import.
         /// </summary>
-        public ProjectElement OriginalElement { get => Link != null ? ImportLink.OriginalElement : _originalElement; internal set => _originalElement = value; }
-
+        public ProjectElement? OriginalElement
+        {
+            get => ImportLink != null ? ImportLink.OriginalElement : _originalElement;
+            internal set => _originalElement = value;
+        }
 
         /// <summary>
-        /// <see cref="Framework.SdkReference"/> if applicable to this import element.
+        ///     <see cref="Framework.SdkReference" /> if applicable to this import element.
         /// </summary>
-        internal SdkReference SdkReference { get; set; }
+        internal SdkReference? SdkReference => _sdkReferenceSource switch
+        {
+            ISdkReferenceMutableSource mutableSource => ComputeSdkReference(mutableSource),
+            SdkReferenceConstantSource constantSource => constantSource.SdkReference.Reference,
+            _ => throw CreateUnknownSourceException()
+        };
+
+        internal SdkReferenceWithOrigin? SdkReferenceWithOrigin => _sdkReferenceSource switch
+        {
+            ISdkReferenceMutableSource mutableSource => ComputeSdkReferenceWithOrigin(mutableSource),
+            SdkReferenceConstantSource constantSource => constantSource.SdkReference,
+            _ => throw CreateUnknownSourceException()
+        };
+
+        private SdkReferenceOrigin? SdkReferenceOrigin => _sdkReferenceSource switch
+        {
+            ISdkReferenceMutableSource mutableSource => ComputeSdkReferenceOrigin(mutableSource),
+            SdkReferenceConstantSource constantSource => constantSource.SdkReference.Origin,
+            _ => throw CreateUnknownSourceException()
+        };
 
         /// <summary>
-        /// Creates an unparented ProjectImportElement, wrapping an unparented XmlElement.
-        /// Validates the project value.
-        /// Caller should then ensure the element is added to a parent
+        ///     Creates an unparented ProjectImportElement, wrapping an unparented XmlElement.
+        ///     Validates the project value.
+        ///     Caller should then ensure the element is added to a parent
         /// </summary>
         internal static ProjectImportElement CreateDisconnected(string project, ProjectRootElement containingProject)
         {
             XmlElementWithLocation element = containingProject.CreateElement(XMakeElements.import);
-            return new ProjectImportElement(element, containingProject) {Project = project};
-        }
-
-        /// <summary>
-        /// Creates an implicit ProjectImportElement as if it was in the project.
-        /// </summary>
-        /// <returns></returns>
-        internal static ProjectImportElement CreateImplicit(
-            string project,
-            ProjectRootElement containingProject,
-            ImplicitImportLocation implicitImportLocation,
-            SdkReference sdkReference,
-            ProjectElement originalElement)
-        {
-            XmlElementWithLocation element = containingProject.CreateElement(XMakeElements.import);
             return new ProjectImportElement(element, containingProject)
             {
-                Project = project,
-                Sdk = sdkReference.ToString(),
-                ImplicitImportLocation = implicitImportLocation,
-                SdkReference = sdkReference,
-                OriginalElement = originalElement
+                Project = project
             };
         }
 
         /// <summary>
-        /// Overridden to verify that the potential parent and siblings
-        /// are acceptable. Throws InvalidOperationException if they are not.
+        ///     Creates an implicit ProjectImportElement as if it was in the project.
         /// </summary>
-        internal override void VerifyThrowInvalidOperationAcceptableLocation(ProjectElementContainer parent, ProjectElement previousSibling, ProjectElement nextSibling)
+        internal static ProjectImportElement CreateImplicit(
+            string project,
+            ProjectRootElement containingProject,
+            ImplicitImportLocation implicitImportLocation,
+            ISdkReferenceSource? sdkReferenceSource,
+            ProjectElement originalElement)
         {
-            ErrorUtilities.VerifyThrowInvalidOperation(parent is ProjectRootElement || parent is ProjectImportGroupElement, "OM_CannotAcceptParent");
+            XmlElementWithLocation element = containingProject.CreateElement(XMakeElements.import);
+            return new ProjectImportElement(element, null, containingProject, sdkReferenceSource)
+            {
+                Project = project,
+                ImplicitImportLocation = implicitImportLocation,
+                OriginalElement = originalElement
+            };
         }
 
+#nullable restore
+
         /// <inheritdoc />
-        protected override ProjectElement CreateNewInstance(ProjectRootElement owner)
+        internal override void VerifyThrowInvalidOperationAcceptableLocation(ProjectElementContainer parent,
+                                                                             ProjectElement previousSibling,
+                                                                             ProjectElement nextSibling) =>
+            ErrorUtilities.VerifyThrowInvalidOperation(
+                parent is ProjectRootElement || parent is ProjectImportGroupElement,
+                "OM_CannotAcceptParent"
+            );
+
+        /// <inheritdoc />
+        protected override ProjectElement CreateNewInstance(ProjectRootElement owner) =>
+            owner.CreateImportElement(Project);
+
+#nullable enable
+
+        /// <summary>
+        ///     Ensure that the value set on this element is equal to the value from the immutable source.
+        /// </summary>
+        /// <param name="current">The current attribute value</param>
+        /// <param name="candidate">The value expected to be set after mutation</param>
+        /// <param name="attribute">The <see cref="SdkReferenceAttribute" /> on which the mutation is performed</param>
+        /// <exception cref="NotSupportedException">Exception thrown when candidate value isn't equal to the current value</exception>
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
+        private void PushValueFromImmutable(string? current, string? candidate, SdkReferenceAttribute attribute)
         {
-            return owner.CreateImportElement(Project);
+            if (!string.Equals(current, candidate))
+                throw CreateImmutableSourceException();
+
+            SetValue(this, attribute, candidate);
         }
 
         /// <summary>
-        /// Helper method to update the <see cref="SdkReference" /> property if necessary (update only when changed).
+        ///     Apply the attribute mutation, both to the data source and this element.
         /// </summary>
-        /// <returns>True if the <see cref="SdkReference" /> property was updated, otherwise false (no update necessary).</returns>
-        private bool UpdateSdkReference(string name, string version, string minimumVersion)
+        /// <param name="query">The <see cref="ISdkReferenceMutableSource" /> data source context</param>
+        /// <param name="attribute">The <see cref="SdkReferenceAttribute" /> on which the mutation is performed</param>
+        /// <param name="value">The new value to be set</param>
+        private void Mutate(in SdkReferenceSourceQuery query, SdkReferenceAttribute attribute, string? value)
         {
-            SdkReference sdk = new SdkReference(name, version, minimumVersion);
+            SetValue(query.Element, query.Factory, value);
 
-            if (sdk.Equals(SdkReference))
-            {
-                return false;
-            }
-
-            SdkReference = sdk;
-
-            return true;
+            if (!ReferenceEquals(query.Element, this))
+                SetValue(this, attribute, value);
         }
+
+        private static SdkReferenceWithOrigin? ComputeSdkReferenceWithOrigin(ISdkReferenceMutableSource source)
+        {
+            var query = source.SdkReferenceFullQuery;
+
+            GetValueLocation(query.Element, query.Sdk, out var name, out var nameLocation);
+
+            if (name == null)
+                return null;
+
+            GetValueLocation(query.Element, query.Version, out var version, out var versionLocation);
+            GetValueLocation(query.Element, query.MinimumVersion,
+                             out var minimumVersion, out var minimumVersionLocation);
+
+            return new SdkReferenceWithOrigin(
+                new SdkReference(name, version, minimumVersion),
+                new SdkReferenceOrigin(nameLocation, versionLocation, minimumVersionLocation)
+            );
+        }
+
+        private static SdkReference? ComputeSdkReference(ISdkReferenceMutableSource source)
+        {
+            var query = source.SdkReferenceFullQuery;
+
+            var name = GetValue(query.Element, query.Sdk);
+
+            if (name == null)
+                return null;
+
+            var version = GetValue(query.Element, query.Version);
+            var minimumVersion = GetValue(query.Element, query.MinimumVersion);
+
+            return new SdkReference(name, version, minimumVersion);
+        }
+
+        private static SdkReferenceOrigin? ComputeSdkReferenceOrigin(ISdkReferenceMutableSource source)
+        {
+            var query = source.SdkReferenceFullQuery;
+
+            GetValueLocation(query.Element, query.Sdk, out var name, out var nameLocation);
+
+            if (name == null)
+                return null;
+
+            var versionLocation = GetLocation(query.Element, query.Version);
+            var minimumVersionLocation = GetLocation(query.Element, query.MinimumVersion);
+
+            return new SdkReferenceOrigin(nameLocation, versionLocation, minimumVersionLocation);
+        }
+
+        private static ArgumentOutOfRangeException CreateUnknownSourceException() =>
+            new ArgumentOutOfRangeException(nameof(_sdkReferenceSource));
+
+        private static Exception CreateImmutableSourceException() =>
+            new NotSupportedException();
+
+        private static string? GetValue(ProjectElement element, SdkReferenceAttribute factory) =>
+            element.GetAttributeValue(factory.AttributeName, true);
+
+        private static void SetValue(ProjectElement element, SdkReferenceAttribute factory, string? value)
+        {
+            var attributeName = factory.AttributeName;
+
+            if (string.Equals(element.GetAttributeValue(attributeName, true), value))
+                return;
+
+            element.SetOrRemoveAttribute(attributeName, value, factory.ChangeReasonMessage, value);
+        }
+
+        private static IElementLocation? GetLocation(ProjectElement element, SdkReferenceAttribute factory) =>
+            element.GetAttributeLocation(factory.AttributeName);
+
+        private static void GetValueLocation(ProjectElement element, SdkReferenceAttribute factory,
+                                             out string? value, out IElementLocation? location)
+        {
+            var attributeName = factory.AttributeName;
+
+            if (element.Link == null &&
+                element.XmlElement?.GetAttributeNode(attributeName) is XmlAttributeWithLocation attribute)
+            {
+                value = attribute.Value;
+                location = attribute.Location;
+            }
+            else
+            {
+                value = element.GetAttributeValue(attributeName, true);
+                location = element.GetAttributeLocation(attributeName);
+            }
+        }
+
+        SdkReferenceSourceQuery ISdkReferenceMutableSource.SdkReferenceNameQuery =>
+            new SdkReferenceSourceQuery(this, NameAttributeFactory);
+
+        SdkReferenceSourceQuery ISdkReferenceMutableSource.SdkReferenceVersionQuery =>
+            new SdkReferenceSourceQuery(this, VersionAttributeFactory);
+
+        SdkReferenceSourceQuery ISdkReferenceMutableSource.SdkReferenceMinimumVersionQuery =>
+            new SdkReferenceSourceQuery(this, MinimumVersionAttributeFactory);
+
+        SdkReferenceSourceFullQuery ISdkReferenceMutableSource.SdkReferenceFullQuery =>
+            new SdkReferenceSourceFullQuery(
+                this, NameAttributeFactory, VersionAttributeFactory, MinimumVersionAttributeFactory
+            );
     }
 }

--- a/src/Build/Construction/SdkReferenceAttribute.cs
+++ b/src/Build/Construction/SdkReferenceAttribute.cs
@@ -1,0 +1,19 @@
+﻿#nullable enable
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    ///     <see cref="ProjectImportElement" /> implementation detail.
+    /// </summary>
+    internal sealed class SdkReferenceAttribute
+    {
+        public readonly string AttributeName;
+        public readonly string ChangeReasonMessage;
+
+        public SdkReferenceAttribute(string attributeName, string changeReasonMessage)
+        {
+            AttributeName = attributeName;
+            ChangeReasonMessage = changeReasonMessage;
+        }
+    }
+}

--- a/src/Build/Construction/SdkReferenceConstantSource.cs
+++ b/src/Build/Construction/SdkReferenceConstantSource.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    ///     <see cref="ProjectImportElement" /> implementation detail for the &lt;Project /&gt; "Sdk" attribute.
+    /// </summary>
+    internal sealed class SdkReferenceConstantSource : ISdkReferenceSource
+    {
+        private readonly SdkReferenceWithOrigin _sdkReference;
+
+        public SdkReferenceConstantSource(in SdkReferenceWithOrigin source) => _sdkReference = source;
+
+        public ref readonly SdkReferenceWithOrigin SdkReference => ref _sdkReference;
+    }
+}

--- a/src/Build/Construction/SdkReferenceOrigin.cs
+++ b/src/Build/Construction/SdkReferenceOrigin.cs
@@ -1,0 +1,61 @@
+#nullable enable
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    ///     Storage for the XML attributes locations for the matching <see cref="SdkReference" /> values.
+    /// </summary>
+    internal sealed class SdkReferenceOrigin : IEquatable<SdkReferenceOrigin>
+    {
+        public readonly IElementLocation? MinimumVersion;
+        public readonly IElementLocation? Name;
+        public readonly IElementLocation? Version;
+
+        public SdkReferenceOrigin(IElementLocation? name, IElementLocation? version, IElementLocation? minimumVersion)
+        {
+            Name = name;
+            Version = version;
+            MinimumVersion = minimumVersion;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(SdkReferenceOrigin? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Equals(Name, other.Name) && Equals(Version, other.Version) &&
+                   Equals(MinimumVersion, other.MinimumVersion);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) =>
+            ReferenceEquals(this, obj) || obj is SdkReferenceOrigin other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Name != null ? Name.GetHashCode() : 0;
+                hashCode = (hashCode * 397) ^ (Version != null ? Version.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (MinimumVersion != null ? MinimumVersion.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        public static bool operator ==(SdkReferenceOrigin? left, SdkReferenceOrigin? right) => Equals(left, right);
+
+        public static bool operator !=(SdkReferenceOrigin? left, SdkReferenceOrigin? right) => !Equals(left, right);
+
+        /// <inheritdoc />
+        public override string ToString() =>
+            $"{nameof(Name)}: {FormatNullable(Name)}, {nameof(Version)}: {FormatNullable(Version)}, {nameof(MinimumVersion)}: {FormatNullable(MinimumVersion)}";
+
+        private static string FormatNullable(IElementLocation? elementLocation) =>
+            elementLocation?.ToString() ?? "<null>";
+    }
+}

--- a/src/Build/Construction/SdkReferenceSourceFullQuery.cs
+++ b/src/Build/Construction/SdkReferenceSourceFullQuery.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    ///     <see cref="ProjectImportElement" /> implementation detail.
+    /// </summary>
+    internal readonly ref struct SdkReferenceSourceFullQuery
+    {
+        public readonly ProjectElement Element;
+        public readonly SdkReferenceAttribute Sdk;
+        public readonly SdkReferenceAttribute Version;
+        public readonly SdkReferenceAttribute MinimumVersion;
+
+        public SdkReferenceSourceFullQuery(ProjectElement element,
+                                           SdkReferenceAttribute sdk,
+                                           SdkReferenceAttribute version,
+                                           SdkReferenceAttribute minimumVersion)
+        {
+            Sdk = sdk;
+            Version = version;
+            MinimumVersion = minimumVersion;
+            Element = element;
+        }
+    }
+}

--- a/src/Build/Construction/SdkReferenceSourceQuery.cs
+++ b/src/Build/Construction/SdkReferenceSourceQuery.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    ///     <see cref="ProjectImportElement" /> implementation detail.
+    /// </summary>
+    internal readonly ref struct SdkReferenceSourceQuery
+    {
+        public readonly ProjectElement Element;
+        public readonly SdkReferenceAttribute Factory;
+
+        public SdkReferenceSourceQuery(ProjectElement element, SdkReferenceAttribute factory)
+        {
+            Element = element;
+            Factory = factory;
+        }
+    }
+}

--- a/src/Build/Construction/SdkReferenceWithOrigin.cs
+++ b/src/Build/Construction/SdkReferenceWithOrigin.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+using System;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    ///     Microsoft Build SDK reference values and their XML attributes' locations.
+    /// </summary>
+    internal readonly struct SdkReferenceWithOrigin
+    {
+        public readonly SdkReference Reference;
+        public readonly SdkReferenceOrigin Origin;
+
+        public SdkReferenceWithOrigin(SdkReference reference, SdkReferenceOrigin origin)
+        {
+            Reference = reference;
+            Origin = origin;
+        }
+    }
+}

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -457,16 +457,7 @@ namespace Microsoft.Build.Construction
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.project);
             ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element);
 
-            SdkReference sdk = null;
-            if (element.HasAttribute(XMakeAttributes.sdk))
-            {
-                sdk = new SdkReference(
-                    ProjectXmlUtilities.GetAttributeValue(element, XMakeAttributes.sdk, nullIfNotExists: true),
-                    ProjectXmlUtilities.GetAttributeValue(element, XMakeAttributes.sdkVersion, nullIfNotExists: true),
-                    ProjectXmlUtilities.GetAttributeValue(element, XMakeAttributes.sdkMinimumVersion, nullIfNotExists: true));
-            }
-
-            return new ProjectImportElement(element, parent, _project, sdk);
+            return new ProjectImportElement(element, parent, _project);
         }
 
         /// <summary>

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\FileSystemSources.proj" />
   <Import Project="..\Shared\DebuggingSources.proj" />
@@ -241,8 +241,6 @@
     <Compile Include="Collections\RetrievableEntryHashSet\HashHelpers.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="Construction\ImplicitImportLocation.cs" />
-    <Compile Include="Construction\ProjectSdkElement.cs" />
     <Compile Include="Definition\ProjectOptions.cs" />
     <Compile Include="Definition\NewProjectFileOptions.cs" />
     <Compile Include="Definition\ProjectCollectionChangedEventArgs.cs" />
@@ -378,26 +376,27 @@
     <!-- ######################## -->
     <Compile Include="Collections\WeakValueDictionary.cs" />
     <!-- #### CONSTRUCTION MODEL ### -->
+    <Compile Include="Construction\ProjectChooseElement.cs" />
     <Compile Include="Construction\ProjectElement.cs" />
     <Compile Include="Construction\ProjectElementContainer.cs" />
+    <Compile Include="Construction\ProjectExtensionsElement.cs" />
     <Compile Include="Construction\ProjectImportElement.cs" />
     <Compile Include="Construction\ProjectImportGroupElement.cs" />
-    <Compile Include="Construction\ProjectItemDefinitionGroupElement.cs" />
     <Compile Include="Construction\ProjectItemDefinitionElement.cs" />
-    <Compile Include="Construction\ProjectItemGroupElement.cs" />
+    <Compile Include="Construction\ProjectItemDefinitionGroupElement.cs" />
     <Compile Include="Construction\ProjectItemElement.cs" />
+    <Compile Include="Construction\ProjectItemGroupElement.cs" />
     <Compile Include="Construction\ProjectMetadataElement.cs" />
     <Compile Include="Construction\ProjectOnErrorElement.cs" />
     <Compile Include="Construction\ProjectOtherwiseElement.cs" />
     <Compile Include="Construction\ProjectOutputElement.cs" />
-    <Compile Include="Construction\ProjectExtensionsElement.cs" />
-    <Compile Include="Construction\ProjectPropertyGroupElement.cs" />
     <Compile Include="Construction\ProjectPropertyElement.cs" />
+    <Compile Include="Construction\ProjectPropertyGroupElement.cs" />
+    <Compile Include="Construction\ProjectRootElement.cs" />
+    <Compile Include="Construction\ProjectSdkElement.cs" />
     <Compile Include="Construction\ProjectTargetElement.cs" />
     <Compile Include="Construction\ProjectTaskElement.cs" />
     <Compile Include="Construction\ProjectUsingTaskElement.cs" />
-    <Compile Include="Construction\ProjectRootElement.cs" />
-    <Compile Include="Construction\ProjectChooseElement.cs" />
     <Compile Include="Construction\ProjectWhenElement.cs" />
     <Compile Include="Construction\UsingTaskParameterGroupElement.cs" />
     <Compile Include="Construction\ProjectUsingTaskParameterElement.cs" />
@@ -410,6 +409,15 @@
     <Compile Include="Construction\Solution\SolutionFile.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Construction\ISdkReferenceMutableSource.cs" />
+    <Compile Include="Construction\ISdkReferenceSource.cs" />
+    <Compile Include="Construction\ImplicitImportLocation.cs" />
+    <Compile Include="Construction\SdkReferenceAttribute.cs" />
+    <Compile Include="Construction\SdkReferenceConstantSource.cs" />
+    <Compile Include="Construction\SdkReferenceOrigin.cs" />
+    <Compile Include="Construction\SdkReferenceSourceFullQuery.cs" />
+    <Compile Include="Construction\SdkReferenceSourceQuery.cs" />
+    <Compile Include="Construction\SdkReferenceWithOrigin.cs" />
     <!-- #### DEFINITION MODEL ### -->
     <Compile Include="Definition\BuiltInMetadata.cs" />
     <Compile Include="Definition\ProjectCollection.cs" />


### PR DESCRIPTION
* Fix `<Import />` `ProjectImportElement.CreateImplicit` setting Sdk to an invalid value (stringified `SdkReference`)
* Provide means to get `SdkReference` and XML attribute locations for the values `SdkReference` was created with.
* Improve support for implicit `<Import />` (so, for instance, if one changes the value on `<Sdk />` element, it will reflect on `<Import />` elements created for this element)
* Drop `ProjectImportElement.SdkReference` cache to reduce data duplication (XML tree is now the authority)
* To compensate for the previous point, be careful about memory allocations (make newly-introduced `internal` types `struct`, `readonly struct`, `readonly ref struct`, pass arguments with `in` when the resulting IL is better) and not doing extra work
* Nullable Reference Types annotations for modified code ranges

Note: this is the preparation part of resolving #5349 _without_ the actual change.