### PR TITLE
Visual Basic Resource Manifest Names Now Respect Relative Path

### DIFF
--- a/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
@@ -247,7 +247,7 @@ End Namespace
                     null,
                     null);
 
-            Assert.Equal("RootNamespace.MyForm.en-GB", result);
+            Assert.Equal("RootNamespace.SubFolder.MyForm.en-GB", result);
         }
 
         /// <summary>
@@ -628,7 +628,7 @@ End Namespace
                     null,
                     null);
 
-            Assert.Equal(@"RootNamespace.MyResource.fr.resources", result);
+            Assert.Equal(@"RootNamespace.SubFolder.MyResource.fr.resources", result);
         }
 
         /// <summary>

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -149,11 +149,11 @@ namespace Microsoft.Build.Tasks
                 // only strip extension for .resx and .restext files
                 string sourceExtension = Path.GetExtension(info.cultureNeutralFilename);
                 if (
-                        (0 == String.Compare(sourceExtension, ".resx", StringComparison.OrdinalIgnoreCase))
+                        (String.Equals(sourceExtension, ".resx", StringComparison.OrdinalIgnoreCase))
                         ||
-                        (0 == String.Compare(sourceExtension, ".restext", StringComparison.OrdinalIgnoreCase))
+                        (String.Equals(sourceExtension, ".restext", StringComparison.OrdinalIgnoreCase))
                         ||
-                        (0 == String.Compare(sourceExtension, ".resources", StringComparison.OrdinalIgnoreCase))
+                        (String.Equals(sourceExtension, ".resources", StringComparison.OrdinalIgnoreCase))
                     )
                 {
                     // Take directory into account when forming manifest resource names

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -147,7 +147,6 @@ namespace Microsoft.Build.Tasks
                 string everettCompatibleDirectoryName = MakeValidEverettIdentifier(Path.GetDirectoryName(info.cultureNeutralFilename));
 
                 // only strip extension for .resx and .restext files
-
                 string sourceExtension = Path.GetExtension(info.cultureNeutralFilename);
                 if (
                         (0 == String.Compare(sourceExtension, ".resx", StringComparison.OrdinalIgnoreCase))
@@ -157,6 +156,7 @@ namespace Microsoft.Build.Tasks
                         (0 == String.Compare(sourceExtension, ".resources", StringComparison.OrdinalIgnoreCase))
                     )
                 {
+                    // Take directory into account when forming manifest resource names
                     manifestName.Append(Path.Combine(everettCompatibleDirectoryName, Path.GetFileNameWithoutExtension(info.cultureNeutralFilename)));
 
                     // Replace all '\' with '.'

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -153,11 +153,11 @@ namespace Microsoft.Build.Tasks
                 // only strip extension for .resx and .restext files
                 string sourceExtension = Path.GetExtension(info.cultureNeutralFilename);
                 if (
-                        (0 == String.Compare(sourceExtension, ".resx", StringComparison.OrdinalIgnoreCase))
+                        (String.Equals(sourceExtension, ".resx", StringComparison.OrdinalIgnoreCase))
                         ||
-                        (0 == String.Compare(sourceExtension, ".restext", StringComparison.OrdinalIgnoreCase))
+                        (String.Equals(sourceExtension, ".restext", StringComparison.OrdinalIgnoreCase))
                         ||
-                        (0 == String.Compare(sourceExtension, ".resources", StringComparison.OrdinalIgnoreCase))
+                        (String.Equals(sourceExtension, ".resources", StringComparison.OrdinalIgnoreCase))
                     )
                 {
                     // Take directory into account when forming manifest resource names
@@ -167,7 +167,7 @@ namespace Microsoft.Build.Tasks
                     manifestName.Replace(Path.DirectorySeparatorChar, '.');
                     manifestName.Replace(Path.AltDirectorySeparatorChar, '.');
 
-                    // Append the culture if there is one.        
+                    // Append the culture if there is one.
                     if (!string.IsNullOrEmpty(info.culture))
                     {
                         manifestName.Append(".").Append(info.culture);
@@ -181,7 +181,11 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
-                    manifestName.Append(Path.GetFileName(info.cultureNeutralFilename));
+                    manifestName.Append(Path.Combine(everettCompatibleDirectoryName, Path.GetFileName(info.cultureNeutralFilename)));
+
+                    // Replace all '\' with '.'
+                    manifestName.Replace(Path.DirectorySeparatorChar, '.');
+                    manifestName.Replace(Path.AltDirectorySeparatorChar, '.');
 
                     if (prependCultureAsDirectory)
                     {

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -146,6 +146,10 @@ namespace Microsoft.Build.Tasks
                     manifestName.Append(rootNamespace).Append(".");
                 }
 
+                // Replace spaces in the directory name with underscores. Needed for compatibility with Everett.
+                // Note that spaces in the file name itself are preserved.
+                string everettCompatibleDirectoryName = MakeValidEverettIdentifier(Path.GetDirectoryName(info.cultureNeutralFilename));
+
                 // only strip extension for .resx and .restext files
                 string sourceExtension = Path.GetExtension(info.cultureNeutralFilename);
                 if (
@@ -156,7 +160,12 @@ namespace Microsoft.Build.Tasks
                         (0 == String.Compare(sourceExtension, ".resources", StringComparison.OrdinalIgnoreCase))
                     )
                 {
-                    manifestName.Append(Path.GetFileNameWithoutExtension(info.cultureNeutralFilename));
+                    // Take directory into account when forming manifest resource names
+                    manifestName.Append(Path.Combine(everettCompatibleDirectoryName, Path.GetFileNameWithoutExtension(info.cultureNeutralFilename)));
+
+                    // Replace all '\' with '.'
+                    manifestName.Replace(Path.DirectorySeparatorChar, '.');
+                    manifestName.Replace(Path.AltDirectorySeparatorChar, '.');
 
                     // Append the culture if there is one.        
                     if (!string.IsNullOrEmpty(info.culture))


### PR DESCRIPTION
Fixes #5469 

For some reason, Visual Basic did not take relative folder path into account when coming up with manifest names. C# on the other hand already does this.

The age old question (/cc: @rainersigwald ): Who are we breaking by fixing this? Will we need an escape hatch?