### PR TITLE
Add ability to set a help link for errors/warnings

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Framework
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
-        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, string helpLink, params object[] messageArgs) { }
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, string helpLink, System.DateTime eventTimestamp, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }
@@ -120,7 +120,7 @@ namespace Microsoft.Build.Framework
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
-        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string helpLink, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, string helpLink, System.DateTime eventTimestamp, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Framework
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
-        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string helpLink, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, string helpLink, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -16,11 +16,13 @@ namespace Microsoft.Build.Framework
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string helpLink, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }
         public int EndLineNumber { get { throw null; } }
         public string File { get { throw null; } }
+        public string HelpLink { get { throw null; } }
         public int LineNumber { get { throw null; } }
         public string ProjectFile { get { throw null; } set { } }
         public string Subcategory { get { throw null; } }
@@ -118,11 +120,13 @@ namespace Microsoft.Build.Framework
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string helpLink, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }
         public int EndLineNumber { get { throw null; } }
         public string File { get { throw null; } }
+        public string HelpLink { get { throw null; } }
         public int LineNumber { get { throw null; } }
         public string ProjectFile { get { throw null; } set { } }
         public string Subcategory { get { throw null; } }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Framework
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
-        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, string helpLink, params object[] messageArgs) { }
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, string helpLink, System.DateTime eventTimestamp, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }
@@ -120,7 +120,7 @@ namespace Microsoft.Build.Framework
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
-        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string helpLink, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, string helpLink, System.DateTime eventTimestamp, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Framework
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
-        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string helpLink, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, string helpLink, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -16,11 +16,13 @@ namespace Microsoft.Build.Framework
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string helpLink, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }
         public int EndLineNumber { get { throw null; } }
         public string File { get { throw null; } }
+        public string HelpLink { get { throw null; } }
         public int LineNumber { get { throw null; } }
         public string ProjectFile { get { throw null; } set { } }
         public string Subcategory { get { throw null; } }
@@ -118,11 +120,13 @@ namespace Microsoft.Build.Framework
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
         public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string helpLink, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
         public string Code { get { throw null; } }
         public int ColumnNumber { get { throw null; } }
         public int EndColumnNumber { get { throw null; } }
         public int EndLineNumber { get { throw null; } }
         public string File { get { throw null; } }
+        public string HelpLink { get { throw null; } }
         public int LineNumber { get { throw null; } }
         public string ProjectFile { get { throw null; } set { } }
         public string Subcategory { get { throw null; } }

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -277,6 +277,7 @@ namespace Microsoft.Build.Tasks
         public string Code { get { throw null; } set { } }
         public string File { get { throw null; } set { } }
         public string HelpKeyword { get { throw null; } set { } }
+        public string HelpLink { get { throw null; } set { } }
         public string Text { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
@@ -1229,6 +1230,7 @@ namespace Microsoft.Build.Tasks
         public string Code { get { throw null; } set { } }
         public string File { get { throw null; } set { } }
         public string HelpKeyword { get { throw null; } set { } }
+        public string HelpLink { get { throw null; } set { } }
         public string Text { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -207,6 +207,7 @@ namespace Microsoft.Build.Tasks
         public string Code { get { throw null; } set { } }
         public string File { get { throw null; } set { } }
         public string HelpKeyword { get { throw null; } set { } }
+        public string HelpLink { get { throw null; } set { } }
         public string Text { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
@@ -782,6 +783,7 @@ namespace Microsoft.Build.Tasks
         public string Code { get { throw null; } set { } }
         public string File { get { throw null; } set { } }
         public string HelpKeyword { get { throw null; } set { } }
+        public string HelpLink { get { throw null; } set { } }
         public string Text { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }

--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -401,6 +401,7 @@ namespace Microsoft.Build.Utilities
         public void LogCriticalMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogError(string message, params object[] messageArgs) { }
         public void LogError(string subcategory, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+        public void LogError(string subcategory, string errorCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogErrorFromException(System.Exception exception) { }
         public void LogErrorFromException(System.Exception exception, bool showStackTrace) { }
         public void LogErrorFromException(System.Exception exception, bool showStackTrace, bool showDetail, string file) { }
@@ -422,6 +423,7 @@ namespace Microsoft.Build.Utilities
         public void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties) { }
         public void LogWarning(string message, params object[] messageArgs) { }
         public void LogWarning(string subcategory, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+        public void LogWarning(string subcategory, string warningCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogWarningFromException(System.Exception exception) { }
         public void LogWarningFromException(System.Exception exception, bool showStackTrace) { }
         public void LogWarningFromResources(string messageResourceName, params object[] messageArgs) { }

--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Build.Utilities
         public void LogCriticalMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogError(string message, params object[] messageArgs) { }
         public void LogError(string subcategory, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
-        public void LogError(string subcategory, string errorCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+        public void LogError(string subcategory, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpLink, params object[] messageArgs) { }
         public void LogErrorFromException(System.Exception exception) { }
         public void LogErrorFromException(System.Exception exception, bool showStackTrace) { }
         public void LogErrorFromException(System.Exception exception, bool showStackTrace, bool showDetail, string file) { }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -243,6 +243,7 @@ namespace Microsoft.Build.Utilities
         public void LogCriticalMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogError(string message, params object[] messageArgs) { }
         public void LogError(string subcategory, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+        public void LogError(string subcategory, string errorCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogErrorFromException(System.Exception exception) { }
         public void LogErrorFromException(System.Exception exception, bool showStackTrace) { }
         public void LogErrorFromException(System.Exception exception, bool showStackTrace, bool showDetail, string file) { }
@@ -264,6 +265,7 @@ namespace Microsoft.Build.Utilities
         public void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties) { }
         public void LogWarning(string message, params object[] messageArgs) { }
         public void LogWarning(string subcategory, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+        public void LogWarning(string subcategory, string warningCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogWarningFromException(System.Exception exception) { }
         public void LogWarningFromException(System.Exception exception, bool showStackTrace) { }
         public void LogWarningFromResources(string messageResourceName, params object[] messageArgs) { }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Build.Utilities
         public void LogCriticalMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogError(string message, params object[] messageArgs) { }
         public void LogError(string subcategory, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
-        public void LogError(string subcategory, string errorCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+        public void LogError(string subcategory, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpLink, params object[] messageArgs) { }
         public void LogErrorFromException(System.Exception exception) { }
         public void LogErrorFromException(System.Exception exception, bool showStackTrace) { }
         public void LogErrorFromException(System.Exception exception, bool showStackTrace, bool showDetail, string file) { }

--- a/src/Framework.UnitTests/BuildErrorEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/BuildErrorEventArgs_Tests.cs
@@ -23,11 +23,10 @@ namespace Microsoft.Build.UnitTests
             beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender");
             beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender", DateTime.Now);
             beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "sender", DateTime.Now, "Message");
-            beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "HelpLink", "sender", DateTime.Now, "Message");
+            beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "sender", DateTime.Now, "HelpLink", "Message");
             beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null);
             beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now);
-            beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now, null);
-            beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, null, DateTime.Now, null);
+            beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now, null, null);
         }
 
         /// <summary>

--- a/src/Framework.UnitTests/BuildErrorEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/BuildErrorEventArgs_Tests.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Build.UnitTests
             beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender");
             beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender", DateTime.Now);
             beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "sender", DateTime.Now, "Message");
-            beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "sender", DateTime.Now, "HelpLink", "Message");
+            beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "sender", "HelpLink", DateTime.Now, "Message");
             beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null);
             beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now);
-            beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now, null, null);
+            beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, null, DateTime.Now, null);
         }
 
         /// <summary>

--- a/src/Framework.UnitTests/BuildErrorEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/BuildErrorEventArgs_Tests.cs
@@ -23,9 +23,11 @@ namespace Microsoft.Build.UnitTests
             beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender");
             beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender", DateTime.Now);
             beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "sender", DateTime.Now, "Message");
+            beea = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "HelpLink", "sender", DateTime.Now, "Message");
             beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null);
             beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now);
             beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now, null);
+            beea = new BuildErrorEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, null, DateTime.Now, null);
         }
 
         /// <summary>

--- a/src/Framework.UnitTests/BuildWarningEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/BuildWarningEventArgs_Tests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Build.UnitTests
             buildWarningEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender");
             buildWarningEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender", DateTime.Now);
             buildWarningEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "sender", DateTime.Now, "Message");
-            buildWarningEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "HelpLink", "sender", DateTime.Now, "Message");
+            buildWarningEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "sender", "HelpLink", DateTime.Now, "Message");
             buildWarningEvent = new BuildWarningEventArgs(null, null, null, 1, 2, 3, 4, null, null, null);
             buildWarningEvent = new BuildWarningEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now);
             buildWarningEvent = new BuildWarningEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now, null);

--- a/src/Framework.UnitTests/BuildWarningEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/BuildWarningEventArgs_Tests.cs
@@ -28,9 +28,11 @@ namespace Microsoft.Build.UnitTests
             buildWarningEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender");
             buildWarningEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "sender", DateTime.Now);
             buildWarningEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "sender", DateTime.Now, "Message");
+            buildWarningEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "HelpLink", "sender", DateTime.Now, "Message");
             buildWarningEvent = new BuildWarningEventArgs(null, null, null, 1, 2, 3, 4, null, null, null);
             buildWarningEvent = new BuildWarningEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now);
             buildWarningEvent = new BuildWarningEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, DateTime.Now, null);
+            buildWarningEvent = new BuildWarningEventArgs(null, null, null, 1, 2, 3, 4, null, null, null, null, DateTime.Now, null);
         }
 
         /// <summary>

--- a/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
+++ b/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Build.UnitTests
 
             // Test using HelpLink
             _stream.Position = 0;
-            genericEvent = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "HelpLink", "SenderName", DateTime.Now);
+            genericEvent = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "SenderName", DateTime.Now, "HelpLink");
             genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
 
             // Serialize
@@ -184,7 +184,7 @@ namespace Microsoft.Build.UnitTests
 
             // Deserialize and Verify
             _stream.Position = 0;
-            newGenericEvent = new BuildErrorEventArgs("Something", "SomeThing", "SomeThing", -1, -1, -1, -1, "Something", "SomeThing", "Something");
+            newGenericEvent = new BuildErrorEventArgs("Something", "SomeThing", "SomeThing", -1, -1, -1, -1, "Something", "SomeThing", "Something", DateTime.Now, "HelpLink");
             newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
             _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
             VerifyGenericEventArg(genericEvent, newGenericEvent);

--- a/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
+++ b/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
@@ -172,6 +172,23 @@ namespace Microsoft.Build.UnitTests
             _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
             VerifyGenericEventArg(genericEvent, newGenericEvent);
             VerifyBuildErrorEventArgs(genericEvent, newGenericEvent);
+
+            // Test using HelpLink
+            _stream.Position = 0;
+            genericEvent = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "HelpLink", "SenderName", DateTime.Now);
+            genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
+
+            // Serialize
+            genericEvent.WriteToStream(_writer);
+            streamWriteEndPosition = _stream.Position;
+
+            // Deserialize and Verify
+            _stream.Position = 0;
+            newGenericEvent = new BuildErrorEventArgs("Something", "SomeThing", "SomeThing", -1, -1, -1, -1, "Something", "SomeThing", "Something");
+            newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
+            _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
+            VerifyGenericEventArg(genericEvent, newGenericEvent);
+            VerifyBuildErrorEventArgs(genericEvent, newGenericEvent);
         }
 
         /// <summary>
@@ -184,6 +201,7 @@ namespace Microsoft.Build.UnitTests
             newGenericEvent.ColumnNumber.ShouldBe(genericEvent.ColumnNumber); // "Expected ColumnNumber to Match"
             newGenericEvent.EndColumnNumber.ShouldBe(genericEvent.EndColumnNumber); // "Expected EndColumnNumber to Match"
             newGenericEvent.EndLineNumber.ShouldBe(genericEvent.EndLineNumber); // "Expected EndLineNumber to Match"
+            newGenericEvent.HelpLink.ShouldBe(genericEvent.HelpLink); // "Expected HelpLink to Match"
         }
 
 
@@ -464,6 +482,23 @@ namespace Microsoft.Build.UnitTests
             _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
             VerifyGenericEventArg(genericEvent, newGenericEvent);
             VerifyBuildWarningEventArgs(genericEvent, newGenericEvent);
+
+            // Test with help link
+            _stream.Position = 0;
+            genericEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "HelpLink", "SenderName", DateTime.Now, null);
+            genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
+
+            // Serialize
+            genericEvent.WriteToStream(_writer);
+            streamWriteEndPosition = _stream.Position;
+
+            // Deserialize and Verify
+            _stream.Position = 0;
+            newGenericEvent = new BuildWarningEventArgs("Something", "SomeThing", "SomeThing", -1, -1, -1, -1, "Something", "SomeThing", "Something");
+            newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
+            _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
+            VerifyGenericEventArg(genericEvent, newGenericEvent);
+            VerifyBuildWarningEventArgs(genericEvent, newGenericEvent);
         }
 
         /// <summary>
@@ -477,6 +512,7 @@ namespace Microsoft.Build.UnitTests
             newGenericEvent.ColumnNumber.ShouldBe(genericEvent.ColumnNumber); // "Expected ColumnNumber to Match"
             newGenericEvent.EndColumnNumber.ShouldBe(genericEvent.EndColumnNumber); // "Expected EndColumnNumber to Match"
             newGenericEvent.EndLineNumber.ShouldBe(genericEvent.EndLineNumber); // "Expected EndLineNumber to Match"
+            newGenericEvent.HelpLink.ShouldBe(genericEvent.HelpLink); // "Expected HelpLink to Match"
         }
 
         [Fact]

--- a/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
+++ b/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Build.UnitTests
 
             // Test using HelpLink
             _stream.Position = 0;
-            genericEvent = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "SenderName", DateTime.Now, "HelpLink");
+            genericEvent = new BuildErrorEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "SenderName", "HelpLink", DateTime.Now);
             genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
 
             // Serialize
@@ -184,7 +184,7 @@ namespace Microsoft.Build.UnitTests
 
             // Deserialize and Verify
             _stream.Position = 0;
-            newGenericEvent = new BuildErrorEventArgs("Something", "SomeThing", "SomeThing", -1, -1, -1, -1, "Something", "SomeThing", "Something", DateTime.Now, "HelpLink");
+            newGenericEvent = new BuildErrorEventArgs("Something", "SomeThing", "SomeThing", -1, -1, -1, -1, "Something", "SomeThing", "Something", "HelpLink", DateTime.Now);
             newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
             _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
             VerifyGenericEventArg(genericEvent, newGenericEvent);
@@ -485,7 +485,7 @@ namespace Microsoft.Build.UnitTests
 
             // Test with help link
             _stream.Position = 0;
-            genericEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "HelpLink", "SenderName", DateTime.Now, null);
+            genericEvent = new BuildWarningEventArgs("Subcategory", "Code", "File", 1, 2, 3, 4, "Message", "HelpKeyword", "SenderName", "HelpLink", DateTime.Now, null);
             genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
 
             // Serialize

--- a/src/Framework/BuildErrorEventArgs.cs
+++ b/src/Framework/BuildErrorEventArgs.cs
@@ -316,7 +316,14 @@ namespace Microsoft.Build.Framework
             endLineNumber = reader.ReadInt32();
             endColumnNumber = reader.ReadInt32();
 
-            helpLink = reader.ReadByte() == 0 ? null : reader.ReadString();
+            if (version >= 40)
+            {
+                helpLink = reader.ReadByte() == 0 ? null : reader.ReadString();
+            }
+            else
+            {
+                helpLink = null;
+            }
         }
         #endregion
     }

--- a/src/Framework/BuildErrorEventArgs.cs
+++ b/src/Framework/BuildErrorEventArgs.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Framework
             string senderName,
             DateTime eventTimestamp
             )
-            : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, eventTimestamp, null)
+            : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, eventTimestamp, null, null)
         {
             // do nothing
         }
@@ -160,7 +160,7 @@ namespace Microsoft.Build.Framework
             DateTime eventTimestamp,
             params object[] messageArgs
             )
-            : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, null, senderName, eventTimestamp, messageArgs)
+            : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, eventTimestamp, null, messageArgs)
         {
             // do nothing
         }
@@ -192,9 +192,9 @@ namespace Microsoft.Build.Framework
             int endColumnNumber,
             string message,
             string helpKeyword,
-            string helpLink,
             string senderName,
             DateTime eventTimestamp,
+            string helpLink,
             params object[] messageArgs
             )
             : base(message, helpKeyword, senderName, eventTimestamp, messageArgs)

--- a/src/Framework/BuildErrorEventArgs.cs
+++ b/src/Framework/BuildErrorEventArgs.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Build.Framework
         private int endColumnNumber;
 
         /// <summary>
+        /// A link pointing to more information about the error
+        /// </summary>
+        private string helpLink;
+
+        /// <summary>
         /// This constructor allows all event data to be initialized
         /// </summary>
         /// <param name="subcategory">event sub-category</param>
@@ -124,6 +129,7 @@ namespace Microsoft.Build.Framework
             // do nothing
         }
 
+
         /// <summary>
         /// This constructor which allows a timestamp to be set
         /// </summary>
@@ -154,6 +160,43 @@ namespace Microsoft.Build.Framework
             DateTime eventTimestamp,
             params object[] messageArgs
             )
+            : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, null, senderName, eventTimestamp, messageArgs)
+        {
+            // do nothing
+        }
+
+        /// <summary>
+        /// This constructor which allows a timestamp to be set
+        /// </summary>
+        /// <param name="subcategory">event sub-category</param>
+        /// <param name="code">event code</param>
+        /// <param name="file">file associated with the event</param>
+        /// <param name="lineNumber">line number (0 if not applicable)</param>
+        /// <param name="columnNumber">column number (0 if not applicable)</param>
+        /// <param name="endLineNumber">end line number (0 if not applicable)</param>
+        /// <param name="endColumnNumber">end column number (0 if not applicable)</param>
+        /// <param name="message">text message</param>
+        /// <param name="helpKeyword">help keyword </param>
+        /// <param name="helpLink">A link pointing to more information about the error </param>
+        /// <param name="senderName">name of event sender</param>
+        /// <param name="eventTimestamp">Timestamp when event was created</param>
+        /// <param name="messageArgs">message arguments</param>
+        public BuildErrorEventArgs
+            (
+            string subcategory,
+            string code,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            string helpKeyword,
+            string helpLink,
+            string senderName,
+            DateTime eventTimestamp,
+            params object[] messageArgs
+            )
             : base(message, helpKeyword, senderName, eventTimestamp, messageArgs)
         {
             this.subcategory = subcategory;
@@ -163,6 +206,7 @@ namespace Microsoft.Build.Framework
             this.columnNumber = columnNumber;
             this.endLineNumber = endLineNumber;
             this.endColumnNumber = endColumnNumber;
+            this.helpLink = helpLink;
         }
 
         /// <summary>
@@ -175,18 +219,18 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
-        /// The custom sub-type of the event.         
+        /// The custom sub-type of the event.
         /// </summary>
         public string Subcategory => subcategory;
 
         /// <summary>
-        /// Code associated with event. 
+        /// Code associated with event.
         /// </summary>
         public string Code => code;
 
         /// <summary>
-        /// File associated with event.   
-        /// </summary>  
+        /// File associated with event.
+        /// </summary>
         public string File => file;
 
         /// <summary>
@@ -199,24 +243,29 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
-        /// Line number of interest in associated file. 
+        /// Line number of interest in associated file.
         /// </summary>
         public int LineNumber => lineNumber;
 
         /// <summary>
-        /// Column number of interest in associated file. 
+        /// Column number of interest in associated file.
         /// </summary>
         public int ColumnNumber => columnNumber;
 
         /// <summary>
-        /// Ending line number of interest in associated file. 
+        /// Ending line number of interest in associated file.
         /// </summary>
         public int EndLineNumber => endLineNumber;
 
         /// <summary>
-        /// Ending column number of interest in associated file. 
+        /// Ending column number of interest in associated file.
         /// </summary>
         public int EndColumnNumber => endColumnNumber;
+
+        /// <summary>
+        /// A link pointing to more information about the error.
+        /// </summary>
+        public string HelpLink => helpLink;
 
         #region CustomSerializationToStream
         /// <summary>
@@ -236,6 +285,8 @@ namespace Microsoft.Build.Framework
             writer.Write((Int32)columnNumber);
             writer.Write((Int32)endLineNumber);
             writer.Write((Int32)endColumnNumber);
+
+            writer.WriteOptionalString(helpLink);
         }
 
         /// <summary>
@@ -264,6 +315,8 @@ namespace Microsoft.Build.Framework
             columnNumber = reader.ReadInt32();
             endLineNumber = reader.ReadInt32();
             endColumnNumber = reader.ReadInt32();
+
+            helpLink = reader.ReadByte() == 0 ? null : reader.ReadString();
         }
         #endregion
     }

--- a/src/Framework/BuildErrorEventArgs.cs
+++ b/src/Framework/BuildErrorEventArgs.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Framework
             string senderName,
             DateTime eventTimestamp
             )
-            : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, eventTimestamp, null, null)
+            : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, null, eventTimestamp, null)
         {
             // do nothing
         }
@@ -160,7 +160,7 @@ namespace Microsoft.Build.Framework
             DateTime eventTimestamp,
             params object[] messageArgs
             )
-            : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, eventTimestamp, null, messageArgs)
+            : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, null, eventTimestamp, messageArgs)
         {
             // do nothing
         }
@@ -193,8 +193,8 @@ namespace Microsoft.Build.Framework
             string message,
             string helpKeyword,
             string senderName,
-            DateTime eventTimestamp,
             string helpLink,
+            DateTime eventTimestamp,
             params object[] messageArgs
             )
             : base(message, helpKeyword, senderName, eventTimestamp, messageArgs)

--- a/src/Framework/BuildWarningEventArgs.cs
+++ b/src/Framework/BuildWarningEventArgs.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.Framework
     public class BuildWarningEventArgs : LazyFormattedBuildEventArgs
     {
         /// <summary>
-        /// Default constructor 
+        /// Default constructor
         /// </summary>
         protected BuildWarningEventArgs()
             : base()
@@ -123,6 +123,42 @@ namespace Microsoft.Build.Framework
             string senderName,
             DateTime eventTimestamp,
             params object[] messageArgs
+        ) : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, null, senderName, eventTimestamp, null)
+        {
+            // do nothing
+        }
+
+        /// <summary>
+        /// This constructor allows timestamp to be set
+        /// </summary>
+        /// <param name="subcategory">event subcategory</param>
+        /// <param name="code">event code</param>
+        /// <param name="file">file associated with the event</param>
+        /// <param name="lineNumber">line number (0 if not applicable)</param>
+        /// <param name="columnNumber">column number (0 if not applicable)</param>
+        /// <param name="endLineNumber">end line number (0 if not applicable)</param>
+        /// <param name="endColumnNumber">end column number (0 if not applicable)</param>
+        /// <param name="message">text message</param>
+        /// <param name="helpKeyword">help keyword </param>
+        /// <param name="helpLink">A link pointing to more  information about the warning</param>
+        /// <param name="senderName">name of event sender</param>
+        /// <param name="eventTimestamp">custom timestamp for the event</param>
+        /// <param name="messageArgs">message arguments</param>
+        public BuildWarningEventArgs
+        (
+            string subcategory,
+            string code,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            string helpKeyword,
+            string helpLink,
+            string senderName,
+            DateTime eventTimestamp,
+            params object[] messageArgs
         )
             : base(message, helpKeyword, senderName, eventTimestamp, messageArgs)
         {
@@ -133,6 +169,7 @@ namespace Microsoft.Build.Framework
             this.columnNumber = columnNumber;
             this.endLineNumber = endLineNumber;
             this.endColumnNumber = endColumnNumber;
+            this.helpLink = helpLink;
         }
 
         private string subcategory;
@@ -143,6 +180,7 @@ namespace Microsoft.Build.Framework
         private int columnNumber;
         private int endLineNumber;
         private int endColumnNumber;
+        private string helpLink;
 
         #region CustomSerializationToStream
         /// <summary>
@@ -162,6 +200,8 @@ namespace Microsoft.Build.Framework
             writer.Write((Int32)columnNumber);
             writer.Write((Int32)endLineNumber);
             writer.Write((Int32)endColumnNumber);
+
+            writer.WriteOptionalString(helpLink);
         }
 
         /// <summary>
@@ -186,41 +226,43 @@ namespace Microsoft.Build.Framework
             columnNumber = reader.ReadInt32();
             endLineNumber = reader.ReadInt32();
             endColumnNumber = reader.ReadInt32();
+
+            helpLink = reader.ReadByte() == 0 ? null : reader.ReadString();
         }
         #endregion
 
         /// <summary>
-        /// The custom sub-type of the event.         
+        /// The custom sub-type of the event.
         /// </summary>
         public string Subcategory => subcategory;
 
         /// <summary>
-        /// Code associated with event. 
+        /// Code associated with event.
         /// </summary>
         public string Code => code;
 
         /// <summary>
-        /// File associated with event.   
+        /// File associated with event.
         /// </summary>
         public string File => file;
 
         /// <summary>
-        /// Line number of interest in associated file. 
+        /// Line number of interest in associated file.
         /// </summary>
         public int LineNumber => lineNumber;
 
         /// <summary>
-        /// Column number of interest in associated file. 
+        /// Column number of interest in associated file.
         /// </summary>
         public int ColumnNumber => columnNumber;
 
         /// <summary>
-        /// Ending line number of interest in associated file. 
+        /// Ending line number of interest in associated file.
         /// </summary>
         public int EndLineNumber => endLineNumber;
 
         /// <summary>
-        /// Ending column number of interest in associated file. 
+        /// Ending column number of interest in associated file.
         /// </summary>
         public int EndColumnNumber => endColumnNumber;
 
@@ -232,5 +274,10 @@ namespace Microsoft.Build.Framework
             get => projectFile;
             set => projectFile = value;
         }
+
+        /// <summary>
+        /// A link pointing to more information about the warning.
+        /// </summary>
+        public string HelpLink => helpLink;
     }
 }

--- a/src/Framework/BuildWarningEventArgs.cs
+++ b/src/Framework/BuildWarningEventArgs.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Build.Framework
             string senderName,
             DateTime eventTimestamp,
             params object[] messageArgs
-        ) : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, null, senderName, eventTimestamp, null)
+        ) : this(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, null, eventTimestamp, messageArgs)
         {
             // do nothing
         }
@@ -155,8 +155,8 @@ namespace Microsoft.Build.Framework
             int endColumnNumber,
             string message,
             string helpKeyword,
-            string helpLink,
             string senderName,
+            string helpLink,
             DateTime eventTimestamp,
             params object[] messageArgs
         )

--- a/src/Framework/BuildWarningEventArgs.cs
+++ b/src/Framework/BuildWarningEventArgs.cs
@@ -227,7 +227,14 @@ namespace Microsoft.Build.Framework
             endLineNumber = reader.ReadInt32();
             endColumnNumber = reader.ReadInt32();
 
-            helpLink = reader.ReadByte() == 0 ? null : reader.ReadString();
+            if (version >= 40)
+            {
+                helpLink = reader.ReadByte() == 0 ? null : reader.ReadString();
+            }
+            else
+            {
+                helpLink = null;
+            }
         }
         #endregion
 

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Utilities
         {
             get
             {
-                // If the task instance does not equal null then use its build engine because
+                // If the task instance does not equal null then use its build engine because 
                 // the task instances build engine can be changed for example during tests. This changing of the engine on the same task object is not expected to happen
                 // during normal operation.
                 if (_taskInstance != null)
@@ -185,10 +185,10 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Loads the specified resource string and optionally formats it using the given arguments. The current thread's culture
         /// is used for formatting.
-        ///
+        /// 
         /// Requires the owner task to have registered its resources either via the Task (or TaskMarshalByRef) base
         /// class constructor, or the Task.TaskResources (or AppDomainIsolatedTask.TaskResources) property.
-        ///
+        /// 
         /// Thread safe.
         /// </summary>
         /// <param name="resourceName">The name of the string resource to load.</param>
@@ -277,7 +277,7 @@ namespace Microsoft.Build.Utilities
                 (
                     message,                             // message
                     null,                                // help keyword
-                    TaskName,                            // sender
+                    TaskName,                            // sender 
                     importance,                          // importance
                     DateTime.UtcNow,                     // timestamp
                     messageArgs                          // message arguments
@@ -755,14 +755,14 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Logs an error using the specified resource string.
+        /// Logs an error using the specified resource string. 
         /// If the message has an error code prefixed to it, the code is extracted and logged with the message. If a help keyword
         /// prefix has been provided, a help keyword for the host IDE is also logged with the message. The help keyword is
         /// composed by appending the string resource name to the prefix.
-        ///
+        /// 
         /// A task can provide a help keyword prefix either via the Task (or TaskMarshalByRef) base class constructor, or the
         /// Task.HelpKeywordPrefix (or AppDomainIsolatedTask.HelpKeywordPrefix) property.
-        ///
+        /// 
         /// Thread safe.
         /// </summary>
         /// <param name="messageResourceName">The name of the string resource to load.</param>
@@ -774,14 +774,14 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Logs an error using the specified resource string and other error details.
+        /// Logs an error using the specified resource string and other error details. 
         /// If the message has an error code prefixed, the code is extracted and logged with the message. If a
         /// help keyword prefix has been provided, a help keyword for the host IDE is also logged with the message. The help
         /// keyword is composed by appending the error message resource string name to the prefix.
-        ///
+        /// 
         /// A task can provide a help keyword prefix either via the Task (or TaskMarshalByRef) base class constructor, or the
         /// Task.HelpKeywordPrefix (or AppDomainIsolatedTask.HelpKeywordPrefix) property.
-        ///
+        /// 
         /// Thread safe.
         /// </summary>
         /// <param name="subcategoryResourceName">The name of the string resource that describes the error type (can be null).</param>

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -668,8 +668,8 @@ namespace Microsoft.Build.Utilities
                     message,
                     helpKeyword,
                     TaskName,
-                    DateTime.UtcNow,
                     helpLink,
+                    DateTime.UtcNow,
                     messageArgs
                 );
             BuildEngine.LogErrorEvent(e);
@@ -1021,8 +1021,8 @@ namespace Microsoft.Build.Utilities
                     endColumnNumber,
                     message,
                     helpKeyword,
-                    helpLink,
                     TaskName,
+                    helpLink,
                     DateTime.UtcNow,
                     messageArgs
                 );

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Build.Utilities
             params object[] messageArgs
         )
         {
-            LogError(subcategory, errorCode, helpKeyword, null, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, messageArgs);
+            LogError(subcategory, errorCode, helpKeyword, null, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, messageArgs);
         }
 
         /// <summary>

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Utilities
         {
             get
             {
-                // If the task instance does not equal null then use its build engine because 
+                // If the task instance does not equal null then use its build engine because
                 // the task instances build engine can be changed for example during tests. This changing of the engine on the same task object is not expected to happen
                 // during normal operation.
                 if (_taskInstance != null)
@@ -185,10 +185,10 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Loads the specified resource string and optionally formats it using the given arguments. The current thread's culture
         /// is used for formatting.
-        /// 
+        ///
         /// Requires the owner task to have registered its resources either via the Task (or TaskMarshalByRef) base
         /// class constructor, or the Task.TaskResources (or AppDomainIsolatedTask.TaskResources) property.
-        /// 
+        ///
         /// Thread safe.
         /// </summary>
         /// <param name="resourceName">The name of the string resource to load.</param>
@@ -277,7 +277,7 @@ namespace Microsoft.Build.Utilities
                 (
                     message,                             // message
                     null,                                // help keyword
-                    TaskName,                            // sender 
+                    TaskName,                            // sender
                     importance,                          // importance
                     DateTime.UtcNow,                     // timestamp
                     messageArgs                          // message arguments
@@ -604,6 +604,40 @@ namespace Microsoft.Build.Utilities
             params object[] messageArgs
         )
         {
+            LogError(subcategory, errorCode, helpKeyword, null, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, messageArgs);
+        }
+
+        /// <summary>
+        /// Logs an error using the specified string and other error details.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="subcategory">Description of the error type (can be null).</param>
+        /// <param name="errorCode">The error code (can be null).</param>
+        /// <param name="helpKeyword">The help keyword for the host IDE (can be null).</param>
+        /// <param name="helpLink">A link pointing to more information about the error.</param>
+        /// <param name="file">The path to the file containing the error (can be null).</param>
+        /// <param name="lineNumber">The line in the file where the error occurs (set to zero if not available).</param>
+        /// <param name="columnNumber">The column in the file where the error occurs (set to zero if not available).</param>
+        /// <param name="endLineNumber">The last line of a range of lines in the file where the error occurs (set to zero if not available).</param>
+        /// <param name="endColumnNumber">The last column of a range of columns in the file where the error occurs (set to zero if not available).</param>
+        /// <param name="message">The message string.</param>
+        /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
+        public void LogError
+        (
+            string subcategory,
+            string errorCode,
+            string helpKeyword,
+            string helpLink,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs
+        )
+        {
             // No lock needed, as BuildEngine methods from v4.5 onwards are thread safe.
             ErrorUtilities.VerifyThrowArgumentNull(message, nameof(message));
 
@@ -633,6 +667,7 @@ namespace Microsoft.Build.Utilities
                     endColumnNumber,
                     message,
                     helpKeyword,
+                    helpLink,
                     TaskName,
                     DateTime.UtcNow,
                     messageArgs
@@ -720,14 +755,14 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Logs an error using the specified resource string. 
+        /// Logs an error using the specified resource string.
         /// If the message has an error code prefixed to it, the code is extracted and logged with the message. If a help keyword
         /// prefix has been provided, a help keyword for the host IDE is also logged with the message. The help keyword is
         /// composed by appending the string resource name to the prefix.
-        /// 
+        ///
         /// A task can provide a help keyword prefix either via the Task (or TaskMarshalByRef) base class constructor, or the
         /// Task.HelpKeywordPrefix (or AppDomainIsolatedTask.HelpKeywordPrefix) property.
-        ///    
+        ///
         /// Thread safe.
         /// </summary>
         /// <param name="messageResourceName">The name of the string resource to load.</param>
@@ -739,14 +774,14 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Logs an error using the specified resource string and other error details. 
+        /// Logs an error using the specified resource string and other error details.
         /// If the message has an error code prefixed, the code is extracted and logged with the message. If a
         /// help keyword prefix has been provided, a help keyword for the host IDE is also logged with the message. The help
         /// keyword is composed by appending the error message resource string name to the prefix.
-        /// 
+        ///
         /// A task can provide a help keyword prefix either via the Task (or TaskMarshalByRef) base class constructor, or the
         /// Task.HelpKeywordPrefix (or AppDomainIsolatedTask.HelpKeywordPrefix) property.
-        ///    
+        ///
         /// Thread safe.
         /// </summary>
         /// <param name="subcategoryResourceName">The name of the string resource that describes the error type (can be null).</param>
@@ -923,6 +958,40 @@ namespace Microsoft.Build.Utilities
             params object[] messageArgs
         )
         {
+            LogWarning(subcategory, warningCode, helpKeyword, null, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, messageArgs);
+        }
+
+        /// <summary>
+        /// Logs a warning using the specified string and other warning details.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="subcategory">Description of the warning type (can be null).</param>
+        /// <param name="warningCode">The warning code (can be null).</param>
+        /// <param name="helpKeyword">The help keyword for the host IDE (can be null).</param>
+        /// <param name="helpLink">A link pointing to more information about the warning (can be null).</param>
+        /// <param name="file">The path to the file causing the warning (can be null).</param>
+        /// <param name="lineNumber">The line in the file causing the warning (set to zero if not available).</param>
+        /// <param name="columnNumber">The column in the file causing the warning (set to zero if not available).</param>
+        /// <param name="endLineNumber">The last line of a range of lines in the file causing the warning (set to zero if not available).</param>
+        /// <param name="endColumnNumber">The last column of a range of columns in the file causing the warning (set to zero if not available).</param>
+        /// <param name="message">The message string.</param>
+        /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
+        public void LogWarning
+        (
+            string subcategory,
+            string warningCode,
+            string helpKeyword,
+            string helpLink,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs
+        )
+        {
             // No lock needed, as BuildEngine methods from v4.5 onwards are thread safe.
             ErrorUtilities.VerifyThrowArgumentNull(message, nameof(message));
 
@@ -952,6 +1021,7 @@ namespace Microsoft.Build.Utilities
                     endColumnNumber,
                     message,
                     helpKeyword,
+                    helpLink,
                     TaskName,
                     DateTime.UtcNow,
                     messageArgs
@@ -1036,14 +1106,14 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Logs a warning using the specified resource string. 
+        /// Logs a warning using the specified resource string.
         /// If the message has a warning code prefixed to it, the code is extracted and logged with the message. If a help keyword
         /// prefix has been provided, a help keyword for the host IDE is also logged with the message. The help keyword is
         /// composed by appending the string resource name to the prefix.
-        /// 
+        ///
         /// A task can provide a help keyword prefix either via the Task (or TaskMarshalByRef) base class constructor, or the
         /// Task.HelpKeywordPrefix (or AppDomainIsolatedTask.HelpKeywordPrefix) property.
-        /// 
+        ///
         /// Thread safe.
         /// </summary>
         /// <param name="messageResourceName">The name of the string resource to load.</param>
@@ -1055,14 +1125,14 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Logs a warning using the specified resource string and other warning details. 
+        /// Logs a warning using the specified resource string and other warning details.
         /// If the message has a warning code, the code is extracted and logged with the message.
         /// If a help keyword prefix has been provided, a help keyword for the host IDE is also logged with the message. The help
         /// keyword is composed by appending the warning message resource string name to the prefix.
-        /// 
+        ///
         /// A task can provide a help keyword prefix either via the Task (or TaskMarshalByRef) base class constructor, or the
         /// Task.HelpKeywordPrefix (or AppDomainIsolatedTask.HelpKeywordPrefix) property.
-        /// 
+        ///
         /// Thread safe.
         /// </summary>
         /// <param name="subcategoryResourceName">The name of the string resource that describes the warning type (can be null).</param>
@@ -1188,8 +1258,8 @@ namespace Microsoft.Build.Utilities
 
             bool errorsFound;
 
-            // Command-line tools are generally going to emit their output using the current 
-            // codepage, so that it displays correctly in the console window.  
+            // Command-line tools are generally going to emit their output using the current
+            // codepage, so that it displays correctly in the console window.
             using (StreamReader fileStream = FileUtilities.OpenRead(fileName, Encoding.GetEncoding(0))) // HIGHCHAR: Use ANSI for logging messages.
             {
                 errorsFound = LogMessagesFromStream(fileStream, messageImportance);
@@ -1329,7 +1399,7 @@ namespace Microsoft.Build.Utilities
 #region AppDomain Code
 
         /// <summary>
-        /// InitializeLifetimeService is called when the remote object is activated. 
+        /// InitializeLifetimeService is called when the remote object is activated.
         /// This method will determine how long the lifetime for the object will be.
         /// Thread safe. However, InitializeLifetimeService and MarkAsInactive should
         /// only be called in that order, together or not at all, and no more than once.
@@ -1365,7 +1435,7 @@ namespace Microsoft.Build.Utilities
                 // increase the lease time allowing the object to stay in memory
                 _sponsor = new ClientSponsor();
 
-                // When a new lease is requested lets make it last 1 minutes longer. 
+                // When a new lease is requested lets make it last 1 minutes longer.
                 int leaseExtensionTime = 1;
 
                 string leaseExtensionTimeFromEnvironment = Environment.GetEnvironmentVariable("MSBUILDTASKLOGGINGHELPERLEASEEXTENSIONTIME");

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -572,7 +572,7 @@ namespace Microsoft.Build.Utilities
         /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
         public void LogError(string message, params object[] messageArgs)
         {
-            LogError(null, null, null, null, 0, 0, 0, 0, message, messageArgs);
+            LogError(null, null, null, null, 0, 0, 0, 0, message, null, messageArgs);
         }
 
         /// <summary>
@@ -604,7 +604,7 @@ namespace Microsoft.Build.Utilities
             params object[] messageArgs
         )
         {
-            LogError(subcategory, errorCode, helpKeyword, null, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, messageArgs);
+            LogError(subcategory, errorCode, helpKeyword, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, null, messageArgs);
         }
 
         /// <summary>
@@ -614,13 +614,13 @@ namespace Microsoft.Build.Utilities
         /// <param name="subcategory">Description of the error type (can be null).</param>
         /// <param name="errorCode">The error code (can be null).</param>
         /// <param name="helpKeyword">The help keyword for the host IDE (can be null).</param>
-        /// <param name="helpLink">A link pointing to more information about the error.</param>
         /// <param name="file">The path to the file containing the error (can be null).</param>
         /// <param name="lineNumber">The line in the file where the error occurs (set to zero if not available).</param>
         /// <param name="columnNumber">The column in the file where the error occurs (set to zero if not available).</param>
         /// <param name="endLineNumber">The last line of a range of lines in the file where the error occurs (set to zero if not available).</param>
         /// <param name="endColumnNumber">The last column of a range of columns in the file where the error occurs (set to zero if not available).</param>
         /// <param name="message">The message string.</param>
+        /// <param name="helpLink">A link pointing to more information about the error.</param>
         /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
         /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
         public void LogError
@@ -628,13 +628,13 @@ namespace Microsoft.Build.Utilities
             string subcategory,
             string errorCode,
             string helpKeyword,
-            string helpLink,
             string file,
             int lineNumber,
             int columnNumber,
             int endLineNumber,
             int endColumnNumber,
             string message,
+            string helpLink,
             params object[] messageArgs
         )
         {
@@ -667,9 +667,9 @@ namespace Microsoft.Build.Utilities
                     endColumnNumber,
                     message,
                     helpKeyword,
-                    helpLink,
                     TaskName,
                     DateTime.UtcNow,
+                    helpLink,
                     messageArgs
                 );
             BuildEngine.LogErrorEvent(e);

--- a/src/Tasks/Error.cs
+++ b/src/Tasks/Error.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// Relevant file if any.
-        /// If none is provided, the file containing the Error 
+        /// If none is provided, the file containing the Error
         /// task will be used.
         /// </summary>
         public string File { get; set; }
@@ -30,6 +30,11 @@ namespace Microsoft.Build.Tasks
         /// Error help keyword
         /// </summary>
         public string HelpKeyword { get; set; }
+
+        /// <summary>
+        /// A link pointing to more information about the error
+        /// </summary>
+        public string HelpLink { get; set; }
 
         /// <summary>
         /// Main task method

--- a/src/Tasks/Error.cs
+++ b/src/Tasks/Error.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         public override bool Execute()
         {
-            Log.LogError(null, Code, HelpKeyword, HelpLink, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("ErrorAndWarning.EmptyMessage"));
+            Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("ErrorAndWarning.EmptyMessage"), HelpLink);
 
             // careful to return false. Otherwise the build would continue.
             return false;

--- a/src/Tasks/Error.cs
+++ b/src/Tasks/Error.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         public override bool Execute()
         {
-            Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("ErrorAndWarning.EmptyMessage"));
+            Log.LogError(null, Code, HelpKeyword, HelpLink, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("ErrorAndWarning.EmptyMessage"));
 
             // careful to return false. Otherwise the build would continue.
             return false;

--- a/src/Tasks/Warning.cs
+++ b/src/Tasks/Warning.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         public override bool Execute()
         {
-            Log.LogWarning(null, Code, HelpKeyword, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("ErrorAndWarning.EmptyMessage"));
+            Log.LogWarning(null, Code, HelpKeyword, HelpLink, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("ErrorAndWarning.EmptyMessage"));
 
             return true;
         }

--- a/src/Tasks/Warning.cs
+++ b/src/Tasks/Warning.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// Relevant file if any.
-        /// If none is provided, the file containing the Warning 
+        /// If none is provided, the file containing the Warning
         /// task will be used.
         /// </summary>
         public string File { get; set; }
@@ -30,6 +30,11 @@ namespace Microsoft.Build.Tasks
         /// Warning help keyword
         /// </summary>
         public string HelpKeyword { get; set; }
+
+        /// <summary>
+        /// A link pointing to more information about the warning
+        /// </summary>
+        public string HelpLink { get; set; }
 
         /// <summary>
         /// Main task method


### PR DESCRIPTION
As discussed in #4029 (see this [comment](https://github.com/microsoft/msbuild/issues/4029#issuecomment-652131756)) I've added the ability to set a help link for both the Error and Warning tasks. This would allow authors of MSBuild targets to issue warnings and/or errors and point users to some page describing more details about the error/warning. Obviously these would need to show up in the IDE somewhere, but I'm hoping that @davkean can take care of that. I think I've done everything that needs to be done on the MSBuild side of things, but this is my first PR here so I'm not entirely sure.