### PR TITLE
Switch only the bin upload to a pipeline artifact

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -147,11 +147,11 @@ stages:
         ArtifactName: logs
       condition: succeededOrFailed()
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: symbols'
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Artifact: bin'
       inputs:
-        PathtoPublish: 'artifacts\bin'
-        ArtifactName: symbols
+        path: 'artifacts\bin'
+        artifactName: bin
       condition: succeededOrFailed()
 
     # Publishes setup VSIXes to a drop.


### PR DESCRIPTION
This brings back a part of #5062, but only for the upload that Arcade knows nothing about, so it shouldn't break.

Internal PR establishing that insertion still works: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/261969?_a=files