### PR TITLE
SignFile: Treat empty TimestampUrl as null

### DIFF
--- a/src/Tasks/SignFile.cs
+++ b/src/Tasks/SignFile.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Tasks
             try
             {
                 SecurityUtilities.SignFile(CertificateThumbprint,
-                TimestampUrl == null ? null : new Uri(TimestampUrl),
+                string.IsNullOrEmpty(TimestampUrl) ? null : new Uri(TimestampUrl),
                 SigningTarget.ItemSpec, TargetFrameworkVersion);
                 return true;
             }


### PR DESCRIPTION
Unless I'm missing something, it's quite difficult to set a Property to be null in MSBuild once it's been declared as having a value. An empty string is as close as it gets.

So, if you're making the TimestampUrl a configurable property as part of a build pipeline you can only specify an empty string. This causes this task to throw an exception because `new Uri("")` produces the following

> System.UriFormatException: Invalid URI: The URI is empty.