### PR TITLE
Use UnhandledException handler only in MSBuild.exe

### DIFF
--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -140,10 +140,6 @@ namespace Microsoft.Build.Execution
         {
             s_isOutOfProcNode = true;
 
-#if FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION
-            AppDomain.CurrentDomain.UnhandledException += ExceptionHandling.UnhandledExceptionHandler;
-#endif
-
             _debugCommunications = (Environment.GetEnvironmentVariable("MSBUILDDEBUGCOMM") == "1");
 
             _receivedPackets = new ConcurrentQueue<INodePacket>();

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -227,16 +227,6 @@ namespace Microsoft.Build.Evaluation
         private int _maxNodeCount;
 
         /// <summary>
-        /// Hook up last minute dumping of any exceptions bringing down the process
-        /// </summary>
-        static ProjectCollection()
-        {
-#if FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION
-            AppDomain.CurrentDomain.UnhandledException += ExceptionHandling.UnhandledExceptionHandler;
-#endif
-        }
-
-        /// <summary>
         /// Instantiates a project collection with no global properties or loggers that reads toolset 
         /// information from the configuration file and registry.
         /// </summary>

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -178,10 +178,6 @@ namespace Microsoft.Build.CommandLine
             // was initially launched. 
             _debugCommunications = (Environment.GetEnvironmentVariable("MSBUILDDEBUGCOMM") == "1");
 
-#if FEATURE_APPDOMAIN
-            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(ExceptionHandling.UnhandledExceptionHandler);
-#endif
-
             _receivedPackets = new Queue<INodePacket>();
 
             // These WaitHandles are disposed in HandleShutDown()

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -512,6 +512,10 @@ namespace Microsoft.Build.CommandLine
             ErrorUtilities.VerifyThrowArgumentLength(commandLine, "commandLine");
 #endif
 
+#if FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION
+            AppDomain.CurrentDomain.UnhandledException += ExceptionHandling.UnhandledExceptionHandler;
+#endif
+
             ExitType exitType = ExitType.Success;
 
             ConsoleCancelEventHandler cancelHandler = Console_CancelKeyPress;


### PR DESCRIPTION
This change moves adding the UnhandledException handler to the current AppDomain from various places in the MSBuild library to one location in MSBuild.exe. This ensures that it is not done when MSBuild is running hosted in another process where such handler with its side-effects is considered problematic.

Fixes #5543