### PR TITLE
Share file system caches via the EvaluationContext

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -869,6 +869,7 @@ namespace Microsoft.Build.Evaluation.Context
     {
         internal EvaluationContext() { }
         public static Microsoft.Build.Evaluation.Context.EvaluationContext Create(Microsoft.Build.Evaluation.Context.EvaluationContext.SharingPolicy policy) { throw null; }
+        public static Microsoft.Build.Evaluation.Context.EvaluationContext Create(Microsoft.Build.Evaluation.Context.EvaluationContext.SharingPolicy policy, Microsoft.Build.FileSystem.MSBuildFileSystemBase fileSystem) { throw null; }
         public enum SharingPolicy
         {
             Isolated = 1,

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1402,6 +1402,25 @@ namespace Microsoft.Build.Execution
         Success = (byte)1,
     }
 }
+namespace Microsoft.Build.FileSystem
+{
+    public abstract partial class MSBuildFileSystemBase
+    {
+        protected MSBuildFileSystemBase() { }
+        public abstract bool DirectoryExists(string path);
+        public abstract System.Collections.Generic.IEnumerable<string> EnumerateDirectories(string path, string searchPattern="*", System.IO.SearchOption searchOption=(System.IO.SearchOption)(0));
+        public abstract System.Collections.Generic.IEnumerable<string> EnumerateFiles(string path, string searchPattern="*", System.IO.SearchOption searchOption=(System.IO.SearchOption)(0));
+        public abstract System.Collections.Generic.IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern="*", System.IO.SearchOption searchOption=(System.IO.SearchOption)(0));
+        public abstract bool FileExists(string path);
+        public abstract bool FileOrDirectoryExists(string path);
+        public abstract System.IO.FileAttributes GetAttributes(string path);
+        public abstract System.IO.Stream GetFileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share);
+        public abstract System.DateTime GetLastWriteTimeUtc(string path);
+        public abstract System.IO.TextReader ReadFile(string path);
+        public abstract byte[] ReadFileAllBytes(string path);
+        public abstract string ReadFileAllText(string path);
+    }
+}
 namespace Microsoft.Build.Globbing
 {
     public partial class CompositeGlob : Microsoft.Build.Globbing.IMSBuildGlob

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -869,6 +869,7 @@ namespace Microsoft.Build.Evaluation.Context
     {
         internal EvaluationContext() { }
         public static Microsoft.Build.Evaluation.Context.EvaluationContext Create(Microsoft.Build.Evaluation.Context.EvaluationContext.SharingPolicy policy) { throw null; }
+        public static Microsoft.Build.Evaluation.Context.EvaluationContext Create(Microsoft.Build.Evaluation.Context.EvaluationContext.SharingPolicy policy, Microsoft.Build.FileSystem.MSBuildFileSystemBase fileSystem) { throw null; }
         public enum SharingPolicy
         {
             Isolated = 1,

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1396,6 +1396,25 @@ namespace Microsoft.Build.Execution
         Success = (byte)1,
     }
 }
+namespace Microsoft.Build.FileSystem
+{
+    public abstract partial class MSBuildFileSystemBase
+    {
+        protected MSBuildFileSystemBase() { }
+        public abstract bool DirectoryExists(string path);
+        public abstract System.Collections.Generic.IEnumerable<string> EnumerateDirectories(string path, string searchPattern="*", System.IO.SearchOption searchOption=(System.IO.SearchOption)(0));
+        public abstract System.Collections.Generic.IEnumerable<string> EnumerateFiles(string path, string searchPattern="*", System.IO.SearchOption searchOption=(System.IO.SearchOption)(0));
+        public abstract System.Collections.Generic.IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern="*", System.IO.SearchOption searchOption=(System.IO.SearchOption)(0));
+        public abstract bool FileExists(string path);
+        public abstract bool FileOrDirectoryExists(string path);
+        public abstract System.IO.FileAttributes GetAttributes(string path);
+        public abstract System.IO.Stream GetFileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share);
+        public abstract System.DateTime GetLastWriteTimeUtc(string path);
+        public abstract System.IO.TextReader ReadFile(string path);
+        public abstract byte[] ReadFileAllBytes(string path);
+        public abstract string ReadFileAllText(string path);
+    }
+}
 namespace Microsoft.Build.Globbing
 {
     public partial class CompositeGlob : Microsoft.Build.Globbing.IMSBuildGlob

--- a/src/Build/FileSystem/MSBuildFileSystemAdapter.cs
+++ b/src/Build/FileSystem/MSBuildFileSystemAdapter.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Shared.FileSystem;
+
+namespace Microsoft.Build.FileSystem
+{
+     internal class MSBuildFileSystemAdapter : IFileSystem
+    {
+        private readonly MSBuildFileSystemBase _msbuildFileSystem;
+        public MSBuildFileSystemAdapter(MSBuildFileSystemBase msbuildFileSystem)
+        {
+            _msbuildFileSystem = msbuildFileSystem;
+        }
+        public TextReader ReadFile(string path) => _msbuildFileSystem.ReadFile(path);
+
+        public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share) => _msbuildFileSystem.GetFileStream(path, mode, access, share);
+
+        public string ReadFileAllText(string path) => _msbuildFileSystem.ReadFileAllText(path);
+
+        public byte[] ReadFileAllBytes(string path) => _msbuildFileSystem.ReadFileAllBytes(path);
+
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            return _msbuildFileSystem.EnumerateFiles(path, searchPattern, searchOption);
+        }
+
+        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            return _msbuildFileSystem.EnumerateDirectories(path, searchPattern, searchOption);
+        }
+
+        public IEnumerable<string> EnumerateFileSystemEntries(
+            string path,
+            string searchPattern = "*",
+            SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            return _msbuildFileSystem.EnumerateFileSystemEntries(path, searchPattern, searchOption);
+        }
+
+        public FileAttributes GetAttributes(string path) => _msbuildFileSystem.GetAttributes(path);
+
+        public DateTime GetLastWriteTimeUtc(string path) => _msbuildFileSystem.GetLastWriteTimeUtc(path);
+
+        public bool DirectoryExists(string path) => _msbuildFileSystem.DirectoryExists(path);
+
+        public bool FileExists(string path) => _msbuildFileSystem.FileExists(path);
+
+        public bool DirectoryEntryExists(string path) => _msbuildFileSystem.FileOrDirectoryExists(path);
+    }
+}

--- a/src/Build/FileSystem/MSBuildFileSystemBase.cs
+++ b/src/Build/FileSystem/MSBuildFileSystemBase.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.FileSystem
+{
+    /// <summary>
+    /// Abstracts away some file system operations.
+    ///
+    /// Implementations:
+    /// - must be thread safe
+    /// - may cache some or all the calls.
+    /// </summary>
+    public abstract class MSBuildFileSystemBase
+    {
+        /// <summary>
+        /// Use this for var sr = new StreamReader(path)
+        /// </summary>
+        public abstract TextReader ReadFile(string path);
+
+        /// <summary>
+        /// Use this for new FileStream(path, mode, access, share)
+        /// </summary>
+        public abstract Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share);
+
+        /// <summary>
+        /// Use this for File.ReadAllText(path)
+        /// </summary>
+        public abstract string ReadFileAllText(string path);
+
+        /// <summary>
+        /// Use this for File.ReadAllBytes(path)
+        /// </summary>
+        public abstract byte[] ReadFileAllBytes(string path);
+
+        /// <summary>
+        /// Use this for Directory.EnumerateFiles(path, pattern, option)
+        /// </summary>
+        public abstract IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        /// <summary>
+        /// Use this for Directory.EnumerateFolders(path, pattern, option)
+        /// </summary>
+        public abstract IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        /// <summary>
+        /// Use this for Directory.EnumerateFileSystemEntries(path, pattern, option)
+        /// </summary>
+        public abstract IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        /// <summary>
+        /// Use this for File.GetAttributes()
+        /// </summary>
+        public abstract FileAttributes GetAttributes(string path);
+
+        /// <summary>
+        /// Use this for File.GetLastWriteTimeUtc(path)
+        /// </summary>
+        public abstract DateTime GetLastWriteTimeUtc(string path);
+
+        /// <summary>
+        /// Use this for Directory.Exists(path)
+        /// </summary>
+        public abstract bool DirectoryExists(string path);
+
+        /// <summary>
+        /// Use this for File.Exists(path)
+        /// </summary>
+        public abstract bool FileExists(string path);
+
+        /// <summary>
+        /// Use this for File.Exists(path) || Directory.Exists(path)
+        /// </summary>
+        public abstract bool FileOrDirectoryExists(string path);
+    }
+}

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -157,6 +157,7 @@
     <Compile Include="BackEnd\Components\Caching\ConfigCacheWithOverride.cs" />
     <Compile Include="BackEnd\Components\Caching\ResultsCacheWithOverride.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\TranslationHelpers.cs" />
+    <Compile Include="FileSystem\MSBuildFileSystemBase.cs" />
     <Compile Include="Utilities\NuGetFrameworkWrapper.cs" />
     <Compile Include="ObjectModelRemoting\ConstructionObjectLinks\ProjectUsingTaskParameterElementLink.cs" />
     <Compile Include="ObjectModelRemoting\ExternalProjectsProvider.cs" />
@@ -263,6 +264,7 @@
     <Compile Include="Evaluation\LazyItemEvaluator.ItemFactoryWrapper.cs" />
     <Compile Include="Evaluation\LazyItemEvaluator.RemoveOperation.cs" />
     <Compile Include="Evaluation\MetadataReference.cs" />
+    <Compile Include="FileSystem\MSBuildFileSystemAdapter.cs" />
     <Compile Include="Graph\ProjectGraphEntryPoint.cs" />
     <Compile Include="Graph\ProjectGraph.cs" />
     <Compile Include="Graph\ProjectGraphNode.cs" />

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1831,4 +1831,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="StaticGraphConstructionMetrics" xml:space="preserve">
     <value>"Static graph loaded in {0} seconds: {1} nodes, {2} edges"</value>
   </data>
+  <data name="IsolatedContextDoesNotSupportFileSystem" xml:space="preserve">
+    <value>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</value>
+  </data>
 </root>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -100,6 +100,11 @@
         <target state="translated">Řetězec verze nemá správný formát.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Podrobnost protokolování je nastavená na: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -100,6 +100,11 @@
         <target state="translated">Die Versionszeichenfolge liegt nicht im richtigen Format vor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Die Ausführlichkeit der Protokollierung ist auf "{0}" festgelegt.</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -100,6 +100,11 @@
         <target state="new">Version string was not in a correct format.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="new">Logging verbosity is set to: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -100,6 +100,11 @@
         <target state="translated">La cadena de versión no tenía el formato correcto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">El nivel de detalle de registro está establecido en {0}.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -100,6 +100,11 @@
         <target state="translated">La chaîne de version n'était pas au format approprié.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">La verbosité de la journalisation a la valeur {0}.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -100,6 +100,11 @@
         <target state="translated">Il formato della stringa di versione non è corretto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Il livello di dettaglio della registrazione è impostato su: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -100,6 +100,11 @@
         <target state="translated">バージョン文字列の形式が正しくありません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">ログの詳細度は次のように設定されています: {0}。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -100,6 +100,11 @@
         <target state="translated">버전 문자열의 형식이 잘못되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">로깅의 세부 정보 표시가 {0}(으)로 설정되었습니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -100,6 +100,11 @@
         <target state="translated">Nieprawidłowy format ciągu wersji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Szczegółowość rejestrowania została ustawiona na: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -100,6 +100,11 @@
         <target state="translated">A cadeia de caracteres de versão não estava em um formato correto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">O detalhamento do log está definido como: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -100,6 +100,11 @@
         <target state="translated">Строка версии имела неверный формат.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Уровень детализации журнала: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -100,6 +100,11 @@
         <target state="translated">Sürüm dizesi doğru biçimde değildi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Günlük kaydı ayrıntı düzeyi {0} olarak ayarlandı.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -100,6 +100,11 @@
         <target state="translated">版本字符串的格式不正确。</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">日志记录详细程度设置为: {0}。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -100,6 +100,11 @@
         <target state="translated">版本字串格式不正確。</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
+        <source>"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</source>
+        <target state="new">"EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">記錄詳細程度設定為: {0}。</target>

--- a/src/MSBuildTaskHost/FileSystem/MSBuildTaskHostFileSystem.cs
+++ b/src/MSBuildTaskHost/FileSystem/MSBuildTaskHostFileSystem.cs
@@ -21,6 +21,16 @@ namespace Microsoft.Build.Shared.FileSystem
             return NativeMethodsShared.FileOrDirectoryExists(path);
         }
 
+        public FileAttributes GetAttributes(string path)
+        {
+            return File.GetAttributes(path);
+        }
+
+        public DateTime GetLastWriteTimeUtc(string path)
+        {
+            return File.GetLastWriteTimeUtc(path);
+        }
+
         public bool DirectoryExists(string path)
         {
             return NativeMethodsShared.DirectoryExists(path);
@@ -29,6 +39,26 @@ namespace Microsoft.Build.Shared.FileSystem
         public IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             return Directory.GetDirectories(path, searchPattern, searchOption);
+        }
+
+        public TextReader ReadFile(string path)
+        {
+            return new StreamReader(path);
+        }
+
+        public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            return new FileStream(path, mode, access, share);
+        }
+
+        public string ReadFileAllText(string path)
+        {
+            return File.ReadAllText(path);
+        }
+
+        public byte[] ReadFileAllBytes(string path)
+        {
+            return File.ReadAllBytes(path);
         }
 
         public IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)

--- a/src/Shared/FileSystem/CachingFileSystemWrapper.cs
+++ b/src/Shared/FileSystem/CachingFileSystemWrapper.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Build.Shared.FileSystem
     {
         private readonly IFileSystem _fileSystem;
         private readonly ConcurrentDictionary<string, bool> _existenceCache = new ConcurrentDictionary<string, bool>();
+        private readonly ConcurrentDictionary<string, DateTime> _lastWriteTimeCache = new ConcurrentDictionary<string, DateTime>();
 
         public CachingFileSystemWrapper(IFileSystem fileSystem)
         {
@@ -21,6 +22,16 @@ namespace Microsoft.Build.Shared.FileSystem
         public bool DirectoryEntryExists(string path)
         {
             return CachedExistenceCheck(path, p => _fileSystem.DirectoryEntryExists(p));
+        }
+
+        public FileAttributes GetAttributes(string path)
+        {
+            return _fileSystem.GetAttributes(path);
+        }
+
+        public DateTime GetLastWriteTimeUtc(string path)
+        {
+            return _lastWriteTimeCache.GetOrAdd(path, p =>_fileSystem.GetLastWriteTimeUtc(p));
         }
 
         public bool DirectoryExists(string path)
@@ -36,6 +47,26 @@ namespace Microsoft.Build.Shared.FileSystem
         public IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             return _fileSystem.EnumerateDirectories(path, searchPattern, searchOption);
+        }
+
+        public TextReader ReadFile(string path)
+        {
+            return _fileSystem.ReadFile(path);
+        }
+
+        public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            return _fileSystem.GetFileStream(path, mode, access, share);
+        }
+
+        public string ReadFileAllText(string path)
+        {
+            return _fileSystem.ReadFileAllText(path);
+        }
+
+        public byte[] ReadFileAllBytes(string path)
+        {
+            return _fileSystem.ReadFileAllBytes(path);
         }
 
         public IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)

--- a/src/Shared/FileSystem/IFileSystem.cs
+++ b/src/Shared/FileSystem/IFileSystem.cs
@@ -1,44 +1,47 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.Build.Shared.FileSystem
 {
-    /// <summary>
-    /// Abstracts away some file system operations
-    /// </summary>
+
+    /*
+     * This is a clone of Microsoft.Build.FileSystem.MSBuildFileSystemBase.
+     * MSBuildFileSystemBase is the public, reference interface. Changes should be made to MSBuildFileSystemBase and cloned in IFileSystem.
+     * Any new code should depend on MSBuildFileSystemBase instead of IFileSystem, if possible.
+     *
+     * MSBuild uses IFileSystem internally and adapts MSBuildFileSystemBase instances received from the outside to IFileSystem.
+     * Ideally there should be only one, public interface. However, such an interface would need to be put into the 
+     * Microsoft.Build.Framework assembly, but that assembly cannot take new types because it breaks some old version of Nuget.exe.
+     * IFileSystem cannot be deleted for the same reason.
+     */
     internal interface IFileSystem
     {
-        /// <summary>
-        /// Returns an enumerable collection of file names that match a search pattern in a specified path, and optionally searches subdirectories.
-        /// </summary>
+        TextReader ReadFile(string path);
+
+        Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share);
+
+        string ReadFileAllText(string path);
+
+        byte[] ReadFileAllBytes(string path);
+
         IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
 
-        /// <summary>
-        /// Returns an enumerable collection of directory names that match a search pattern in a specified path, and optionally searches subdirectories.
-        /// </summary>
         IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
 
-        /// <summary>
-        /// Returns an enumerable collection of file names and directory names that match a search pattern in a specified path, and optionally searches subdirectories.
-        /// </summary>
         IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
 
-        /// <summary>
-        /// Determines whether the given path refers to an existing directory on disk.
-        /// </summary>
+        FileAttributes GetAttributes(string path);
+
+        public DateTime GetLastWriteTimeUtc(string path);
+
         bool DirectoryExists(string path);
 
-        /// <summary>
-        /// Determines whether the given path refers to an existing file on disk.
-        /// </summary>
         bool FileExists(string path);
 
-        /// <summary>
-        /// Determines whether the given path refers to an existing entry in the directory service.
-        /// </summary>
         bool DirectoryEntryExists(string path);
     }
 }

--- a/src/Shared/FileSystem/MSBuildOnWindowsFileSystem.cs
+++ b/src/Shared/FileSystem/MSBuildOnWindowsFileSystem.cs
@@ -1,55 +1,80 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 
 namespace Microsoft.Build.Shared.FileSystem
 {
     /// <summary>
-    /// Implementation of file system operations directly over the dot net managed layer
+    /// Implementation of file system operations on windows. Combination of native and managed implementations.
+    /// TODO Remove this class and replace with WindowsFileSystem. Test perf to ensure no regressions.
     /// </summary>
-    internal sealed class MSBuildOnWindowsFileSystem : IFileSystem
+    internal class MSBuildOnWindowsFileSystem : IFileSystem
     {
         private static readonly MSBuildOnWindowsFileSystem Instance = new MSBuildOnWindowsFileSystem();
 
-        /// <nodoc/>
         public static MSBuildOnWindowsFileSystem Singleton() => Instance;
 
-        private MSBuildOnWindowsFileSystem()
-        { }
+        protected MSBuildOnWindowsFileSystem() { }
 
-        /// <inheritdoc/>
+        public TextReader ReadFile(string path)
+        {
+            return ManagedFileSystem.Singleton().ReadFile(path);
+        }
+
+        public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            return ManagedFileSystem.Singleton().GetFileStream(path, mode, access, share);
+        }
+
+        public string ReadFileAllText(string path)
+        {
+            return ManagedFileSystem.Singleton().ReadFileAllText(path);
+        }
+
+        public byte[] ReadFileAllBytes(string path)
+        {
+            return ManagedFileSystem.Singleton().ReadFileAllBytes(path);
+        }
+
         public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
         {
             return ManagedFileSystem.Singleton().EnumerateFiles(path, searchPattern, searchOption);
         }
 
-        /// <inheritdoc/>
         public IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {
             return ManagedFileSystem.Singleton().EnumerateDirectories(path, searchPattern, searchOption);
         }
 
-        /// <inheritdoc/>
         public IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
         {
             return ManagedFileSystem.Singleton().EnumerateFileSystemEntries(path, searchPattern, searchOption);
         }
 
-        /// <inheritdoc/>
+        public FileAttributes GetAttributes(string path)
+        {
+            return ManagedFileSystem.Singleton().GetAttributes(path);
+        }
+
+        public DateTime GetLastWriteTimeUtc(string path)
+        {
+            return ManagedFileSystem.Singleton().GetLastWriteTimeUtc(path);
+        }
+
         public bool DirectoryExists(string path)
         {
             return WindowsFileSystem.Singleton().DirectoryExists(path);
         }
 
-        /// <inheritdoc/>
         public bool FileExists(string path)
         {
             return WindowsFileSystem.Singleton().FileExists(path);
         }
 
-        /// <inheritdoc/>
         public bool DirectoryEntryExists(string path)
         {
             return WindowsFileSystem.Singleton().DirectoryEntryExists(path);

--- a/src/Shared/FileSystem/ManagedFileSystem.cs
+++ b/src/Shared/FileSystem/ManagedFileSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -9,48 +10,70 @@ namespace Microsoft.Build.Shared.FileSystem
     /// <summary>
     /// Implementation of file system operations directly over the dot net managed layer
     /// </summary>
-    internal sealed class ManagedFileSystem : IFileSystem
+    internal class ManagedFileSystem : IFileSystem
     {
         private static readonly ManagedFileSystem Instance = new ManagedFileSystem();
 
-        /// <nodoc/>
         public static ManagedFileSystem Singleton() => ManagedFileSystem.Instance;
 
-        private ManagedFileSystem()
-        { }
+        protected ManagedFileSystem() { }
 
-        /// <inheritdoc/>
-        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        public TextReader ReadFile(string path)
+        {
+            return new StreamReader(path);
+        }
+
+        public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            return new FileStream(path, mode, access, share);
+        }
+
+        public string ReadFileAllText(string path)
+        {
+            return File.ReadAllText(path);
+        }
+
+        public byte[] ReadFileAllBytes(string path)
+        {
+            return File.ReadAllBytes(path);
+        }
+
+        public virtual IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
         {
             return Directory.EnumerateFiles(path, searchPattern, searchOption);
         }
 
-        /// <inheritdoc/>
-        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
+        public virtual IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {
             return Directory.EnumerateDirectories(path, searchPattern, searchOption);
         }
 
-        /// <inheritdoc/>
-        public IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
+        public virtual IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
         {
             return Directory.EnumerateFileSystemEntries(path, searchPattern, searchOption);
         }
 
-        /// <inheritdoc/>
-        public bool DirectoryExists(string path)
+        public FileAttributes GetAttributes(string path)
+        {
+            return File.GetAttributes(path);
+        }
+
+        public virtual DateTime GetLastWriteTimeUtc(string path)
+        {
+            return File.GetLastWriteTimeUtc(path);
+        }
+
+        public virtual bool DirectoryExists(string path)
         {
             return Directory.Exists(path);
         }
 
-        /// <inheritdoc/>
-        public bool FileExists(string path)
+        public virtual bool FileExists(string path)
         {
             return File.Exists(path);
         }
 
-        /// <inheritdoc/>
-        public bool DirectoryEntryExists(string path)
+        public virtual bool DirectoryEntryExists(string path)
         {
             return FileExists(path) || DirectoryExists(path);
         }

--- a/src/Shared/FileSystem/WindowsFileSystem.cs
+++ b/src/Shared/FileSystem/WindowsFileSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -22,52 +23,60 @@ namespace Microsoft.Build.Shared.FileSystem
     }
 
     /// <summary>
-    /// Windows-specific implementation of file system operations using Windows native invocations
+    /// Windows-specific implementation of file system operations using Windows native invocations.
+    /// TODO For potential extra perf gains, provide native implementations for all IFileSystem methods and stop inheriting from ManagedFileSystem
     /// </summary>
-    internal class WindowsFileSystem : IFileSystem
+    internal class WindowsFileSystem : ManagedFileSystem
     {
         private static readonly WindowsFileSystem Instance = new WindowsFileSystem();
 
-        /// <nodoc/>
-        public static WindowsFileSystem Singleton() => WindowsFileSystem.Instance;
+        public new static WindowsFileSystem Singleton() => WindowsFileSystem.Instance;
 
-        private WindowsFileSystem()
-        { }
+        private WindowsFileSystem(){ }
 
-        /// <inheritdoc/>
-        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        public override IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
         {
             return EnumerateFileOrDirectories(path, FileArtifactType.File, searchPattern, searchOption);
         }
 
-        /// <inheritdoc/>
-        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
+        public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {
             return EnumerateFileOrDirectories(path, FileArtifactType.Directory, searchPattern, searchOption);
         }
 
-        /// <inheritdoc/>
-        public IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
+        public override IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
         {
             return EnumerateFileOrDirectories(path, FileArtifactType.FileOrDirectory, searchPattern, searchOption);
         }
 
-        /// <inheritdoc/>
-        public bool DirectoryExists(string path)
+        public override bool DirectoryExists(string path)
         {
             return NativeMethodsShared.DirectoryExistsWindows(path);
         }
 
-        /// <inheritdoc/>
-        public bool FileExists(string path)
+        public override bool FileExists(string path)
         {
             return NativeMethodsShared.FileExistsWindows(path);
         }
 
-        /// <inheritdoc/>
-        public bool DirectoryEntryExists(string path)
+        public override bool DirectoryEntryExists(string path)
         {
             return NativeMethodsShared.FileOrDirectoryExistsWindows(path);
+        }
+
+        public override DateTime GetLastWriteTimeUtc(string path)
+        {
+            var fileLastWriteTime = NativeMethodsShared.GetLastWriteFileUtcTime(path);
+
+            if (fileLastWriteTime != DateTime.MinValue)
+            {
+                return fileLastWriteTime;
+            }
+            else
+            {
+                NativeMethodsShared.GetLastWriteDirectoryUtcTime(path, out var directoryLastWriteTime);
+                return directoryLastWriteTime;
+            }
         }
 
         private static IEnumerable<string> EnumerateFileOrDirectories(

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -2545,6 +2545,14 @@ namespace Microsoft.Build.UnitTests
                 _mockFileSystem = mockFileSystem;
             }
 
+            public TextReader ReadFile(string path) => throw new NotImplementedException();
+
+            public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share) => throw new NotImplementedException();
+
+            public string ReadFileAllText(string path) => throw new NotImplementedException();
+
+            public byte[] ReadFileAllBytes(string path) => throw new NotImplementedException();
+
             public IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
             {
                 return FileSystems.Default.EnumerateFiles(path, searchPattern, searchOption);
@@ -2559,6 +2567,10 @@ namespace Microsoft.Build.UnitTests
             {
                 return FileSystems.Default.EnumerateFileSystemEntries(path, searchPattern, searchOption);
             }
+
+            public FileAttributes GetAttributes(string path) => throw new NotImplementedException();
+
+            public DateTime GetLastWriteTimeUtc(string path) => throw new NotImplementedException();
 
             public bool DirectoryExists(string path)
             {

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -3,16 +3,19 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Xml;
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
+using Microsoft.Build.FileSystem;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Graph;
 using Microsoft.Build.Logging;
@@ -1934,6 +1937,134 @@ namespace Microsoft.Build.UnitTests
             {
                 _buildManager.EndBuild();
                 _buildManager.Dispose();
+            }
+        }
+
+        internal class LoggingFileSystem : MSBuildFileSystemBase
+        {
+            private readonly IFileSystem _wrappingFileSystem;
+            private int _fileSystemCalls;
+
+            public int FileSystemCalls => _fileSystemCalls;
+
+            public ConcurrentDictionary<string, int> ExistenceChecks { get; } = new ConcurrentDictionary<string, int>();
+
+            public LoggingFileSystem(IFileSystem wrappingFileSystem = null)
+            {
+                _wrappingFileSystem = wrappingFileSystem ?? FileSystems.Default;
+            }
+
+            public override TextReader ReadFile(string path)
+            {
+                IncrementCalls(ref _fileSystemCalls);
+
+                return _wrappingFileSystem.ReadFile(path);
+            }
+
+            public override Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+            {
+                IncrementCalls(ref _fileSystemCalls);
+
+                return _wrappingFileSystem.GetFileStream(path, mode, access, share);
+            }
+
+            public override string ReadFileAllText(string path)
+            {
+                IncrementCalls(ref _fileSystemCalls);
+
+                return _wrappingFileSystem.ReadFileAllText(path);
+            }
+
+            public override byte[] ReadFileAllBytes(string path)
+            {
+                IncrementCalls(ref _fileSystemCalls);
+
+                return _wrappingFileSystem.ReadFileAllBytes(path);
+            }
+
+            public override IEnumerable<string> EnumerateFiles(
+                string path,
+                string searchPattern = "*",
+                SearchOption searchOption = SearchOption.TopDirectoryOnly
+            )
+            {
+                IncrementCalls(ref _fileSystemCalls);
+
+                return _wrappingFileSystem.EnumerateFiles(path, searchPattern, searchOption);
+            }
+
+            public override IEnumerable<string> EnumerateDirectories(
+                string path,
+                string searchPattern = "*",
+                SearchOption searchOption = SearchOption.TopDirectoryOnly
+            )
+            {
+                IncrementCalls(ref _fileSystemCalls);
+
+                return _wrappingFileSystem.EnumerateDirectories(path, searchPattern, searchOption);
+            }
+
+            public override IEnumerable<string> EnumerateFileSystemEntries(
+                string path,
+                string searchPattern = "*",
+                SearchOption searchOption = SearchOption.TopDirectoryOnly
+            )
+            {
+                IncrementCalls(ref _fileSystemCalls);
+
+                return _wrappingFileSystem.EnumerateFileSystemEntries(path, searchPattern, searchOption);
+            }
+
+            public override FileAttributes GetAttributes(string path)
+            {
+                IncrementCalls(ref _fileSystemCalls);
+
+                return _wrappingFileSystem.GetAttributes(path);
+            }
+
+            public override DateTime GetLastWriteTimeUtc(string path)
+            {
+                IncrementCalls(ref _fileSystemCalls);
+
+                return _wrappingFileSystem.GetLastWriteTimeUtc(path);
+            }
+
+            public override bool DirectoryExists(string path)
+            {
+                IncrementCalls(ref _fileSystemCalls);
+                IncrementExistenceChecks(path);
+
+                return _wrappingFileSystem.DirectoryExists(path);
+            }
+
+            public override bool FileExists(string path)
+            {
+                IncrementCalls(ref _fileSystemCalls);
+                IncrementExistenceChecks(path);
+
+                return _wrappingFileSystem.FileExists(path);
+            }
+
+            private int _directoryEntryExistsCalls;
+            public int DirectoryEntryExistsCalls => _directoryEntryExistsCalls;
+
+            public override bool FileOrDirectoryExists(string path)
+            {
+                IncrementCalls(ref _fileSystemCalls);
+                IncrementCalls(ref _directoryEntryExistsCalls);
+                IncrementExistenceChecks(path);
+
+                return _wrappingFileSystem.DirectoryEntryExists(path);
+            }
+
+            private void IncrementCalls(ref int incremented)
+            {
+                Interlocked.Increment(ref incremented);
+            }
+
+            private void IncrementExistenceChecks(string path)
+            {
+                ExistenceChecks.AddOrUpdate(path, p => 1, (p, c) => c + 1);
             }
         }
     }


### PR DESCRIPTION
- Made IFileSystem public. Added some extra methods to it from QuickBuild's file system interface. This interface will also be passed to the future project cache interface so that caches can reuse IO from evaluation and between themselves.
- EvaluationContext can take an IFileSystem. This enables QuickBuild and VisualStudio to share their file system caches with msbuild evaluations.

Possible Next steps (future PRs):
- Pass the interface to sdk resolvers in a non breaking manner. AFAIK they do a lot of IO
- I saw some evaluation bits that do IO without passing through the interface, so propagating the interface to those places as well seems like a potential perf gain.