### PR TITLE
Truncate Target/Task skipped log messages to 1024 chars

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -1490,6 +1490,59 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         /// <summary>
+        /// Exercises ExpandIntoStringAndUnescape and ExpanderOptions.Truncate
+        /// </summary>
+        [Fact]
+        public void ExpandAllIntoStringTruncated()
+        {
+            ProjectInstance project = ProjectHelpers.CreateEmptyProjectInstance();
+            var manySpaces = "".PadLeft(2000);
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            pg.Set(ProjectPropertyInstance.Create("ManySpacesProperty", manySpaces));
+            var itemMetadataTable = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "ManySpacesMetadata", manySpaces }
+            };
+            var itemMetadata = new StringMetadataTable(itemMetadataTable);
+            var projectItemGroups = new ItemDictionary<ProjectItemInstance>();
+            var itemGroup = new List<ProjectItemInstance>();
+            for (int i = 0; i < 50; i++)
+            {
+                var item = new ProjectItemInstance(project, "ManyItems", $"ThisIsAFairlyLongFileName_{i}.bmp", project.FullPath);
+                item.SetMetadata("Foo", $"ThisIsAFairlyLongMetadataValue_{i}");
+                itemGroup.Add(item);
+            }
+            var lookup = new Lookup(projectItemGroups, pg);
+            lookup.EnterScope("x");
+            lookup.PopulateWithItems("ManySpacesItem", new []
+            {
+                new ProjectItemInstance (project, "ManySpacesItem", "Foo", project.FullPath),
+                new ProjectItemInstance (project, "ManySpacesItem", manySpaces, project.FullPath),
+                new ProjectItemInstance (project, "ManySpacesItem", "Bar", project.FullPath),
+            });
+            lookup.PopulateWithItems("Exactly1024", new[]
+            {
+                new ProjectItemInstance (project, "Exactly1024", "".PadLeft(1024), project.FullPath),
+                new ProjectItemInstance (project, "Exactly1024", "Foo", project.FullPath),
+            });
+            lookup.PopulateWithItems("ManyItems", itemGroup);
+
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata, FileSystems.Default);
+
+            XmlAttribute xmlattribute = (new XmlDocument()).CreateAttribute("dummy");
+            xmlattribute.Value = "'%(ManySpacesMetadata)' != '' and '$(ManySpacesProperty)' != '' and '@(ManySpacesItem)' != '' and '@(Exactly1024)' != '' and '@(ManyItems)' != '' and '@(ManyItems->'%(Foo)')' != ''";
+
+            var expected =
+                $"'{"",1021}...' != '' and " +
+                $"'{"",1021}...' != '' and " +
+                $"'Foo;{"",1017}...' != '' and " +
+                $"'{"",1024};...' != '' and " +
+                "'ThisIsAFairlyLongFileName_0.bmp;ThisIsAFairlyLongFileName_1.bmp;ThisIsAFairlyLongFileName_2.bmp;...' != '' and " +
+                "'ThisIsAFairlyLongMetadataValue_0;ThisIsAFairlyLongMetadataValue_1;ThisIsAFairlyLongMetadataValue_2;...' != ''";
+            Assert.Equal(expected, expander.ExpandIntoStringAndUnescape(xmlattribute.Value, ExpanderOptions.ExpandAll | ExpanderOptions.Truncate, MockElementLocation.Instance));
+        }
+
+        /// <summary>
         /// Exercises ExpandAllIntoString with a string that does not need expanding.
         /// In this case the expanded string should be reference identical to the passed in string.
         /// </summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -362,7 +362,7 @@ namespace Microsoft.Build.BackEnd
                 if (!projectLoggingContext.LoggingService.OnlyLogCriticalEvents)
                 {
                     // Expand the expression for the Log.  Since we know the condition evaluated to false, leave unexpandable properties in the condition so as not to cause an error
-                    string expanded = _expander.ExpandIntoStringAndUnescape(_target.Condition, ExpanderOptions.ExpandPropertiesAndItems | ExpanderOptions.LeavePropertiesUnexpandedOnError, _target.ConditionLocation);
+                    string expanded = _expander.ExpandIntoStringAndUnescape(_target.Condition, ExpanderOptions.ExpandPropertiesAndItems | ExpanderOptions.LeavePropertiesUnexpandedOnError | ExpanderOptions.Truncate, _target.ConditionLocation);
 
                     // By design: Not building dependencies. This is what NAnt does too.
                     // NOTE: In the original code, this was logged from the target logging context.  However, the target

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -619,7 +619,7 @@ namespace Microsoft.Build.BackEnd
                     if (!_targetLoggingContext.LoggingService.OnlyLogCriticalEvents)
                     {
                         // Expand the expression for the Log.  Since we know the condition evaluated to false, leave unexpandable properties in the condition so as not to cause an error
-                        string expanded = bucket.Expander.ExpandIntoStringAndUnescape(_targetChildInstance.Condition, ExpanderOptions.ExpandAll | ExpanderOptions.LeavePropertiesUnexpandedOnError, _targetChildInstance.ConditionLocation);
+                        string expanded = bucket.Expander.ExpandIntoStringAndUnescape(_targetChildInstance.Condition, ExpanderOptions.ExpandAll | ExpanderOptions.LeavePropertiesUnexpandedOnError | ExpanderOptions.Truncate, _targetChildInstance.ConditionLocation);
 
                         // Whilst we are within the processing of the task, we haven't actually started executing it, so
                         // our skip task message needs to be in the context of the target. However any errors should be reported

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1753,7 +1753,7 @@ namespace Microsoft.Build.Evaluation
                 if (_logProjectImportedEvents)
                 {
                     // Expand the expression for the Log.  Since we know the condition evaluated to false, leave unexpandable properties in the condition so as not to cause an error
-                    string expanded = _expander.ExpandIntoStringAndUnescape(importElement.Condition, ExpanderOptions.ExpandProperties | ExpanderOptions.LeavePropertiesUnexpandedOnError, importElement.ConditionLocation);
+                    string expanded = _expander.ExpandIntoStringAndUnescape(importElement.Condition, ExpanderOptions.ExpandProperties | ExpanderOptions.LeavePropertiesUnexpandedOnError | ExpanderOptions.Truncate, importElement.ConditionLocation);
 
                     ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
                         importElement.Location.Line,

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -82,6 +82,11 @@ namespace Microsoft.Build.Evaluation
         LeavePropertiesUnexpandedOnError = 0x20,
 
         /// <summary>
+        /// When an expansion occurs, truncate it to Expander.DefaultTruncationCharacterLimit or Expander.DefaultTruncationItemLimit.
+        /// </summary>
+        Truncate = 0x40,
+
+        /// <summary>
         /// Expand only properties and then item lists
         /// </summary>
         ExpandPropertiesAndItems = ExpandProperties | ExpandItems,
@@ -119,6 +124,16 @@ namespace Microsoft.Build.Evaluation
         where P : class, IProperty
         where I : class, IItem
     {
+        /// <summary>
+        /// A limit for truncating string expansions within an evaluated Condition. Properties, item metadata, or item groups will be truncated to N characters such as 'N...'.
+        /// Enabled by ExpanderOptions.Truncate.
+        /// </summary>
+        private const int CharacterLimitPerExpansion = 1024;
+        /// <summary>
+        /// A limit for truncating string expansions for item groups within an evaluated Condition. N items will be evaluated such as 'A;B;C;...'.
+        /// Enabled by ExpanderOptions.Truncate.
+        /// </summary>
+        private const int ItemLimitPerExpansion = 3;
         private static readonly char[] s_singleQuoteChar = { '\'' };
         private static readonly char[] s_backtickChar = { '`' };
         private static readonly char[] s_doubleQuoteChar = { '"' };
@@ -461,6 +476,14 @@ namespace Microsoft.Build.Evaluation
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Returns true if ExpanderOptions.Truncate is set and EscapeHatches.DoNotTruncateConditions is not set
+        /// </summary>
+        private static bool IsTruncationEnabled(ExpanderOptions options)
+        {
+            return (options & ExpanderOptions.Truncate) != 0 && !Traits.Instance.EscapeHatches.DoNotTruncateConditions;
         }
 
         /// <summary>
@@ -841,7 +864,7 @@ namespace Microsoft.Build.Evaluation
                 internal MetadataMatchEvaluator(IMetadataTable metadata, ExpanderOptions options)
                 {
                     _metadata = metadata;
-                    _options = (options & ExpanderOptions.ExpandMetadata);
+                    _options = options & (ExpanderOptions.ExpandMetadata | ExpanderOptions.Truncate);
 
                     ErrorUtilities.VerifyThrow(options != ExpanderOptions.Invalid, "Must be expanding metadata of some kind");
                 }
@@ -873,6 +896,10 @@ namespace Microsoft.Build.Evaluation
                         )
                     {
                         metadataValue = _metadata.GetEscapedValue(itemType, metadataName);
+                        if (IsTruncationEnabled(_options) && metadataValue.Length > CharacterLimitPerExpansion)
+                        {
+                            metadataValue = metadataValue.Substring(0, CharacterLimitPerExpansion - 3) + "...";
+                        }
                     }
 
                     return metadataValue;
@@ -1087,6 +1114,15 @@ namespace Microsoft.Build.Evaluation
                         else // This is a regular property
                         {
                             propertyValue = LookupProperty(properties, expression, propertyStartIndex + 2, propertyEndIndex - 1, elementLocation, usedUninitializedProperties);
+                        }
+
+                        if (IsTruncationEnabled(options) && propertyValue != null)
+                        {
+                            var value = propertyValue.ToString();
+                            if (value.Length > CharacterLimitPerExpansion)
+                            {
+                                propertyValue = value.Substring(0, CharacterLimitPerExpansion - 3) + "...";
+                            }
                         }
 
                         // Record our result, and advance
@@ -2022,9 +2058,32 @@ namespace Microsoft.Build.Evaluation
                     return true;
                 }
 
+                int startLength = builder.Length;
+                bool truncate = IsTruncationEnabled(options);
+
                 // if the capture.Separator is not null, then ExpandExpressionCapture would have joined the items using that separator itself
-                foreach (var item in itemsFromCapture)
+                for (int i = 0; i < itemsFromCapture.Count; i++)
                 {
+                    var item = itemsFromCapture[i];
+                    if (truncate)
+                    {
+                        if (i >= ItemLimitPerExpansion)
+                        {
+                            builder.Append("...");
+                            return false;
+                        }
+                        int currentLength = builder.Length - startLength;
+                        if (currentLength + item.Key.Length > CharacterLimitPerExpansion)
+                        {
+                            int truncateIndex = CharacterLimitPerExpansion - currentLength - 3;
+                            if (truncateIndex > 0)
+                            {
+                                builder.Append(item.Key, 0, truncateIndex);
+                            }
+                            builder.Append("...");
+                            return false;
+                        }
+                    }
                     builder.Append(item.Key);
                     builder.Append(';');
                 }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -137,6 +137,11 @@ namespace Microsoft.Build.Utilities
         public readonly bool TruncateTaskInputs = Environment.GetEnvironmentVariable("MSBUILDTRUNCATETASKINPUTS") == "1";
 
         /// <summary>
+        /// Disables truncation of Condition messages in Tasks/Targets via ExpanderOptions.Truncate.
+        /// </summary>
+        public readonly bool DoNotTruncateConditions = Environment.GetEnvironmentVariable("MSBuildDoNotTruncateConditions") == "1";
+
+        /// <summary>
         /// Emit events for project imports.
         /// </summary>
         private bool? _logProjectImports;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/msbuild/issues/5315

I have seen some comically long log messages such as:

    Task "GetDependsOnNETStandard" skipped, due to false condition; ('$(_HasReferenceToSystemRuntime)' != 'true' and '$(_IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(_XACandidateNETStandardReferences)' != '') was evaluated as ('true' != 'true' and 'true' != 'true' and '' == '' and 'C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.CSharp.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.VisualBasic.Core.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.VisualBasic.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.Win32.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.AppContext.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Buffers.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Concurrent.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Immutable.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.NonGeneric.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Specialized.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.Annotations.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.DataAnnotations.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.EventBasedAsync.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.TypeConverter.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Configuration.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Console.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Core.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.Common.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.DataSetExtensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Contracts.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Debug.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.DiagnosticSource.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.FileVersionInfo.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Process.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.StackTrace.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.TextWriterTraceListener.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Tools.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.TraceSource.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Tracing.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Drawing.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Drawing.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Dynamic.Runtime.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Formats.Asn1.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.Calendars.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.Brotli.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.FileSystem.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.ZipFile.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.DriveInfo.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.Watcher.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.IsolatedStorage.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.MemoryMappedFiles.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Pipes.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.UnmanagedMemoryStream.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Expressions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Parallel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Queryable.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Memory.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Http.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Http.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.HttpListener.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Mail.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.NameResolution.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.NetworkInformation.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Ping.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Requests.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Security.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.ServicePoint.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Sockets.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebClient.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebHeaderCollection.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebProxy.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebSockets.Client.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebSockets.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Numerics.Vectors.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Numerics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ObjectModel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.DispatchProxy.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.ILGeneration.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.Lightweight.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Metadata.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.TypeExtensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.Reader.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.ResourceManager.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.Writer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.CompilerServices.Unsafe.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.CompilerServices.VisualC.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Handles.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.JavaScript.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.RuntimeInformation.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Intrinsics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Loader.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Numerics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Formatters.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Xml.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Claims.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Algorithms.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Csp.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Encoding.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.X509Certificates.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Principal.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.SecureString.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ServiceModel.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ServiceProcess.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.CodePages.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encodings.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.RegularExpressions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Channels.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Overlapped.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Dataflow.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Parallel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Thread.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.ThreadPool.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Timer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Transactions.Local.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Transactions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ValueTuple.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Web.HttpUtility.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Windows.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.Linq.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.ReaderWriter.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.Serialization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XPath.XDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XPath.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XmlDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XmlSerializer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\WindowsBase.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\mscorlib.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\netstandard.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Java.Interop.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Mono.Android.Export.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Mono.Android.dll' != '').

This message is ~18K characters long.

This particular example has been around since PCL support was added
for Xamarin.Android:

https://github.com/xamarin/xamarin-android/blob/8a88207de27b2eab13e33ba235df0b757f6f3935/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets#L41-L45

We should probably change this ourselves, as it isn't beneficial to
create an enormous string like this.

As #5315 mentions, we could shorten this log message to something like:

    Task "GetDependsOnNETStandard" skipped, due to false condition; ('$(_HasReferenceToSystemRuntime)' != 'true' and '$(_IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(_XACandidateNETStandardReferences)' != '') was evaluated as ('true' != 'true' and 'true' != 'true' and '' == '' and 'C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.CSharp.dll;...' != '')

I don't think any information would be lost here? You should be able
to figure out the value of each variable in the surrounding log.

I chose 1024 as a limit for string length and 3 as an item limit, some
examples:

    '$(Foo)' would be expanded to 'n{1024}...'
    '%(Foo)' would be expanded to 'n{1024}...'
    '@(Foo)' would be expanded to 'n0;n1;n2;...' 3 items or 1024 chars

I created a test case that has an example of all of the above.

To implement this, I created `ExpanderOptions.Truncate` to only be
used when creating the skip messages for tasks and targets.

I then had to make changes to `Substring()` in three places: metadata,
properties, and item groups.

Open to suggestions, this is the first time I've really dug into this
codebase, thanks.

![image](https://user-images.githubusercontent.com/840039/88748261-3496b880-d116-11ea-9213-16c003e14647.png)
