### PR TITLE
Fix StringBuilder capacity for <Hash/> task

### DIFF
--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -90,9 +90,8 @@ namespace Microsoft.Build.Tasks
                 totalItemSize += item.ItemSpec.Length;
             }
 
-            var separatorSize = itemsToHash.Length - 1;
-
-            return totalItemSize + separatorSize;
+            // Add one ItemSeparatorCharacter per item
+            return totalItemSize + itemsToHash.Length;
         }
     }
 }


### PR DESCRIPTION
I was profiling `<Hash/>` to see if I could improve it:

https://github.com/jonathanpeppers/Benchmarks/tree/msbuild-hash

Then I noticed a simple bug that calculates the `StringBuilder`
capacity:

    var separatorSize = itemsToHash.Length - 1;
    return totalItemSize + separatorSize;

The `- 1`, seems wrong because the separator is always appended:

    foreach (var item in ItemsToHash)
    {
        string itemSpec = item.ItemSpec;
        stringBuilder.Append(IgnoreCase ? itemSpec.ToUpperInvariant() : itemSpec);
        stringBuilder.Append(ItemSeparatorCharacter);
    }

This means the capacity is 1 less than it should be, and the
underlying `StringBuilder` has to "resize" itself at least once.

Just removing the `- 1`, I could see a noticeable memory usage
difference in a benchmark:

    | Method |     Mean |    Error |   StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
    |------- |---------:|---------:|---------:|--------:|-------:|------:|----------:|
    |  Hash2 | 85.57 us | 0.364 us | 0.340 us | 14.6484 | 1.5869 |     - |  90.88 KB |
    |  Hash1 | 90.27 us | 0.374 us | 0.313 us | 25.3906 | 5.0049 |     - | 157.18 KB |

I think what is happening here, is the `StringBuilder` is doubling the
capacity in my benchmark when it needs to grow:

https://referencesource.microsoft.com/#mscorlib/system/text/stringbuilder.cs,1962

This seems like an "easy fix", so I sent this in.