### PR TITLE
Enable MSBuild building without 3.5 SP1 targeting pack installed.

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Update="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
     <PackageReference Update="LargeAddressAware" Version="1.0.3" />
     <PackageReference Update="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetBuildTasksVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-beta1-61516-01" />

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -24,6 +24,9 @@
     <LargeAddressAware>true</LargeAddressAware>
     <ApplicationIcon>..\MSBuild\MSBuild.ico</ApplicationIcon>
 
+    <!-- workaround for https://github.com/dotnet/msbuild/issues/5620 -->
+    <BypassFrameworkInstallChecks>true</BypassFrameworkInstallChecks>
+
     <DebugType>full</DebugType><!-- Work around arcade stomping on symbols for same-program-different-arches. -->
   </PropertyGroup>
   <ItemGroup>
@@ -213,6 +216,7 @@
     <PackageReference Include="PdbGit" /> -->
     <PackageReference Include="SourceLink.Create.CommandLine" />
     <PackageReference Include="LargeAddressAware" PrivateAssets="All" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/5620.

Unfortunately the Microsoft.NETFramework.ReferencesAssemblies does not include net35, so we're using https://www.nuget.org/packages/jnm2.ReferenceAssemblies.net35 combined with a workaround to bypass looking for System.Data.Entity.dll 3.5.0.0 in the GAC.