### PR TITLE
Fix paths to solution items

### DIFF
--- a/MSBuild.Dev.sln
+++ b/MSBuild.Dev.sln
@@ -5,8 +5,8 @@ VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4900B3B8-4310-4D5B-B1F7-2FDF9199765F}"
 	ProjectSection(SolutionItems) = preProject
-		..\NuGet.Config = ..\NuGet.Config
-		..\targets\xunit.runner.json = ..\targets\xunit.runner.json
+		NuGet.Config = NuGet.Config
+		src\Shared\UnitTests\xunit.runner.json = src\Shared\UnitTests\xunit.runner.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Build", "src\Build\Microsoft.Build.csproj", "{69BE05E2-CBDA-4D27-9733-44E12B0F5627}"

--- a/MSBuild.sln
+++ b/MSBuild.sln
@@ -5,8 +5,8 @@ VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4900B3B8-4310-4D5B-B1F7-2FDF9199765F}"
 	ProjectSection(SolutionItems) = preProject
-		..\NuGet.Config = ..\NuGet.Config
-		..\targets\xunit.runner.json = ..\targets\xunit.runner.json
+		NuGet.Config = NuGet.Config
+		src\Shared\UnitTests\xunit.runner.json = src\Shared\UnitTests\xunit.runner.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{760FF85D-8BEB-4992-8095-A9678F88FD47}"


### PR DESCRIPTION
Small change which fixes paths to NuGet.Config and xunit.runner.json. This enables to open these files directly from VS (and other editors).
