### PR TITLE
Do not call GetHashCode() on enums

### DIFF
--- a/src/Build/Logging/EvaluationLocationIdAgnosticComparer.cs
+++ b/src/Build/Logging/EvaluationLocationIdAgnosticComparer.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Build.Logging
         public int GetHashCode(EvaluationLocation obj)
         {
             var hashCode = 1198539463;
-            hashCode = hashCode * -1521134295 + obj.EvaluationPass.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<EvaluationPass>.Default.GetHashCode(obj.EvaluationPass);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.EvaluationPassDescription);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.File);
             hashCode = hashCode * -1521134295 + EqualityComparer<int?>.Default.GetHashCode(obj.Line);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.ElementName);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.ElementDescription);
-            hashCode = hashCode * -1521134295 + obj.Kind.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<EvaluationLocationKind>.Default.GetHashCode(obj.Kind);
             return hashCode;
         }
     }

--- a/src/Framework/Profiler/EvaluationLocation.cs
+++ b/src/Framework/Profiler/EvaluationLocation.cs
@@ -255,16 +255,15 @@ namespace Microsoft.Build.Framework.Profiler
         public override int GetHashCode()
         {
             var hashCode = 1198539463;
-            hashCode = hashCode * -1521134295 + base.GetHashCode();
             hashCode = hashCode * -1521134295 + Id.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<long?>.Default.GetHashCode(ParentId);
-            hashCode = hashCode * -1521134295 + EvaluationPass.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<EvaluationPass>.Default.GetHashCode(EvaluationPass);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EvaluationPassDescription);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(File);
             hashCode = hashCode * -1521134295 + EqualityComparer<int?>.Default.GetHashCode(Line);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ElementName);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ElementDescription);
-            hashCode = hashCode * -1521134295 + Kind.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<EvaluationLocationKind>.Default.GetHashCode(Kind);
             return hashCode;
         }
 

--- a/src/Framework/Profiler/ProfilerResult.cs
+++ b/src/Framework/Profiler/ProfilerResult.cs
@@ -86,7 +86,6 @@ namespace Microsoft.Build.Framework.Profiler
         public override int GetHashCode()
         {
             var hashCode = -2131368567;
-            hashCode = hashCode * -1521134295 + base.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<TimeSpan>.Default.GetHashCode(InclusiveTime);
             hashCode = hashCode * -1521134295 + EqualityComparer<TimeSpan>.Default.GetHashCode(ExclusiveTime);
             hashCode = hashCode * -1521134295 + NumberOfHits.GetHashCode();


### PR DESCRIPTION
Calling `GetHashCode()` on an enum results in boxing (i.e. a GC allocation) when running on .NET Framework. This has been addressed in .NET Core (https://github.com/dotnet/coreclr/pull/7895) but we want to fix it on our side still because it's showing in Visual Studio profiles:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1166715

This PR is also removing the calls to `base.GetHashCode()` which are pointless in structures that calculate the hashcode out of all their fields.