### PR TITLE
Get target framework info from inner builds in GetTargetFrameworks

### DIFF
--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -54,9 +54,13 @@ These targets are all defined in `Microsoft.Common.targets` and are defined in M
 If implementing a project with an “outer” (determine what properties to pass to the real build) and “inner” (fully specified) build, only `GetTargetFrameworkProperties` is required in the “outer” build. The other targets listed can be “inner” build only.
 
 * `GetTargetFrameworks` tells referencing projects what options are available to the build.
-  * It returns an item with metadata `TargetFrameworks` indicating what TargetFrameworks are available in the project, as well as boolean metadata `HasSingleTargetFramework` and `IsRidAgnostic`.
+  * It returns an item with the following metadata:
+    * `TargetFrameworks` indicating what TargetFrameworks are available in the project
+    * `TargetFrameworkMonikers` and `TargetPlatformMonikers` indicating what framework / platform the `TargetFrameworks` map to.  This is to support implicitly setting the target platform version (for example inferring that `net5.0-windows` means the same as `net5.0-windows7.0`) as well as treating the `TargetFramework` values [as aliases](https://github.com/NuGet/Home/issues/5154)
+    * Boolean metadata for `HasSingleTargetFramework` and `IsRidAgnostic`.
+  * The `GetReferenceNearestTargetFrameworkTask` (provided by NuGet) is responsible for selecting the best matching `TargetFramework` of the referenced project
   * This target is _optional_. If not present, the reference will be built with no additional properties.
-  * **New** in MSBuild 15.5.
+  * **New** in MSBuild 15.5.  (`TargetFrameworkMonikers` and `TargetPlatformMonikers` metadata is new in MSBuild 16.8)
 * `GetTargetFrameworkProperties` determines what properties should be passed to the “main” target for a given `ReferringTargetFramework`.
   * **Deprecated** in MSBuild 15.5.
   * New for MSBuild 15/Visual Studio 2017. Supports the cross-targeting feature allowing a project to have multiple `TargetFrameworks`.

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -21,13 +21,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(CustomBeforeMicrosoftCommonCrossTargetingTargets)" Condition="'$(CustomBeforeMicrosoftCommonCrossTargetingTargets)' != '' and Exists('$(CustomBeforeMicrosoftCommonCrossTargetingTargets)')"/>
 
   <Target Name="GetTargetFrameworks"
+          DependsOnTargets="GetTargetFrameworksWithPlatformFromInnerBuilds"
           Returns="@(_ThisProjectBuildMetadata)">
+
+    <Error Condition="'$(IsCrossTargetingBuild)' != 'true'"
+           Text="Internal MSBuild error: CrossTargeting GetTargetFrameworks target should only be used in cross targeting (outer) build" />
+    
     <ItemGroup>
       <_ThisProjectBuildMetadata Include="$(MSBuildProjectFullPath)">
-        <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$(TargetFrameworks)</TargetFrameworks>
-        <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(TargetFramework)</TargetFrameworks>
-        <HasSingleTargetFramework>true</HasSingleTargetFramework>
-        <HasSingleTargetFramework Condition="'$(IsCrossTargetingBuild)' == 'true'">false</HasSingleTargetFramework>
+        <TargetFrameworks>@(_TargetFrameworkInfo)</TargetFrameworks>
+        <TargetFrameworkMonikers>@(_TargetFrameworkInfo->'%(TargetFrameworkMonikers)')</TargetFrameworkMonikers>
+        <TargetPlatformMonikers>@(_TargetFrameworkInfo->'%(TargetPlatformMonikers)')</TargetPlatformMonikers>
+
+        <HasSingleTargetFramework>false</HasSingleTargetFramework>
+
         <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
         <IsRidAgnostic>false</IsRidAgnostic>
         <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
@@ -44,6 +51,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <AdditionalProperties>TargetFramework=%(_TargetFrameworkNormalized.Identity)</AdditionalProperties>
       </_InnerBuildProjects>
     </ItemGroup>
+  </Target>
+
+  <Target Name="GetTargetFrameworksWithPlatformFromInnerBuilds"
+          DependsOnTargets="_ComputeTargetFrameworkItems">
+
+    <MSBuild Projects="@(_InnerBuildProjects)"
+             Condition="'@(_InnerBuildProjects)' != '' "
+             Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework"
+             BuildInParallel="$(BuildInParallel)">
+      <Output ItemName="_TargetFrameworkInfo" TaskParameter="TargetOutputs" />
+    </MSBuild>
+
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1697,18 +1697,39 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Target>
 
   <Target Name="GetTargetFrameworks"
+          DependsOnTargets="GetTargetFrameworksWithPlatformForSingleTargetFramework"
           Returns="@(_ThisProjectBuildMetadata)">
+
+    <Error Condition="'$(IsCrossTargetingBuild)' == 'true'"
+           Text="Internal MSBuild error: Non-CrossTargeting GetTargetFrameworks target should not be used in cross targeting (outer) build" />
+
     <ItemGroup>
       <_ThisProjectBuildMetadata Include="$(MSBuildProjectFullPath)">
-        <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$(TargetFrameworks)</TargetFrameworks>
-        <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(TargetFramework)</TargetFrameworks>
+        <TargetFrameworks>@(_TargetFrameworkInfo)</TargetFrameworks>
+        <TargetFrameworkMonikers>@(_TargetFrameworkInfo->'%(TargetFrameworkMonikers)')</TargetFrameworkMonikers>
+        <TargetPlatformMonikers>@(_TargetFrameworkInfo->'%(TargetPlatformMonikers)')</TargetPlatformMonikers>
+
         <HasSingleTargetFramework>true</HasSingleTargetFramework>
-        <HasSingleTargetFramework Condition="'$(IsCrossTargetingBuild)' == 'true'">false</HasSingleTargetFramework>
+        
         <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
-      <IsRidAgnostic>false</IsRidAgnostic>
-      <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
+        <IsRidAgnostic>false</IsRidAgnostic>
+        <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
       </_ThisProjectBuildMetadata>
     </ItemGroup>
+  </Target>
+
+  <Target Name="GetTargetFrameworksWithPlatformForSingleTargetFramework"
+        Returns="@(_TargetFrameworkInfo)">
+
+    <ItemGroup>
+      <_TargetFrameworkInfo Include="$(TargetFramework)">
+        <TargetFrameworks>$(TargetFramework)</TargetFrameworks>
+        <TargetFrameworkMonikers>$(TargetFrameworkMoniker)</TargetFrameworkMonikers>
+        <TargetPlatformMonikers>$(TargetPlatformMoniker)</TargetPlatformMonikers>
+        <TargetPlatformMonikers Condition="'$(TargetPlatformMoniker)' == ''">None</TargetPlatformMonikers>
+      </_TargetFrameworkInfo>
+    </ItemGroup>
+
   </Target>
 
   <!--


### PR DESCRIPTION
In order to support implicitly setting the `TargetPlatformVersion` (for example for a `TargetFramework` of `net5.0-windows`), as well as to eventually support [TargetFramework values as aliases](https://github.com/NuGet/Home/issues/5154), we need to update the project reference protocol.  The `GetTargetFrameworks` target needs to return information not just about the `TargetFrameworks`, but also about the `TargetFrameworkMoniker` and `TargetPlatformMoniker` that it parses out to.  This requires dispatching an inner build to get this information.

The new information will be consumed by the `GetReferenceNearestTargetFrameworkTask` task, which is being updated here: https://github.com/NuGet/NuGet.Client/pull/3578

FYI @nkolev92