### PR TITLE
Don't hang on cycles in AfterTargets

### DIFF
--- a/src/Build.UnitTests/BackEnd/TargetBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetBuilder_Tests.cs
@@ -923,6 +923,26 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// Test a project that has a cycle in AfterTargets
+        /// </summary>
+        [Fact]
+        public void TestAfterTargetsWithCycleDoesNotHang()
+        {
+            string projectBody = @"
+<Target Name='Build' AfterTargets='After2' />
+
+<Target Name='After1' AfterTargets='Build' />
+
+<Target Name='After2' AfterTargets='After1' />
+";
+
+            BuildResult result = BuildSimpleProject(projectBody, new string[] { "Build" }, failTaskNumber: int.MaxValue /* no task failure needed here */);
+            result.ResultsByTarget["Build"].ResultCode.ShouldBe(TargetResultCode.Success);
+            result.ResultsByTarget["Build"].AfterTargetsHaveFailed.ShouldBe(false);
+        }
+
+
+        /// <summary>
         /// Test after target on a skipped target
         /// </summary>
         [Fact]

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -777,11 +777,9 @@ namespace Microsoft.Build.BackEnd
                     var targetsToCheckForAfterTargets = new Queue<string>();
                     targetsToCheckForAfterTargets.Enqueue(targetName);
 
-                    // Set of targets already processed, to break cycles of AfterTargets
-                    var targetsChecked = new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default)
-                    {
-                        targetName
-                    };
+                    // Set of targets already processed, to break cycles of AfterTargets.
+                    // Initialized lazily when needed below.
+                    HashSet<string> targetsChecked = null;
 
                     while (targetsToCheckForAfterTargets?.Count > 0)
                     {
@@ -798,6 +796,11 @@ namespace Microsoft.Build.BackEnd
                                 targetsToCheckForAfterTargets = null;
                                 break;
                             }
+
+                            targetsChecked ??= new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default)
+                                {
+                                    targetName
+                                };
 
                             // If we haven't seen this target yet, add it to the list to check.
                             if (targetsChecked.Add(afterTarget.TargetName))

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -777,6 +777,12 @@ namespace Microsoft.Build.BackEnd
                     var targetsToCheckForAfterTargets = new Queue<string>();
                     targetsToCheckForAfterTargets.Enqueue(targetName);
 
+                    // Set of targets already processed, to break cycles of AfterTargets
+                    var targetsChecked = new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default)
+                    {
+                        targetName
+                    };
+
                     while (targetsToCheckForAfterTargets?.Count > 0)
                     {
                         string targetToCheck = targetsToCheckForAfterTargets.Dequeue();
@@ -793,8 +799,11 @@ namespace Microsoft.Build.BackEnd
                                 break;
                             }
 
-                            // We haven't seen this target yet, add it to the list to check.
-                            targetsToCheckForAfterTargets.Enqueue(afterTarget.TargetName);
+                            // If we haven't seen this target yet, add it to the list to check.
+                            if (targetsChecked.Add(afterTarget.TargetName))
+                            {
+                                targetsToCheckForAfterTargets.Enqueue(afterTarget.TargetName);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #5662 by keeping track of visited targets and avoiding an infinite loop when encountering an already-visited target.