### PR TITLE
Don't expand full drive globs with false condition

### DIFF
--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -420,29 +420,15 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         [InlineData(@"<i Condition='false' Include='somedir/**/*.cs'/>")]
         public void PartialFileSystemScanGlobWithFalseCondition(string itemDefinition)
         {
-            string directory = null;
-            string file = null;
-
-            try
+            using (TestEnvironment env = TestEnvironment.Create())
             {
-                directory = Path.Combine(Path.GetTempPath(), "somedir");
-                if (File.Exists(directory))
-                {
-                    File.Delete(directory);
-                }
+                TransientTestFolder directory = env.CreateFolder(createFolder: true);
+                TransientTestFile file = env.CreateFile(directory, "a.cs");
 
-                file = Path.Combine(directory, "a.cs");
-                Directory.CreateDirectory(directory);
+                File.WriteAllText(file.Path, String.Empty);
 
-                File.WriteAllText(file, String.Empty);
-
-                IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(itemDefinition.Replace("somedir", directory), allItems: false, ignoreCondition: true);
+                IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(itemDefinition.Replace("somedir", directory.Path), allItems: false, ignoreCondition: true);
                 items.ShouldNotBeEmpty();
-            }
-            finally
-            {
-                File.Delete(file);
-                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -409,6 +409,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         [Theory]
         [InlineData(@"<i Condition='false' Include='\**\*.cs'/>")]
         [InlineData(@"<i Condition='false' Include='/**/*.cs'/>")]
+        [InlineData(@"<i Condition='false' Include='/**\*.cs'/>")]
+        [InlineData(@"<i Condition='false' Include='\**/*.cs'/>")]
         public void FullFileSystemScanGlobWithFalseCondition(string itemDefinition)
         {
             IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(itemDefinition, allItems: false, ignoreCondition: true);
@@ -418,6 +420,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         [Theory]
         [InlineData(@"<i Condition='false' Include='somedir\**\*.cs'/>")]
         [InlineData(@"<i Condition='false' Include='somedir/**/*.cs'/>")]
+        [InlineData(@"<i Condition='false' Include='somedir/**\*.cs'/>")]
+        [InlineData(@"<i Condition='false' Include='somedir\**/*.cs'/>")]
         public void PartialFileSystemScanGlobWithFalseCondition(string itemDefinition)
         {
             using (TestEnvironment env = TestEnvironment.Create())

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -423,9 +423,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 TransientTestFolder directory = env.CreateFolder(createFolder: true);
-                TransientTestFile file = env.CreateFile(directory, "a.cs");
-
-                File.WriteAllText(file.Path, String.Empty);
+                TransientTestFile file = env.CreateFile(directory, "a.cs", String.Empty);
 
                 IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(itemDefinition.Replace("somedir", directory.Path), allItems: false, ignoreCondition: true);
                 items.ShouldNotBeEmpty();

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -498,5 +498,7 @@ namespace Microsoft.Build.Evaluation
             : base(textFragment, projectDirectory)
         {
         }
+
+        public bool IsFullFileSystemScan => (TextFragment.StartsWith(@"\**\") || TextFragment.StartsWith(@"/**/"));
     }
 }

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -499,6 +499,13 @@ namespace Microsoft.Build.Evaluation
         {
         }
 
-        public bool IsFullFileSystemScan => (TextFragment.StartsWith(@"\**\") || TextFragment.StartsWith(@"/**/"));
+        /// <summary>
+        /// True if TextFragment starts with /**/ or a variation thereof with backslashes.
+        /// </summary>
+        public bool IsFullFileSystemScan => TextFragment.Length >= 4
+            && FileUtilities.IsAnySlash(TextFragment[0])
+            && TextFragment[1] == '*'
+            && TextFragment[2] == '*'
+            && FileUtilities.IsAnySlash(TextFragment[3]);
     }
 }

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Eventing;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -89,7 +90,10 @@ namespace Microsoft.Build.Evaluation
                     }
                     else if (fragment is GlobFragment globFragment)
                     {
-                        if (_conditionResult || !globFragment.IsFullFileSystemScan)
+                        // If this item is behind a false condition and represents a full drive/filesystem scan, expanding it is
+                        // almost certainly undesired. It should be skipped to avoid evaluation taking an excessive amount of time.
+                        bool skipGlob = !_conditionResult && globFragment.IsFullFileSystemScan && !Traits.Instance.EscapeHatches.AlwaysEvaluateDangerousGlobs;
+                        if (!skipGlob)
                         {
                             string glob = globFragment.TextFragment;
 

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -89,34 +89,37 @@ namespace Microsoft.Build.Evaluation
                     }
                     else if (fragment is GlobFragment globFragment)
                     {
-                        string glob = globFragment.TextFragment;
+                        if (_conditionResult || !globFragment.IsFullFileSystemScan)
+                        {
+                            string glob = globFragment.TextFragment;
 
-                        if (excludePatternsForGlobs == null)
-                        {
-                            excludePatternsForGlobs = BuildExcludePatternsForGlobs(globsToIgnore, excludePatterns);
-                        }
+                            if (excludePatternsForGlobs == null)
+                            {
+                                excludePatternsForGlobs = BuildExcludePatternsForGlobs(globsToIgnore, excludePatterns);
+                            }
 
-                        string[] includeSplitFilesEscaped;
-                        if (MSBuildEventSource.Log.IsEnabled())
-                        {
-                            MSBuildEventSource.Log.ExpandGlobStart(_rootDirectory, glob, string.Join(", ", excludePatternsForGlobs));
-                        }
-                        using (_lazyEvaluator._evaluationProfiler.TrackGlob(_rootDirectory, glob, excludePatternsForGlobs))
-                        {
-                            includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(
-                                _rootDirectory,
-                                glob,
-                                excludePatternsForGlobs
-                            );
-                        }
-                        if (MSBuildEventSource.Log.IsEnabled())
-                        {
-                            MSBuildEventSource.Log.ExpandGlobStop(_rootDirectory, glob, string.Join(", ", excludePatternsForGlobs));
-                        }
+                            string[] includeSplitFilesEscaped;
+                            if (MSBuildEventSource.Log.IsEnabled())
+                            {
+                                MSBuildEventSource.Log.ExpandGlobStart(_rootDirectory, glob, string.Join(", ", excludePatternsForGlobs));
+                            }
+                            using (_lazyEvaluator._evaluationProfiler.TrackGlob(_rootDirectory, glob, excludePatternsForGlobs))
+                            {
+                                includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(
+                                    _rootDirectory,
+                                    glob,
+                                    excludePatternsForGlobs
+                                );
+                            }
+                            if (MSBuildEventSource.Log.IsEnabled())
+                            {
+                                MSBuildEventSource.Log.ExpandGlobStop(_rootDirectory, glob, string.Join(", ", excludePatternsForGlobs));
+                            }
 
-                        foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)
-                        {
-                            itemsToAdd.Add(_itemFactory.CreateItem(includeSplitFileEscaped, glob, _itemElement.ContainingProject.FullPath));
+                            foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)
+                            {
+                                itemsToAdd.Add(_itemFactory.CreateItem(includeSplitFileEscaped, glob, _itemElement.ContainingProject.FullPath));
+                            }
                         }
                     }
                     else

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -142,6 +142,11 @@ namespace Microsoft.Build.Utilities
         public readonly bool DoNotTruncateConditions = Environment.GetEnvironmentVariable("MSBuildDoNotTruncateConditions") == "1";
 
         /// <summary>
+        /// Disables skipping full drive/filesystem globs that are behind a false condition.
+        /// </summary>
+        public readonly bool AlwaysEvaluateDangerousGlobs = Environment.GetEnvironmentVariable("MSBuildAlwaysEvaluateDangerousGlobs") == "1";
+
+        /// <summary>
         /// Emit events for project imports.
         /// </summary>
         private bool? _logProjectImports;

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1042,11 +1042,11 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Get items of item type "i" with using the item xml fragment passed in
         /// </summary>
-        internal static IList<ProjectItem> GetItemsFromFragment(string fragment, bool allItems = false)
+        internal static IList<ProjectItem> GetItemsFromFragment(string fragment, bool allItems = false, bool ignoreCondition = false)
         {
             string content = FormatProjectContentsWithItemGroupFragment(fragment);
 
-            IList<ProjectItem> items = GetItems(content, allItems);
+            IList<ProjectItem> items = GetItems(content, allItems, ignoreCondition);
             return items;
         }
 
@@ -1058,11 +1058,14 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Get the items of type "i" in the project provided
         /// </summary>
-        internal static IList<ProjectItem> GetItems(string content, bool allItems = false)
+        internal static IList<ProjectItem> GetItems(string content, bool allItems = false, bool ignoreCondition = false)
         {
             var projectXml = ProjectRootElement.Create(XmlReader.Create(new StringReader(CleanupFileContents(content))));
             Project project = new Project(projectXml);
-            IList<ProjectItem> item = Helpers.MakeList(allItems ? project.Items : project.GetItems("i"));
+            IList<ProjectItem> item = Helpers.MakeList(
+                ignoreCondition ?
+                (allItems ? project.ItemsIgnoringCondition : project.GetItemsIgnoringCondition("i")) :
+                (allItems ? project.Items : project.GetItems("i")));
 
             return item;
         }


### PR DESCRIPTION
We often see hangs where MSBuild is enumerating the entire drive because conditions similar to this one are ignored at design time, most notably when loading projects in Visual Studio.

```xml
<Content Include="$(SomeDir)\**\*.*" Condition="'$(SomeDir)' != ''">
```

This PR addresses the problem by honoring the condition in cases where the evaluated glob file spec represents a full drive/filesystem walk, i.e. starts with ```\**\``` or ```/**/```.

Fixes #4091 after adding the condition.