### PR TITLE
Detect whitespace in property name

### DIFF
--- a/src/Build.UnitTests/Parser_Tests.cs
+++ b/src/Build.UnitTests/Parser_Tests.cs
@@ -526,18 +526,5 @@ namespace Microsoft.Build.UnitTests
             // Make sure the log contains the correct strings.
             Assert.DoesNotContain("MSB4130:", ml.FullLog); // "No need to warn for this expression - ($(a) == 1 or $(b) == 2) and $(c) == 3."
         }
-
-        [Fact]
-        public void WhitespaceTest()
-        {
-            MockLogger ml = ObjectModelHelpers.BuildProjectExpectFailure(@"
-                    <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
-                        <Target Name=`Build`>
-                            <Warning Text=`should error on this line` Condition=`$(MSBuildProjectFullPath ) != ''`/>
-                        </Target>
-                    </Project>");
-
-            Assert.Contains("MSB4151:", ml.FullLog);
-        }
     }
 }

--- a/src/Build.UnitTests/Parser_Tests.cs
+++ b/src/Build.UnitTests/Parser_Tests.cs
@@ -526,5 +526,18 @@ namespace Microsoft.Build.UnitTests
             // Make sure the log contains the correct strings.
             Assert.DoesNotContain("MSB4130:", ml.FullLog); // "No need to warn for this expression - ($(a) == 1 or $(b) == 2) and $(c) == 3."
         }
+
+        [Fact]
+        public void WhitespaceTest()
+        {
+            MockLogger ml = ObjectModelHelpers.BuildProjectExpectFailure(@"
+                    <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
+                        <Target Name=`Build`>
+                            <Warning Text=`should error on this line` Condition=`$(MSBuildProjectFullPath ) != ''`/>
+                        </Target>
+                    </Project>");
+
+            Assert.Contains("MSB4151:", ml.FullLog);
+        }
     }
 }

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -98,7 +98,6 @@ namespace Microsoft.Build.UnitTests
             lexer = new Scanner("$x", ParserOptions.AllowProperties);
             AdvanceToScannerError(lexer);
             Assert.Equal("IllFormedPropertyOpenParenthesisInCondition", lexer.GetErrorResource());
-
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -117,10 +117,10 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        public void SpacePropertyOptOutWave17()
+        public void SpacePropertyOptOutWave16_10()
         {
             using TestEnvironment env = TestEnvironment.Create();
-            env.SetChangeWave(ChangeWaves.Wave17_0);
+            env.SetChangeWave(ChangeWaves.Wave16_10);
 
             Scanner lexer = new Scanner("$(x )", ParserOptions.AllowProperties);
             AdvanceToScannerError(lexer);

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -102,22 +102,22 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Tests the whitespace errors case
+        /// Tests the space errors case
         /// </summary>
         [Fact]
-        public void WhitespaceProperty()
+        public void SpaceProperty()
         {
             Scanner lexer = new Scanner("$(x )", ParserOptions.AllowProperties);
             AdvanceToScannerError(lexer);
-            Assert.Equal("IllFormedPropertyWhitespaceInCondition", lexer.GetErrorResource());
+            Assert.Equal("IllFormedPropertySpaceInCondition", lexer.GetErrorResource());
 
             lexer = new Scanner("$( x)", ParserOptions.AllowProperties);
             AdvanceToScannerError(lexer);
-            Assert.Equal("IllFormedPropertyWhitespaceInCondition", lexer.GetErrorResource());
+            Assert.Equal("IllFormedPropertySpaceInCondition", lexer.GetErrorResource());
         }
 
         [Fact]
-        public void WhitespacePropertyOptOutWave17()
+        public void SpacePropertyOptOutWave17()
         {
             using TestEnvironment env = TestEnvironment.Create();
             env.SetChangeWave(ChangeWaves.Wave17_0);

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -98,6 +98,22 @@ namespace Microsoft.Build.UnitTests
             lexer = new Scanner("$x", ParserOptions.AllowProperties);
             AdvanceToScannerError(lexer);
             Assert.Equal("IllFormedPropertyOpenParenthesisInCondition", lexer.GetErrorResource());
+
+        }
+
+        /// <summary>
+        /// Tests the whitespace errors case
+        /// </summary>
+        [Fact]
+        public void WhitespaceProperty()
+        {
+            Scanner lexer = new Scanner("$(x )", ParserOptions.AllowProperties);
+            AdvanceToScannerError(lexer);
+            Assert.Equal("IllFormedPropertyWhitespaceInCondition", lexer.GetErrorResource());
+
+            lexer = new Scanner("$( x)", ParserOptions.AllowProperties);
+            AdvanceToScannerError(lexer);
+            Assert.Equal("IllFormedPropertyWhitespaceInCondition", lexer.GetErrorResource());
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -5,6 +5,7 @@ using System;
 
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
+using Microsoft.Build.Utilities;
 using Xunit;
 
 
@@ -113,6 +114,21 @@ namespace Microsoft.Build.UnitTests
             lexer = new Scanner("$( x)", ParserOptions.AllowProperties);
             AdvanceToScannerError(lexer);
             Assert.Equal("IllFormedPropertyWhitespaceInCondition", lexer.GetErrorResource());
+        }
+
+        [Fact]
+        public void WhitespacePropertyOptOutWave17()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetChangeWave(ChangeWaves.Wave17_0);
+
+            Scanner lexer = new Scanner("$(x )", ParserOptions.AllowProperties);
+            AdvanceToScannerError(lexer);
+            Assert.Null(lexer.UnexpectedlyFound);
+
+            lexer = new Scanner("$( x)", ParserOptions.AllowProperties);
+            AdvanceToScannerError(lexer);
+            Assert.Null(lexer.UnexpectedlyFound);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -340,7 +340,7 @@ namespace Microsoft.Build.Evaluation
                             nestLevel--;
                             whitespaceCheck = false;
                         }
-                        else if (whitespaceCheck && char.IsWhiteSpace(character) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
+                        else if (whitespaceCheck && char.IsWhiteSpace(character) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10))
                         {
                             indexResult = index;
                             return false;

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -320,6 +320,7 @@ namespace Microsoft.Build.Evaluation
         private static bool ScanForPropertyExpressionEnd(string expression, int index, out int indexResult)
         {
             int nestLevel = 0;
+            bool whitespaceCheck = false;
 
             unsafe
             {
@@ -331,12 +332,14 @@ namespace Microsoft.Build.Evaluation
                         if (character == '(')
                         {
                             nestLevel++;
+                            whitespaceCheck = true;
                         }
                         else if (character == ')')
                         {
                             nestLevel--;
+                            whitespaceCheck = false;
                         }
-                        else if (char.IsWhiteSpace(character))
+                        else if (whitespaceCheck && char.IsWhiteSpace(character))
                         {
                             indexResult = index;
                             return false;

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 
 using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -339,7 +340,7 @@ namespace Microsoft.Build.Evaluation
                             nestLevel--;
                             whitespaceCheck = false;
                         }
-                        else if (whitespaceCheck && char.IsWhiteSpace(character))
+                        else if (whitespaceCheck && char.IsWhiteSpace(character) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
                         {
                             indexResult = index;
                             return false;

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Build.Evaluation
             {
                 _errorState = true;
                 _errorPosition = indexResult;
-                _errorResource = "IllFormedPropertyWhitespaceInCondition";
+                _errorResource = "IllFormedPropertySpaceInCondition";
                 _unexpectedlyFound = Convert.ToString(_expression[indexResult], CultureInfo.InvariantCulture);
                 return null;
             }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -491,8 +491,8 @@
     <comment>{StrBegin="MSB4110: "}</comment>
   </data>
   <data name="IllFormedPropertyWhitespaceInCondition" xml:space="preserve">
-    <value>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</value>
-    <comment>{StrBegin="MSB4151: "}</comment>
+    <value>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</value>
+    <comment>{StrBegin="MSB4259: "}</comment>
   </data>
   <data name="IllFormedQuotedStringInCondition" xml:space="preserve">
     <value>MSB4101: Expected a closing quote after position {1} in condition "{0}".</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -491,8 +491,8 @@
     <comment>{StrBegin="MSB4110: "}</comment>
   </data>
   <data name="IllFormedPropertyWhitespaceInCondition" xml:space="preserve">
-    <value>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</value>
-    <comment>{StrBegin="MSB4111: "}</comment>
+    <value>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</value>
+    <comment>{StrBegin="MSB4151: "}</comment>
   </data>
   <data name="IllFormedQuotedStringInCondition" xml:space="preserve">
     <value>MSB4101: Expected a closing quote after position {1} in condition "{0}".</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -490,6 +490,10 @@
     <value>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</value>
     <comment>{StrBegin="MSB4110: "}</comment>
   </data>
+  <data name="IllFormedPropertyWhitespaceInCondition" xml:space="preserve">
+    <value>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</value>
+    <comment>{StrBegin="MSB4111: "}</comment>
+  </data>
   <data name="IllFormedQuotedStringInCondition" xml:space="preserve">
     <value>MSB4101: Expected a closing quote after position {1} in condition "{0}".</value>
     <comment>{StrBegin="MSB4101: "}</comment>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -490,8 +490,8 @@
     <value>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</value>
     <comment>{StrBegin="MSB4110: "}</comment>
   </data>
-  <data name="IllFormedPropertyWhitespaceInCondition" xml:space="preserve">
-    <value>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</value>
+  <data name="IllFormedPropertySpaceInCondition" xml:space="preserve">
+    <value>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</value>
     <comment>{StrBegin="MSB4259: "}</comment>
   </data>
   <data name="IllFormedQuotedStringInCondition" xml:space="preserve">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: Při zápisu do výstupních souborů mezipaměti pro výsledky v cestě {0} byla zjištěna chyba: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: Při zápisu do výstupních souborů mezipaměti pro výsledky v cestě {0} byla zjištěna chyba: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Následující vstupní soubory mezipaměti pro výsledky neexistují: {0}</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: Beim Schreiben der Cachedatei für Ausgabeergebnisse im Pfad "{0}" wurde ein Fehler festgestellt: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Die folgenden Cachedateien für Eingabeergebnisse sind nicht vorhanden: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: Beim Schreiben der Cachedatei für Ausgabeergebnisse im Pfad "{0}" wurde ein Fehler festgestellt: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -104,9 +104,9 @@
         <target state="new">MSB4258: Writing output result cache file in path "{0}" encountered an error: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -104,6 +104,11 @@
         <target state="new">MSB4258: Writing output result cache file in path "{0}" encountered an error: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="new">MSB4255: The following input result cache files do not exist: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: Error al escribir el archivo de caché de resultados de salida en la ruta de acceso "{0}": {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: Error al escribir el archivo de caché de resultados de salida en la ruta de acceso "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Los siguientes archivos de caché de resultados de entrada no existen: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: L'écriture du fichier cache des résultats de sortie dans le chemin "{0}" a rencontré une erreur : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Les fichiers cache des résultats d'entrée suivants n'existent pas : "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: L'écriture du fichier cache des résultats de sortie dans le chemin "{0}" a rencontré une erreur : {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: durante la scrittura del file della cache dei risultati di output nel percorso "{0}" è stato rilevato un errore: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: durante la scrittura del file della cache dei risultati di output nel percorso "{0}" è stato rilevato un errore: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: i file della cache dei risultati di input seguenti non esistono: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: パス "{0}" の出力結果キャッシュ ファイルに書き込む処理でエラーが発生しました: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: パス "{0}" の出力結果キャッシュ ファイルに書き込む処理でエラーが発生しました: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: 以下の入力結果キャッシュ ファイルが存在しません: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: "{0}" 경로에서 출력 결과 캐시 파일을 쓰는 중 오류가 발생했습니다. {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: "{0}" 경로에서 출력 결과 캐시 파일을 쓰는 중 오류가 발생했습니다. {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: 다음 입력 결과 캐시 파일이 존재하지 않습니다. "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: Podczas zapisywania pliku wyjściowej pamięci podręcznej wyników w ścieżce „{0}” wystąpił błąd: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Następujące pliki wejściowej pamięci podręcznej wyników nie istnieją: „{0}”</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: Podczas zapisywania pliku wyjściowej pamięci podręcznej wyników w ścieżce „{0}” wystąpił błąd: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: a gravação do arquivo de cache do resultado de saída no caminho "{0}" encontrou um erro: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: a gravação do arquivo de cache do resultado de saída no caminho "{0}" encontrou um erro: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: os arquivos de cache do resultado de entrada a seguir não existem: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: произошла ошибка при записи выходного файла кэша результатов в пути "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: следующие входные файлы кэша результатов не существуют: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: произошла ошибка при записи выходного файла кэша результатов в пути "{0}": {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: Çıkış sonucu önbellek dosyası "{0}" yoluna yazılırken bir hatayla karşılaşıldı: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Şu giriş sonucu önbellek dosyaları mevcut değil: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: Çıkış sonucu önbellek dosyası "{0}" yoluna yazılırken bir hatayla karşılaşıldı: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: 从路径“{0}”写入输出结果缓存文件时遇到错误: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: 从路径“{0}”写入输出结果缓存文件时遇到错误: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: 以下输入结果缓存文件不存在:“{0}”</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -104,9 +104,9 @@
         <target state="translated">MSB4258: 在路徑 "{0}" 中寫入輸出結果快取檔案發生錯誤: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+      <trans-unit id="IllFormedPropertySpaceInCondition">
+        <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
-        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
-        <note>{StrBegin="MSB4111: "}</note>
+        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4151: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -104,6 +104,11 @@
         <target state="translated">MSB4258: 在路徑 "{0}" 中寫入輸出結果快取檔案發生錯誤: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IllFormedPropertyWhitespaceInCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed with whitespace. Remove whitespaces from the property.</target>
+        <note>{StrBegin="MSB4111: "}</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: 下列輸入結果快取檔案不存在: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -105,9 +105,9 @@
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertyWhitespaceInCondition">
-        <source>MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
-        <target state="new">MSB4151: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
-        <note>{StrBegin="MSB4151: "}</note>
+        <source>MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</source>
+        <target state="new">MSB4259: Unexpected whitespace at position "{1}" of condition "{0}". Did you forget to remove a whitespace?</target>
+        <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>


### PR DESCRIPTION
Attempt at https://github.com/dotnet/msbuild/issues/5615

- It is mentioned in https://github.com/dotnet/msbuild/issues/5615 that MSBuild should both error and warn about this so not sure which is the correct approach here. An error might break a lot of existing code, but it might be the correct thing to do (?).
- Also not sure whether this warrants a new string error message, though I did create one. If so, should I commit my untranslated xlf files? I am not familiar with the i18n process in MSBuild.

Any feedback welcome.