### PR TITLE
Fix Inadvertent Call to MSBuildExeStop

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -525,7 +525,7 @@ namespace Microsoft.Build.CommandLine
                 MSBuildEventSource.Log.MSBuildExeStart(commandLine);
 #else
                 if (MSBuildEventSource.Log.IsEnabled()) {
-                    MSBuildEventSource.Log.MSBuildExeStop(string.Join(" ", commandLine));
+                    MSBuildEventSource.Log.MSBuildExeStart(string.Join(" ", commandLine));
                 }
 #endif
                 Console.CancelKeyPress += cancelHandler;


### PR DESCRIPTION
The `MSBuildExeStop` event is being fired at the beginning of execution when `MSBuildExeStart` should be fired instead.