### PR TITLE
Allow Synergy DBL to be a known supported type GUID #5159

### DIFF
--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Build.Construction
         private const string fsProjectGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
         private const string dbProjectGuid = "{C8D11400-126E-41CD-887F-60BD40844F9E}";
         private const string wdProjectGuid = "{2CFEAB61-6A3B-4EB8-B523-560B4BEEF521}";
-        private const string synProjectGuid = "{BBD0F5D1-1CC4-42fd-BA4C-A96779C64378}";
+        private const string synProjectGuid = "{BBD0F5D1-1CC4-42FD-BA4C-A96779C64378}";
         private const string webProjectGuid = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
         private const string solutionFolderGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
         private const string sharedProjectGuid = "{D954291E-2A0B-460D-934E-DC6B0785DB48}";

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Build.Construction
         private const string fsProjectGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
         private const string dbProjectGuid = "{C8D11400-126E-41CD-887F-60BD40844F9E}";
         private const string wdProjectGuid = "{2CFEAB61-6A3B-4EB8-B523-560B4BEEF521}";
+        private const string synProjectGuid = "{BBD0F5D1-1CC4-42fd-BA4C-A96779C64378}";
         private const string webProjectGuid = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
         private const string solutionFolderGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
         private const string sharedProjectGuid = "{D954291E-2A0B-460D-934E-DC6B0785DB48}";
@@ -1266,7 +1267,8 @@ namespace Microsoft.Build.Construction
                 (String.Equals(projectTypeGuid, cpsFsProjectGuid, StringComparison.OrdinalIgnoreCase)) ||
                 (String.Equals(projectTypeGuid, fsProjectGuid, StringComparison.OrdinalIgnoreCase)) ||
                 (String.Equals(projectTypeGuid, dbProjectGuid, StringComparison.OrdinalIgnoreCase)) ||
-                (String.Equals(projectTypeGuid, vjProjectGuid, StringComparison.OrdinalIgnoreCase)))
+                (String.Equals(projectTypeGuid, vjProjectGuid, StringComparison.OrdinalIgnoreCase)) ||
+                (String.Equals(projectTypeGuid, synProjectGuid, StringComparison.OrdinalIgnoreCase)))
             {
                 proj.ProjectType = SolutionProjectType.KnownToBeMSBuildFormat;
             }


### PR DESCRIPTION
This PR adds another language to the list of project type guids considered as _KnownToBeMSBuildFormat_. Without presence in this list, newer features such as _/graphBuild_ will silently exclude the language from participation (per #5159). Synergy DBL (*.synproj) conforms to the [MSBuild Project Reference Protocol](https://github.com/dotnet/msbuild/blob/master/documentation/ProjectReference-Protocol.md) and is otherwise a compatible language other than being missing from this list.
