### PR TITLE
Add support for ClickOnce manifest generation for .NET (Core) applications

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -489,6 +489,17 @@ namespace Microsoft.Build.Tasks
         protected override bool OnManifestResolved(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest) { throw null; }
         protected internal override bool ValidateInputs() { throw null; }
     }
+    public sealed partial class GenerateLauncher : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GenerateLauncher() { }
+        public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+        public string LauncherPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
+        public string OutputPath { get { throw null; } set { } }
+        public string VisualStudioVersion { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
     public abstract partial class GenerateManifestBase : Microsoft.Build.Utilities.Task
     {
         protected GenerateManifestBase() { }
@@ -497,6 +508,7 @@ namespace Microsoft.Build.Tasks
         public string Description { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem InputManifest { get { throw null; } set { } }
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
         public int MaxTargetPath { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem OutputManifest { get { throw null; } set { } }
@@ -1595,6 +1607,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public bool IsClickOnceManifest { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
         public int MaxTargetPath { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public string OSDescription { get { throw null; } set { } }
@@ -2138,6 +2152,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference FindTargetPath(string targetPath) { throw null; }
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public void Remove(Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference file) { }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public partial class LauncherBuilder
+    {
+        public LauncherBuilder(string launcherPath) { }
+        public string LauncherPath { get { throw null; } set { } }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildResults Build(string filename, string outputPath) { throw null; }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public abstract partial class Manifest

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -493,6 +493,10 @@ namespace Microsoft.Build.Tasks
     {
         public GenerateLauncher() { }
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkName { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion { get { throw null; } set { } }
         public string LauncherPath { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1034,6 +1034,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] SatelliteAssemblies { get { throw null; } set { } }
         public bool SigningManifests { get { throw null; } set { } }
         public string TargetCulture { get { throw null; } set { } }
+        public string TargetFrameworkIdentifier { get { throw null; } set { } }
         public string TargetFrameworkVersion { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -493,10 +493,6 @@ namespace Microsoft.Build.Tasks
     {
         public GenerateLauncher() { }
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public string FrameworkName { get { throw null; } set { } }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public string FrameworkVersion { get { throw null; } set { } }
         public string LauncherPath { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
@@ -2158,7 +2154,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public void Remove(Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference file) { }
     }
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public partial class LauncherBuilder
     {
         public LauncherBuilder(string launcherPath) { }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -771,6 +771,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] SatelliteAssemblies { get { throw null; } set { } }
         public bool SigningManifests { get { throw null; } set { } }
         public string TargetCulture { get { throw null; } set { } }
+        public string TargetFrameworkIdentifier { get { throw null; } set { } }
         public string TargetFrameworkVersion { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -387,10 +387,6 @@ namespace Microsoft.Build.Tasks
     {
         public GenerateLauncher() { }
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public string FrameworkName { get { throw null; } set { } }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public string FrameworkVersion { get { throw null; } set { } }
         public string LauncherPath { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
@@ -1793,7 +1789,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public void Remove(Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference file) { }
     }
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public partial class LauncherBuilder
     {
         public LauncherBuilder(string launcherPath) { }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -383,6 +383,7 @@ namespace Microsoft.Build.Tasks
         public string Description { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem InputManifest { get { throw null; } set { } }
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
         public int MaxTargetPath { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem OutputManifest { get { throw null; } set { } }
@@ -1222,6 +1223,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public bool IsClickOnceManifest { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
         public int MaxTargetPath { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public string OSDescription { get { throw null; } set { } }
@@ -1765,6 +1768,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference FindTargetPath(string targetPath) { throw null; }
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public void Remove(Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference file) { }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public partial class LauncherBuilder
+    {
+        public LauncherBuilder(string launcherPath) { }
+        public string LauncherPath { get { throw null; } set { } }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildResults Build(string filename, string outputPath) { throw null; }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public abstract partial class Manifest

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -375,6 +375,21 @@ namespace Microsoft.Build.Tasks
         protected override bool OnManifestResolved(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest) { throw null; }
         protected internal override bool ValidateInputs() { throw null; }
     }
+    public sealed partial class GenerateLauncher : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GenerateLauncher() { }
+        public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkName { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion { get { throw null; } set { } }
+        public string LauncherPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
+        public string OutputPath { get { throw null; } set { } }
+        public string VisualStudioVersion { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
     public abstract partial class GenerateManifestBase : Microsoft.Build.Utilities.Task
     {
         protected GenerateManifestBase() { }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -303,6 +303,14 @@ namespace Microsoft.Build.Tasks
         public bool UpdateToAbsolutePaths { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    public sealed partial class FormatUrl : Microsoft.Build.Tasks.TaskExtension
+    {
+        public FormatUrl() { }
+        public string InputUrl { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string OutputUrl { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
     public sealed partial class FormatVersion : Microsoft.Build.Tasks.TaskExtension
     {
         public FormatVersion() { }

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -2562,6 +2562,7 @@ elementFormDefault="qualified">
                     <xs:attribute name="IconFile" />
                     <xs:attribute name="InputManifest" />
                     <xs:attribute name="IsolatedComReferences" />
+                    <xs:attribute name="LauncherBasedDeployment" type="msb:boolean" />
                     <xs:attribute name="ManifestType" />
                     <xs:attribute name="MaxTargetPath" />
                     <xs:attribute name="OSVersion" />
@@ -2621,6 +2622,7 @@ elementFormDefault="qualified">
                     <xs:attribute name="ErrorReportUrl" />
                     <xs:attribute name="InputManifest" />
                     <xs:attribute name="Install" type="msb:boolean" />
+                    <xs:attribute name="LauncherBasedDeployment" type="msb:boolean" />
                     <xs:attribute name="MapFileExtensions" type="msb:boolean" />
                     <xs:attribute name="MaxTargetPath" />
                     <xs:attribute name="MinimumRequiredVersion" />
@@ -2638,6 +2640,17 @@ elementFormDefault="qualified">
                     <xs:attribute name="UpdateInterval" />
                     <xs:attribute name="UpdateMode" />
                     <xs:attribute name="UpdateUnit" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="GenerateLauncher" substitutionGroup="msb:Task">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="msb:TaskType">
+                    <xs:attribute name="EntryPoint" />
+                    <xs:attribute name="OutputPath" />
+                    <xs:attribute name="VisualStudioVersion" />
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>

--- a/src/Tasks/FormatUrl.cs
+++ b/src/Tasks/FormatUrl.cs
@@ -19,8 +19,13 @@ namespace Microsoft.Build.Tasks
 
         public override bool Execute()
         {
+#if RUNTIME_TYPE_NETCORE
+            Log.LogErrorFromResources("TaskRequiresFrameworkFailure", nameof(FormatUrl));
+            return false;
+#else
             OutputUrl = InputUrl != null ? PathUtil.Format(InputUrl) : String.Empty;
             return true;
+#endif
         }
     }
 }

--- a/src/Tasks/GenerateApplicationManifest.cs
+++ b/src/Tasks/GenerateApplicationManifest.cs
@@ -125,7 +125,15 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (ITaskItem item in Dependencies)
                 {
-                    AddAssemblyFromItem(item);
+                    if (LauncherBasedDeployment)
+                    {
+                        // In Launcher-based deployments, everything needs to be a regular file.
+                        AddFileFromItem(item);
+                    }
+                    else
+                    {
+                        AddAssemblyFromItem(item);
+                    }
                 }
             }
 

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -34,12 +34,6 @@ namespace Microsoft.Build.Tasks
 
         [Output]
         public ITaskItem OutputEntryPoint { get; set; }
-
-        [Output]
-        public string FrameworkName { get; set; }
-
-        [Output]
-        public string FrameworkVersion { get; set; }
         #endregion
 
         public override bool Execute()
@@ -58,17 +52,6 @@ namespace Microsoft.Build.Tasks
             {
                 Log.LogErrorWithCodeFromResources("GenerateLauncher.EmptyEntryPoint");
                 return false;
-            }
-
-            // Get Framework name and version.
-            // Launcher-based manifest generation has to use Framework elements that match Launcher identity.
-            Assembly a = Assembly.UnsafeLoadFrom(LauncherPath);
-            var targetFrameworkAttribute = a.GetCustomAttribute<TargetFrameworkAttribute>();
-            if (targetFrameworkAttribute != null)
-            {
-                FrameworkName = targetFrameworkAttribute.FrameworkName;
-                string[] split = FrameworkName.Split(new string[] { "Version=" }, StringSplitOptions.None);
-                FrameworkVersion = split.Length > 1 ? split[split.Length - 1] : string.Empty;
             }
 
             var launcherBuilder = new LauncherBuilder(LauncherPath);

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Build.Tasks
 
             if (EntryPoint == null)
             {
+                Log.LogErrorWithCodeFromResources("GenerateLauncher.EmptyEntryPoint");
                 return false;
             }
 
@@ -78,13 +79,17 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (BuildMessage message in messages)
                 {
-                    if (message.Severity == BuildMessageSeverity.Error)
+                    switch (message.Severity)
                     {
-                        Log.LogError(null, message.HelpCode, message.HelpKeyword, null, 0, 0, 0, 0, message.Message);
-                    }
-                    else if (message.Severity == BuildMessageSeverity.Warning)
-                    {
-                        Log.LogWarning(null, message.HelpCode, message.HelpKeyword, null, 0, 0, 0, 0, message.Message);
+                        case BuildMessageSeverity.Error:
+                            Log.LogError(null, message.HelpCode, message.HelpKeyword, null, 0, 0, 0, 0, message.Message);
+                            break;
+                        case BuildMessageSeverity.Warning:
+                            Log.LogWarning(null, message.HelpCode, message.HelpKeyword, null, 0, 0, 0, 0, message.Message);
+                            break;
+                        case BuildMessageSeverity.Info:
+                            Log.LogMessage(null, message.HelpCode, message.HelpKeyword, null, 0, 0, 0, 0, message.Message);
+                            continue;
                     }
                 }
             }
@@ -92,7 +97,7 @@ namespace Microsoft.Build.Tasks
             OutputEntryPoint = new TaskItem(Path.Combine(Path.GetDirectoryName(EntryPoint.ItemSpec), results.KeyFile));
             OutputEntryPoint.SetMetadata(ItemMetadataNames.targetPath, results.KeyFile);
 
-            return results.Succeeded;
+            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Tasks.Deployment.Bootstrapper;
+using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.Tasks
+{
+    /// <summary>
+    /// Generates a bootstrapper for ClickOnce deployment projects.
+    /// </summary>
+    public sealed class GenerateLauncher : TaskExtension
+    {
+        private const string ENGINE_PATH = "Engine"; // relative to ClickOnce bootstrapper path
+
+        #region Properties
+
+        public ITaskItem EntryPoint { get; set; }
+
+        public string LauncherPath { get; set; }
+
+        public string OutputPath { get; set; }
+
+        public string VisualStudioVersion { get; set; }
+
+        [Output]
+        public ITaskItem OutputEntryPoint { get; set; }
+
+        #endregion
+
+        public override bool Execute()
+        {
+            if (LauncherPath == null)
+            {
+                // Launcher lives next to ClickOnce bootstrapper.
+                // GetDefaultPath obtains the root ClickOnce boostrapper path.
+                LauncherPath = Path.Combine(
+                    Microsoft.Build.Tasks.Deployment.Bootstrapper.Util.GetDefaultPath(VisualStudioVersion),
+                    ENGINE_PATH);
+            }
+
+            if (EntryPoint == null)
+            {
+                return false;
+            }
+
+            var launcherBuilder = new LauncherBuilder(LauncherPath);
+            BuildResults results = launcherBuilder.Build(Path.GetFileName(EntryPoint.ItemSpec), OutputPath);
+
+            BuildMessage[] messages = results.Messages;
+            if (messages != null)
+            {
+                foreach (BuildMessage message in messages)
+                {
+                    if (message.Severity == BuildMessageSeverity.Error)
+                    {
+                        Log.LogError(null, message.HelpCode, message.HelpKeyword, null, 0, 0, 0, 0, message.Message);
+                    }
+                    else if (message.Severity == BuildMessageSeverity.Warning)
+                    {
+                        Log.LogWarning(null, message.HelpCode, message.HelpKeyword, null, 0, 0, 0, 0, message.Message);
+                    }
+                }
+            }
+
+            OutputEntryPoint = new TaskItem(Path.Combine(Path.GetDirectoryName(EntryPoint.ItemSpec), results.KeyFile));
+            OutputEntryPoint.SetMetadata(ItemMetadataNames.targetPath, results.KeyFile);
+
+            return results.Succeeded;
+        }
+    }
+}

--- a/src/Tasks/GenerateManifestBase.cs
+++ b/src/Tasks/GenerateManifestBase.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Build.Tasks
 
         public ITaskItem InputManifest { get; set; }
 
+        public bool LauncherBasedDeployment { get; set; }
+
         public int MaxTargetPath { get; set; }
 
         [Output]
@@ -460,6 +462,8 @@ namespace Microsoft.Build.Tasks
                 {
                     applicationManifest.TargetFrameworkVersion = TargetFrameworkVersion;
                 }
+
+                applicationManifest.LauncherBasedDeployment = LauncherBasedDeployment;
             }
 
             if (!String.IsNullOrEmpty(EntryPoint?.ItemSpec))

--- a/src/Tasks/ManifestUtil/ApplicationManifest.cs
+++ b/src/Tasks/ManifestUtil/ApplicationManifest.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private FileAssociation[] _fileAssociations;
         private FileAssociationCollection _fileAssociationList;
         private string _targetFrameworkVersion;
+        private bool _launcherBasedDeployment = false;
 
         /// <summary>
         /// Initializes a new instance of the ApplicationManifest class.
@@ -109,6 +110,17 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         {
             get => _errorReportUrl;
             set => _errorReportUrl = value;
+        }
+
+        /// <summary>
+        /// Indicates if manifest is part of Launcher-based deployment, which requires
+        /// somewhat different manifest generation and validation.
+        /// </summary>
+        [XmlIgnore]
+        public bool LauncherBasedDeployment
+        {
+            get => _launcherBasedDeployment;
+            set => _launcherBasedDeployment = value;
         }
 
         // Make sure we have a CLR dependency, add it if not...
@@ -655,7 +667,10 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             foreach (FileReference file in FileReferences)
             {
                 // Check that file is not an assembly...
-                if (!String.IsNullOrEmpty(file.ResolvedPath) && PathUtil.IsAssembly(file.ResolvedPath))
+                // Unless this is a Launcher-based deployments where all files except launcher
+                // are added as regular file references and not assembly references.
+                if (!_launcherBasedDeployment &&
+                    !String.IsNullOrEmpty(file.ResolvedPath) && PathUtil.IsAssembly(file.ResolvedPath))
                 {
                     OutputMessages.AddWarningMessage("GenerateManifest.AssemblyAsFile", file.ToString());
                 }

--- a/src/Tasks/ManifestUtil/Constants.cs
+++ b/src/Tasks/ManifestUtil/Constants.cs
@@ -26,5 +26,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public const int MaxFileAssociationExtensionLength = 24;
         public const string ClientFrameworkSubset = "Client";
         public const string DotNetFrameworkIdentifier = ".NETFramework";
+        public const string DotNetCoreIdentifier = ".NETCore";
+        public const string DotNetCoreAppIdentifier = ".NETCoreApp";
     }
 }

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Xml.Serialization;
+using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.Tasks.Deployment.Bootstrapper;
+
+namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
+{
+    /// <summary>
+    /// Adds Launcher and updates its resource
+    /// </summary>
+    [ComVisible(true)]
+    public class LauncherBuilder
+    {
+        private const string LAUNCHER_EXE = "Launcher.exe";
+        private const string LAUNCHER_RESOURCENAME = "FILENAME";
+        private const int LAUNCHER_RESOURCE_TABLE = 50;
+
+        private BuildResults _results;
+
+        public LauncherBuilder(string launcherPath)
+        {
+            LauncherPath = launcherPath;
+        }
+
+        /// <summary>
+        /// Specifies the location of the required Launcher files.
+        /// </summary>
+        /// <value>Path to Launcher files.</value>
+        public string LauncherPath { get; set; }
+
+        public BuildResults Build(string filename, string outputPath)
+        {
+            _results = new BuildResults();
+
+            try
+            {
+                if (filename == null)
+                {
+                    _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.InvalidInput"));
+                    return _results;
+                }
+
+                if (String.IsNullOrEmpty(outputPath))
+                {
+                    _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.NoOutputPath"));
+                    return _results;
+                }
+
+                // Copy setup.bin to the output directory
+                string strOutputExe = System.IO.Path.Combine(outputPath, LAUNCHER_EXE);
+                if (!CopyLauncherToOutputDirectory(strOutputExe))
+                {
+                    // Appropriate messages should have been stuffed into the results already
+                    return _results;
+                }
+
+                var resourceUpdater = new ResourceUpdater();
+                resourceUpdater.AddStringResource(LAUNCHER_RESOURCE_TABLE, LAUNCHER_RESOURCENAME, filename);
+                if (!resourceUpdater.UpdateResources(strOutputExe, _results))
+                {
+                    return _results;
+                }
+
+                _results.SetKeyFile(LAUNCHER_EXE);
+                _results.BuildSucceeded();
+            }
+            catch (Exception ex)
+            {
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.General", ex.Message));
+            }
+
+            return _results;
+        }
+
+        private bool CopyLauncherToOutputDirectory(string strOutputExe)
+        {
+            string launcherPath = LauncherPath;
+            string launcherSourceFile = System.IO.Path.Combine(launcherPath, LAUNCHER_EXE);
+
+            if (!FileSystems.Default.FileExists(launcherSourceFile))
+            {
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", LAUNCHER_EXE, launcherPath));
+                return false;
+            }
+
+            try
+            {
+                EnsureFolderExists(Path.GetDirectoryName(strOutputExe));
+                File.Copy(launcherSourceFile, strOutputExe, true);
+                ClearReadOnlyAttribute(strOutputExe);
+            }
+            catch (Exception ex)
+            {
+                if (ex is IOException ||
+                    ex is UnauthorizedAccessException ||
+                    ex is ArgumentException ||
+                    ex is NotSupportedException)
+                {
+                    _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", launcherSourceFile, strOutputExe, ex.Message));
+                    return false;
+                }
+
+                throw;
+            }
+
+            return true;
+        }
+
+        private static void EnsureFolderExists(string strFolderPath)
+        {
+            if (!FileSystems.Default.DirectoryExists(strFolderPath))
+            {
+                Directory.CreateDirectory(strFolderPath);
+            }
+        }
+
+        private static void ClearReadOnlyAttribute(string strFileName)
+        {
+            FileAttributes attribs = File.GetAttributes(strFileName);
+            if ((attribs & FileAttributes.ReadOnly) != 0)
+            {
+                attribs &= (~FileAttributes.ReadOnly);
+                File.SetAttributes(strFileName, attribs);
+            }
+        }
+    }
+}

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
     [ComVisible(true)]
     public class LauncherBuilder
     {
-        private const string LAUNCHER_EXE = "Launcher.exe";
         private const string LAUNCHER_RESOURCENAME = "FILENAME";
         private const int LAUNCHER_RESOURCE_TABLE = 50;
 
@@ -36,6 +35,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
         public BuildResults Build(string filename, string outputPath)
         {
+            string launcherFilename = Path.GetFileName(LauncherPath);
+
             _results = new BuildResults();
 
             try
@@ -53,7 +54,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 }
 
                 // Copy setup.bin to the output directory
-                string strOutputExe = System.IO.Path.Combine(outputPath, LAUNCHER_EXE);
+                string strOutputExe = System.IO.Path.Combine(outputPath, launcherFilename);
                 if (!CopyLauncherToOutputDirectory(strOutputExe))
                 {
                     // Appropriate messages should have been stuffed into the results already
@@ -67,7 +68,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     return _results;
                 }
 
-                _results.SetKeyFile(LAUNCHER_EXE);
+                _results.SetKeyFile(launcherFilename);
                 _results.BuildSucceeded();
             }
             catch (Exception ex)
@@ -80,19 +81,16 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
         private bool CopyLauncherToOutputDirectory(string strOutputExe)
         {
-            string launcherPath = LauncherPath;
-            string launcherSourceFile = System.IO.Path.Combine(launcherPath, LAUNCHER_EXE);
-
-            if (!FileSystems.Default.FileExists(launcherSourceFile))
+            if (!FileSystems.Default.FileExists(LauncherPath))
             {
-                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", LAUNCHER_EXE, launcherPath));
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", LauncherPath));
                 return false;
             }
 
             try
             {
                 EnsureFolderExists(Path.GetDirectoryName(strOutputExe));
-                File.Copy(launcherSourceFile, strOutputExe, true);
+                File.Copy(LauncherPath, strOutputExe, true);
                 ClearReadOnlyAttribute(strOutputExe);
             }
             catch (Exception ex)
@@ -102,7 +100,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     ex is ArgumentException ||
                     ex is NotSupportedException)
                 {
-                    _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", launcherSourceFile, strOutputExe, ex.Message));
+                    _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", LauncherPath, strOutputExe, ex.Message));
                     return false;
                 }
 

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
     /// <summary>
     /// Adds Launcher and updates its resource
     /// </summary>
-    [ComVisible(true)]
     public class LauncherBuilder
     {
         private const string LAUNCHER_RESOURCENAME = "FILENAME";

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -93,18 +93,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 File.Copy(LauncherPath, strOutputExe, true);
                 ClearReadOnlyAttribute(strOutputExe);
             }
-            catch (Exception ex)
-            {
-                if (ex is IOException ||
+            catch (Exception ex) when (ex is IOException ||
                     ex is UnauthorizedAccessException ||
                     ex is ArgumentException ||
                     ex is NotSupportedException)
-                {
-                    _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", LauncherPath, strOutputExe, ex.Message));
-                    return false;
-                }
-
-                throw;
+            {
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", LauncherPath, strOutputExe, ex.Message));
+                return false;
             }
 
             return true;

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
+using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Tasks.Deployment.Bootstrapper;
 
@@ -93,10 +94,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 File.Copy(LauncherPath, strOutputExe, true);
                 ClearReadOnlyAttribute(strOutputExe);
             }
-            catch (Exception ex) when (ex is IOException ||
-                    ex is UnauthorizedAccessException ||
-                    ex is ArgumentException ||
-                    ex is NotSupportedException)
+            catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
             {
                 _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", LauncherPath, strOutputExe, ex.Message));
                 return false;

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -428,6 +428,9 @@
     <Compile Include="GenerateDeploymentManifest.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="GenerateLauncher.cs" Condition="'$(MonoBuild)' != 'true'">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="GenerateManifestBase.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -613,9 +616,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="GenerateBootstrapper.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="GenerateLauncher.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="GenerateTrustInfo.cs" Condition="'$(MonoBuild)' != 'true'">

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -615,6 +615,9 @@
     <Compile Include="GenerateBootstrapper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="GenerateLauncher.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="GenerateTrustInfo.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -416,6 +416,9 @@
     <Compile Include="FindInList.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="FormatUrl.cs" Condition="'$(MonoBuild)' != 'true'">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="FormatVersion.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -612,9 +615,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="FindInvalidProjectReferences.cs" />
-    <Compile Include="FormatUrl.cs" Condition="'$(MonoBuild)' != 'true'">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="GenerateBootstrapper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3970,7 +3970,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Name="_DeploymentGenerateLauncher"
       Condition="'$(GenerateClickOnceManifests)'=='true' and '$(_DeploymentLauncherBased)' == 'true'">
 
-    <-- 
+    <!-- 
       If apphost based built EXE is found, use that as the Launcher.exe's entry point otherwise
       use the built DLL as the entry point
     -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3918,7 +3918,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         MaxTargetPath="$(MaxTargetPath)"
         OutputManifest="@(ApplicationManifest)"
         OSVersion="$(OSVersion)"
-        Platform="$(PlatformTarget)"
+        Platform="$(_DeploymentPlatformTarget)"
         Product="$(ProductName)"
         Publisher="$(PublisherName)"
         RequiresMinimumFramework35SP1="$(_DeploymentRequiresMinimumFramework35SP1)"
@@ -4129,6 +4129,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_DeploymentManifestType>ClickOnce</_DeploymentManifestType>
     </PropertyGroup>
 
+    <!--
+      Manifest platform should always be MSIL for Launcher-based deployments, as the Launcher is MSIL.
+      Do not set _DeploymentPlatformTarget property in Launcher case - this is interpreted as MSIL,
+      by GenerateApplicationManifest and GenerateDeploymentManifest tasks.
+      Otherwise, set it to PlatformTarget.
+    -->
+    <PropertyGroup>
+      <_DeploymentPlatformTarget Condition="'$(_DeploymentLauncherBased)' != 'true'">$(PlatformTarget)</_DeploymentPlatformTarget>
+    </PropertyGroup>
+
     <!-- Obtain manifest version from ApplicationVersion and ApplicationRevision properties -->
     <FormatVersion Version="$(ApplicationVersion)" Revision="$(ApplicationRevision)">
       <Output TaskParameter="OutputVersion" PropertyName="_DeploymentManifestVersion"/>
@@ -4210,7 +4220,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           MaxTargetPath="$(MaxTargetPath)"
           MinimumRequiredVersion="$(_DeploymentBuiltMinimumRequiredVersion)"
           OutputManifest="@(DeployManifest)"
-          Platform="$(PlatformTarget)"
+          Platform="$(_DeploymentPlatformTarget)"
           Product="$(ProductName)"
           Publisher="$(PublisherName)"
           SuiteName="$(SuiteName)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3865,6 +3865,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target
       Name="GenerateApplicationManifest"
       DependsOnTargets="
+            _DeploymentSetClickOnceVersions;
             _DeploymentGenerateLauncher;
             _DeploymentComputeNativeManifestInfo;
             _DeploymentComputeClickOnceManifestInfo;
@@ -3925,7 +3926,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         TargetCulture="$(TargetCulture)"
         TargetFrameworkSubset="$(TargetFrameworkSubset)"
         TargetFrameworkProfile="$(TargetFrameworkProfile)"
-        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        TargetFrameworkVersion="$(_DeploymentManifestTargetFrameworkVersion)"
         TrustInfoFile="@(_DeploymentIntermediateTrustInfoFile)"
         UseApplicationTrust="$(UseApplicationTrust)">
 
@@ -3941,6 +3942,24 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ============================================================
+                                        _DeploymentSetClickOnceVersions
+
+    Sets ClickOnce versions
+    ============================================================
+    -->
+  <Target
+      Name="_DeploymentSetClickOnceVersions"
+      Condition="'$(GenerateClickOnceManifests)'=='true'">
+
+    <PropertyGroup>
+      <_DeploymentManifestTargetFrameworkMoniker>$(TargetFrameworkMoniker)</_DeploymentManifestTargetFrameworkMoniker>
+      <_DeploymentManifestTargetFrameworkVersion>$(TargetFrameworkVersion)</_DeploymentManifestTargetFrameworkVersion>
+    </PropertyGroup>
+
+  </Target>
+
+  <!--
+    ============================================================
                                         _DeploymentGenerateLauncher
 
     Generates Launcher if needed
@@ -3950,13 +3969,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Name="_DeploymentGenerateLauncher"
       Condition="'$(GenerateClickOnceManifests)'=='true' and '$(_DeploymentLauncherBased)' == 'true'">
 
-    <!-- Create list of items for manifest generation -->
+    <!-- Generates Launcher and obtains its Framework version and moniker -->
     <GenerateLauncher
         EntryPoint="@(_DeploymentManifestEntryPoint)"
         OutputPath="$(IntermediateOutputPath)"
         VisualStudioVersion="$(VisualStudioVersion)">
 
       <Output TaskParameter="OutputEntryPoint" ItemName="_DeploymentManifestLauncherEntryPoint"/>
+      <Output TaskParameter="FrameworkName" PropertyName="_DeploymentManifestTargetFrameworkMoniker"/>
+      <Output TaskParameter="FrameworkVersion" PropertyName="_DeploymentManifestTargetFrameworkVersion"/>
 
     </GenerateLauncher>
 
@@ -4173,8 +4194,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           SuiteName="$(SuiteName)"
           SupportUrl="$(_DeploymentFormattedSupportUrl)"
           TargetCulture="$(TargetCulture)"
-          TargetFrameworkVersion="$(TargetFrameworkVersion)"
-          TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+          TargetFrameworkVersion="$(_DeploymentManifestTargetFrameworkVersion)"
+          TargetFrameworkMoniker="$(_DeploymentManifestTargetFrameworkMoniker)"
           TrustUrlParameters="$(TrustUrlParameters)"
           UpdateEnabled="$(UpdateEnabled)"
           UpdateInterval="$(_DeploymentBuiltUpdateInterval)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -256,6 +256,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DeploymentBuiltUpdateIntervalUnits Condition="'$(UpdatePeriodically)'!='true'">Days</_DeploymentBuiltUpdateIntervalUnits>
     <_DeploymentBuiltMinimumRequiredVersion Condition="'$(UpdateRequired)'=='true' and '$(Install)'=='true'">$(MinimumRequiredVersion)</_DeploymentBuiltMinimumRequiredVersion>
 
+    <_DeploymentLauncherBased Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</_DeploymentLauncherBased>
+
     <MaxTargetPath Condition="'$(MaxTargetPath)'==''">100</MaxTargetPath>
   </PropertyGroup>
 
@@ -3863,6 +3865,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target
       Name="GenerateApplicationManifest"
       DependsOnTargets="
+            _DeploymentGenerateLauncher;
             _DeploymentComputeNativeManifestInfo;
             _DeploymentComputeClickOnceManifestInfo;
             ResolveComReferences;
@@ -3908,6 +3911,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         IconFile="@(_DeploymentManifestIconFile)"
         InputManifest="$(_DeploymentBaseManifest)"
         IsolatedComReferences="@(ResolvedIsolatedComModules)"
+        LauncherBasedDeployment="$(_DeploymentLauncherBased)"
         ManifestType="$(_DeploymentManifestType)"
         MaxTargetPath="$(MaxTargetPath)"
         OutputManifest="@(ApplicationManifest)"
@@ -3933,6 +3937,37 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_DeploymentCopyApplicationManifest>true</_DeploymentCopyApplicationManifest>
     </PropertyGroup>
 
+  </Target>
+
+  <!--
+    ============================================================
+                                        _DeploymentGenerateLauncher
+
+    Generates Launcher if needed
+    ============================================================
+    -->
+  <Target
+      Name="_DeploymentGenerateLauncher"
+      Condition="'$(GenerateClickOnceManifests)'=='true' and '$(_DeploymentLauncherBased)' == 'true'">
+
+    <!-- Create list of items for manifest generation -->
+    <GenerateLauncher
+        EntryPoint="@(_DeploymentManifestEntryPoint)"
+        OutputPath="$(IntermediateOutputPath)"
+        VisualStudioVersion="$(VisualStudioVersion)">
+
+      <Output TaskParameter="OutputEntryPoint" ItemName="_DeploymentManifestLauncherEntryPoint"/>
+
+    </GenerateLauncher>
+
+    <!--
+      Replace entry-point with Launcher and move original project's entry-point to content group.
+    -->
+    <ItemGroup>
+      <ContentWithTargetPath Include="@(_DeploymentManifestEntryPoint)"/>
+      <_DeploymentManifestEntryPoint Remove="@(_DeploymentManifestEntryPoint)"/>
+      <_DeploymentManifestEntryPoint Include="@(_DeploymentManifestLauncherEntryPoint)"/>
+    </ItemGroup>
   </Target>
 
   <!--
@@ -4127,6 +4162,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           EntryPoint="@(_DeploymentResolvedDeploymentManifestEntryPoint)"
           ErrorReportUrl="$(_DeploymentFormattedErrorReportUrl)"
           Install="$(Install)"
+          LauncherBasedDeployment="$(_DeploymentLauncherBased)"
           MapFileExtensions="$(MapFileExtensions)"
           MaxTargetPath="$(MaxTargetPath)"
           MinimumRequiredVersion="$(_DeploymentBuiltMinimumRequiredVersion)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5629,7 +5629,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Update entry point path in deploy manifest -->
     <UpdateManifest
         ApplicationPath="$(_DeploymentApplicationFolderName)\$(_DeploymentTargetApplicationManifestFileName)"
-        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        TargetFrameworkVersion="$(_DeploymentManifestTargetFrameworkVersion)"
         ApplicationManifest="$(_DeploymentApplicationDir)$(_DeploymentTargetApplicationManifestFileName)"
         InputManifest="$(OutDir)$(TargetDeployManifestFileName)"
         OutputManifest="$(PublishDir)$(TargetDeployManifestFileName)">

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4093,7 +4093,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SigningManifests="$(SignManifests)"
         EntryPoint="@(_DeploymentClickOnceApplicationExecutable)"
         ExtraFiles="@(_DebugSymbolsIntermediatePath);$(IntermediateOutputPath)$(TargetName).xml;@(_ReferenceRelatedPaths)"
-        Files="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath)"
         Files="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce)"
         ManagedAssemblies="@(_ManifestManagedReferences)"
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3829,6 +3829,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <ResolveManifestFiles
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
         SigningManifests="$(SignManifests)"
         DeploymentManifestEntryPoint="@(ApplicationManifest)"
         PublishFiles="@(_DeploymentPublishFileOfTypeManifestEntryPoint)">
@@ -3981,6 +3982,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     </GenerateLauncher>
 
+    <!-- Sign Launcher EXE -->
+    <SignFile
+        CertificateThumbprint="$(_DeploymentResolvedManifestCertificateThumbprint)"
+        TimestampUrl="$(ManifestTimestampUrl)"
+        SigningTarget="@(_DeploymentManifestLauncherEntryPoint)"
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        Condition="'$(_DeploymentSignClickOnceManifests)'=='true'" />
+
     <!--
       Replace entry-point with Launcher and move original project's entry-point to content group.
     -->
@@ -4080,10 +4089,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Create list of items for manifest generation -->
     <ResolveManifestFiles
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
         SigningManifests="$(SignManifests)"
         EntryPoint="@(_DeploymentClickOnceApplicationExecutable)"
         ExtraFiles="@(_DebugSymbolsIntermediatePath);$(IntermediateOutputPath)$(TargetName).xml;@(_ReferenceRelatedPaths)"
         Files="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath)"
+        Files="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce)"
         ManagedAssemblies="@(_ManifestManagedReferences)"
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"
         PublishFiles="@(PublishFile)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4043,6 +4043,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
+  <PropertyGroup>
+    <DeploymentComputeClickOnceManifestInfoDependsOn>
+      CleanPublishFolder;
+      _DeploymentGenerateTrustInfo
+      $(DeploymentComputeClickOnceManifestInfoDependsOn)
+    </DeploymentComputeClickOnceManifestInfoDependsOn>
+  </PropertyGroup>
+
   <!--
     ============================================================
                                         _DeploymentComputeClickOnceManifestInfo
@@ -4050,12 +4058,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Compute info for  ClickOnce manifest generation
     ============================================================
     -->
+
   <Target
       Name="_DeploymentComputeClickOnceManifestInfo"
       Condition="'$(GenerateClickOnceManifests)'=='true'"
-      DependsOnTargets="
-            CleanPublishFolder;
-            _DeploymentGenerateTrustInfo">
+      DependsOnTargets="$(DeploymentComputeClickOnceManifestInfoDependsOn)">
 
     <!-- Grab just the serialization assemblies for a referenced assembly.  There may also be a symbols file in ReferenceRelatedPaths -->
     <ItemGroup>
@@ -4077,8 +4084,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
       <_DeploymentReferencePaths Include="@(_DeploymentReferencePaths);@(_CopyLocalFalseRefPathsWithExclusion)" />
+    </ItemGroup>
+
+    <!-- Include managed references in clickonce manifest only if single file publish is false -->
+    <ItemGroup Condition="'$(PublishSingleFile)' != 'true'">
       <_ManifestManagedReferences Include="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly);@(ReferenceCOMWrappersToCopyLocal)"
                                Exclude="@(_SatelliteAssemblies);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)" />
+    </ItemGroup>
+
+    <!-- Include the following files in clickonce manifest only if single file publish is false -->
+    <ItemGroup Condition="'$(PublishSingleFile)' != 'true'">
+      <ClickOnceFiles Include="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce)"/>
+    </ItemGroup>
+
+    <!-- For single file publish, we only need to include the SF EXE in the clickonce manifest -->
+    <ItemGroup Condition="'$(PublishSingleFile)' == 'true'">
+      <ClickOnceFiles Include="$(PublishedSingleFilePath)"/>
     </ItemGroup>
 
     <!-- Copy the application executable from Obj folder to app.publish folder.
@@ -4105,7 +4126,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SigningManifests="$(SignManifests)"
         EntryPoint="@(_DeploymentClickOnceApplicationExecutable)"
         ExtraFiles="@(_DebugSymbolsIntermediatePath);$(IntermediateOutputPath)$(TargetName).xml;@(_ReferenceRelatedPaths)"
-        Files="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce)"
+        Files="@(ClickOnceFiles)"
         ManagedAssemblies="@(_ManifestManagedReferences)"
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"
         PublishFiles="@(PublishFile)"
@@ -5553,6 +5574,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Copy files to publish folder -->
     <Copy
+        Condition="'$(PublishSingleFile)' != 'true'"
         SourceFiles=
                 "@(_ApplicationManifestFinal);
                 @(_DeploymentResolvedManifestEntryPoint);
@@ -5583,9 +5605,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
         UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
         UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)"
-        Condition="'%(_DeploymentManifestDependencies.DependencyType)'=='Install'"/>
+        Condition="'$(PublishSingleFile)' != 'true' and '%(_DeploymentManifestDependencies.DependencyType)'=='Install'"/>
 
     <Copy
+        Condition="'$(PublishSingleFile)' != 'true'"
         SourceFiles="@(_ReferenceScatterPaths)"
         DestinationFiles="@(_ReferenceScatterPaths->'$(_DeploymentApplicationDir)%(Filename)%(Extension)$(_DeploymentFileMappingExtension)')"
         SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
@@ -5595,6 +5618,28 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
         UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)"
             />
+
+    <ItemGroup Condition="'$(PublishSingleFile)' == 'true'">
+      <PublishedSingleFileToBeCopied Include="$(PublishedSingleFilePath)" TargetPath="$(PublishedSingleFileName)"/>
+    </ItemGroup>
+
+    <!-- For single-file publish case, we need to only copy the clickonce manifest, manifest entry point (launcher) and the SF EXE -->
+    <Copy
+        Condition="'$(PublishSingleFile)' == 'true'"
+        SourceFiles=
+                "@(_ApplicationManifestFinal);
+                 @(_DeploymentResolvedManifestEntryPoint);
+                 @(PublishedSingleFileToBeCopied);"
+        DestinationFiles=
+                "@(_ApplicationManifestFinal->'$(_DeploymentApplicationDir)%(TargetPath)');
+                 @(_DeploymentManifestEntryPoint->'$(_DeploymentApplicationDir)%(TargetPath)$(_DeploymentFileMappingExtension)');
+                 @(PublishedSingleFileToBeCopied->'$(_DeploymentApplicationDir)%(TargetPath)$(_DeploymentFileMappingExtension)')"
+        SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+        OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+        Retries="$(CopyRetryCount)"
+        UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
+        UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)"
+        RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"/>
 
     <FormatUrl InputUrl="$(_DeploymentApplicationUrl)">
       <Output TaskParameter="OutputUrl" PropertyName="_DeploymentFormattedApplicationUrl"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3970,9 +3970,21 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Name="_DeploymentGenerateLauncher"
       Condition="'$(GenerateClickOnceManifests)'=='true' and '$(_DeploymentLauncherBased)' == 'true'">
 
+    <-- 
+      If apphost based built EXE is found, use that as the Launcher.exe's entry point otherwise
+      use the built DLL as the entry point
+    -->
+    <ItemGroup Condition="'$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true' and exists('$(AppHostIntermediatePath)')">
+      <EntryPointForLauncher Include="$(AppHostIntermediatePath)"/>
+      <ContentWithTargetPath Include="@(EntryPointForLauncher)"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(EntryPointForLauncher)'==''">
+      <EntryPointForLauncher Include="$(_DeploymentManifestEntryPoint)"/>
+    </ItemGroup>
+
     <!-- Generates Launcher and obtains its Framework version and moniker -->
     <GenerateLauncher
-        EntryPoint="@(_DeploymentManifestEntryPoint)"
+        EntryPoint="@(EntryPointForLauncher)"
         OutputPath="$(IntermediateOutputPath)"
         VisualStudioVersion="$(VisualStudioVersion)">
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3989,10 +3989,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         VisualStudioVersion="$(VisualStudioVersion)">
 
       <Output TaskParameter="OutputEntryPoint" ItemName="_DeploymentManifestLauncherEntryPoint"/>
-      <Output TaskParameter="FrameworkName" PropertyName="_DeploymentManifestTargetFrameworkMoniker"/>
-      <Output TaskParameter="FrameworkVersion" PropertyName="_DeploymentManifestTargetFrameworkVersion"/>
-
     </GenerateLauncher>
+
+    <!--
+      .NET Core ClickOnce deployments use Launcher, which targets .NET FX 4.5 as the minimum
+      supported ClickOnce runtime version on target user's machine.
+
+      TargetFramework Verion and Moniker properties are used in Deployment manifest generation
+      task to set compatibleFrameworks element, which needs to match Launcher's target version.
+
+      Version can be overriden with DeploymentManifestTargetFrameworkVersionOverride property.
+    -->
+    <PropertyGroup>
+      <_DeploymentManifestTargetFrameworkVersion Condition="'$(DeploymentManifestTargetFrameworkVersionOverride)' == ''">v4.5</_DeploymentManifestTargetFrameworkVersion>
+      <_DeploymentManifestTargetFrameworkVersion Condition="'$(DeploymentManifestTargetFrameworkVersionOverride)' != ''">$(DeploymentManifestTargetFrameworkVersionOverride)</_DeploymentManifestTargetFrameworkVersion>
+      <_DeploymentManifestTargetFrameworkMoniker>.NETFramework,Version=$(_DeploymentManifestTargetFrameworkVersion)</_DeploymentManifestTargetFrameworkMoniker>
+    </PropertyGroup>
 
     <!-- Sign Launcher EXE -->
     <SignFile

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -116,6 +116,7 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateBindingRedirects"              AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateBootstrapper"                  AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateDeploymentManifest"            AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.GenerateLauncher"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
 
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateResource"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateResource"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Runtime="CLR4" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' == ''" />

--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Build.Tasks
         private CultureInfo _targetCulture;
         private bool _includeAllSatellites;
 
+        private string _targetFrameworkIdentifier;
         private string _targetFrameworkVersion;
         // if signing manifests is on and not all app files are included, then the project can't be published.
         private bool _canPublish;
@@ -120,6 +121,19 @@ namespace Microsoft.Build.Tasks
                 return _targetFrameworkVersion;
             }
             set => _targetFrameworkVersion = value;
+        }
+
+        public string TargetFrameworkIdentifier
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_targetFrameworkIdentifier))
+                {
+                    return Constants.DotNetFrameworkIdentifier;
+                }
+                return _targetFrameworkIdentifier;
+            }
+            set => _targetFrameworkIdentifier = value;
         }
 
         #endregion
@@ -630,7 +644,14 @@ namespace Microsoft.Build.Tasks
                 return true;
             }
 
-            if (identity?.IsInFramework(Constants.DotNetFrameworkIdentifier, TargetFrameworkVersion) == true)
+            if (String.Equals(TargetFrameworkIdentifier, Constants.DotNetCoreAppIdentifier, StringComparison.InvariantCultureIgnoreCase))
+            {
+                if (identity?.IsInFramework(Constants.DotNetCoreIdentifier, null) == true)
+                {
+                    return true;
+                }
+            }
+            else if (identity?.IsInFramework(Constants.DotNetFrameworkIdentifier, TargetFrameworkVersion) == true)
             {
                 return true;
             }

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2832,6 +2832,31 @@
     <value>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</value>
     <comment>{StrBegin="MSB3954: "}</comment>
   </data>
+
+  <!--
+        MSB3961 - MSB3970   Task: GenerateLauncher
+        If this bucket overflows, pls. contact 'vsppbdev'.
+  -->
+  <data name="GenerateLauncher.CopyError">
+    <value>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</value>
+    <comment>{StrBegin="MSB3961: "}</comment>
+  </data>
+  <data name="GenerateLauncher.General">
+    <value>MSB3962: An error occurred generating a launcher: {0}</value>
+    <comment>{StrBegin="MSB3962: "}</comment>
+  </data>
+  <data name="GenerateLauncher.InvalidInput">
+    <value>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</value>
+    <comment>{StrBegin="MSB3963: "}</comment>
+  </data>
+  <data name="GenerateLauncher.MissingLauncherExe">
+    <value>MSB3964: Could not find required file '{0}' in '{1}'.</value>
+    <comment>{StrBegin="MSB3964: "}</comment>
+  </data>
+  <data name="GenerateLauncher.NoOutputPath">
+    <value>MSB3965: No output path specified in build settings.</value>
+    <comment>{StrBegin="MSB3965: "}</comment>
+  </data>
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 
@@ -2915,6 +2940,7 @@
             MSB3931 - MSB3940   Task: Unzip
             MSB3941 - MSB3950   Task: ZipDirectory
             MSB3951 - MSB3960   Task: VerifyFileHash
+            MSB3961 - MSB3970   Task: GenerateLauncher
 
             MSB4000 - MSB4200   Portable targets & tasks (vsproject\flavors\portable\msbuild)
             MSB9000 - MSB9900   MSBuild targets files (C++)

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2850,7 +2850,7 @@
     <comment>{StrBegin="MSB3963: "}</comment>
   </data>
   <data name="GenerateLauncher.MissingLauncherExe">
-    <value>MSB3964: Could not find required file '{0}' in '{1}'.</value>
+    <value>MSB3964: Could not find required file '{0}'.</value>
     <comment>{StrBegin="MSB3964: "}</comment>
   </data>
   <data name="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2857,6 +2857,10 @@
     <value>MSB3965: No output path specified in build settings.</value>
     <comment>{StrBegin="MSB3965: "}</comment>
   </data>
+  <data name="GenerateLauncher.EmptyEntryPoint">
+    <value>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</value>
+    <comment>{StrBegin="MSB3965: "}</comment>
+  </data>
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: Upozornění ověření Xml v souboru {0}: {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: Odkaz {0} nepovoluje částečně důvěryhodné volající.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: XML-Validierungswarnung in der Datei "{0}": {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: Der Verweis "{0}" lässt Aufrufer, die nur teilweise vertrauenswürdig sind, nicht zu.</target>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -819,6 +819,31 @@
         <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -835,8 +835,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -824,6 +824,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: Advertencia de validación XML en el archivo '{0}': {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: La referencia '{0}' no permite llamadores de confianza parcial.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: Avertissement de validation XML dans le fichier '{0}' : {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: La référence '{0}' n'autorise pas les appelants dont le niveau de confiance n'est pas suffisant.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: avviso di convalida XML nel file '{0}': {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: il riferimento '{0}' non consente chiamanti parzialmente attendibili.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: ファイル '{0}' での XML 検証警告です: {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: 参照 '{0}' は部分的に信頼された呼び出し側を許可しません。</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: '{0}' 파일에서 XML 유효성 검사 경고가 발생했습니다. {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: '{0}' 참조에는 부분적으로 신뢰할 수 있는 호출자를 사용할 수 없습니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: Ostrzeżenie walidacji kodu xml w pliku '{0}': {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: Odwołanie '{0}' nie zezwala na dostęp częściowo zaufanych wywołań.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: Aviso de validação de XML no arquivo "{0}": {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: A referência "{0}" não admite chamadores parcialmente confiáveis.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: Предупреждение проверки Xml в файле "{0}": {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: Ссылка "{0}" не допускает частично безопасные вызывающие стороны.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: '{0}' dosyasında Xml Doğrulaması uyarısı oluştu: {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: '{0}' başvurusu, kısmen güvenilen çağıranlara izin vermiyor.</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: 文件“{0}”中的 XML 验证警告: {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: 引用“{0}”不允许部分信任的调用方。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -779,6 +779,11 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
+        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
+        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -790,8 +790,8 @@
         <note>{StrBegin="MSB3963: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.MissingLauncherExe">
-        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
-        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <source>MSB3964: Could not find required file '{0}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}'.</target>
         <note>{StrBegin="MSB3964: "}</note>
       </trans-unit>
       <trans-unit id="GenerateLauncher.NoOutputPath">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -774,6 +774,31 @@
         <target state="translated">MSB3160: 檔案 '{0}' 中發生 XML 驗證警告: {1}</target>
         <note>{StrBegin="MSB3160: "}</note>
       </trans-unit>
+      <trans-unit id="GenerateLauncher.CopyError">
+        <source>MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3961: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.General">
+        <source>MSB3962: An error occurred generating a launcher: {0}</source>
+        <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>
+        <note>{StrBegin="MSB3962: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.InvalidInput">
+        <source>MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</source>
+        <target state="new">MSB3963: Not enough data was provided to generate a launcher. Please provide a value for: 'EntryPoint'.</target>
+        <note>{StrBegin="MSB3963: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.MissingLauncherExe">
+        <source>MSB3964: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3964: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3964: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateLauncher.NoOutputPath">
+        <source>MSB3965: No output path specified in build settings.</source>
+        <target state="new">MSB3965: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3965: "}</note>
+      </trans-unit>
       <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
         <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
         <target state="translated">MSB3177: 參考 '{0}' 不允許部分信任的呼叫端。</target>


### PR DESCRIPTION
Enables manifest generation for .NET (Core) applications.

.NET (Core) deployments in ClickOnce require a .NET FX based Launcher binary that activates Core application.

The rest of the code deals with setting proper properties and item groups to collect .NET Core files for deployment and set correct parameters for various manifest generation tasks.

For end-to-end scenarios, a change in .NET SDK is needed: https://github.com/dotnet/sdk/pull/13208

Relevant links:
ClickOnce for .NET 5 - Architecture: https://microsoft.sharepoint.com/teams/dotNETDeployment/Shared%20Documents/ClickOnce/ClickOnce%20for%20.NET%205%20%E2%80%93%20Architecture.docx?web=1