### PR TITLE
Ignore comments when parsing solution file

### DIFF
--- a/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
@@ -1068,6 +1068,60 @@ namespace Microsoft.Build.UnitTests.Construction
         }
 
         /// <summary>
+        /// Parse solution file with comments
+        /// </summary>
+        [Fact]
+        public void ParseSolutionWithComments()
+        {
+            string solutionFileContent = @"
+                    Microsoft Visual Studio Solution File, Format Version 12.00
+                    # Visual Studio Version 16
+                    VisualStudioVersion = 16.0.29123.89
+                    MinimumVisualStudioVersion = 10.0.40219.1
+                    # Comment 1
+                    Project('{9A19103F-16F7-4668-BE54-9A1E7A4F7556}') = 'SlnCommentTest', 'SlnCommentTest.csproj', '{00000000-0000-0000-FFFF-FFFFFFFFFFFF}'
+	                    # Comment 2
+                    EndProject
+                    Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'Solution Items', 'Solution Items', '{054DED3B-B890-4652-B449-839F581E5D86}'
+	                    # Comment 3
+	                    ProjectSection(SolutionItems) = preProject
+		                    # Comment 4
+		                    SlnFile.txt = SlnFile.txt
+	                    EndProjectSection
+	                    # Comment 5
+                    EndProject
+                    # Comment 6
+                    Global
+	                    # Comment 7
+	                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		                    # Comment 8
+		                    Debug|Any CPU = Debug|Any CPU
+		                    Release|Any CPU = Release|Any CPU
+	                    EndGlobalSection
+	                    # Comment 9
+	                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		                    # Comment 10
+		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Release|Any CPU.Build.0 = Release|Any CPU
+	                    EndGlobalSection
+	                    GlobalSection(SolutionProperties) = preSolution
+		                    # Comment 11
+		                    HideSolutionNode = FALSE
+	                    EndGlobalSection
+	                    GlobalSection(ExtensibilityGlobals) = postSolution
+		                    # Comment 12
+		                    SolutionGuid = {FFFFFFFF-FFFF-FFFF-0000-000000000000}
+	                    EndGlobalSection
+                    EndGlobal
+                    # Comment 13
+                    ";
+
+            ParseSolutionHelper(solutionFileContent);
+        }
+
+        /// <summary>
         /// Helper method to create a SolutionFile object, and call it to parse the SLN file
         /// represented by the string contents passed in.
         /// </summary>

--- a/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Exceptions;
 using Shouldly;
 using Xunit;
+using System.Text;
 
 namespace Microsoft.Build.UnitTests.Construction
 {
@@ -1073,52 +1074,51 @@ namespace Microsoft.Build.UnitTests.Construction
         [Fact]
         public void ParseSolutionWithComments()
         {
-            string solutionFileContent = @"
+            const string solutionFileContent = @"
                     Microsoft Visual Studio Solution File, Format Version 12.00
                     # Visual Studio Version 16
                     VisualStudioVersion = 16.0.29123.89
                     MinimumVisualStudioVersion = 10.0.40219.1
-                    # Comment 1
                     Project('{9A19103F-16F7-4668-BE54-9A1E7A4F7556}') = 'SlnCommentTest', 'SlnCommentTest.csproj', '{00000000-0000-0000-FFFF-FFFFFFFFFFFF}'
-	                    # Comment 2
                     EndProject
                     Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'Solution Items', 'Solution Items', '{054DED3B-B890-4652-B449-839F581E5D86}'
-	                    # Comment 3
 	                    ProjectSection(SolutionItems) = preProject
-		                    # Comment 4
 		                    SlnFile.txt = SlnFile.txt
 	                    EndProjectSection
-	                    # Comment 5
                     EndProject
-                    # Comment 6
                     Global
-	                    # Comment 7
 	                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		                    # Comment 8
 		                    Debug|Any CPU = Debug|Any CPU
 		                    Release|Any CPU = Release|Any CPU
 	                    EndGlobalSection
-	                    # Comment 9
 	                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		                    # Comment 10
 		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Release|Any CPU.Build.0 = Release|Any CPU
 	                    EndGlobalSection
 	                    GlobalSection(SolutionProperties) = preSolution
-		                    # Comment 11
 		                    HideSolutionNode = FALSE
 	                    EndGlobalSection
 	                    GlobalSection(ExtensibilityGlobals) = postSolution
-		                    # Comment 12
 		                    SolutionGuid = {FFFFFFFF-FFFF-FFFF-0000-000000000000}
 	                    EndGlobalSection
                     EndGlobal
-                    # Comment 13
                     ";
 
-            ParseSolutionHelper(solutionFileContent);
+            StringBuilder stringBuilder = new StringBuilder();
+
+            // Put comment between all lines
+            const string comment = "\t# comment";
+            string[] lines = solutionFileContent.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                stringBuilder.AppendLine(comment);
+                stringBuilder.AppendLine(lines[i]);
+            }
+            stringBuilder.AppendLine(comment);
+
+            Should.NotThrow(() => ParseSolutionHelper(stringBuilder.ToString()));
         }
 
         /// <summary>

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Build.Construction
         private const string solutionFolderGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
         private const string sharedProjectGuid = "{D954291E-2A0B-460D-934E-DC6B0785DB48}";
 
+        private const char CommentStartChar = '#';
         #endregion
         #region Member data
         private string _solutionFile;                 // Could be absolute or relative path to the .SLN file.
@@ -1328,7 +1329,8 @@ namespace Microsoft.Build.Construction
                     break;
                 }
 
-                if (String.IsNullOrWhiteSpace(str))
+                // Ignore empty line or comment
+                if (String.IsNullOrWhiteSpace(str) || str[0] == CommentStartChar)
                 {
                     continue;
                 }
@@ -1375,7 +1377,8 @@ namespace Microsoft.Build.Construction
                     break;
                 }
 
-                if (String.IsNullOrWhiteSpace(str))
+                // Ignore empty line or comment
+                if (String.IsNullOrWhiteSpace(str) || str[0] == CommentStartChar)
                 {
                     continue;
                 }
@@ -1440,7 +1443,8 @@ namespace Microsoft.Build.Construction
                     break;
                 }
 
-                if (String.IsNullOrWhiteSpace(str))
+                // Ignore empty line or comment
+                if (String.IsNullOrWhiteSpace(str) || str[0] == CommentStartChar)
                 {
                     continue;
                 }


### PR DESCRIPTION
This is fairly simple PR which fixes #4328.

One thing which may seem dangerous is check for start of line with `#`. I am accessing it by index, but I an be sure that I will not get `NullReferenceException` or `IndexOutOfRangeException`, because it is not null (previous if) and it is not empty, because of previous check in if.
