### PR TITLE
Add code analysis properties to project XSD

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1158,6 +1158,18 @@ elementFormDefault="qualified">
     <xs:element name="MinimumVisualStudioVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="AdditionalFileItemNames" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="AllowUnsafeBlocks" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="AnalysisMode" substitutionGroup="msb:Property">
+      <xs:annotation>
+        <xs:documentation><!-- _locID_text="AnalysisMode" _locComment="" -->Customizes the set of rules that are enabled by default.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="Default" />
+          <xs:enumeration value="AllEnabledByDefault" />
+          <xs:enumeration value="AllDisabledByDefault" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
     <xs:element name="AppConfigForCompiler" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="ApplicationIcon" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="ApplicationRevision" type="msb:StringPropertyType" substitutionGroup="msb:Property">
@@ -1501,6 +1513,11 @@ elementFormDefault="qualified">
     <xs:element name="EnableSQLServerDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="EnableSecurityDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="EnableUnmanagedDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="EnforceCodeStyleInBuild" type="msb:boolean" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="EnforceCodeStyleInBuild" _locComment="" -->Controls whether code style analysis rules configured as warnings or errors should execute on build and report violations. The default is false.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="ErrorLog" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="ErrorReport" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="EmbedManifest" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1728,6 +1728,21 @@ elementFormDefault="qualified">
       </xs:annotation>
     </xs:element>
     <xs:element name="ResponseFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="RunAnalyzers" type="msb:boolean" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="RunAnalyzers" _locComment="" -->Disables analyzers at both build and design time. This property takes precedence over RunAnalyzersDuringBuild and RunAnalyzersDuringLiveAnalysis. Default is true.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="RunAnalyzersDuringBuild" type="msb:boolean" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="RunAnalyzersDuringBuild" _locComment="" -->Controls whether analyzers run at build time. Default is true.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="RunAnalyzersDuringLiveAnalysis" type="msb:boolean" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="RunAnalyzersDuringLiveAnalysis" _locComment="" -->Controls whether analyzers analyze code live at design time. Default is true.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="RootNamespace" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="RuntimeIdentifier" type="msb:StringPropertyType" substitutionGroup="msb:Property">
       <xs:annotation>


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/6600

Adds:
- `AnalysisMode`
- `EnforceCodeStyleInBuild`