### PR TITLE
Fix incorrect and confusing slnf error Fixes #5712

### DIFF
--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -555,7 +555,7 @@ namespace Microsoft.Build.Construction
                         ProjectFileErrorUtilities.ThrowInvalidProjectFile
                         (
                             "SubCategoryForSolutionParsingErrors",
-                            new BuildEventFileInfo(project),
+                            new BuildEventFileInfo(FileUtilities.GetFullPath(project, Path.GetDirectoryName(_solutionFile))),
                             "SolutionFilterFilterContainsProjectNotInSolution",
                             _solutionFilterFile,
                             project,

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Build.Construction
         #endregion
         #region Member data
         private string _solutionFile;                 // Could be absolute or relative path to the .SLN file.
+        private string _solutionFilterFile;          // Could be absolute or relative path to the .SLNF file.
         private HashSet<string> _solutionFilter;     // The project files to include in loading the solution.
         private bool _parsingForConversionOnly;      // Are we parsing this solution to get project reference data during
                                                      // conversion, or in preparation for actually building the solution?
@@ -364,6 +365,7 @@ namespace Microsoft.Build.Construction
 
         private void ParseSolutionFilter(string solutionFilterFile)
         {
+            _solutionFilterFile = solutionFilterFile;
             try
             {
                 _solutionFile = ParseSolutionFromSolutionFilter(solutionFilterFile, out JsonElement solution);
@@ -555,7 +557,7 @@ namespace Microsoft.Build.Construction
                             "SubCategoryForSolutionParsingErrors",
                             new BuildEventFileInfo(project),
                             "SolutionFilterFilterContainsProjectNotInSolution",
-                            _solutionFilter,
+                            _solutionFilterFile,
                             project,
                             _solutionFile
                         );


### PR DESCRIPTION
The error displayed a hashset instead of the path to the filter file used to create the hash set and extended a relative path into a full path using the current working directory instead of the directory containing the .sln.