### PR TITLE
Prioritize building .sln if a .sln and .slnf are in the same folder Fixes #5739

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1259,7 +1259,23 @@ namespace Microsoft.Build.UnitTests
             logContents.ShouldContain(expected, () => logContents);
         }
 
-#region IgnoreProjectExtensionTests
+        /// <summary>
+        /// Test the default file to build in cases involving at least one solution filter file.
+        /// </summary>
+        [Theory]
+        [InlineData(new string[] { "my.proj", "my.sln", "my.slnf" }, "my.sln")]
+        [InlineData(new string[] { "abc.proj", "bcd.csproj", "slnf.slnf", "other.slnf" }, "abc.proj")]
+        [InlineData(new string[] { "abc.sln", "slnf.slnf", "abc.slnf" }, "abc.sln")]
+        [InlineData(new string[] { "abc.csproj", "abc.slnf", "not.slnf" }, "abc.csproj")]
+        [InlineData(new string[] { "abc.slnf" }, "abc.slnf")]
+        public void TestDefaultBuildWithSolutionFilter(string[] projects, string answer)
+        {
+            string[] extensionsToIgnore = Array.Empty<string>();
+            IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
+            MSBuildApp.ProcessProjectSwitch(Array.Empty<string>(), extensionsToIgnore, projectHelper.GetFiles).ShouldBe(answer, StringCompareShould.IgnoreCase);
+        }
+
+        #region IgnoreProjectExtensionTests
 
         /// <summary>
         /// Test the case where the extension is a valid extension but is not a project
@@ -1285,6 +1301,7 @@ namespace Microsoft.Build.UnitTests
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
         }
+
         /// <summary>
         /// Pass a null and an empty list of project extensions to ignore, this simulates the switch not being set on the commandline
         /// </summary>
@@ -1315,6 +1332,7 @@ namespace Microsoft.Build.UnitTests
             }
            );
         }
+
         /// <summary>
         /// Pass in one extension and an empty string
         /// </summary>
@@ -1582,7 +1600,7 @@ namespace Microsoft.Build.UnitTests
                 {
                     if (String.Equals(searchPattern, "*.sln", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (String.Equals(Path.GetExtension(file), ".sln", StringComparison.OrdinalIgnoreCase))
+                        if (FileUtilities.IsSolutionFilename(file))
                         {
                             fileNamesToReturn.Add(file);
                         }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2769,6 +2769,8 @@ namespace Microsoft.Build.CommandLine
                 string[] potentialProjectFiles = getFiles(projectDirectory ?? ".", "*.*proj");
                 // Get all files in the current directory that have a sln extension
                 string[] potentialSolutionFiles = getFiles(projectDirectory ?? ".", "*.sln");
+                // List of solutionFilterFiles. Unitialized because it often will not need to be.
+                List<string> solutionFilterFiles = null;
 
                 List<string> extensionsToIgnore = new List<string>();
                 if (projectsExtensionsToIgnore != null)
@@ -2795,6 +2797,12 @@ namespace Microsoft.Build.CommandLine
                         {
                             extensionsToIgnore.Add(Path.GetExtension(s));
                         }
+                        else if (FileUtilities.IsSolutionFilterFilename(s))
+                        {
+                            solutionFilterFiles ??= new List<string>();
+                            solutionFilterFiles.Add(s);
+                            extensionsToIgnore.Add(Path.GetExtension(s));
+                        }
                     }
                 }
 
@@ -2817,10 +2825,10 @@ namespace Microsoft.Build.CommandLine
                     }
                 }
                 // If there is exactly 1 project file and exactly 1 solution file
-                if ((potentialProjectFiles.Length == 1) && (potentialSolutionFiles.Length == 1))
+                if (potentialProjectFiles.Length == 1 && (potentialSolutionFiles.Length == 1 || solutionFilterFiles.Count == 1))
                 {
                     // Grab the name of both project and solution without extensions
-                    string solutionName = Path.GetFileNameWithoutExtension(potentialSolutionFiles[0]);
+                    string solutionName = Path.GetFileNameWithoutExtension(potentialSolutionFiles.Length == 1 ? potentialSolutionFiles[0] : solutionFilterFiles[0]);
                     string projectName = Path.GetFileNameWithoutExtension(potentialProjectFiles[0]);
                     // Compare the names and error if they are not identical
                     InitializationException.VerifyThrow(String.Equals(solutionName, projectName, StringComparison.OrdinalIgnoreCase), projectDirectory == null ? "AmbiguousProjectError" : "AmbiguousProjectDirectoryError", null, projectDirectory);
@@ -2864,8 +2872,9 @@ namespace Microsoft.Build.CommandLine
                     InitializationException.VerifyThrow(!isAmbiguousProject, projectDirectory == null ? "AmbiguousProjectError" : "AmbiguousProjectDirectoryError", null, projectDirectory);
                 }
                 // if there are no project or solution files in the directory, we can't build
-                else if ((potentialProjectFiles.Length == 0) &&
-                         (potentialSolutionFiles.Length == 0))
+                else if (potentialProjectFiles.Length == 0 &&
+                         potentialSolutionFiles.Length == 0 &&
+                         solutionFilterFiles.Count == 0)
                 {
                     InitializationException.VerifyThrow(false, "MissingProjectError");
                 }
@@ -2873,7 +2882,7 @@ namespace Microsoft.Build.CommandLine
                 // We are down to only one project or solution.
                 // If only 1 solution build the solution.  If only 1 project build the project
                 // If 1 solution and 1 project and they are of the same name build the solution
-                projectFile = (potentialSolutionFiles.Length == 1) ? potentialSolutionFiles[0] : potentialProjectFiles[0];
+                projectFile = (potentialSolutionFiles.Length == 1) ? potentialSolutionFiles[0] : solutionFilterFiles.Count == 1 ? solutionFilterFiles[0] : potentialProjectFiles[0];
             }
 
             return projectFile;

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2765,90 +2765,70 @@ namespace Microsoft.Build.CommandLine
             // We need to look in a directory for a project file...
             if (projectFile == null)
             {
+                ValidateExtensions(projectsExtensionsToIgnore);
+                HashSet<string> extensionsToIgnore = new HashSet<string>(projectsExtensionsToIgnore ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
                 // Get all files in the current directory that have a proj-like extension
                 string[] potentialProjectFiles = getFiles(projectDirectory ?? ".", "*.*proj");
-                // Get all files in the current directory that have a sln extension
-                string[] potentialSolutionFiles = getFiles(projectDirectory ?? ".", "*.sln");
-                // List of solutionFilterFiles. Unitialized because it often will not need to be.
-                List<string> solutionFilterFiles = null;
-
-                List<string> extensionsToIgnore = new List<string>();
-                if (projectsExtensionsToIgnore != null)
-                {
-                    extensionsToIgnore.AddRange(projectsExtensionsToIgnore);
-                }
-
+                List<string> actualProjectFiles = new List<string>();
                 if (potentialProjectFiles != null)
                 {
                     foreach (string s in potentialProjectFiles)
                     {
-                        if (s.EndsWith("~", StringComparison.CurrentCultureIgnoreCase))
+                        if (!extensionsToIgnore.Contains(Path.GetExtension(s)) && !s.EndsWith("~", StringComparison.CurrentCultureIgnoreCase))
                         {
-                            extensionsToIgnore.Add(Path.GetExtension(s));
+                            actualProjectFiles.Add(s);
                         }
                     }
                 }
 
+                // Get all files in the current directory that have a sln extension
+                string[] potentialSolutionFiles = getFiles(projectDirectory ?? ".", "*.sln");
+                List<string> actualSolutionFiles = new List<string>();
+                List<string> solutionFilterFiles = new List<string>();
                 if (potentialSolutionFiles != null)
                 {
                     foreach (string s in potentialSolutionFiles)
                     {
-                        if (!FileUtilities.IsSolutionFilename(s))
+                        if (!extensionsToIgnore.Contains(Path.GetExtension(s)))
                         {
-                            extensionsToIgnore.Add(Path.GetExtension(s));
-                        }
-                        else if (FileUtilities.IsSolutionFilterFilename(s))
-                        {
-                            solutionFilterFiles ??= new List<string>();
-                            solutionFilterFiles.Add(s);
-                            extensionsToIgnore.Add(Path.GetExtension(s));
+                            if (FileUtilities.IsSolutionFilterFilename(s))
+                            {
+                                solutionFilterFiles.Add(s);
+                            }
+                            else if (FileUtilities.IsSolutionFilename(s))
+                            {
+                                actualSolutionFiles.Add(s);
+                            }
                         }
                     }
                 }
 
-                Dictionary<string, object> extensionsToIgnoreDictionary = ValidateExtensions(extensionsToIgnore.ToArray());
-
-                // Remove projects that are in the projectExtensionsToIgnore List
-                // If we have no extensions to ignore we can skip removing any extensions
-                if (extensionsToIgnoreDictionary.Count > 0)
-                {
-                    // No point removing extensions if we have no project files
-                    if (potentialProjectFiles?.Length > 0)
-                    {
-                        potentialProjectFiles = RemoveFilesWithExtensionsToIgnore(potentialProjectFiles, extensionsToIgnoreDictionary);
-                    }
-
-                    // No point removing extensions if we have no solutions
-                    if (potentialSolutionFiles?.Length > 0)
-                    {
-                        potentialSolutionFiles = RemoveFilesWithExtensionsToIgnore(potentialSolutionFiles, extensionsToIgnoreDictionary);
-                    }
-                }
                 // If there is exactly 1 project file and exactly 1 solution file
-                if (potentialProjectFiles.Length == 1 && (potentialSolutionFiles.Length == 1 || solutionFilterFiles.Count == 1))
+                if (actualProjectFiles.Count == 1 && actualSolutionFiles.Count == 1)
                 {
                     // Grab the name of both project and solution without extensions
-                    string solutionName = Path.GetFileNameWithoutExtension(potentialSolutionFiles.Length == 1 ? potentialSolutionFiles[0] : solutionFilterFiles[0]);
-                    string projectName = Path.GetFileNameWithoutExtension(potentialProjectFiles[0]);
+                    string solutionName = Path.GetFileNameWithoutExtension(actualSolutionFiles[0]);
+                    string projectName = Path.GetFileNameWithoutExtension(actualProjectFiles[0]);
                     // Compare the names and error if they are not identical
                     InitializationException.VerifyThrow(String.Equals(solutionName, projectName, StringComparison.OrdinalIgnoreCase), projectDirectory == null ? "AmbiguousProjectError" : "AmbiguousProjectDirectoryError", null, projectDirectory);
+                    projectFile = actualSolutionFiles[0];
                 }
                 // If there is more than one solution file in the current directory we have no idea which one to use
-                else if (potentialSolutionFiles.Length > 1)
+                else if (actualSolutionFiles.Count > 1)
                 {
                     InitializationException.VerifyThrow(false, projectDirectory == null ? "AmbiguousProjectError" : "AmbiguousProjectDirectoryError", null, projectDirectory);
                 }
                 // If there is more than one project file in the current directory we may be able to figure it out
-                else if (potentialProjectFiles.Length > 1)
+                else if (actualProjectFiles.Count > 1)
                 {
                     // We have more than one project, it is ambiguous at the moment
                     bool isAmbiguousProject = true;
 
                     // If there are exactly two projects and one of them is a .proj use that one and ignore the other
-                    if (potentialProjectFiles.Length == 2)
+                    if (actualProjectFiles.Count == 2)
                     {
-                        string firstPotentialProjectExtension = Path.GetExtension(potentialProjectFiles[0]);
-                        string secondPotentialProjectExtension = Path.GetExtension(potentialProjectFiles[1]);
+                        string firstPotentialProjectExtension = Path.GetExtension(actualProjectFiles[0]);
+                        string secondPotentialProjectExtension = Path.GetExtension(actualProjectFiles[1]);
 
                         // If the two projects have the same extension we can't decide which one to pick
                         if (!String.Equals(firstPotentialProjectExtension, secondPotentialProjectExtension, StringComparison.OrdinalIgnoreCase))
@@ -2856,14 +2836,14 @@ namespace Microsoft.Build.CommandLine
                             // Check to see if the first project is the proj, if it is use it
                             if (String.Equals(firstPotentialProjectExtension, ".proj", StringComparison.OrdinalIgnoreCase))
                             {
-                                potentialProjectFiles = new string[] { potentialProjectFiles[0] };
+                                projectFile = actualProjectFiles[0];
                                 // We have made a decision
                                 isAmbiguousProject = false;
                             }
                             // If the first project is not the proj check to see if the second one is the proj, if so use it
                             else if (String.Equals(secondPotentialProjectExtension, ".proj", StringComparison.OrdinalIgnoreCase))
                             {
-                                potentialProjectFiles = new string[] { potentialProjectFiles[1] };
+                                projectFile = actualProjectFiles[1];
                                 // We have made a decision
                                 isAmbiguousProject = false;
                             }
@@ -2871,109 +2851,44 @@ namespace Microsoft.Build.CommandLine
                     }
                     InitializationException.VerifyThrow(!isAmbiguousProject, projectDirectory == null ? "AmbiguousProjectError" : "AmbiguousProjectDirectoryError", null, projectDirectory);
                 }
-                // if there are no project or solution files in the directory, we can't build
-                else if (potentialProjectFiles.Length == 0 &&
-                         potentialSolutionFiles.Length == 0 &&
+                // if there are no project, solution filter, or solution files in the directory, we can't build
+                else if (actualProjectFiles.Count == 0 &&
+                         actualSolutionFiles.Count== 0 &&
                          solutionFilterFiles.Count == 0)
                 {
                     InitializationException.VerifyThrow(false, "MissingProjectError");
                 }
-
-                // We are down to only one project or solution.
-                // If only 1 solution build the solution.  If only 1 project build the project
-                // If 1 solution and 1 project and they are of the same name build the solution
-                projectFile = (potentialSolutionFiles.Length == 1) ? potentialSolutionFiles[0] : solutionFilterFiles.Count == 1 ? solutionFilterFiles[0] : potentialProjectFiles[0];
+                else
+                {
+                    // We are down to only one project, solution, or solution filter.
+                    // If only 1 solution build the solution.  If only 1 project build the project. Otherwise, build the solution filter.
+                    projectFile = actualSolutionFiles.Count == 1 ? actualSolutionFiles[0] : actualProjectFiles.Count == 1 ? actualProjectFiles[0] : solutionFilterFiles[0];
+                    InitializationException.VerifyThrow(actualSolutionFiles.Count == 1 || actualProjectFiles.Count == 1 || solutionFilterFiles.Count == 1, projectDirectory == null ? "AmbiguousProjectError" : "AmbiguousProjectDirectoryError", null, projectDirectory);
+                }
             }
 
             return projectFile;
         }
 
-        /// <summary>
-        ///  This method takes in a list of file name extensions to ignore. It will then validate the extensions
-        ///  to make sure they start with a period, have atleast one character after the period and do not contain
-        ///  any invalid path chars or wild cards
-        /// </summary>
-        /// <param name="projectsExtensionsToIgnore"></param>
-        /// <returns></returns>
-        private static Dictionary<string, object> ValidateExtensions(string[] projectsExtensionsToIgnore)
+        private static void ValidateExtensions(string[] projectExtensionsToIgnore)
         {
-            // Dictionary to contain the list of files which match the extensions to ignore. We are using a dictionary for fast lookups of extensions to ignore
-            Dictionary<string, object> extensionsToIgnoreDictionary = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-
-            // Go through each of the extensions to ignore and add them as a key in the dictionary
-            if (projectsExtensionsToIgnore?.Length > 0)
+            if (projectExtensionsToIgnore?.Length > 0)
             {
-                string extension = null;
-
-                foreach (string extensionToIgnore in projectsExtensionsToIgnore)
+                foreach (string extension in projectExtensionsToIgnore)
                 {
-                    // Use the path get extension method to figure out if there is an extension in the passed 
-                    // in extension to ignore. Will return null or empty if there is no extension in the string
-                    try
-                    {
-                        // Use GetExtension to parse the extension from the extensionToIgnore
-                        extension = Path.GetExtension(extensionToIgnore);
-                    }
-                    catch (ArgumentException)
-                    {
-                        // There has been an invalid char in the extensionToIgnore
-                        InitializationException.Throw("InvalidExtensionToIgnore", extensionToIgnore, null, false);
-                    }
+                    // There has to be more than a . passed in as the extension.
+                    InitializationException.VerifyThrow(extension?.Length >= 2, "InvalidExtensionToIgnore", extension);
 
-                    // if null or empty is returned that means that there was not extension able to be parsed from the string
-                    InitializationException.VerifyThrow(!string.IsNullOrEmpty(extension), "InvalidExtensionToIgnore", extensionToIgnore);
+                    // There is an invalid char in the extensionToIgnore.
+                    InitializationException.VerifyThrow(extension.IndexOfAny(Path.GetInvalidPathChars()) == -1, "InvalidExtensionToIgnore", extension, null, false);
 
-                    // There has to be more than a . passed in as the extension
-                    InitializationException.VerifyThrow(extension.Length >= 2, "InvalidExtensionToIgnore", extensionToIgnore);
+                    // There were characters before the extension.
+                    InitializationException.VerifyThrow(String.Equals(extension, Path.GetExtension(extension), StringComparison.OrdinalIgnoreCase), "InvalidExtensionToIgnore", extension, null, false);
 
-                    // The parsed extension does not match the passed in extension, this means that there were
-                    // some other chars before the last extension
-                    if (!string.Equals(extension, extensionToIgnore, StringComparison.OrdinalIgnoreCase))
-                    {
-                        InitializationException.Throw("InvalidExtensionToIgnore", extensionToIgnore, null, false);
-                    }
-
-                    // Make sure that no wild cards are in the string because for now we dont allow wild card extensions
-                    if (extensionToIgnore.IndexOfAny(s_wildcards) > -1)
-                    {
-                        InitializationException.Throw("InvalidExtensionToIgnore", extensionToIgnore, null, false);
-                    }
-                    if (!extensionsToIgnoreDictionary.ContainsKey(extensionToIgnore))
-                    {
-                        extensionsToIgnoreDictionary.Add(extensionToIgnore, null);
-                    }
+                    // Make sure that no wild cards are in the string because for now we dont allow wild card extensions.
+                    InitializationException.VerifyThrow(extension.IndexOfAny(s_wildcards) == -1, "InvalidExtensionToIgnore", extension, null, false);
                 }
             }
-            return extensionsToIgnoreDictionary;
-        }
-
-        /// <summary>
-        /// Removes filenames from the given list whose extensions are on the list of extensions to ignore
-        /// </summary>
-        /// <param name="potentialProjectOrSolutionFiles">A list of project or solution file names</param>
-        /// <param name="extensionsToIgnore">A list of extensions to ignore</param>
-        /// <returns>Array of project or solution files names which do not have an extension to be ignored </returns>
-        private static string[] RemoveFilesWithExtensionsToIgnore
-                                (
-                                    string[] potentialProjectOrSolutionFiles,
-                                    Dictionary<string, object> extensionsToIgnoreDictionary
-                                )
-        {
-            // If we got to this method we should have to possible projects or solutions and some extensions to ignore
-            ErrorUtilities.VerifyThrow(potentialProjectOrSolutionFiles?.Length > 0, "There should be some potential project or solution files");
-            ErrorUtilities.VerifyThrow(extensionsToIgnoreDictionary?.Count > 0, "There should be some extensions to Ignore");
-
-            List<string> filesToKeep = new List<string>();
-            foreach (string projectOrSolutionFile in potentialProjectOrSolutionFiles)
-            {
-                string extension = Path.GetExtension(projectOrSolutionFile);
-                // Check to see if the file extension of the project is in our ignore list. If not keep the file
-                if (!extensionsToIgnoreDictionary.ContainsKey(extension))
-                {
-                    filesToKeep.Add(projectOrSolutionFile);
-                }
-            }
-            return filesToKeep.ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
This occurs because .slnf was treated as a .sln. This resolves #5739 by separating the two at this stage.