### PR TITLE
Reduce ImmutableDictionary.Comparers allocations

### DIFF
--- a/src/Build.UnitTests/TestData/ProjectInstanceTestObjects.cs
+++ b/src/Build.UnitTests/TestData/ProjectInstanceTestObjects.cs
@@ -115,8 +115,8 @@ namespace Microsoft.Build.Engine.UnitTests.TestData
             var stringCounter = CounterToString(counter);
 
             var readonlyParameters = parameters != null
-                ? new CopyOnWriteDictionary<string, (string, ElementLocation)>(parameters)
-                : new CopyOnWriteDictionary<string, (string, ElementLocation)>();
+                ? new CopyOnWriteDictionary<(string, ElementLocation)>(parameters)
+                : new CopyOnWriteDictionary<(string, ElementLocation)>();
 
             outputs ??= new List<ProjectTaskInstanceChild>();
 

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Backing dictionary
         /// </summary>
-        private readonly CopyOnWriteDictionary<string, T> _properties;
+        private readonly CopyOnWriteDictionary<T> _properties;
 
         /// <summary>
         /// Creates empty dictionary
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Collections
         public CopyOnWritePropertyDictionary()
         {
             // Tracing.Record("New COWD1");
-            _properties = new CopyOnWriteDictionary<string, T>(MSBuildNameIgnoreCaseComparer.Default);
+            _properties = new CopyOnWriteDictionary<T>(MSBuildNameIgnoreCaseComparer.Default);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Collections
         public CopyOnWritePropertyDictionary(int capacity)
         {
             // Tracing.Record("New COWD2");
-            _properties = new CopyOnWriteDictionary<string, T>(capacity, MSBuildNameIgnoreCaseComparer.Default);
+            _properties = new CopyOnWriteDictionary<T>(capacity, MSBuildNameIgnoreCaseComparer.Default);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectTaskElement.cs
+++ b/src/Build/Construction/ProjectTaskElement.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// The parameters (excepting condition and continue-on-error)
         /// </summary>
-        private CopyOnWriteDictionary<string, (string, ElementLocation)> _parameters;
+        private CopyOnWriteDictionary<(string, ElementLocation)> _parameters;
 
         /// <summary>
         /// Protection for the parameters cache
@@ -210,7 +210,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Retrieves a copy of the parameters as used during evaluation.
         /// </summary>
-        internal CopyOnWriteDictionary<string, (string, ElementLocation)> ParametersForEvaluation
+        internal CopyOnWriteDictionary<(string, ElementLocation)> ParametersForEvaluation
         {
             get
             {
@@ -443,7 +443,7 @@ namespace Microsoft.Build.Construction
         {
             if (_parameters == null)
             {
-                _parameters = new CopyOnWriteDictionary<string, (string, ElementLocation)>(XmlElement.Attributes.Count, StringComparer.OrdinalIgnoreCase);
+                _parameters = new CopyOnWriteDictionary<(string, ElementLocation)>(XmlElement.Attributes.Count, StringComparer.OrdinalIgnoreCase);
 
                 foreach (XmlAttributeWithLocation attribute in XmlElement.Attributes)
                 {

--- a/src/Build/Instance/ProjectTaskInstance.cs
+++ b/src/Build/Instance/ProjectTaskInstance.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Build.Execution
         /// Unordered set of task parameter names and unevaluated values.
         /// This is a dead, read-only collection.
         /// </summary>
-        private CopyOnWriteDictionary<string, (string, ElementLocation)> _parameters;
+        private CopyOnWriteDictionary<(string, ElementLocation)> _parameters;
 
         /// <summary>
         /// Output properties and items below this task. This is an ordered collection
@@ -138,7 +138,7 @@ namespace Microsoft.Build.Execution
             continueOnError,
             msbuildRuntime,
             msbuildArchitecture,
-            new CopyOnWriteDictionary<string, (string, ElementLocation)>(8, StringComparer.OrdinalIgnoreCase),
+            new CopyOnWriteDictionary<(string, ElementLocation)>(8, StringComparer.OrdinalIgnoreCase),
             new List<ProjectTaskInstanceChild>(),
             location,
             condition == string.Empty ? null : ElementLocation.EmptyLocation,
@@ -155,7 +155,7 @@ namespace Microsoft.Build.Execution
             string continueOnError,
             string msbuildRuntime,
             string msbuildArchitecture,
-            CopyOnWriteDictionary<string, (string, ElementLocation)> parameters,
+            CopyOnWriteDictionary<(string, ElementLocation)> parameters,
             List<ProjectTaskInstanceChild> outputs,
             ElementLocation location,
             ElementLocation conditionLocation,
@@ -382,11 +382,11 @@ namespace Microsoft.Build.Execution
                 ref localParameters,
                 ParametersKeyTranslator,
                 ParametersValueTranslator,
-                count => new CopyOnWriteDictionary<string, (string, ElementLocation)>(count));
+                count => new CopyOnWriteDictionary<(string, ElementLocation)>(count));
 
             if (translator.Mode == TranslationDirection.ReadFromStream && localParameters != null)
             {
-                _parameters = (CopyOnWriteDictionary<string, (string, ElementLocation)>) localParameters;
+                _parameters = (CopyOnWriteDictionary<(string, ElementLocation)>) localParameters;
             }
         }
 

--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Build.Collections
         /// </summary>
         private static ImmutableDictionary<K, V> NameComparerDictionaryPrototype = ImmutableDictionary.Create<K, V>((IEqualityComparer<K>)MSBuildNameIgnoreCaseComparer.Default);
 #endif
+        private static ImmutableDictionary<K, V> OrdinalIgnoreCaseComparerDictionaryPrototype = ImmutableDictionary.Create<K, V>((IEqualityComparer<K>)StringComparer.OrdinalIgnoreCase);
+
 
         /// <summary>
         /// The backing dictionary.
@@ -101,7 +103,9 @@ namespace Microsoft.Build.Collections
 #else
             return typeof(K) == typeof(string) && keyComparer is MSBuildNameIgnoreCaseComparer
                             ? NameComparerDictionaryPrototype
-                            : ImmutableDictionary.Create<K, V>(keyComparer);
+                            : keyComparer == StringComparer.OrdinalIgnoreCase
+                              ? OrdinalIgnoreCaseComparerDictionaryPrototype
+                              : ImmutableDictionary.Create<K, V>(keyComparer);
 #endif
         }
 

--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -38,8 +38,14 @@ namespace Microsoft.Build.Collections
         /// allocating new comparers objects.
         /// </summary>
         private readonly static ImmutableDictionary<string, V> NameComparerDictionaryPrototype = ImmutableDictionary.Create<string, V>((IEqualityComparer<string>)MSBuildNameIgnoreCaseComparer.Default);
-#endif
+
+        /// <summary>
+        /// Empty dictionary with <see cref="StringComparer.OrdinalIgnoreCase" />,
+        /// used as the basis of new dictionaries with that comparer to avoid
+        /// allocating new comparers objects.
+        /// </summary>
         private readonly static ImmutableDictionary<string, V> OrdinalIgnoreCaseComparerDictionaryPrototype = ImmutableDictionary.Create<string, V>((IEqualityComparer<string>)StringComparer.OrdinalIgnoreCase);
+#endif
 
 
         /// <summary>

--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Build.Collections
         /// used as the basis of new dictionaries with that comparer to avoid
         /// allocating new comparers objects.
         /// </summary>
-        private static ImmutableDictionary<K, V> NameComparerDictionaryPrototype = ImmutableDictionary.Create<K, V>((IEqualityComparer<K>)MSBuildNameIgnoreCaseComparer.Default);
+        private readonly static ImmutableDictionary<K, V> NameComparerDictionaryPrototype = ImmutableDictionary.Create<K, V>((IEqualityComparer<K>)MSBuildNameIgnoreCaseComparer.Default);
 #endif
-        private static ImmutableDictionary<K, V> OrdinalIgnoreCaseComparerDictionaryPrototype = ImmutableDictionary.Create<K, V>((IEqualityComparer<K>)StringComparer.OrdinalIgnoreCase);
+        private readonly static ImmutableDictionary<K, V> OrdinalIgnoreCaseComparerDictionaryPrototype = ImmutableDictionary.Create<K, V>((IEqualityComparer<K>)StringComparer.OrdinalIgnoreCase);
 
 
         /// <summary>

--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Build.Collections
     /// A dictionary that has copy-on-write semantics.
     /// KEYS AND VALUES MUST BE IMMUTABLE OR COPY-ON-WRITE FOR THIS TO WORK.
     /// </summary>
-    /// <typeparam name="K">The key type.</typeparam>
     /// <typeparam name="V">The value type.</typeparam>
     /// <remarks>
     /// Thread safety: for all users, this class is as thread safe as the underlying Dictionary implementation, that is,
@@ -30,7 +29,7 @@ namespace Microsoft.Build.Collections
     /// be run in a separate appdomain.
     /// </comment>
     [Serializable]
-    internal class CopyOnWriteDictionary<K, V> : IDictionary<K, V>, IDictionary, ISerializable
+    internal class CopyOnWriteDictionary<V> : IDictionary<string, V>, IDictionary, ISerializable
     {
 #if !NET35 // MSBuildNameIgnoreCaseComparer not compiled into MSBuildTaskHost but also allocations not interesting there.
         /// <summary>
@@ -38,23 +37,23 @@ namespace Microsoft.Build.Collections
         /// used as the basis of new dictionaries with that comparer to avoid
         /// allocating new comparers objects.
         /// </summary>
-        private readonly static ImmutableDictionary<K, V> NameComparerDictionaryPrototype = ImmutableDictionary.Create<K, V>((IEqualityComparer<K>)MSBuildNameIgnoreCaseComparer.Default);
+        private readonly static ImmutableDictionary<string, V> NameComparerDictionaryPrototype = ImmutableDictionary.Create<string, V>((IEqualityComparer<string>)MSBuildNameIgnoreCaseComparer.Default);
 #endif
-        private readonly static ImmutableDictionary<K, V> OrdinalIgnoreCaseComparerDictionaryPrototype = ImmutableDictionary.Create<K, V>((IEqualityComparer<K>)StringComparer.OrdinalIgnoreCase);
+        private readonly static ImmutableDictionary<string, V> OrdinalIgnoreCaseComparerDictionaryPrototype = ImmutableDictionary.Create<string, V>((IEqualityComparer<string>)StringComparer.OrdinalIgnoreCase);
 
 
         /// <summary>
         /// The backing dictionary.
         /// Lazily created.
         /// </summary>
-        private ImmutableDictionary<K, V> _backing;
+        private ImmutableDictionary<string, V> _backing;
 
         /// <summary>
         /// Constructor. Consider supplying a comparer instead.
         /// </summary>
         internal CopyOnWriteDictionary()
         {
-            _backing = ImmutableDictionary<K, V>.Empty;
+            _backing = ImmutableDictionary<string, V>.Empty;
         }
 
         /// <summary>
@@ -68,7 +67,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Constructor taking a specified comparer for the keys
         /// </summary>
-        internal CopyOnWriteDictionary(IEqualityComparer<K> keyComparer)
+        internal CopyOnWriteDictionary(IEqualityComparer<string> keyComparer)
             : this(0, keyComparer)
         {
         }
@@ -76,7 +75,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Constructor taking a specified comparer for the keys and an initial capacity
         /// </summary>
-        internal CopyOnWriteDictionary(int capacity, IEqualityComparer<K>? keyComparer)
+        internal CopyOnWriteDictionary(int capacity, IEqualityComparer<string>? keyComparer)
         {
             _backing = GetInitialDictionary(keyComparer);
         }
@@ -87,37 +86,37 @@ namespace Microsoft.Build.Collections
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context", Justification = "Not needed")]
         protected CopyOnWriteDictionary(SerializationInfo info, StreamingContext context)
         {
-            object v = info.GetValue(nameof(_backing), typeof(KeyValuePair<K, V>[]));
+            object v = info.GetValue(nameof(_backing), typeof(KeyValuePair<string, V>[]));
 
-            object comparer = info.GetValue(nameof(Comparer), typeof(IEqualityComparer<K>));
+            object comparer = info.GetValue(nameof(Comparer), typeof(IEqualityComparer<string>));
 
-            var b = GetInitialDictionary((IEqualityComparer<K>)comparer);
+            var b = GetInitialDictionary((IEqualityComparer<string>)comparer);
 
-            _backing = b.AddRange((KeyValuePair<K, V>[])v);
+            _backing = b.AddRange((KeyValuePair<string, V>[])v);
         }
 
-        private static ImmutableDictionary<K, V> GetInitialDictionary(IEqualityComparer<K>? keyComparer)
+        private static ImmutableDictionary<string, V> GetInitialDictionary(IEqualityComparer<string>? keyComparer)
         {
 #if NET35
-            return ImmutableDictionary.Create<K, V>(keyComparer);
+            return ImmutableDictionary.Create<string, V>(keyComparer);
 #else
-            return typeof(K) == typeof(string) && keyComparer is MSBuildNameIgnoreCaseComparer
+            return keyComparer is MSBuildNameIgnoreCaseComparer
                             ? NameComparerDictionaryPrototype
                             : keyComparer == StringComparer.OrdinalIgnoreCase
                               ? OrdinalIgnoreCaseComparerDictionaryPrototype
-                              : ImmutableDictionary.Create<K, V>(keyComparer);
+                              : ImmutableDictionary.Create<string, V>(keyComparer);
 #endif
         }
 
         /// <summary>
         /// Cloning constructor. Defers the actual clone.
         /// </summary>
-        private CopyOnWriteDictionary(CopyOnWriteDictionary<K, V> that)
+        private CopyOnWriteDictionary(CopyOnWriteDictionary<V> that)
         {
             _backing = that._backing;
         }
 
-        public CopyOnWriteDictionary(IDictionary<K, V> dictionary)
+        public CopyOnWriteDictionary(IDictionary<string, V> dictionary)
         {
             _backing = dictionary.ToImmutableDictionary();
         }
@@ -125,12 +124,12 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Returns the collection of keys in the dictionary.
         /// </summary>
-        public ICollection<K> Keys => ((IDictionary<K, V>)_backing).Keys;
+        public ICollection<string> Keys => ((IDictionary<string, V>)_backing).Keys;
 
         /// <summary>
         /// Returns the collection of values in the dictionary.
         /// </summary>
-        public ICollection<V> Values => ((IDictionary<K, V>)_backing).Values;
+        public ICollection<V> Values => ((IDictionary<string, V>)_backing).Values;
 
         /// <summary>
         /// Returns the number of items in the collection.
@@ -140,7 +139,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Returns true if the collection is read-only.
         /// </summary>
-        public bool IsReadOnly => ((IDictionary<K, V>)_backing).IsReadOnly;
+        public bool IsReadOnly => ((IDictionary<string, V>)_backing).IsReadOnly;
 
         /// <summary>
         /// IDictionary implementation
@@ -180,7 +179,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Comparer used for keys
         /// </summary>
-        internal IEqualityComparer<K> Comparer
+        internal IEqualityComparer<string> Comparer
         {
             get => _backing.KeyComparer;
             private set => _backing = _backing.WithComparers(keyComparer: value);
@@ -189,7 +188,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Accesses the value for the specified key.
         /// </summary>
-        public V this[K key]
+        public V this[string key]
         {
             get => _backing[key];
 
@@ -207,18 +206,18 @@ namespace Microsoft.Build.Collections
         {
             get
             {
-                TryGetValue((K) key, out V val);
+                TryGetValue((string) key, out V val);
                 return val;
             }
 
-            set => this[(K)key] = (V)value;
+            set => this[(string)key] = (V)value;
         }
 #nullable restore
 
         /// <summary>
         /// Adds a value to the dictionary.
         /// </summary>
-        public void Add(K key, V value)
+        public void Add(string key, V value)
         {
             _backing = _backing.SetItem(key, value);
         }
@@ -226,7 +225,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Returns true if the dictionary contains the specified key.
         /// </summary>
-        public bool ContainsKey(K key)
+        public bool ContainsKey(string key)
         {
             return _backing.ContainsKey(key);
         }
@@ -234,9 +233,9 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Removes the entry for the specified key from the dictionary.
         /// </summary>
-        public bool Remove(K key)
+        public bool Remove(string key)
         {
-            ImmutableDictionary<K, V> initial = _backing;
+            ImmutableDictionary<string, V> initial = _backing;
 
             _backing = _backing.Remove(key);
 
@@ -246,7 +245,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Attempts to find the value for the specified key in the dictionary.
         /// </summary>
-        public bool TryGetValue(K key, out V value)
+        public bool TryGetValue(string key, out V value)
         {
             return _backing.TryGetValue(key, out value);
         }
@@ -254,7 +253,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Adds an item to the collection.
         /// </summary>
-        public void Add(KeyValuePair<K, V> item)
+        public void Add(KeyValuePair<string, V> item)
         {
             _backing = _backing.SetItem(item.Key, item.Value);
         }
@@ -270,7 +269,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Returns true ff the collection contains the specified item.
         /// </summary>
-        public bool Contains(KeyValuePair<K, V> item)
+        public bool Contains(KeyValuePair<string, V> item)
         {
             return _backing.Contains(item);
         }
@@ -278,17 +277,17 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Copies all of the elements of the collection to the specified array.
         /// </summary>
-        public void CopyTo(KeyValuePair<K, V>[] array, int arrayIndex)
+        public void CopyTo(KeyValuePair<string, V>[] array, int arrayIndex)
         {
-            ((IDictionary<K, V>)_backing).CopyTo(array, arrayIndex);
+            ((IDictionary<string, V>)_backing).CopyTo(array, arrayIndex);
         }
 
         /// <summary>
         /// Remove an item from the dictionary.
         /// </summary>
-        public bool Remove(KeyValuePair<K, V> item)
+        public bool Remove(KeyValuePair<string, V> item)
         {
-            ImmutableDictionary<K, V> initial = _backing;
+            ImmutableDictionary<string, V> initial = _backing;
 
             _backing = _backing.Remove(item.Key);
 
@@ -298,7 +297,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Implementation of generic IEnumerable.GetEnumerator()
         /// </summary>
-        public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+        public IEnumerator<KeyValuePair<string, V>> GetEnumerator()
         {
             return _backing.GetEnumerator();
         }
@@ -308,7 +307,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<KeyValuePair<K, V>>)this).GetEnumerator();
+            return ((IEnumerable<KeyValuePair<string, V>>)this).GetEnumerator();
         }
 
         /// <summary>
@@ -316,7 +315,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         void IDictionary.Add(object key, object value)
         {
-            Add((K)key, (V)value);
+            Add((string)key, (V)value);
         }
 
         /// <summary>
@@ -332,7 +331,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         bool IDictionary.Contains(object key)
         {
-            return ContainsKey((K)key);
+            return ContainsKey((string)key);
         }
 
         /// <summary>
@@ -348,7 +347,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         void IDictionary.Remove(object key)
         {
-            Remove((K)key);
+            Remove((string)key);
         }
 
         /// <summary>
@@ -357,7 +356,7 @@ namespace Microsoft.Build.Collections
         void ICollection.CopyTo(Array array, int index)
         {
             int i = 0;
-            foreach (KeyValuePair<K, V> entry in this)
+            foreach (KeyValuePair<string, V> entry in this)
             {
                 array.SetValue(new DictionaryEntry(entry.Key, entry.Value), index + i);
                 i++;
@@ -367,23 +366,23 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Clone, with the actual clone deferred
         /// </summary>
-        internal CopyOnWriteDictionary<K, V> Clone()
+        internal CopyOnWriteDictionary<V> Clone()
         {
-            return new CopyOnWriteDictionary<K, V>(this);
+            return new CopyOnWriteDictionary<V>(this);
         }
 
         /// <summary>
         /// Returns true if these dictionaries have the same backing.
         /// </summary>
-        internal bool HasSameBacking(CopyOnWriteDictionary<K, V> other)
+        internal bool HasSameBacking(CopyOnWriteDictionary<V> other)
         {
             return ReferenceEquals(other._backing, _backing);
         }
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            ImmutableDictionary<K, V> snapshot = _backing;
-            KeyValuePair<K, V>[] array = snapshot.ToArray();
+            ImmutableDictionary<string, V> snapshot = _backing;
+            KeyValuePair<string, V>[] array = snapshot.ToArray();
 
             info.AddValue(nameof(_backing), array);
             info.AddValue(nameof(Comparer), Comparer);

--- a/src/Shared/UnitTests/CopyOnWriteDictionary_Tests.cs
+++ b/src/Shared/UnitTests/CopyOnWriteDictionary_Tests.cs
@@ -25,10 +25,10 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void Indexer_ReferenceFound()
         {
-            object k1 = new Object();
+            string k1 = new string(nameof(Indexer_ReferenceFound).ToCharArray()); // force create new string
             object v1 = new Object();
 
-            var dictionary = new CopyOnWriteDictionary<object, object>();
+            var dictionary = new CopyOnWriteDictionary<object>();
             dictionary[k1] = v1;
 
             // Now look for the same key we inserted
@@ -46,8 +46,8 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         {
             Assert.Throws<KeyNotFoundException>(() =>
             {
-                var dictionary = new CopyOnWriteDictionary<object, object>();
-                object value = dictionary[new Object()];
+                var dictionary = new CopyOnWriteDictionary<object>();
+                object value = dictionary[string.Empty];
             }
            );
         }
@@ -57,10 +57,10 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void TryGetValue_ReferenceFound()
         {
-            object k1 = new Object();
+            string k1 = new string(nameof(TryGetValue_ReferenceFound).ToCharArray());
             object v1 = new Object();
 
-            var dictionary = new CopyOnWriteDictionary<object, object>();
+            var dictionary = new CopyOnWriteDictionary<object>();
             dictionary[k1] = v1;
 
             // Now look for the same key we inserted
@@ -77,14 +77,14 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void TryGetValue_ReferenceNotFound()
         {
-            var dictionary = new CopyOnWriteDictionary<object, object>();
+            var dictionary = new CopyOnWriteDictionary<object>();
 
             object v;
-            bool result = dictionary.TryGetValue(new Object(), out v);
+            bool result = dictionary.TryGetValue(string.Empty, out v);
 
             Assert.False(result);
             Assert.Null(v);
-            Assert.False(dictionary.ContainsKey(new Object()));
+            Assert.False(dictionary.ContainsKey(string.Empty));
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             string k1 = String.Concat("ke", "y");
             object v1 = new Object();
 
-            var dictionary = new CopyOnWriteDictionary<string, object>();
+            var dictionary = new CopyOnWriteDictionary<object>();
             dictionary[k1] = v1;
 
             // Now look for a different but equatable key
@@ -116,7 +116,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void CloneVisibility()
         {
-            var dictionary = new CopyOnWriteDictionary<string, string>();
+            var dictionary = new CopyOnWriteDictionary<string>();
             dictionary["test"] = "1";
             Assert.Equal("1", dictionary["test"]);
 
@@ -132,7 +132,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void CloneComparer()
         {
-            var dictionary = new CopyOnWriteDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var dictionary = new CopyOnWriteDictionary<string>(StringComparer.OrdinalIgnoreCase);
             dictionary["test"] = "1";
             Assert.Equal("1", dictionary["test"]);
 
@@ -147,7 +147,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void OriginalWritesNotVisibleToClones()
         {
-            var dictionary = new CopyOnWriteDictionary<string, string>();
+            var dictionary = new CopyOnWriteDictionary<string>();
             dictionary["test"] = "1";
             dictionary["test"].ShouldBe("1");
 
@@ -173,7 +173,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void CloneWritesNotVisibleToOriginal()
         {
-            var dictionary = new CopyOnWriteDictionary<string, string>();
+            var dictionary = new CopyOnWriteDictionary<string>();
             dictionary["test"] = "1";
             Assert.Equal("1", dictionary["test"]);
 
@@ -201,8 +201,8 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void SerializeDeserialize()
         {
-            CopyOnWriteDictionary<int, string> dictionary = new CopyOnWriteDictionary<int, string>();
-            dictionary.Add(1, "1");
+            CopyOnWriteDictionary<string> dictionary = new CopyOnWriteDictionary<string>();
+            dictionary.Add("Key1", "1");
 
             using (MemoryStream stream = new MemoryStream())
             {
@@ -211,13 +211,13 @@ namespace Microsoft.Build.UnitTests.OM.Collections
                 formatter.Serialize(stream, dictionary);
                 stream.Position = 0;
 
-                var dictionary2 = (CopyOnWriteDictionary<int, string>)formatter.Deserialize(stream);
+                var dictionary2 = (CopyOnWriteDictionary<string>)formatter.Deserialize(stream);
 
                 Assert.Equal(dictionary.Count, dictionary2.Count);
                 Assert.Equal(dictionary.Comparer, dictionary2.Comparer);
-                Assert.Equal("1", dictionary2[1]);
+                Assert.Equal("1", dictionary2["Key1"]);
 
-                dictionary2.Add(2, "2");
+                dictionary2.Add("key2", "2");
             }
         }
 
@@ -227,7 +227,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void SerializeDeserialize2()
         {
-            CopyOnWriteDictionary<string, string> dictionary = new CopyOnWriteDictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+            CopyOnWriteDictionary<string> dictionary = new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default);
 
             using (MemoryStream stream = new MemoryStream())
             {
@@ -236,7 +236,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
                 formatter.Serialize(stream, dictionary);
                 stream.Position = 0;
 
-                CopyOnWriteDictionary<string, string> deserialized = (CopyOnWriteDictionary<string, string>)formatter.Deserialize(stream);
+                CopyOnWriteDictionary<string> deserialized = (CopyOnWriteDictionary<string>)formatter.Deserialize(stream);
 
                 deserialized.Count.ShouldBe(dictionary.Count);
                 deserialized.Comparer.ShouldBeOfType<MSBuildNameIgnoreCaseComparer>();

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -81,6 +81,7 @@
     <Compile Include="..\Shared\NGen.cs">
       <Link>NGen.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\IConstrainedEqualityComparer.cs"/>
     <Compile Include="..\Shared\IInternable.cs">
       <Link>IInternable.cs</Link>
     </Compile>
@@ -149,6 +150,7 @@
       <Link>Modifiers.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\MSBuildNameIgnoreCaseComparer.cs" />
     <Compile Include="..\Shared\ReadOnlyCollection.cs" />
     <Compile Include="..\Shared\ReadOnlyEmptyDictionary.cs" />
     <Compile Include="..\Shared\Tracing.cs" />

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Build.Utilities
         // project file via XML child elements of the item element.  These have
         // no meaning to MSBuild, but tasks may use them.
         // Values are stored in escaped form.
-        private CopyOnWriteDictionary<string, string> _metadata;
+        private CopyOnWriteDictionary<string> _metadata;
 
         // cache of the fullpath value
         private string _fullPath;
@@ -102,7 +102,7 @@ namespace Microsoft.Build.Utilities
 
             if (itemMetadata.Count > 0)
             {
-                _metadata = new CopyOnWriteDictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+                _metadata = new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default);
 
                 foreach (DictionaryEntry singleMetadata in itemMetadata)
                 {
@@ -214,7 +214,7 @@ namespace Microsoft.Build.Utilities
         /// another appdomain, as the CLR has implemented remoting policies that disallow accessing 
         /// private fields in remoted items. 
         /// </summary>
-        private CopyOnWriteDictionary<string, string> Metadata
+        private CopyOnWriteDictionary<string> Metadata
         {
             get
             {
@@ -264,7 +264,7 @@ namespace Microsoft.Build.Utilities
             ErrorUtilities.VerifyThrowArgument(!FileUtilities.ItemSpecModifiers.IsDerivableItemSpecModifier(metadataName),
                 "Shared.CannotChangeItemSpecModifiers", metadataName);
 
-            _metadata ??= new CopyOnWriteDictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+            _metadata ??= new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default);
 
             _metadata[metadataName] = metadataValue ?? string.Empty;
         }
@@ -360,7 +360,7 @@ namespace Microsoft.Build.Utilities
         /// </comments>
         public IDictionary CloneCustomMetadata()
         {
-            var dictionary = new CopyOnWriteDictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+            var dictionary = new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default);
 
             if (_metadata != null)
             {
@@ -444,7 +444,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         /// <returns>The cloned metadata.</returns>
         IDictionary ITaskItem2.CloneCustomMetadataEscaped() => _metadata == null
-            ? new CopyOnWriteDictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default)
+            ? new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default)
             : _metadata.Clone();
 
         #endregion


### PR DESCRIPTION
Fixes #5736 by keeping a prototype `ImmutableDictionary`-with-comparer
around using the `MSBuildNameIgnoreCaseComparer`, which is the primary
comparer used for all these dictionaries in MSBuild.

Second commit adds `OrdinalIgnoreCase` too--that is all that I found in our codebase.

@lifengl, is there an easy way to replicate your results so I can confirm that this hits everything?