### PR TITLE
AppHost checks in ClickOnce publish

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -492,6 +492,7 @@ namespace Microsoft.Build.Tasks
     public sealed partial class GenerateLauncher : Microsoft.Build.Tasks.TaskExtension
     {
         public GenerateLauncher() { }
+        public string AssemblyName { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
         public string LauncherPath { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
@@ -1014,10 +1015,12 @@ namespace Microsoft.Build.Tasks
     public sealed partial class ResolveManifestFiles : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveManifestFiles() { }
+        public string AssemblyName { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem DeploymentManifestEntryPoint { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] ExtraFiles { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] ManagedAssemblies { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] NativeAssemblies { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
@@ -1610,8 +1613,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public bool IsClickOnceManifest { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
-        public bool LauncherBasedDeployment { get { throw null; } set { } }
-        [System.Xml.Serialization.XmlIgnoreAttribute]
         public int MaxTargetPath { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public string OSDescription { get { throw null; } set { } }
@@ -2169,6 +2170,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity AssemblyIdentity { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string AssemblyName { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReferenceCollection AssemblyReferences { get { throw null; } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public string Description { get { throw null; } set { } }
@@ -2178,6 +2181,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReferenceCollection FileReferences { get { throw null; } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public System.IO.Stream InputStream { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.OutputMessageCollection OutputMessages { get { throw null; } }
         [System.Xml.Serialization.XmlIgnoreAttribute]

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -386,6 +386,7 @@ namespace Microsoft.Build.Tasks
     public sealed partial class GenerateLauncher : Microsoft.Build.Tasks.TaskExtension
     {
         public GenerateLauncher() { }
+        public string AssemblyName { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
         public string LauncherPath { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
@@ -759,10 +760,12 @@ namespace Microsoft.Build.Tasks
     public sealed partial class ResolveManifestFiles : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveManifestFiles() { }
+        public string AssemblyName { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem DeploymentManifestEntryPoint { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] ExtraFiles { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] ManagedAssemblies { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] NativeAssemblies { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
@@ -1244,8 +1247,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public string IconFile { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public bool IsClickOnceManifest { get { throw null; } set { } }
-        [System.Xml.Serialization.XmlIgnoreAttribute]
-        public bool LauncherBasedDeployment { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public int MaxTargetPath { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
@@ -1804,6 +1805,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity AssemblyIdentity { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string AssemblyName { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReferenceCollection AssemblyReferences { get { throw null; } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public string Description { get { throw null; } set { } }
@@ -1813,6 +1816,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReferenceCollection FileReferences { get { throw null; } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public System.IO.Stream InputStream { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public Microsoft.Build.Tasks.Deployment.ManifestUtilities.OutputMessageCollection OutputMessages { get { throw null; } }
         [System.Xml.Serialization.XmlIgnoreAttribute]

--- a/src/Tasks/GenerateManifestBase.cs
+++ b/src/Tasks/GenerateManifestBase.cs
@@ -462,8 +462,6 @@ namespace Microsoft.Build.Tasks
                 {
                     applicationManifest.TargetFrameworkVersion = TargetFrameworkVersion;
                 }
-
-                applicationManifest.LauncherBasedDeployment = LauncherBasedDeployment;
             }
 
             if (!String.IsNullOrEmpty(EntryPoint?.ItemSpec))
@@ -485,6 +483,8 @@ namespace Microsoft.Build.Tasks
             {
                 _manifest.Description = Description;
             }
+            _manifest.LauncherBasedDeployment = LauncherBasedDeployment;
+            _manifest.AssemblyName = AssemblyName;
 
             return true;
         }

--- a/src/Tasks/ManifestUtil/ApplicationManifest.cs
+++ b/src/Tasks/ManifestUtil/ApplicationManifest.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private FileAssociation[] _fileAssociations;
         private FileAssociationCollection _fileAssociationList;
         private string _targetFrameworkVersion;
-        private bool _launcherBasedDeployment = false;
 
         /// <summary>
         /// Initializes a new instance of the ApplicationManifest class.
@@ -110,17 +109,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         {
             get => _errorReportUrl;
             set => _errorReportUrl = value;
-        }
-
-        /// <summary>
-        /// Indicates if manifest is part of Launcher-based deployment, which requires
-        /// somewhat different manifest generation and validation.
-        /// </summary>
-        [XmlIgnore]
-        public bool LauncherBasedDeployment
-        {
-            get => _launcherBasedDeployment;
-            set => _launcherBasedDeployment = value;
         }
 
         // Make sure we have a CLR dependency, add it if not...
@@ -669,7 +657,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 // Check that file is not an assembly...
                 // Unless this is a Launcher-based deployments where all files except launcher
                 // are added as regular file references and not assembly references.
-                if (!_launcherBasedDeployment &&
+                if (!LauncherBasedDeployment &&
                     !String.IsNullOrEmpty(file.ResolvedPath) && PathUtil.IsAssembly(file.ResolvedPath))
                 {
                     OutputMessages.AddWarningMessage("GenerateManifest.AssemblyAsFile", file.ToString());

--- a/src/Tasks/ManifestUtil/Constants.cs
+++ b/src/Tasks/ManifestUtil/Constants.cs
@@ -28,5 +28,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public const string DotNetFrameworkIdentifier = ".NETFramework";
         public const string DotNetCoreIdentifier = ".NETCore";
         public const string DotNetCoreAppIdentifier = ".NETCoreApp";
+        public const string AppHostExe = "apphost.exe";
     }
 }

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3984,6 +3984,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Generates Launcher and obtains its Framework version and moniker -->
     <GenerateLauncher
+        AssemblyName="$(_DeploymentApplicationManifestIdentity)"
         EntryPoint="@(EntryPointForLauncher)"
         OutputPath="$(IntermediateOutputPath)"
         VisualStudioVersion="$(VisualStudioVersion)">
@@ -4133,17 +4134,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Create list of items for manifest generation -->
     <ResolveManifestFiles
-        TargetFrameworkVersion="$(TargetFrameworkVersion)"
-        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
-        SigningManifests="$(SignManifests)"
+        AssemblyName="$(_DeploymentApplicationManifestIdentity)"
         EntryPoint="@(_DeploymentClickOnceApplicationExecutable)"
         ExtraFiles="@(_DebugSymbolsIntermediatePath);$(IntermediateOutputPath)$(TargetName).xml;@(_ReferenceRelatedPaths)"
         Files="@(ClickOnceFiles)"
+        LauncherBasedDeployment="$(_DeploymentLauncherBased)"
         ManagedAssemblies="@(_ManifestManagedReferences)"
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"
         PublishFiles="@(PublishFile)"
         SatelliteAssemblies="@(_SatelliteAssemblies)"
-        TargetCulture="$(TargetCulture)">
+        SigningManifests="$(SignManifests)"
+        TargetCulture="$(TargetCulture)"
+        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+        TargetFrameworkVersion="$(TargetFrameworkVersion)">
 
       <Output TaskParameter="OutputAssemblies" ItemName="_DeploymentManifestDependenciesUnfiltered"/>
       <Output TaskParameter="OutputFiles" ItemName="_DeploymentManifestFiles"/>

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2857,10 +2857,6 @@
     <value>MSB3965: No output path specified in build settings.</value>
     <comment>{StrBegin="MSB3965: "}</comment>
   </data>
-  <data name="GenerateLauncher.EmptyEntryPoint">
-    <value>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</value>
-    <comment>{StrBegin="MSB3965: "}</comment>
-  </data>
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -824,11 +824,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -779,11 +779,6 @@
         <target state="new">MSB3961: An error occurred trying to copy '{0}' to '{1}': {2}</target>
         <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
-      <trans-unit id="GenerateLauncher.EmptyEntryPoint">
-        <source>MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</source>
-        <target state="new">MSB3966: EntryPoint input parameter cannot be empty in the GenerateLauncher task.</target>
-        <note>{StrBegin="MSB3965: "}</note>
-      </trans-unit>
       <trans-unit id="GenerateLauncher.General">
         <source>MSB3962: An error occurred generating a launcher: {0}</source>
         <target state="new">MSB3962: An error occurred generating a launcher: {0}</target>


### PR DESCRIPTION
For .NET Core Console apps of EXE type, the final exe that invokes the built DLL is initially called apphost.exe and then copied to the outdir as {AssemblyName}.exe. When publish tasks are running, it receives references to the apphost.exe from the IntermediateOutputDir. The tasks need to special case this file so that it gets published correctly as {AssembyName}.exe and not apphost.exe