### PR TITLE
Remove new assemblies from VSIX

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -49,13 +49,6 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
-  file source=$(X86BinPath)StreamJsonRpc.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Nerdbank.Streams.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.IO.Pipelines.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.VisualStudio.Threading.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.VisualStudio.Validation.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)MessagePack.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)MessagePack.Annotations.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
@@ -205,13 +198,6 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)StreamJsonRpc.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Nerdbank.Streams.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.IO.Pipelines.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.VisualStudio.Threading.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.VisualStudio.Validation.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)MessagePack.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)MessagePack.Annotations.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks


### PR DESCRIPTION
The presence of versions of these assemblies that don't match those delivered elsewhere in VS is causing problems in some workloads that find them via AssemblyFoldersEx. Short-term fix for #5752 that should be fine because the functionality that requires these new assemblies isn't used in VS.