### PR TITLE
Fix SignFile task to be .NET Core aware

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1149,6 +1149,7 @@ namespace Microsoft.Build.Tasks
         public string CertificateThumbprint { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem SigningTarget { get { throw null; } set { } }
+        public string TargetFrameworkIdentifier { get { throw null; } set { } }
         public string TargetFrameworkVersion { get { throw null; } set { } }
         public string TimestampUrl { get { throw null; } set { } }
         public override bool Execute() { throw null; }
@@ -2304,6 +2305,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public static void SignFile(string certPath, System.Security.SecureString certPassword, System.Uri timestampUrl, string path) { }
         public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path) { }
         public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion) { }
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion, string targetFrameworkIdentifier) { }
         public static System.Security.PermissionSet XmlToPermissionSet(System.Xml.XmlElement element) { throw null; }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -1936,6 +1936,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public static void SignFile(string certPath, System.Security.SecureString certPassword, System.Uri timestampUrl, string path) { }
         public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path) { }
         public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion) { }
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion, string targetFrameworkIdentifier) { }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public sealed partial class TrustInfo

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4013,6 +4013,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         TimestampUrl="$(ManifestTimestampUrl)"
         SigningTarget="@(_DeploymentManifestLauncherEntryPoint)"
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
         Condition="'$(_DeploymentSignClickOnceManifests)'=='true'" />
 
     <!--
@@ -5705,6 +5706,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         CertificateThumbprint="$(_DeploymentResolvedManifestCertificateThumbprint)"
         TimestampUrl="$(ManifestTimestampUrl)"
         SigningTarget="$(_DeploymentApplicationDir)$(_DeploymentTargetApplicationManifestFileName)"
+        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         Condition="'$(_DeploymentSignClickOnceManifests)'=='true'" />
 
@@ -5724,6 +5726,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         CertificateThumbprint="$(_DeploymentResolvedManifestCertificateThumbprint)"
         TimestampUrl="$(ManifestTimestampUrl)"
         SigningTarget="$(PublishDir)$(TargetDeployManifestFileName)"
+        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         Condition="'$(_DeploymentSignClickOnceManifests)'=='true'" />
 
@@ -5732,11 +5735,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         TimestampUrl="$(ManifestTimestampUrl)"
         SigningTarget="$(PublishDir)\setup.exe"
         Condition="'$(BootstrapperEnabled)'=='true' and '$(_DeploymentSignClickOnceManifests)'=='true'" />
-
-
   </Target>
-
-
 
 
   <!--

--- a/src/Tasks/SignFile.cs
+++ b/src/Tasks/SignFile.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Build.Tasks
         [Required]
         public ITaskItem SigningTarget { get; set; }
 
+        public string TargetFrameworkIdentifier { get; set; } = Constants.DotNetFrameworkIdentifier;
+
         public String TargetFrameworkVersion { get; set; }
 
         public string TimestampUrl { get; set; }
@@ -40,7 +42,7 @@ namespace Microsoft.Build.Tasks
             {
                 SecurityUtilities.SignFile(CertificateThumbprint,
                 TimestampUrl == null ? null : new Uri(TimestampUrl),
-                SigningTarget.ItemSpec, TargetFrameworkVersion);
+                SigningTarget.ItemSpec, TargetFrameworkVersion, TargetFrameworkIdentifier);
                 return true;
             }
             catch (ArgumentException ex) when (ex.ParamName.Equals("certThumbprint"))


### PR DESCRIPTION
### Customer Impact
Files will be signed with SHA1 digest when .NETCore app is published with ClickOnce provider.

### Testing
Tested manually by author. Automation scenario will be added in dotnet/sdk repo when this msbuild change propagates to the dotnet/sdk repo.

### Risk
Low.  The code change in the SignFile task maintains compatibility with previous behavior when invoked for publishing .NET FX app. The change only affect .NET Core apps publishing with ClickOnce.

### Code Reviewers
john_hart, @rainersigwald, @NikolaMilosavljevic 

### Description of fix
SignFile looks at the .NET FX version that is passed as an argument to decide if the file specified should be SHA1 or SHA2 signed. It checks that the .NET FX version > 4.5 to turn on SHA2 signing.

.NET Core apps targeting .NET Core 3.1 pass in 3.1 as the version of the FX. This causes SignFile to use SHA1 for signing instead of SHA2. 

The fix is to pass in the .NET FX identifier that the task can then compare to known identifiers for .NET FX and .NETCore. If the identifier supplied in .NETCore, we always use SHA2 signing. If the identifier supplied is .NET FX, we continue to use the existing logic.
