### PR TITLE
Msbuilddisablenodereuse live check

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -16,7 +16,6 @@ using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 using ForwardingLoggerRecord = Microsoft.Build.Logging.ForwardingLoggerRecord;
-using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Execution
 {
@@ -395,7 +394,7 @@ namespace Microsoft.Build.Execution
         public bool EnableNodeReuse
         {
             get => _enableNodeReuse;
-            set => _enableNodeReuse = Traits.Instance.DisableNodeReuse ? false : value;
+            set => _enableNodeReuse = Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE") == "1" ? false : value;
         }
 
         /// <summary>
@@ -906,7 +905,7 @@ namespace Microsoft.Build.Execution
             ResetCaches = true;
             _toolsetProvider = toolsetProvider;
 
-            if (Traits.Instance.DisableNodeReuse) // For example to disable node reuse within Visual Studio
+            if (Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE") == "1") // For example to disable node reuse within Visual Studio
             {
                 _enableNodeReuse = false;
             }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2380,7 +2380,7 @@ namespace Microsoft.Build.CommandLine
             enableNodeReuse = false;
 #endif
 
-            if (Traits.Instance.DisableNodeReuse) // For example to disable node reuse in a gated checkin, without using the flag
+            if (Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE") == "1") // For example to disable node reuse in a gated checkin, without using the flag
             {
                 enableNodeReuse = false;
             }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -94,11 +94,6 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly int LogPropertyTracking = ParseIntFromEnvironmentVariableOrDefault("MsBuildLogPropertyTracking", 0); // Default to logging nothing via the property tracker.
 
-        /// <summary>
-        /// Setting this environment variable to 1 disables the node reuse feature.
-        /// </summary>
-        public readonly bool DisableNodeReuse = Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE") == "1";
-
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {
             return int.TryParse(Environment.GetEnvironmentVariable(environmentVariable), out int result)


### PR DESCRIPTION
This is a fix for [AB#1197992](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1197992).

Customer Impact
Customers can specify whether they want nodes to be reused after startup. A change in 16.7 cached it, breaking a VS extension.

Testing
No current testing, but the author can add a unit test.

Risk
Low. The code change is minimal and although customers could have started changing the value of the environment variable after startup since 16.7, there is no clear benefit to doing so.

Code Reviewers
None (yet)

Description of fix
Disable caching of MSBUILDDISABLENODEREUSE variable.