### PR TITLE
Fix for SCD ClickOnce publish of .NET Core App

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1020,6 +1020,8 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] ExtraFiles { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public bool IsSelfContainedPublish { get { throw null; } set { } }
+        public bool IsSingleFilePublish { get { throw null; } set { } }
         public bool LauncherBasedDeployment { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] ManagedAssemblies { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] NativeAssemblies { get { throw null; } set { } }
@@ -1032,6 +1034,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] OutputFiles { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] PublishFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] RuntimePackAssets { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] SatelliteAssemblies { get { throw null; } set { } }
         public bool SigningManifests { get { throw null; } set { } }
         public string TargetCulture { get { throw null; } set { } }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -765,6 +765,8 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] ExtraFiles { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public bool IsSelfContainedPublish { get { throw null; } set { } }
+        public bool IsSingleFilePublish { get { throw null; } set { } }
         public bool LauncherBasedDeployment { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] ManagedAssemblies { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] NativeAssemblies { get { throw null; } set { } }
@@ -777,6 +779,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] OutputFiles { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] PublishFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] RuntimePackAssets { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] SatelliteAssemblies { get { throw null; } set { } }
         public bool SigningManifests { get { throw null; } set { } }
         public string TargetCulture { get { throw null; } set { } }

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4094,7 +4094,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_SatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
       <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)"
-                                 Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
+                                 Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe' Or '%(Extension)' == '.md'">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
       <_DeploymentReferencePaths Include="@(_DeploymentReferencePaths);@(_CopyLocalFalseRefPathsWithExclusion)" />
@@ -4139,10 +4139,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         EntryPoint="@(_DeploymentClickOnceApplicationExecutable)"
         ExtraFiles="@(_DebugSymbolsIntermediatePath);$(IntermediateOutputPath)$(TargetName).xml;@(_ReferenceRelatedPaths)"
         Files="@(ClickOnceFiles)"
+        IsSelfContainedPublish="$(SelfContained)"
+        IsSingleFilePublish="$(PublishSingleFile)"
         LauncherBasedDeployment="$(_DeploymentLauncherBased)"
         ManagedAssemblies="@(_ManifestManagedReferences)"
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"
         PublishFiles="@(PublishFile)"
+        RuntimePackAssets="@(RuntimePackAsset)"
         SatelliteAssemblies="@(_SatelliteAssemblies)"
         SigningManifests="$(SignManifests)"
         TargetCulture="$(TargetCulture)"


### PR DESCRIPTION
**Customer Impact**
Customer trying to deploy their .NET Core 3.1 or 5.0 application w/ClickOnce using Self Contained Deployment (SCD) mode in its default setting (SingleFile=false) will see app fail to launch due to missing .NET Core runtime files in publish folder.

**Testing**
Core scenarios for both .NET Core 3.1 and .NET 5.0 have been validated by sujitn;johnhart;ningli;yaya.
CTI team is doing a full test validation.

**Risk**
Low. The changes are scoped to .NET Core app ClickOnce deployment in SCD Mode with SingleFile=false.

**Code Reviewers**
johnhart

**Description of fix**
ClickOnce Publish is a new feature being added to .NET Core apps. .NET Core apps have a SCD mode that ClickOnce is not aware of. ClickOnce behavior in .NET FX is to filter out references for files that below to the .NET Framework. This behavior cause ClickOnce to filter out .NET Core assemblies as well in SCD mode which will cause app launch to fail.

To fix this, the ResolveManifestFiles ClickOnce task which is responsible for filtering is being passed following additional arguments:
bool IsSelfContainedPublish
bool IsSingleFilePublish
ITaskItem[] RuntimePackAssets

The task's filtering routine will now do a lookup of the references against RuntimePackAssets and will not filter the reference if it is found in RuntimePackAssets when SCD=true and SingleFile=false.

