### PR TITLE
Support WarningsAsErrors as MSBuildWarningsAsErrors

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -616,7 +616,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Users familiar with how some other repos work try to use NoWarn with MSBuild in place of MSBuildWarningsAsMessages. -->
   <PropertyGroup Condition="$([MSBuild]::AreFeaturesEnabled('16.8'))">
     <MSBuildWarningsAsMessages Condition="'$(MSBuildWarningsAsMessages)'==''">$(NoWarn)</MSBuildWarningsAsMessages>
-    <MSBuildWarningsAsErrors Condition="'$(MSBuildWarningsAsErrors)'==''">$(WarnAsError)</MSBuildWarningsAsErrors>
+    <MSBuildWarningsAsErrors Condition="'$(MSBuildWarningsAsErrors)'==''">$(WarningsAsErrors)</MSBuildWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Common Project System support -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -614,8 +614,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <!-- Users familiar with how some other repos work try to use NoWarn with MSBuild in place of MSBuildWarningsAsMessages. -->
-  <PropertyGroup Condition="'$(MSBuildWarningsAsMessages)'=='' And $([MSBuild]::AreFeaturesEnabled('16.8'))">
-    <MSBuildWarningsAsMessages>$(NoWarn)</MSBuildWarningsAsMessages>
+  <PropertyGroup Condition="$([MSBuild]::AreFeaturesEnabled('16.8'))">
+    <MSBuildWarningsAsMessages Condition="'$(MSBuildWarningsAsMessages)'==''">$(NoWarn)</MSBuildWarningsAsMessages>
+    <MSBuildWarningsAsErrors Condition="'$(MSBuildWarningsAsErrors)'==''">$(WarnAsError)</MSBuildWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Common Project System support -->


### PR DESCRIPTION
In same change wave as NoWarn (can change to a separate one if desired.)

@sbomer, here's WarnAsError. WarnNotAsError is a little more complicated, though I'd be happy to try to help if you want to try to implement it yourself.