### PR TITLE
Improve reliability of node handshake in 16.7 to match 16.8 for version information

### DIFF
--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -124,15 +124,7 @@ namespace Microsoft.Build.Internal
                     // This is easier in .NET 4+:
                     //  var fileIdentity = typeof(CommunicationsUtilities).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
                     // but we need to be 3.5 compatible here to work in MSBuildTaskHost
-                    string fileIdentity = null;
-                    foreach (var attribute in typeof(CommunicationsUtilities).GetTypeInfo().Assembly.GetCustomAttributes(false))
-                    {
-                        if (attribute is AssemblyInformationalVersionAttribute informationalVersionAttribute)
-                        {
-                            fileIdentity = informationalVersionAttribute.InformationalVersion;
-                            break;
-                        }
-                    }
+                    string fileIdentity = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
 
                     ErrorUtilities.VerifyThrow(fileIdentity != null, "Did not successfully retrieve InformationalVersion.");
 


### PR DESCRIPTION
Fixes one of the causes for https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1172859

**Customer Impact**
Some (but not all) customers will stop having repeatedly failing node handshakes, allowing them to build without restarting Visual Studio. A change in 16.7 relied more heavily upon a flaky API that this change avoids.

**Testing**
The current fix is part of 16.8, and one customer who had experienced the problem with 16.7 tentatively suggested that 16.8 was not broken. Also, all the customers who have reported difficulties and provided COMM traces indicating they shared this problem were using 16.7 at the time.

**Risk**
Very low. The code change is minimal, the new way of looking up a version is already in use in 16.8 without it causing problems, as far as we know, and the new version is scoped to a change in a single part of a single function, just responsible for looking up the version.

**Code Reviewers**
@rainersigwald

**Description of fix**
Reflects over the executing assembly to find its version instead of looping over its attributes in search of its version. The latter approach apparently sometimes returns an empty string, which is treated as a valid version that doesn't match any other versions, causing the inability to connect customers experienced.