### PR TITLE
Support '--' in a command line argument as a correct switch indicator

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -437,6 +437,22 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void GetLengthOfSwitchIndicatorTest()
+        {
+            var commandLineSwitchWithSlash = "/Switch";
+            var commandLineSwitchWithSingleDash = "-Switch";
+            var commandLineSwitchWithDoubleDash = "--Switch";
+
+            var commandLineSwitchWithNoneOrIncorrectIndicator = "zSwitch";
+
+            MSBuildApp.GetLengthOfSwitchIndicator(commandLineSwitchWithSlash).ShouldBe(1);
+            MSBuildApp.GetLengthOfSwitchIndicator(commandLineSwitchWithSingleDash).ShouldBe(1);
+            MSBuildApp.GetLengthOfSwitchIndicator(commandLineSwitchWithDoubleDash).ShouldBe(2);
+
+            MSBuildApp.GetLengthOfSwitchIndicator(commandLineSwitchWithNoneOrIncorrectIndicator).ShouldBe(0);
+        }
+
+        [Fact]
         public void Help()
         {
                 MSBuildApp.Execute(

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -455,13 +455,37 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void Help()
         {
-                MSBuildApp.Execute(
+            MSBuildApp.Execute(
 #if FEATURE_GET_COMMANDLINE
-                    @"c:\bin\msbuild.exe -? "
+                @"c:\bin\msbuild.exe -? "
 #else
-                    new [] {@"c:\bin\msbuild.exe", "-?"}
+                new [] {@"c:\bin\msbuild.exe", "-?"}
 #endif
-                ).ShouldBe(MSBuildApp.ExitType.Success);
+            ).ShouldBe(MSBuildApp.ExitType.Success);
+
+            MSBuildApp.Execute(
+#if FEATURE_GET_COMMANDLINE
+                @"c:\bin\msbuild.exe -h "
+#else
+                new [] {@"c:\bin\msbuild.exe", "-h"}
+#endif
+            ).ShouldBe( MSBuildApp.ExitType.Success );
+
+            MSBuildApp.Execute(
+#if FEATURE_GET_COMMANDLINE
+                @"c:\bin\msbuild.exe --help "
+#else
+                new [] {@"c:\bin\msbuild.exe", "--help"}
+#endif
+            ).ShouldBe( MSBuildApp.ExitType.Success );
+
+            MSBuildApp.Execute(
+#if FEATURE_GET_COMMANDLINE
+                @"c:\bin\msbuild.exe /h "
+#else
+                new [] {@"c:\bin\msbuild.exe", "/h"}
+#endif
+            ).ShouldBe( MSBuildApp.ExitType.Success );
         }
 
         [Fact]

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -452,40 +452,20 @@ namespace Microsoft.Build.UnitTests
             MSBuildApp.GetLengthOfSwitchIndicator(commandLineSwitchWithNoneOrIncorrectIndicator).ShouldBe(0);
         }
 
-        [Fact]
-        public void Help()
+        [Theory]
+        [InlineData("-?")]
+        [InlineData("-h")]
+        [InlineData("--help")]
+        [InlineData(@"/h")]
+        public void Help(string indicator)
         {
             MSBuildApp.Execute(
 #if FEATURE_GET_COMMANDLINE
-                @"c:\bin\msbuild.exe -? "
+                @$"c:\bin\msbuild.exe {indicator} "
 #else
-                new [] {@"c:\bin\msbuild.exe", "-?"}
+                new [] {@"c:\bin\msbuild.exe", indicator}
 #endif
             ).ShouldBe(MSBuildApp.ExitType.Success);
-
-            MSBuildApp.Execute(
-#if FEATURE_GET_COMMANDLINE
-                @"c:\bin\msbuild.exe -h "
-#else
-                new [] {@"c:\bin\msbuild.exe", "-h"}
-#endif
-            ).ShouldBe( MSBuildApp.ExitType.Success );
-
-            MSBuildApp.Execute(
-#if FEATURE_GET_COMMANDLINE
-                @"c:\bin\msbuild.exe --help "
-#else
-                new [] {@"c:\bin\msbuild.exe", "--help"}
-#endif
-            ).ShouldBe( MSBuildApp.ExitType.Success );
-
-            MSBuildApp.Execute(
-#if FEATURE_GET_COMMANDLINE
-                @"c:\bin\msbuild.exe /h "
-#else
-                new [] {@"c:\bin\msbuild.exe", "/h"}
-#endif
-            ).ShouldBe( MSBuildApp.ExitType.Success );
         }
 
         [Fact]

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2922,8 +2922,7 @@ namespace Microsoft.Build.CommandLine
         /// </returns>
         private static bool ValidateSwitchIndicatorInUnquotedArgument(string unquotedCommandLineArgument)
         {
-            return unquotedCommandLineArgument.StartsWith("--", StringComparison.Ordinal)
-                || unquotedCommandLineArgument.StartsWith("-", StringComparison.Ordinal)
+            return unquotedCommandLineArgument.StartsWith("-", StringComparison.Ordinal) // superset of "--"
                 || unquotedCommandLineArgument.StartsWith("/", StringComparison.Ordinal);
         }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2939,15 +2939,15 @@ namespace Microsoft.Build.CommandLine
         {
             if (unquotedSwitch.StartsWith("--", StringComparison.Ordinal))
             {
-                return "--".Length;
+                return 2;
             }
             else if (unquotedSwitch.StartsWith("-", StringComparison.Ordinal) || unquotedSwitch.StartsWith("/", StringComparison.Ordinal))
             {
-                return "-".Length;
+                return 1;
             }
             else
             {
-                return "".Length;
+                return 0;
             }
         }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2922,32 +2922,33 @@ namespace Microsoft.Build.CommandLine
         /// </returns>
         private static bool ValidateSwitchIndicatorInUnquotedArgument(string unquotedCommandLineArgument)
         {
-            return unquotedCommandLineArgument.StartsWith("-", StringComparison.Ordinal)
-                || unquotedCommandLineArgument.StartsWith("/", StringComparison.Ordinal)
-                || unquotedCommandLineArgument.StartsWith("--", StringComparison.Ordinal);
+            return unquotedCommandLineArgument.StartsWith("--", StringComparison.Ordinal)
+                || unquotedCommandLineArgument.StartsWith("-", StringComparison.Ordinal)
+                || unquotedCommandLineArgument.StartsWith("/", StringComparison.Ordinal);
         }
 
         /// <summary>
         /// Gets the length of the switch indicator (- or / or --)
         /// <br/>The length returned from this method is deduced from the beginning sequence of unquoted argument.
-        /// This way it will "assume" that there's no further error (e.g. //  or ---) which would also be considered as a correct indicator.
+        /// <br/>This way it will "assume" that there's no further error (e.g. //  or ---) which would also be considered as a correct indicator.
         /// </summary>
         /// <param name="unquotedSwitch">Unquoted argument with leading indicator and name</param>
         /// <returns>Correct length of used indicator
         /// <br/>0 if no leading sequence recognized as correct indicator</returns>
-        internal static int GetLengthOfSwitchIndicator( string unquotedSwitch )
+        /// Internal for testing purposes
+        internal static int GetLengthOfSwitchIndicator(string unquotedSwitch)
         {
             if (unquotedSwitch.StartsWith("--", StringComparison.Ordinal))
             {
-                return 2;
+                return "--".Length;
             }
             else if (unquotedSwitch.StartsWith("-", StringComparison.Ordinal) || unquotedSwitch.StartsWith("/", StringComparison.Ordinal))
             {
-                return 1;
+                return "-".Length;
             }
             else
             {
-                return 0;
+                return "".Length;
             }
         }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1675,8 +1675,8 @@ namespace Microsoft.Build.CommandLine
                         string switchName;
                         string switchParameters;
 
-                        // all switches should start with - or / unless a project is being specified
-                        if (!unquotedCommandLineArg.StartsWith("-", StringComparison.Ordinal) && (!unquotedCommandLineArg.StartsWith("/", StringComparison.Ordinal) || FileUtilities.LooksLikeUnixFilePath(unquotedCommandLineArg)))
+                        // all switches should start with - or / or -- unless a project is being specified
+                        if (!ValidateSwitchIndicatorInUnquotedArgument(unquotedCommandLineArg) || FileUtilities.LooksLikeUnixFilePath(unquotedCommandLineArg))
                         {
                             switchName = null;
                             // add a (fake) parameter indicator for later parsing
@@ -1687,17 +1687,20 @@ namespace Microsoft.Build.CommandLine
                             // check if switch has parameters (look for the : parameter indicator)
                             int switchParameterIndicator = unquotedCommandLineArg.IndexOf(':');
 
+                            // get the length of the beginning sequence considered as a switch indicator (- or / or --)
+                            int switchIndicatorsLength = GetLengthOfSwitchIndicator(unquotedCommandLineArg);
+
                             // extract the switch name and parameters -- the name is sandwiched between the switch indicator (the
-                            // leading - or /) and the parameter indicator (if the switch has parameters); the parameters (if any)
+                            // leading - or / or --) and the parameter indicator (if the switch has parameters); the parameters (if any)
                             // follow the parameter indicator
                             if (switchParameterIndicator == -1)
                             {
-                                switchName = unquotedCommandLineArg.Substring(1);
+                                switchName = unquotedCommandLineArg.Substring(switchIndicatorsLength);
                                 switchParameters = String.Empty;
                             }
                             else
                             {
-                                switchName = unquotedCommandLineArg.Substring(1, switchParameterIndicator - 1);
+                                switchName = unquotedCommandLineArg.Substring(switchIndicatorsLength, switchParameterIndicator - 1);
                                 switchParameters = ExtractSwitchParameters(commandLineArg, unquotedCommandLineArg, doubleQuotesRemovedFromArg, switchName, switchParameterIndicator);
                             }
                         }
@@ -2905,6 +2908,46 @@ namespace Microsoft.Build.CommandLine
                     // Make sure that no wild cards are in the string because for now we dont allow wild card extensions.
                     InitializationException.VerifyThrow(extension.IndexOfAny(s_wildcards) == -1, "InvalidExtensionToIgnore", extension, null, false);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Checks whether an argument given as a parameter starts with valid indicator,
+        /// <br/>which means, whether switch begins with one of: "/", "-", "--"
+        /// </summary>
+        /// <param name="unquotedCommandLineArgument">Command line argument with beginning indicator (e.g. --help).
+        /// <br/>This argument has to be unquoted, otherwise the first character will always be a quote character "</param>
+        /// <returns>true if argument's beginning matches one of possible indicators
+        /// <br/>false if argument's beginning doesn't match any of correct indicator
+        /// </returns>
+        private static bool ValidateSwitchIndicatorInUnquotedArgument(string unquotedCommandLineArgument)
+        {
+            return unquotedCommandLineArgument.StartsWith("-", StringComparison.Ordinal)
+                || unquotedCommandLineArgument.StartsWith("/", StringComparison.Ordinal)
+                || unquotedCommandLineArgument.StartsWith("--", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Gets the length of the switch indicator (- or / or --)
+        /// <br/>The length returned from this method is deduced from the beginning sequence of unquoted argument.
+        /// This way it will "assume" that there's no further error (e.g. //  or ---) which would also be considered as a correct indicator.
+        /// </summary>
+        /// <param name="unquotedSwitch">Unquoted argument with leading indicator and name</param>
+        /// <returns>Correct length of used indicator
+        /// <br/>0 if no leading sequence recognized as correct indicator</returns>
+        internal static int GetLengthOfSwitchIndicator( string unquotedSwitch )
+        {
+            if (unquotedSwitch.StartsWith("--", StringComparison.Ordinal))
+            {
+                return 2;
+            }
+            else if (unquotedSwitch.StartsWith("-", StringComparison.Ordinal) || unquotedSwitch.StartsWith("/", StringComparison.Ordinal))
+            {
+                return 1;
+            }
+            else
+            {
+                return 0;
             }
         }
 


### PR DESCRIPTION
This pull request fixes #5714:

It adds the support for double dash ('--') indicator used in command line arguments.
With these changes it is now possible to invoke MSBuild commands using the same '--' switch indicators as it is currently possible with dotnet call.

---

Changes done in this delivery are:
* Add '--' as another correct sequence when checking for valid argument's beginning
Even if '-' beginning would also be recognized when using '*--*', adding '*--*' keeps the implementation consistent 
* Move the validation of switch beginnings into separate method
* Get the indicator's length, based on found starting string, so it can be used to correctly extract the name of switch
Without it  '*--*'  would still be unrecognized, as hardcoded *1* in 
`switchName = unquotedCommandLineArg.Substring(1, switchParameterIndicator - 1);`
would still result in having the extracted name as "*-name*"
* Cover the `GetLengthOfSwitchIndicator()` method with unit test
This is to check whether each switch variation has correct length of it's indicator returned.

For more details about the implementation, please check the commit messages done for this pull request.

---

The example of how this implementation work (presented on *version* switch for short output) is presented below.
```
P:\Projekty\MSBuild>dotnet artifacts\bin\MSBuild\Debug\netcoreapp2.1\MSBuild.dll --version
Microsoft (R) Build Engine version 16.9.0-ci-20508-01+13c455688 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.


16.9.0.50801
P:\Projekty\MSBuild>artifacts\bin\MSBuild\Debug\net472\MSBuild.exe --version
Microsoft (R) Build Engine version 16.9.0-ci-20508-01+13c455688 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

16.9.0.50801
```

Unit test results are attached to this pull request, presenting only the *Microsoft.Build.CommandLine*, as only this layer should be affected.
*Microsoft.Build.CommandLine.UnitTests_net472_x86_implementation* - showing the results with PR changes
*Microsoft.Build.CommandLine.UnitTests_net472_x86_original* - showing the results on main branch
[CommandLine_UnitTest_Results.zip](https://github.com/dotnet/msbuild/files/5347390/CommandLine_UnitTest_Results.zip)
