### PR TITLE
Remove Nerdbank dependency

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,6 +1,5 @@
 <Project>
     <ItemGroup>
-		<FileSignInfo Include="Nerdbank.Streams.dll" CertificateName="3PartySHA2" /> 
 		<FileSignInfo Include="MessagePack.dll" CertificateName="3PartySHA2" /> 
 		<FileSignInfo Include="MessagePack.Annotations.dll" CertificateName="3PartySHA2" />
 		<ItemsToSign Include="$(VisualStudioSetupInsertionPath)Microsoft.Build.UnGAC.exe" />

--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -41,7 +41,6 @@
     <file src="$X86BinPath$/System.Runtime.CompilerServices.Unsafe.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/StreamJsonRpc.dll" target="v15.0/bin" />
-    <file src="$X86BinPath$/Nerdbank.Streams.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.IO.Pipelines.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.VisualStudio.Threading.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.VisualStudio.Validation.dll" target="v15.0/bin" />
@@ -102,7 +101,6 @@
     <file src="$X86BinPath$/System.Runtime.CompilerServices.Unsafe.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/StreamJsonRpc.dll" target="v15.0/bin/amd64" />
-    <file src="$X86BinPath$/Nerdbank.Streams.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.IO.Pipelines.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.VisualStudio.Threading.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.VisualStudio.Validation.dll" target="v15.0/bin/amd64" />

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -50,7 +50,6 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)StreamJsonRpc.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Nerdbank.Streams.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.IO.Pipelines.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.VisualStudio.Threading.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.VisualStudio.Validation.dll vs.file.ngenArchitecture=all
@@ -206,7 +205,6 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)StreamJsonRpc.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Nerdbank.Streams.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.IO.Pipelines.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.VisualStudio.Threading.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.VisualStudio.Validation.dll vs.file.ngenArchitecture=all

--- a/src/Tasks/ResolveAssemblyReferences/RpcUtils.cs
+++ b/src/Tasks/ResolveAssemblyReferences/RpcUtils.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 
-using Nerdbank.Streams;
 using StreamJsonRpc;
 
 #nullable enable
@@ -13,7 +12,7 @@ namespace Microsoft.Build.Tasks.ResolveAssemblyReferences
     {
         internal static IJsonRpcMessageHandler GetRarMessageHandler(Stream stream)
         {
-            return new LengthHeaderMessageHandler(stream.UsePipe(), new MessagePackFormatter());
+            return new LengthHeaderMessageHandler(stream, stream, new MessagePackFormatter());
         }
     }
 }


### PR DESCRIPTION
This PR removes the Nerdbank dependency by using ctor of `LengthHeaderMessageHandler`, which accepts in/out `Stream`s.