### PR TITLE
Add files missing in ClickOnce SingleFile bundle.

### DIFF
--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -59,10 +59,12 @@ namespace Microsoft.Build.Tasks
             var launcherBuilder = new LauncherBuilder(LauncherPath);
             string entryPointFileName = Path.GetFileName(EntryPoint.ItemSpec);
             //
-            // If the EntryPoint specified is apphost.exe, we need to use the assemblyname instead since
-            // apphost.exe is the source file that will get copied to outdir as {assemblyname}.exe.
+            // If the EntryPoint specified is apphost.exe or singlefilehost.exe, we need to replace the EntryPoint
+            // with the AssemblyName instead since apphost.exe/singlefilehost.exe is an intermediate file for
+            // for final published {assemblyname}.exe.
             //
-            if (entryPointFileName.Equals(Constants.AppHostExe, StringComparison.InvariantCultureIgnoreCase) &&
+            if ((entryPointFileName.Equals(Constants.AppHostExe, StringComparison.InvariantCultureIgnoreCase) || 
+                entryPointFileName.Equals(Constants.SingleFileHostExe, StringComparison.InvariantCultureIgnoreCase)) &&
                 !String.IsNullOrEmpty(AssemblyName))
             {
                 entryPointFileName = AssemblyName;

--- a/src/Tasks/ManifestUtil/Constants.cs
+++ b/src/Tasks/ManifestUtil/Constants.cs
@@ -29,5 +29,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public const string DotNetCoreIdentifier = ".NETCore";
         public const string DotNetCoreAppIdentifier = ".NETCoreApp";
         public const string AppHostExe = "apphost.exe";
+        public const string SingleFileHostExe = "singlefilehost.exe";
     }
 }

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4111,9 +4111,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <ClickOnceFiles Include="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce)"/>
     </ItemGroup>
 
-    <!-- For single file publish, we only need to include the SF EXE in the clickonce manifest -->
+    <!-- For single file publish, we need to include the SF bundle EXE and files excluded from the bundle EXE in the clickonce manifest -->
     <ItemGroup Condition="'$(PublishSingleFile)' == 'true'">
       <ClickOnceFiles Include="$(PublishedSingleFilePath)"/>
+      <ClickOnceFiles Include="@(_FilesExcludedFromBundle)"/>
     </ItemGroup>
 
     <!-- Copy the application executable from Obj folder to app.publish folder.
@@ -5636,7 +5637,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             />
 
     <ItemGroup Condition="'$(PublishSingleFile)' == 'true'">
-      <PublishedSingleFileToBeCopied Include="$(PublishedSingleFilePath)" TargetPath="$(PublishedSingleFileName)"/>
+      <PublishedSingleFileToBeCopied Include="@(_DeploymentManifestFiles)"/>
     </ItemGroup>
 
     <!-- For single-file publish case, we need to only copy the clickonce manifest, manifest entry point (launcher) and the SF EXE -->


### PR DESCRIPTION
**Customer Impact**
Customers trying to deploy their .NET 5.0 application w/ClickOnce using Single File Self Contained Deployment mode will see a runtime failure either due to invalid entrypoint EXE name or due to missing Core CLR files (e.g. clrcompression.dll, coreclr.dll, clrjit.dll).

**Testing**
Core ClickOnce .NET Core scenarios for both .net 3.1 and .net 5.0 have been validated by sujitn;johnhart;ningli;yaya.
CTI team is doing a full test validation.

**Risk**
Low. The changes are scoped to .NET Core ClickOnce deployment in Single File mode.

**Code Reviewers**
johnhart

**Description of fix**
When a .NET 5.0 app is published with Single-File enabled, not all dependent runtime files are included in the single file bundle EXE. Some files get excluded and need to be published individually along with the SF EXE. The list of these files are output by the GenerateSingleFileBundle target in MS.NET.Publish.targets as the _FilesExcludedFromBundle output group.

ClickOnce's ResolveManifestFiles will now also be passed these additional files when we're doing a single file ClickOnce publish. This will ensure these files getting written to ClickOnce's manifest file. ClickOnce's copy files target has also been updated to copy these extra files along with the existing files (SF EXE, Launcher.exe entrypoint EXe and ClickOnce .manifest file) to the publish folder.

In addition, the GenerateLauncher ClickOnce task has been updated to do special handling for singlefilehost.exe in addition to apphost.exe. When IsSingleFile is false, apphost.exe is the name of the intermediate EXE. When IsSingleFile is true, singlefilehost.exe is the name of the intermediate EXE. If GenerateLauncher does not handle this name correctly, Launcher's entrypoint point will be set to singlefilehost.exe instead of the final application EXE.
