### PR TITLE
Check TargetFramework Using Intrinsic Function

### DIFF
--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -110,7 +110,7 @@
     <DefineConstants Condition="$([MSBuild]::IsOSPlatform('windows'))">$(DefineConstants);TEST_ISWINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(MonoBuild)' != 'true' and ($([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp1.0')) or $(TargetFramework.StartsWith('netstandard')))">
+  <PropertyGroup Condition="'$(MonoBuild)' != 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">
     <NetCoreBuild>true</NetCoreBuild>
     <DefineConstants>$(DefineConstants);RUNTIME_TYPE_NETCORE</DefineConstants>
   </PropertyGroup>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -110,7 +110,7 @@
     <DefineConstants Condition="$([MSBuild]::IsOSPlatform('windows'))">$(DefineConstants);TEST_ISWINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(MonoBuild)' != 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">
+  <PropertyGroup Condition="'$(MonoBuild)' != 'true' and ($([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' or $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETStandard')">
     <NetCoreBuild>true</NetCoreBuild>
     <DefineConstants>$(DefineConstants);RUNTIME_TYPE_NETCORE</DefineConstants>
   </PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -78,9 +78,9 @@
   <PropertyGroup Condition="'$(GenerateReferenceAssemblySource)' == 'true' and $([MSBuild]::IsOSPlatform('windows'))">
     <GenAPIAssemblyName>$(AssemblyName)</GenAPIAssemblyName>
     <GenAPIAssemblyName Condition="'$(GenAPIAssemblyName)' == ''">$(MSBuildProjectName)</GenAPIAssemblyName>
-    <GenAPIShortFrameworkIdentifier Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">net</GenAPIShortFrameworkIdentifier>
-    <GenAPIShortFrameworkIdentifier Condition="$(TargetFramework.StartsWith('netstandard'))">netstandard</GenAPIShortFrameworkIdentifier>
-    <GenAPIShortFrameworkIdentifier Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp1.0'))">netstandard</GenAPIShortFrameworkIdentifier>
+    <GenAPIShortFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">net</GenAPIShortFrameworkIdentifier>
+    <GenAPIShortFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">netstandard</GenAPIShortFrameworkIdentifier>
+    <GenAPIShortFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">netstandard</GenAPIShortFrameworkIdentifier>
     <GenAPITargetPath>$(RepoRoot)ref\$(GenAPIAssemblyName)\$(GenAPIShortFrameworkIdentifier)\$(GenAPIAssemblyName).cs</GenAPITargetPath>
   </PropertyGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -78,9 +78,9 @@
   <PropertyGroup Condition="'$(GenerateReferenceAssemblySource)' == 'true' and $([MSBuild]::IsOSPlatform('windows'))">
     <GenAPIAssemblyName>$(AssemblyName)</GenAPIAssemblyName>
     <GenAPIAssemblyName Condition="'$(GenAPIAssemblyName)' == ''">$(MSBuildProjectName)</GenAPIAssemblyName>
-    <GenAPIShortFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">net</GenAPIShortFrameworkIdentifier>
-    <GenAPIShortFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">netstandard</GenAPIShortFrameworkIdentifier>
-    <GenAPIShortFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">netstandard</GenAPIShortFrameworkIdentifier>
+    <GenAPIShortFrameworkIdentifier Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">net</GenAPIShortFrameworkIdentifier>
+    <GenAPIShortFrameworkIdentifier Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETStandard'">netstandard</GenAPIShortFrameworkIdentifier>
+    <GenAPIShortFrameworkIdentifier Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">netstandard</GenAPIShortFrameworkIdentifier>
     <GenAPITargetPath>$(RepoRoot)ref\$(GenAPIAssemblyName)\$(GenAPIShortFrameworkIdentifier)\$(GenAPIAssemblyName).cs</GenAPITargetPath>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -51,7 +51,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Store values of certain intrinsic functions that won't change throughout the build. -->
   <PropertyGroup Condition="'$(TargetFramework)' != ''">
     <TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkIdentifier)' == ''">$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))</TargetFrameworkVersion>
   </PropertyGroup>
 
   <!-- Because .NET 2.0 apps did not set TargetFrameworkIdentifier, we need to set it for them here by default.  If

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -48,12 +48,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <TargetRuntime>Managed</TargetRuntime>
   </PropertyGroup>
 
-    <!-- Store values of certain intrinsic functions that won't change throughout the build. -->
-  <PropertyGroup Condition="'$(TargetFramework)' != ''">
-    <TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))</TargetFrameworkVersion>
-  </PropertyGroup>
-
   <!-- Because .NET 2.0 apps did not set TargetFrameworkIdentifier, we need to set it for them here by default.  If
        the runtime is set to Managed, we also need to set these.  Otherwise they should be blank (for instance Javascript or
        Native apps) because they do not target a .NET Framework. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -48,18 +48,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <TargetRuntime>Managed</TargetRuntime>
   </PropertyGroup>
 
+    <!-- Store values of certain intrinsic functions that won't change throughout the build. -->
+  <PropertyGroup Condition="'$(TargetFramework)' != ''">
+    <TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkIdentifier)' == ''">$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))</TargetFrameworkIdentifier>
+  </PropertyGroup>
+
   <!-- Because .NET 2.0 apps did not set TargetFrameworkIdentifier, we need to set it for them here by default.  If
        the runtime is set to Managed, we also need to set these.  Otherwise they should be blank (for instance Javascript or
        Native apps) because they do not target a .NET Framework. -->
   <PropertyGroup Condition="'$(TargetRuntime)' == 'Managed'">
     <TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.0</TargetFrameworkVersion>
-  </PropertyGroup>
-
-  <!-- Store values of certain intrinsic functions that won't change throughout the build. -->
-  <PropertyGroup Condition="'$(TargetFramework)' != ''">
-    <_TargetFrameworkIdentifier Condition="'$(_TargetFrameworkIdentifier)' == ''">$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))</_TargetFrameworkIdentifier>
-    <_TargetFrameworkVersion Condition="'$(_TargetFrameworkIdentifier)' == ''">$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))</_TargetFrameworkVersion>
   </PropertyGroup>
 
   <!-- AvailablePlatforms is the list of platform targets available. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -56,6 +56,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.0</TargetFrameworkVersion>
   </PropertyGroup>
 
+  <!-- Store values of certain intrinsic functions that won't change throughout the build. -->
+  <PropertyGroup Condition="'$(TargetFramework)' != ''">
+    <_TargetFrameworkIdentifier Condition="'$(_TargetFrameworkIdentifier)' == ''">$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))</_TargetFrameworkIdentifier>
+    <_TargetFrameworkVersion Condition="'$(_TargetFrameworkIdentifier)' == ''">$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))</_TargetFrameworkVersion>
+  </PropertyGroup>
+
   <!-- AvailablePlatforms is the list of platform targets available. -->
   <PropertyGroup>
     <AvailablePlatforms Condition="'$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == ''">Any CPU,x86,x64,Itanium</AvailablePlatforms>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/5792

We had two areas where MSBuild checked TargetFramework based on whether it started with `netcore` and `netstandard`.

Ex:
https://github.com/dotnet/msbuild/blob/a71067913c82bcb5d79a13f40ff8b12cbd384c1c/src/Directory.BeforeCommon.targets#L114

With net5.0 resolving to `net5.0` instead of `netcoreapp5.0`, this logic would no longer succeed, so here's a quick fix via intrinsic function `GetTargetFrameworkIdentifier` introduced in https://github.com/dotnet/msbuild/pull/5429.

------
Some other notes:

There are a few other areas that look like we could use these intrinsic functions, but it would overcomplicate the logic. Here's what I found with `rg -iF "StartsWith('net"`
```
src\MSBuild.Bootstrap\MSBuild.Bootstrap.csproj
55:  <Import Project="..\Package\GetBinPaths.targets" Condition="$(TargetFramework.StartsWith('net4'))"/>

src\Directory.Build.props
71:  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
77:  <PropertyGroup Condition="!$(TargetFramework.StartsWith('net4'))">

src\Directory.Build.targets
141:  <Import Project="$(BUILD_STAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.IBCMerge.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(BUILD_STAGINGDIRECTORY)' != '' and $(TargetFramework.StartsWith('net4')) and '$(MicroBuild_EnablePGO)' != 'false'" />

src\Directory.BeforeCommon.targets
19:  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net3'))">

eng\BootStrapMSBuild.targets
15:    <BootstrapDependsOn Condition="$(TargetFramework.StartsWith('net4'))">BootstrapFull</BootstrapDependsOn>
16:    <BootstrapDependsOn Condition="!$(TargetFramework.StartsWith('net4'))">BootstrapNetCore</BootstrapDependsOn>
```

These checks are likely better than 
```
[MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework' and [MSBuild]::GetTargetPlatformVersion('$(TargetFramework)', 1)) == '4'
```