### PR TITLE
Nonshipping nuget compliance

### DIFF
--- a/src/Package/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
+++ b/src/Package/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
@@ -4,8 +4,11 @@
     <id>VS.ExternalAPIs.MSBuild</id>
     <summary>CoreXT package containing MSBuild binaries for the VS build.</summary>
     <description>CoreXT package containing MSBuild binaries for the VS build. Produced from the MSBuild $branchname$ branch.</description>
-    <authors>MSBuild</authors>
+    <authors>Microsoft</authors>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>$projectUrl$</projectUrl>
     <version>0.0</version>
+    <license type="expression">$licenseExpression$</license>
     <dependencies>
       <group targetFramework=".NETFramework4.7.2" />
     </dependencies>

--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -4,8 +4,11 @@
     <id>MsBuild.Engine.Corext</id>
     <summary>Aggregate of MsBuild.Corext with the latest MSBuild team deliverables</summary>
     <description>Use this package to update your existing MsBuild.Corext package to the latest MSBuild binaries and core build files.</description>
+    <projectUrl>$projectUrl$</projectUrl>
+    <license type="expression">$licenseExpression$</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <authors>msbtm@microsoft.com</authors>
+    <authors>Microsoft</authors>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <version>$version$</version>
   </metadata>
 


### PR DESCRIPTION
Clean up some of our Microsoft-internal nonshipping packages so that they are compliant with what a dotnet package should look like.