### PR TITLE
Allow Cultures Within Names For EmbeddedResources

### DIFF
--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -31,14 +31,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.resx",
-                    null,
-                    true,
-                    null,    // Root namespace
-                    null,
-                    null,
-                    StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
-                    null
+                    fileName: @"f:\myproject\SubFolder\MyForm.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: null,    // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
+                    log: null
                 );
 
             Assert.Equal("MyStuff.Namespace.Class", result);
@@ -71,14 +71,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"irrelevant",
-                    null,
-                    true,
-                    null,    // Root namespace
-                    null,
-                    null,
-                    sourcesStream,
-                    null
+                    fileName: @"irrelevant",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: null,    // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: sourcesStream,
+                    log: null
                 );
 
             MemoryStream m = new MemoryStream();
@@ -119,14 +119,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"irrelevant",
-                    null,
-                    true,
-                    null,    // Root namespace
-                    null,
-                    null,
-                    sourcesStream,
-                    null
+                    fileName: @"irrelevant",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: null,    // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: sourcesStream,
+                    log: null
                 );
 
             Assert.Equal("d\u00C4a.Class", result);
@@ -141,14 +141,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.resx",
-                    null,
-                    true,
-                    null,    // Root namespace
-                    null,
-                    null,
-                    StreamHelpers.StringToStream("namespace Namespace { class Class {} }"),
-                    null
+                    fileName: @"f:\myproject\SubFolder\MyForm.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: null,    // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream("namespace Namespace { class Class {} }"),
+                    log: null
                 );
 
             Assert.Equal("Namespace.Class", result);
@@ -163,14 +163,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.resx",
-                    null,
-                    true,
-                    "RootNamespace",    // Root namespace (will be ignored because it's dependent)
-                    null,
-                    null,
-                    StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
-                    null
+                    fileName: @"f:\myproject\SubFolder\MyForm.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace (will be ignored because it's dependent)
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
+                    log: null
                 );
 
             Assert.Equal("MyStuff.Namespace.Class", result);
@@ -185,14 +185,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.en-GB.resx",
-                    null,
-                    true,
-                    "RootNamespace",    // Root namespace (will be ignored because it's dependent)
-                    null,
-                    null,
-                    StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
-                    null
+                    fileName: @"f:\myproject\SubFolder\MyForm.en-GB.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace (will be ignored because it's dependent)
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
+                    log: null
                 );
 
             Assert.Equal("MyStuff.Namespace.Class.en-GB", result);
@@ -208,14 +208,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.resx",
-                    null,
-                    true,
-                    "RootNamespace",    // Root namespace (will be ignored because it's dependent)
-                    null,
-                    "en-GB",
-                    StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
-                    null
+                    fileName: @"f:\myproject\SubFolder\MyForm.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace (will be ignored because it's dependent)
+                    dependentUponFileName: null,
+                    culture: "en-GB",
+                    binaryStream: StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
+                    log: null
                 );
 
             Assert.Equal("MyStuff.Namespace.Class.en-GB", result);
@@ -230,14 +230,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.fr-fr.resx",
-                    null,
-                    true,
-                    "RootNamespace",    // Root namespace (will be ignored because it's dependent)
-                    null,
-                    null,
-                    StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
-                    null
+                    fileName: @"f:\myproject\SubFolder\MyForm.fr-fr.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace (will be ignored because it's dependent)
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }"),
+                    log: null
                 );
 
             Assert.Equal("MyStuff.Namespace.Class.fr-fr", result);
@@ -253,14 +253,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"SubFolder\MyForm.en-GB.ResX",
-                    null,
-                    true,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"SubFolder\MyForm.en-GB.ResX",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal("RootNamespace.SubFolder.MyForm.en-GB", result);
@@ -275,15 +275,15 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"Subfolder\File.cs.cshtml",
-                    null,
-                    true,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null,
-                    true // retain culture in name
+                    fileName: @"Subfolder\File.cs.cshtml",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null,
+                    treatAsCultureNeutral: true // retain culture in name
                 );
 
             result.ShouldBe("RootNamespace.Subfolder.File.cs.cshtml");
@@ -298,14 +298,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"..\..\XmlEditor\Setup\XmlEditor.rgs",
-                    @"XmlEditor.rgs",
-                    true,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"..\..\XmlEditor\Setup\XmlEditor.rgs",
+                    linkFileName: @"XmlEditor.rgs",
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal("RootNamespace.XmlEditor.rgs", result);
@@ -320,14 +320,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"SubFolder\SplashScreen.bmp",
-                    null,
-                    true,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"SubFolder\SplashScreen.bmp",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal("RootNamespace.SubFolder.SplashScreen.bmp", result);
@@ -342,14 +342,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"SubFolder\SplashScreen.fr.bmp",
-                    null,
-                    true,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"SubFolder\SplashScreen.fr.bmp",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal(FileUtilities.FixFilePath(@"fr\RootNamespace.SubFolder.SplashScreen.bmp"), result);
@@ -364,14 +364,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"SubFolder\SplashScreen.fr.bmp",
-                    null,    // Link file name
-                    false,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"SubFolder\SplashScreen.fr.bmp",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: false,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal(@"RootNamespace.SubFolder.SplashScreen.bmp", result);
@@ -718,14 +718,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    "MyForm.en-GB.resx",
-                    null,
-                    true,
-                    "RootNamespace",    // Root namespace (will be ignored because it's dependent)
-                    "MyForm.en-GB.cs",
-                    null,
-                    StreamHelpers.StringToStream("namespace ClassLibrary1 { class MyForm {} }"),
-                    null
+                    fileName: "MyForm.en-GB.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace (will be ignored because it's dependent)
+                    dependentUponFileName: "MyForm.en-GB.cs",
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream("namespace ClassLibrary1 { class MyForm {} }"),
+                    log: null
                 );
 
             Assert.Equal("ClassLibrary1.MyForm", result);
@@ -747,14 +747,14 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    "MyForm.en-GB.resx",
-                    null,
-                    true,
-                    "RootNamespace",
-                    "MyForm.en-GB.cs",
-                    null,
-                    StreamHelpers.StringToStream(""),
-                    null
+                    fileName: "MyForm.en-GB.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",
+                    dependentUponFileName: "MyForm.en-GB.cs",
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(""),
+                    log: null
                 );
 
             Assert.Equal("RootNamespace.MyForm.en-GB", result);
@@ -774,13 +774,13 @@ namespace Microsoft.Build.UnitTests
 
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    "MyForm.resx",
-                    null,
-                    true,
-                    "RootNamespace",    // Root namespace (will be ignored because it's dependent)
-                    "MyForm.cs",
-                    null,
-                    StreamHelpers.StringToStream(
+                    fileName: "MyForm.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace (will be ignored because it's dependent)
+                    dependentUponFileName: "MyForm.cs",
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(
 @"using System;
 #if false
 namespace ClassLibrary1
@@ -796,7 +796,7 @@ namespace ClassLibrary3
     }
 }"
                     ),
-                    c.Log
+                    log: c.Log
                 );
 
             Assert.Contains(
@@ -933,14 +933,14 @@ namespace ClassLibrary3
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"SubFolder\MyResource.fr.resources",
-                    null,    // Link file name
-                    false,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"SubFolder\MyResource.fr.resources",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: false,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal(@"RootNamespace.SubFolder.MyResource.fr.resources", result);
@@ -955,14 +955,14 @@ namespace ClassLibrary3
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"MyResource.fr.resources",
-                    null,    // Link file name
-                    false,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"MyResource.fr.resources",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: false,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal(@"RootNamespace.MyResource.fr.resources", result);
@@ -977,14 +977,14 @@ namespace ClassLibrary3
             string result =
             CreateCSharpManifestResourceName.CreateManifestNameImpl
                 (
-                    @"MyResource.resources",
-                    null,    // Link file name
-                    false,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"MyResource.resources",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: false,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal(@"RootNamespace.MyResource.resources", result);

--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -267,6 +267,29 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// Explicitly retain culture
+        /// </summary>
+        [Fact]
+        public void RootnamespaceWithCulture_RetainCultureInFileName()
+        {
+            string result =
+            CreateCSharpManifestResourceName.CreateManifestNameImpl
+                (
+                    @"Subfolder\File.cs.cshtml",
+                    null,
+                    true,
+                    "RootNamespace",        // Root namespace
+                    null,
+                    null,
+                    null,
+                    null,
+                    true // retain culture in name
+                );
+
+            Assert.Equal("RootNamespace.Subfolder.File.cs.cshtml", result);
+        }
+
+        /// <summary>
         /// If there is a link file name then it is preferred over the main file name.
         /// </summary>
         [Fact]

--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Build.UnitTests
                     true // retain culture in name
                 );
 
-            Assert.Equal("RootNamespace.Subfolder.File.cs.cshtml", result);
+            result.ShouldBe("RootNamespace.Subfolder.File.cs.cshtml");
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
@@ -32,20 +32,20 @@ namespace Microsoft.Build.UnitTests
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.resx",
-                    null,    // Link file name
-                    true,
-                    null,    // Root namespace
-                    null,
-                    null,
-                    StreamHelpers.StringToStream(
+                    fileName: @"f:\myproject\SubFolder\MyForm.resx",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: null,    // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(
 @"
 Namespace Nested.TestNamespace 
     Class TestClass 
     End Class
 End Namespace
 "),
-                    null
+                    log: null
                 );
 
             Assert.Equal("Nested.TestNamespace.TestClass", result);
@@ -60,20 +60,20 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.resx",
-                    null,    // Link file name
-                    true,
-                    null,    // Root namespace
-                    null,
-                    null,
-                    StreamHelpers.StringToStream(
+                    fileName: @"f:\myproject\SubFolder\MyForm.resx",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: null,    // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(
 @"
 Namespace TestNamespace 
     Class TestClass 
     End Class
 End Namespace
 "),
-                    null
+                    log: null
 
                 );
 
@@ -89,20 +89,20 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.resx",
-                    null,    // Link file name
-                    true,
-                    null,    // Root namespace
-                    null,
-                    null,
-                    StreamHelpers.StringToStream(
+                    fileName: @"f:\myproject\SubFolder\MyForm.resx",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: null,    // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(
 @"
 Namespace Nested.TestNamespace 
     Class TestClass 
     End Class
 End Namespace
 "),
-                    null
+                    log: null
 
                 );
 
@@ -118,20 +118,20 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.en-GB.resx",
-                    null,    // Link file name
-                    true,
-                    null,        // Root namespace
-                    null,
-                    null,
-                    StreamHelpers.StringToStream(
+                    fileName: @"f:\myproject\SubFolder\MyForm.en-GB.resx",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: null,        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(
 @"
 Namespace Nested.TestNamespace 
     Class TestClass 
     End Class
 End Namespace
 "),
-                    null
+                    log: null
 
                 );
 
@@ -148,20 +148,20 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.resx",
-                    null,    // Link file name
-                    true,
-                    null,        // Root namespace
-                    null,
-                    "en-GB",
-                    StreamHelpers.StringToStream(
+                    fileName: @"f:\myproject\SubFolder\MyForm.resx",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: null,        // Root namespace
+                    dependentUponFileName: null,
+                    culture: "en-GB",
+                    binaryStream: StreamHelpers.StringToStream(
 @"
 Namespace Nested.TestNamespace 
     Class TestClass 
     End Class
 End Namespace
 "),
-                    null
+                    log: null
 
                 );
 
@@ -177,20 +177,20 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.en-GB.resx",
-                    null,    // Link file name
-                    true,
-                    "RootNamespace",
-                    null,
-                    null,
-                    StreamHelpers.StringToStream(
+                    fileName: @"f:\myproject\SubFolder\MyForm.en-GB.resx",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(
 @"
 Namespace Nested.TestNamespace 
     Class TestClass 
     End Class
 End Namespace
 "),
-                    null
+                    log: null
 
                 );
 
@@ -206,20 +206,20 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"f:\myproject\SubFolder\MyForm.fr-fr.resx",
-                    null,    // Link file name
-                    true,
-                    "RootNamespace",    // Root namespace
-                    null,
-                    null,
-                    StreamHelpers.StringToStream(
+                    fileName: @"f:\myproject\SubFolder\MyForm.fr-fr.resx",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(
 @"
 Namespace Nested.TestNamespace 
     Class TestClass 
     End Class
 End Namespace
 "),
-                    null
+                    log: null
 
                 );
 
@@ -235,18 +235,44 @@ End Namespace
         {
             string result =
                 CreateVisualBasicManifestResourceName.CreateManifestNameImpl(
-                    FileUtilities.FixFilePath(@"SubFolder\MyForm.en-GB.ResX"),
-                    null,
+                    fileName: FileUtilities.FixFilePath(@"SubFolder\MyForm.en-GB.ResX"),
+                    linkFileName: null,
+                    // Link file name
+                    prependCultureAsDirectory:
                     // Link file name
                     true,
-                    "RootNamespace",
+                    rootNamespace: "RootNamespace",
+                    // Root namespace
+                    dependentUponFileName:
                     // Root namespace
                     null,
-                    null,
-                    null,
-                    null);
+                    culture: null,
+                    binaryStream: null,
+                    log: null);
 
             Assert.Equal("RootNamespace.MyForm.en-GB", result);
+        }
+
+        [Fact]
+        public void RootnamespaceWithCulture_RetainCultureInFileName()
+        {
+            string result =
+            CreateVisualBasicManifestResourceName.CreateManifestNameImpl
+                (
+                    fileName: @"Subfolder\File.cs.cshtml",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null,
+                    treatAsCultureNeutral: true // retain culture in name
+                );
+
+            // Visual basic does not carry subfolder.
+            // See https://github.com/dotnet/msbuild/pull/5477
+            result.ShouldBe("RootNamespace.File.cs.cshtml");
         }
 
         /// <summary>
@@ -258,14 +284,14 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"..\..\XmlEditor\Setup\XmlEditor.rgs",
-                    @"MyXmlEditor.rgs",
-                    true,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"..\..\XmlEditor\Setup\XmlEditor.rgs",
+                    linkFileName: @"MyXmlEditor.rgs",
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
 
                 );
 
@@ -280,14 +306,14 @@ End Namespace
         {
             string result =
                 CreateVisualBasicManifestResourceName.CreateManifestNameImpl(
-                    FileUtilities.FixFilePath(@"SubFolder\SplashScreen.bmp"),
-                    null,             // Link file name
-                    true,
-                    "RootNamespace", // Root namespace
-                    null,
-                    null,
-                    null,
-                    null);
+                    fileName: FileUtilities.FixFilePath(@"SubFolder\SplashScreen.bmp"),
+                    linkFileName: null,             // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace", // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null);
 
             Assert.Equal("RootNamespace.SplashScreen.bmp", result);
         }
@@ -300,14 +326,14 @@ End Namespace
         {
             string result =
                 CreateVisualBasicManifestResourceName.CreateManifestNameImpl(
-                    FileUtilities.FixFilePath(@"SubFolder\SplashScreen.fr.bmp"),
-                    null,             // Link file name
-                    true,
-                    "RootNamespace",  // Root namespace
-                    null,
-                    null,
-                    null,
-                    null);
+                    fileName: FileUtilities.FixFilePath(@"SubFolder\SplashScreen.fr.bmp"),
+                    linkFileName: null,             // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",  // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null);
 
             Assert.Equal(FileUtilities.FixFilePath(@"fr\RootNamespace.SplashScreen.bmp"), result);
         }
@@ -320,14 +346,14 @@ End Namespace
         {
             string result =
                 CreateVisualBasicManifestResourceName.CreateManifestNameImpl(
-                    FileUtilities.FixFilePath(@"SubFolder\SplashScreen.fr.bmp"),
-                    null,             // Link file name
-                    false,
-                    "RootNamespace",  // Root namespace
-                    null,
-                    null,
-                    null,
-                    null);
+                    fileName: FileUtilities.FixFilePath(@"SubFolder\SplashScreen.fr.bmp"),
+                    linkFileName: null,             // Link file name
+                    prependCultureAsDirectory: false,
+                    rootNamespace: "RootNamespace",  // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null);
 
             Assert.Equal(@"RootNamespace.SplashScreen.bmp", result);
         }
@@ -444,18 +470,18 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    "MyForm.ro.resx",
-                    null,    // Link file name
-                    true,
-                    "RootNamespace",    // Root namespace
-                    "MyForm.ro.vb",
-                    null,
-                    StreamHelpers.StringToStream(
+                    fileName: "MyForm.ro.resx",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace
+                    dependentUponFileName: "MyForm.ro.vb",
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(
 @"
     Class MyForm 
     End Class
 "),
-                    null
+                    log: null
 
                 );
 
@@ -477,13 +503,13 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    "MyForm.resx",
-                    null,
-                    true,
-                    "RootNamespace",    // Root namespace (will be ignored because it's dependent)
-                    "MyForm.vb",
-                    null,
-                    StreamHelpers.StringToStream(
+                    fileName: "MyForm.resx",
+                    linkFileName: null,
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace (will be ignored because it's dependent)
+                    dependentUponFileName: "MyForm.vb",
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(
 @"Imports System
 
 #if false
@@ -499,7 +525,7 @@ Namespace ClassLibrary3
 End Namespace
 "
                     ),
-                    c.Log
+                    log: c.Log
                 );
 
             Assert.Contains(
@@ -618,14 +644,14 @@ End Namespace
         {
             string result =
                 CreateVisualBasicManifestResourceName.CreateManifestNameImpl(
-                    FileUtilities.FixFilePath(@"SubFolder\MyResource.fr.resources"),
-                    null,             // Link file name
-                    false,
-                    "RootNamespace",  // Root namespace
-                    null,
-                    null,
-                    null,
-                    null);
+                    fileName: FileUtilities.FixFilePath(@"SubFolder\MyResource.fr.resources"),
+                    linkFileName: null,             // Link file name
+                    prependCultureAsDirectory: false,
+                    rootNamespace: "RootNamespace",  // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null);
 
             Assert.Equal(@"RootNamespace.MyResource.fr.resources", result);
         }
@@ -639,14 +665,14 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"MyResource.fr.resources",
-                    null,    // Link file name
-                    false,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"MyResource.fr.resources",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: false,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal(@"RootNamespace.MyResource.fr.resources", result);
@@ -661,14 +687,14 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    @"MyResource.resources",
-                    null,    // Link file name
-                    false,
-                    "RootNamespace",        // Root namespace
-                    null,
-                    null,
-                    null,
-                    null
+                    fileName: @"MyResource.resources",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: false,
+                    rootNamespace: "RootNamespace",        // Root namespace
+                    dependentUponFileName: null,
+                    culture: null,
+                    binaryStream: null,
+                    log: null
                 );
 
             Assert.Equal(@"RootNamespace.MyResource.resources", result);
@@ -679,14 +705,14 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    "MyForm.resx",
-                    null,    // Link file name
-                    true,
-                    "RootNamespace",    // Root namespace
-                    "MyForm.vb",
-                    null,
-                    StreamHelpers.StringToStream(code),
-                    null
+                    fileName: "MyForm.resx",
+                    linkFileName: null,    // Link file name
+                    prependCultureAsDirectory: true,
+                    rootNamespace: "RootNamespace",    // Root namespace
+                    dependentUponFileName: "MyForm.vb",
+                    culture: null,
+                    binaryStream: StreamHelpers.StringToStream(code),
+                    log: null
                 );
 
             Assert.Equal(expected, result);

--- a/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
@@ -259,7 +259,7 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    fileName: @"Subfolder\File.cs.cshtml",
+                    fileName: @"Subfolder\File.vb.cshtml",
                     linkFileName: null,
                     prependCultureAsDirectory: true,
                     rootNamespace: "RootNamespace",        // Root namespace

--- a/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
@@ -259,7 +259,7 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    fileName: @"Subfolder\File.cs.vb",
+                    fileName: @"File.cs.vb",
                     linkFileName: null,
                     prependCultureAsDirectory: true,
                     rootNamespace: "RootNamespace",        // Root namespace

--- a/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
@@ -259,7 +259,7 @@ End Namespace
             string result =
             CreateVisualBasicManifestResourceName.CreateManifestNameImpl
                 (
-                    fileName: @"Subfolder\File.vb.cshtml",
+                    fileName: @"Subfolder\File.cs.vb",
                     linkFileName: null,
                     prependCultureAsDirectory: true,
                     rootNamespace: "RootNamespace",        // Root namespace
@@ -272,7 +272,7 @@ End Namespace
 
             // Visual basic does not carry subfolder.
             // See https://github.com/dotnet/msbuild/pull/5477
-            result.ShouldBe("RootNamespace.File.cs.cshtml");
+            result.ShouldBe("RootNamespace.File.cs.vb");
         }
 
         /// <summary>

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -134,6 +134,8 @@ namespace Microsoft.Build.Tasks
                         (
                             AssignedFiles[i].ItemSpec,
                             dependentUpon,
+                            // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
+                            // https://github.com/dotnet/msbuild/issues/3064
                             AssignedFiles[i].GetMetadata("WithCulture") == "false"
                         );
 

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Build.Tasks
                     AssignedFiles[i] = new TaskItem(Files[i]);
 
                     string dependentUpon = AssignedFiles[i].GetMetadata(ItemMetadataNames.dependentUpon);
-                    Culture.ItemCultureInfo info = Culture.GetItemCultureInfo
+                    Culture.ItemCultureInfo info = string.IsNullOrEmpty(AssignedFiles[i].GetMetadata("Culture")) ? new Culture.ItemCultureInfo() : Culture.GetItemCultureInfo
                         (
                             AssignedFiles[i].ItemSpec,
                             dependentUpon

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Build.Tasks
                             dependentUpon,
                             // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
                             // https://github.com/dotnet/msbuild/issues/3064
-                            AssignedFiles[i].GetMetadata("WithCulture") == "false"
+                            AssignedFiles[i].GetMetadata("WithCulture").Equals("false", StringComparison.OrdinalIgnoreCase)
                         );
 
                     if (!string.IsNullOrEmpty(info.culture))

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -130,7 +130,12 @@ namespace Microsoft.Build.Tasks
                     AssignedFiles[i] = new TaskItem(Files[i]);
 
                     string dependentUpon = AssignedFiles[i].GetMetadata(ItemMetadataNames.dependentUpon);
-                    Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(FileUtilities.FixFilePath(AssignedFiles[i].ItemSpec), dependentUpon, AssignedFiles[i]);
+                    Culture.ItemCultureInfo info = Culture.GetItemCultureInfo
+                        (
+                            AssignedFiles[i].ItemSpec,
+                            dependentUpon,
+                            AssignedFiles[i].GetMetadata("WithCulture") == "false"
+                        );
 
                     if (!string.IsNullOrEmpty(info.culture))
                     {

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -130,11 +130,7 @@ namespace Microsoft.Build.Tasks
                     AssignedFiles[i] = new TaskItem(Files[i]);
 
                     string dependentUpon = AssignedFiles[i].GetMetadata(ItemMetadataNames.dependentUpon);
-                    Culture.ItemCultureInfo info = string.IsNullOrEmpty(AssignedFiles[i].GetMetadata("Culture")) ? new Culture.ItemCultureInfo() : Culture.GetItemCultureInfo
-                        (
-                            AssignedFiles[i].ItemSpec,
-                            dependentUpon
-                        );
+                    Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(FileUtilities.FixFilePath(AssignedFiles[i].ItemSpec), dependentUpon, AssignedFiles[i]);
 
                     if (!string.IsNullOrEmpty(info.culture))
                     {

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Build.Tasks
         )
         {
             string culture = null;
-            if (fileName != null && itemSpecToTaskitem.TryGetValue(fileName, out ITaskItem item))
+            ITaskItem item = null;
+            if (fileName != null && itemSpecToTaskitem.TryGetValue(fileName, out item))
             {
                 culture = item.GetMetadata("Culture");
             }
@@ -59,7 +60,8 @@ namespace Microsoft.Build.Tasks
                 dependentUponFileName,
                 culture,
                 binaryStream,
-                Log
+                Log,
+                item
             );
         }
 
@@ -78,6 +80,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="culture">The override culture of this resource, if any</param>
         /// <param name="binaryStream">File contents binary stream, may be null</param>
         /// <param name="log">Task's TaskLoggingHelper, for logging warnings or errors</param>
+        /// <param name="item">The item itself, may be null</param>
         /// <returns>Returns the manifest name</returns>
         internal static string CreateManifestNameImpl
         (
@@ -88,7 +91,8 @@ namespace Microsoft.Build.Tasks
             string dependentUponFileName, // May be null
             string culture, // may be null 
             Stream binaryStream, // File contents binary stream, may be null
-            TaskLoggingHelper log
+            TaskLoggingHelper log,
+            ITaskItem item = null
         )
         {
             // Use the link file name if there is one, otherwise, fall back to file name.
@@ -99,7 +103,7 @@ namespace Microsoft.Build.Tasks
             }
 
             dependentUponFileName = FileUtilities.FixFilePath(dependentUponFileName);
-            Culture.ItemCultureInfo info = string.IsNullOrEmpty(culture) ? new Culture.ItemCultureInfo() : Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName);
+            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, item);
 
             // If the item has a culture override, respect that. 
             if (!string.IsNullOrEmpty(culture))

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Build.Tasks
             }
 
             dependentUponFileName = FileUtilities.FixFilePath(dependentUponFileName);
-            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName);
+            Culture.ItemCultureInfo info = string.IsNullOrEmpty(culture) ? new Culture.ItemCultureInfo() : Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName);
 
             // If the item has a culture override, respect that. 
             if (!string.IsNullOrEmpty(culture))

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Tasks
                 culture = item.GetMetadata("Culture");
                 // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
                 // https://github.com/dotnet/msbuild/issues/3064
-                treatAsCultureNeutral = item.GetMetadata("WithCulture") == "false";
+                treatAsCultureNeutral = item.GetMetadata("WithCulture").Equals("false", StringComparison.OrdinalIgnoreCase);
             }
 
             /*

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -39,13 +39,13 @@ namespace Microsoft.Build.Tasks
         )
         {
             string culture = null;
-            bool retainCultureInResourceName = false;
+            bool treatAsCultureNeutral = false;
             if (fileName != null && itemSpecToTaskitem.TryGetValue(fileName, out ITaskItem item))
             {
                 culture = item.GetMetadata("Culture");
-                // If 'WithCulture' is explicitly set to false, keep the name of the resource even if it has a culture as part of its name.
+                // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
                 // https://github.com/dotnet/msbuild/issues/3064
-                retainCultureInResourceName = item.GetMetadata("WithCulture") == "false";
+                treatAsCultureNeutral = item.GetMetadata("WithCulture") == "false";
             }
 
             /*
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Tasks
                 culture,
                 binaryStream,
                 Log,
-                retainCultureInResourceName
+                treatAsCultureNeutral
             );
         }
 
@@ -83,7 +83,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="culture">The override culture of this resource, if any</param>
         /// <param name="binaryStream">File contents binary stream, may be null</param>
         /// <param name="log">Task's TaskLoggingHelper, for logging warnings or errors</param>
-        /// <param name="retainCultureInResourceName">Whether to treat the current file as 'culture-neutral'.</param>
+        /// <param name="treatAsCultureNeutral">Whether to treat the current file as 'culture-neutral' and retain the culture in the name.</param>
         /// <returns>Returns the manifest name</returns>
         internal static string CreateManifestNameImpl
         (
@@ -95,7 +95,7 @@ namespace Microsoft.Build.Tasks
             string culture, // may be null 
             Stream binaryStream, // File contents binary stream, may be null
             TaskLoggingHelper log,
-            bool retainCultureInResourceName = false
+            bool treatAsCultureNeutral = false
         )
         {
             // Use the link file name if there is one, otherwise, fall back to file name.
@@ -106,7 +106,7 @@ namespace Microsoft.Build.Tasks
             }
 
             dependentUponFileName = FileUtilities.FixFilePath(dependentUponFileName);
-            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, retainCultureInResourceName);
+            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
 
             // If the item has a culture override, respect that. 
             if (!string.IsNullOrEmpty(culture))

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Build.Tasks
                 culture = item.GetMetadata("Culture");
                 // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
                 // https://github.com/dotnet/msbuild/issues/3064
-                treatAsCultureNeutral = item.GetMetadata("WithCulture") == "false";
+                treatAsCultureNeutral = item.GetMetadata("WithCulture").Equals("false", StringComparison.OrdinalIgnoreCase);
             }
 
             /*

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -37,13 +37,13 @@ namespace Microsoft.Build.Tasks
         )
         {
             string culture = null;
-            bool retainCultureInResourceName = false;
+            bool treatAsCultureNeutral = false;
             if (fileName != null && itemSpecToTaskitem.TryGetValue(fileName, out ITaskItem item))
             {
                 culture = item.GetMetadata("Culture");
-                // If 'WithCulture' is explicitly set to false, keep the name of the resource even if it has a culture as part of its name.
+                // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
                 // https://github.com/dotnet/msbuild/issues/3064
-                retainCultureInResourceName = item.GetMetadata("WithCulture") == "false";
+                treatAsCultureNeutral = item.GetMetadata("WithCulture") == "false";
             }
 
             /*
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Tasks
                 culture,
                 binaryStream,
                 Log,
-                retainCultureInResourceName
+                treatAsCultureNeutral
             );
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="culture">The override culture of this resource, if any</param>
         /// <param name="binaryStream">File contents binary stream, may be null</param>
         /// <param name="log">Task's TaskLoggingHelper, for logging warnings or errors</param>
-        /// <param name="retainCultureInResourceName">Whether to treat the current file as 'culture-neutral'.</param>
+        /// <param name="treatAsCultureNeutral">Whether to treat the current file as 'culture-neutral' and retain the culture in the name.</param>
         /// <returns>Returns the manifest name</returns>
         internal static string CreateManifestNameImpl
         (
@@ -93,7 +93,7 @@ namespace Microsoft.Build.Tasks
             string culture,
             Stream binaryStream, // File contents binary stream, may be null
             TaskLoggingHelper log,
-            bool retainCultureInResourceName = false
+            bool treatAsCultureNeutral = false
         )
         {
             // Use the link file name if there is one, otherwise, fall back to file name.
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Tasks
                 embeddedFileName = fileName;
             }
 
-            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, retainCultureInResourceName);
+            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
 
             // If the item has a culture override, respect that. 
             if (!string.IsNullOrEmpty(culture))

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Build.Tasks
                 embeddedFileName = fileName;
             }
 
-            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName);
+            Culture.ItemCultureInfo info = string.IsNullOrEmpty(culture) ? new Culture.ItemCultureInfo() : Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName);
 
             // If the item has a culture override, respect that. 
             if (!string.IsNullOrEmpty(culture))

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Build.Tasks
         )
         {
             string culture = null;
-            if (fileName != null && itemSpecToTaskitem.TryGetValue(fileName, out ITaskItem item))
+            ITaskItem item = null;
+            if (fileName != null && itemSpecToTaskitem.TryGetValue(fileName, out item))
             {
                 culture = item.GetMetadata("Culture");
             }
@@ -57,7 +58,8 @@ namespace Microsoft.Build.Tasks
                 dependentUponFileName,
                 culture,
                 binaryStream,
-                Log
+                Log,
+                item
             );
         }
 
@@ -76,6 +78,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="culture">The override culture of this resource, if any</param>
         /// <param name="binaryStream">File contents binary stream, may be null</param>
         /// <param name="log">Task's TaskLoggingHelper, for logging warnings or errors</param>
+        /// <param name="item">The item itself, may be null</param>
         /// <returns>Returns the manifest name</returns>
         internal static string CreateManifestNameImpl
         (
@@ -86,7 +89,8 @@ namespace Microsoft.Build.Tasks
             string dependentUponFileName, // May be null
             string culture,
             Stream binaryStream, // File contents binary stream, may be null
-            TaskLoggingHelper log
+            TaskLoggingHelper log,
+            ITaskItem item = null
         )
         {
             // Use the link file name if there is one, otherwise, fall back to file name.
@@ -96,7 +100,7 @@ namespace Microsoft.Build.Tasks
                 embeddedFileName = fileName;
             }
 
-            Culture.ItemCultureInfo info = string.IsNullOrEmpty(culture) ? new Culture.ItemCultureInfo() : Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName);
+            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, item);
 
             // If the item has a culture override, respect that. 
             if (!string.IsNullOrEmpty(culture))

--- a/src/Tasks/Culture.cs
+++ b/src/Tasks/Culture.cs
@@ -37,10 +37,9 @@ namespace Microsoft.Build.Tasks
             info.culture = null;
             string parentName = dependentUponFilename ?? String.Empty;
 
-            if (String.Equals(Path.GetFileNameWithoutExtension(parentName),
+            if (treatAsCultureNeutral || string.Equals(Path.GetFileNameWithoutExtension(parentName),
                                    Path.GetFileNameWithoutExtension(name),
-                                   StringComparison.OrdinalIgnoreCase) ||
-                                   treatAsCultureNeutral)
+                                   StringComparison.OrdinalIgnoreCase))
             {
                 // Dependent but we treat it is as not localized because they have same base filename
                 // Or we want to treat this as a 'culture-neutral' file and retain the culture in the name. https://github.com/dotnet/msbuild/pull/5824

--- a/src/Tasks/Culture.cs
+++ b/src/Tasks/Culture.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Build.Framework;
 using System;
 using System.IO;
 
@@ -29,7 +30,8 @@ namespace Microsoft.Build.Tasks
         internal static ItemCultureInfo GetItemCultureInfo
         (
             string name,
-            string dependentUponFilename
+            string dependentUponFilename,
+            ITaskItem item = null
         )
         {
             ItemCultureInfo info;
@@ -38,9 +40,11 @@ namespace Microsoft.Build.Tasks
 
             if (String.Equals(Path.GetFileNameWithoutExtension(parentName),
                                    Path.GetFileNameWithoutExtension(name),
-                                   StringComparison.OrdinalIgnoreCase))
+                                   StringComparison.OrdinalIgnoreCase) ||
+                                   item?.GetMetadata("WithCulture") == "false")
             {
-                // Dependent, but we treat it is as not localized because they have same base filename
+                // Dependent or explicitly using culture as part of the file name
+                // but we treat it is as not localized because they have same base filename
                 info.cultureNeutralFilename = name;
             }
             else

--- a/src/Tasks/Culture.cs
+++ b/src/Tasks/Culture.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Build.Framework;
 using System;
 using System.IO;
 
@@ -31,7 +30,7 @@ namespace Microsoft.Build.Tasks
         (
             string name,
             string dependentUponFilename,
-            ITaskItem item = null
+            bool retainCultureInResourceName = false
         )
         {
             ItemCultureInfo info;
@@ -41,7 +40,7 @@ namespace Microsoft.Build.Tasks
             if (String.Equals(Path.GetFileNameWithoutExtension(parentName),
                                    Path.GetFileNameWithoutExtension(name),
                                    StringComparison.OrdinalIgnoreCase) ||
-                                   item?.GetMetadata("WithCulture") == "false")
+                                   retainCultureInResourceName)
             {
                 // Dependent or explicitly using culture as part of the file name
                 // but we treat it is as not localized because they have same base filename

--- a/src/Tasks/Culture.cs
+++ b/src/Tasks/Culture.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Tasks
         (
             string name,
             string dependentUponFilename,
-            bool retainCultureInResourceName = false
+            bool treatAsCultureNeutral = false
         )
         {
             ItemCultureInfo info;
@@ -40,10 +40,10 @@ namespace Microsoft.Build.Tasks
             if (String.Equals(Path.GetFileNameWithoutExtension(parentName),
                                    Path.GetFileNameWithoutExtension(name),
                                    StringComparison.OrdinalIgnoreCase) ||
-                                   retainCultureInResourceName)
+                                   treatAsCultureNeutral)
             {
-                // Dependent or explicitly using culture as part of the file name
-                // but we treat it is as not localized because they have same base filename
+                // Dependent but we treat it is as not localized because they have same base filename
+                // Or we want to treat this as a 'culture-neutral' file and retain the culture in the name. https://github.com/dotnet/msbuild/pull/5824
                 info.cultureNeutralFilename = name;
             }
             else

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2946,7 +2946,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </EmbeddedResource>
     </ItemGroup>
     
-    <!-- Only assign culture if 'WithCulture' isn't explcitly defined to false. See https://github.com/dotnet/msbuild/issues/3064 -->
     <AssignCulture Files="@(EmbeddedResource)" Condition="'%(Extension)'!='.licx'">
       <!-- Create the list of culture resx and embedded resource files -->
       <Output TaskParameter="AssignedFilesWithCulture" ItemName="_MixedResourceWithCulture"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2945,7 +2945,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <Type>Non-Resx</Type>
       </EmbeddedResource>
     </ItemGroup>
-    
+
     <AssignCulture Files="@(EmbeddedResource)" Condition="'%(Extension)'!='.licx'">
       <!-- Create the list of culture resx and embedded resource files -->
       <Output TaskParameter="AssignedFilesWithCulture" ItemName="_MixedResourceWithCulture"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2947,7 +2947,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
     
     <!-- Only assign culture if 'WithCulture' isn't explcitly defined to false. See https://github.com/dotnet/msbuild/issues/3064 -->
-    <AssignCulture Files="@(EmbeddedResource)" Condition="'%(Extension)'!='.licx' and '%(EmbeddedResource.WithCulture)'!='false'">
+    <AssignCulture Files="@(EmbeddedResource)" Condition="'%(Extension)'!='.licx'">
       <!-- Create the list of culture resx and embedded resource files -->
       <Output TaskParameter="AssignedFilesWithCulture" ItemName="_MixedResourceWithCulture"/>
       <!-- Create the list of non-culture resx and embedded resource files -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2945,8 +2945,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <Type>Non-Resx</Type>
       </EmbeddedResource>
     </ItemGroup>
-
-    <AssignCulture Files="@(EmbeddedResource)" Condition="'%(Extension)'!='.licx'">
+    
+    <!-- Only assign culture if 'WithCulture' isn't explcitly defined to false. See https://github.com/dotnet/msbuild/issues/3064 -->
+    <AssignCulture Files="@(EmbeddedResource)" Condition="'%(Extension)'!='.licx' and '%(EmbeddedResource.WithCulture)'!='false'">
       <!-- Create the list of culture resx and embedded resource files -->
       <Output TaskParameter="AssignedFilesWithCulture" ItemName="_MixedResourceWithCulture"/>
       <!-- Create the list of non-culture resx and embedded resource files -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/3064

Allows a workaround for those that want to embed resources that have cultures within their filenames. 

### The Workaround
Add the `WithCulture` metadata to your EmbeddedResource and set it to `false`.
```xml
<EmbeddedResource Include="a.cs.b" WithCulture="false"/>
<EmbeddedResource Include="light.sms.text" WithCulture="false" />
<EmbeddedResource Include="Resources.en.xml" WithCulture="false" />
<EmbeddedResource Include="some.cs.template" WithCulture="false" />
```