### PR TITLE
Update 16.7 error message when trying to use net5.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>16.7.1</VersionPrefix>
+    <VersionPrefix>16.7.2</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Tasks/GetReferenceAssemblyPaths.cs
+++ b/src/Tasks/GetReferenceAssemblyPaths.cs
@@ -246,9 +246,11 @@ namespace Microsoft.Build.Tasks
                 // 1/26/16: Note this was changed from a warning to an error (see GitHub #173).
                 if (pathsToReturn.Count == 0)
                 {
-                    if (frameworkmoniker.Identifier == "net" && frameworkmoniker.Version >= new Version(5, 0))
+                    // Fixes bad error message when an old SDK assumes "net50" means ".NETFramework 5.0" instead of "netcoreapp 5.0"
+                    // https://github.com/dotnet/msbuild/issues/5820
+                    if (frameworkmoniker.Identifier == ".NETFramework" && frameworkmoniker.Version.Major >= 5)
                     {
-                        Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported", frameworkmoniker.ToString());
+                        Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.OutOfDateSDK", frameworkmoniker.ToString());
                     }
                     else
                     {

--- a/src/Tasks/GetReferenceAssemblyPaths.cs
+++ b/src/Tasks/GetReferenceAssemblyPaths.cs
@@ -246,7 +246,14 @@ namespace Microsoft.Build.Tasks
                 // 1/26/16: Note this was changed from a warning to an error (see GitHub #173).
                 if (pathsToReturn.Count == 0)
                 {
-                    Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound", frameworkmoniker.ToString());
+                    if (frameworkmoniker.Identifier == "net" && frameworkmoniker.Version >= new Version(5, 0))
+                    {
+                        Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported", frameworkmoniker.ToString());
+                    }
+                    else
+                    {
+                        Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound", frameworkmoniker.ToString());
+                    }
                 }
             }
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2160,9 +2160,9 @@
     <value>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</value>
     <comment>{StrBegin="MSB3645: "}</comment>
   </data>
-  <data name="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-    <value>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</value>
-    <comment>{StrBegin="MSB3646: "}</comment>
+  <data name="GetReferenceAssemblyPaths.OutOfDateSDK">
+    <value>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</value>
+    <comment>{StrBegin="MSB3961: "}</comment>
   </data>
   
 
@@ -2836,6 +2836,8 @@
     <value>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</value>
     <comment>{StrBegin="MSB3954: "}</comment>
   </data>
+
+  
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 
@@ -2919,6 +2921,7 @@
             MSB3931 - MSB3940   Task: Unzip
             MSB3941 - MSB3950   Task: ZipDirectory
             MSB3951 - MSB3960   Task: VerifyFileHash
+            MSB3961 - MSB3970   Task: GetReferenceAssemblyPaths overflow
 
             MSB4000 - MSB4200   Portable targets & tasks (vsproject\flavors\portable\msbuild)
             MSB9000 - MSB9900   MSBuild targets files (C++)

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2160,7 +2160,11 @@
     <value>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</value>
     <comment>{StrBegin="MSB3645: "}</comment>
   </data>
-
+  <data name="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+    <value>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</value>
+    <comment>{StrBegin="MSB3646: "}</comment>
+  </data>
+  
 
   <!--
         The WinMDExp task has the error buckets of MSB3762 - MSB3772

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2161,7 +2161,7 @@
     <comment>{StrBegin="MSB3645: "}</comment>
   </data>
   <data name="GetReferenceAssemblyPaths.OutOfDateSDK">
-    <value>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</value>
+    <value>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</value>
     <comment>{StrBegin="MSB3971: "}</comment>
   </data>
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2161,10 +2161,9 @@
     <comment>{StrBegin="MSB3645: "}</comment>
   </data>
   <data name="GetReferenceAssemblyPaths.OutOfDateSDK">
-    <value>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</value>
-    <comment>{StrBegin="MSB3961: "}</comment>
+    <value>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</value>
+    <comment>{StrBegin="MSB3971: "}</comment>
   </data>
-  
 
   <!--
         The WinMDExp task has the error buckets of MSB3762 - MSB3772
@@ -2836,7 +2835,6 @@
     <value>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</value>
     <comment>{StrBegin="MSB3954: "}</comment>
   </data>
-
   
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
@@ -2921,7 +2919,7 @@
             MSB3931 - MSB3940   Task: Unzip
             MSB3941 - MSB3950   Task: ZipDirectory
             MSB3951 - MSB3960   Task: VerifyFileHash
-            MSB3961 - MSB3970   Task: GetReferenceAssemblyPaths overflow
+            MSB3971 - MSB3980   Task: GetReferenceAssemblyPaths overflow
 
             MSB4000 - MSB4200   Portable targets & tasks (vsproject\flavors\portable\msbuild)
             MSB9000 - MSB9900   MSBuild targets files (C++)

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Byla nalezena instalace sady Microsoft Windows SDK v umístění {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Byla nalezena instalace sady Microsoft Windows SDK v umístění {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">Probíhá vytváření adresáře {0}.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Eine Installation des Microsoft Windows SDK wurde in "{0}" gefunden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Eine Installation des Microsoft Windows SDK wurde in "{0}" gefunden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">Das Verzeichnis "{0}" wird erstellt.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -1351,6 +1351,11 @@
         <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="new">Creating directory "{0}".</target>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -1352,9 +1352,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -1352,8 +1352,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -1351,10 +1351,10 @@
         <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Se encontró Microsoft Windows SDK instalado en "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Se encontró Microsoft Windows SDK instalado en "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">Creando directorio "{0}".</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Le Kit de développement Microsoft Windows SDK a été trouvé dans "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">Création du répertoire "{0}".</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Le Kit de développement Microsoft Windows SDK a été trouvé dans "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Rilevato Microsoft Windows SDK installato in "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">Creazione directory "{0}".</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Rilevato Microsoft Windows SDK installato in "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Microsoft Windows SDK が "{0}" にインストールされていました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">ディレクトリ "{0}" を作成しています。</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Microsoft Windows SDK が "{0}" にインストールされていました。</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Microsoft Windows SDK가 "{0}"에 설치되어 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">"{0}" 디렉터리를 만들고 있습니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Microsoft Windows SDK가 "{0}"에 설치되어 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Znaleziono zestaw Microsoft Windows SDK zainstalowany w lokalizacji „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Znaleziono zestaw Microsoft Windows SDK zainstalowany w lokalizacji „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">Tworzenie katalogu „{0}”.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Localizado o SDK do Microsoft Windows instalado em "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Localizado o SDK do Microsoft Windows instalado em "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">Criando o diretório "{0}".</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">Обнаружен пакет средств разработки Microsoft Windows SDK, установленный в "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">Создание каталога "{0}".</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">Обнаружен пакет средств разработки Microsoft Windows SDK, установленный в "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">"{0}" konumuna yüklenmiş Microsoft Windows SDK bulundu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">"{0}" dizini oluşturuluyor.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">"{0}" konumuna yüklenmiş Microsoft Windows SDK bulundu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">找到安装在“{0}”的 Microsoft Windows SDK。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">正在创建目录“{0}”。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">找到安装在“{0}”的 Microsoft Windows SDK。</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1306,6 +1306,11 @@
         <target state="translated">找到安裝在 "{0}" 的 Microsoft Windows SDK。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
+        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
+        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>
         <target state="translated">正在建立目錄 "{0}"。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1306,10 +1306,10 @@
         <target state="translated">找到安裝在 "{0}" 的 Microsoft Windows SDK。</target>
         <note />
       </trans-unit>
-      <trans-unit id="GetReferenceAssemblyPaths.ReferenceAssemblyNotSupported">
-        <source>MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</source>
-        <target state="new">MSB3646: The discovered assembly "{0}" is not supported with this version of Visual Studio. To resolve this, retarget your application or update Visual Studio. You can download the latest version of Visual Studio at http://aka.ms/vsdownload</target>
-        <note>{StrBegin="MSB3646: "}</note>
+      <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
+        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3961: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1307,9 +1307,9 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3961: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
-        <note>{StrBegin="MSB3961: "}</note>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">
         <source>Creating directory "{0}".</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1307,8 +1307,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetReferenceAssemblyPaths.OutOfDateSDK">
-        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
-        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
+        <source>MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</source>
+        <target state="new">MSB3971: The reference assemblies for "{0}" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.</target>
         <note>{StrBegin="MSB3971: "}</note>
       </trans-unit>
       <trans-unit id="MakeDir.Comment">


### PR DESCRIPTION
### Description
MSBuild currently gives a bad error message when using older .NET Core sdk's and targeting `net5.0`. The error message is not helpful so we want to update it for that specific scenario.

### Customer Impact
Customers using an older SDK and targeting `net5.0` currently receive an error that does _not_ help their scenario. This PR fixes that message.

### Risk
Low. We've acknowledged that this change will break legacy UWP projects that target `netcore50`, and are okay with that. The discussion for that is located here: https://github.com/dotnet/msbuild/issues/5833. Based on telemetry there seem to be somewhere between 1~4 users that would hit this scenario.

### Code Reviewers
@Forgind 
@rainersigwald 

### Description of fix
Change the error message when the discovered assembly is `net5.0` and we're on an older SDK.

---

Fixes https://github.com/dotnet/msbuild/issues/5820

Resource Name: `GetReferenceAssemblyPaths.OutOfDateSDK`

Old bad message: `The reference assemblies for {0} were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks`

New good message (when targeting net5.0 and using an older SDK: `The reference assemblies for "{0}" were not found. You might be using an older SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.`

