### PR TITLE
Add xunit timeout to hanging CancelledBuild test

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -1500,7 +1500,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <summary>
         /// A canceled build
         /// </summary>
-        [Fact]
+        [Fact(Timeout = 20_000)]
         public void CancelledBuild()
         {
             string contents = CleanupFileContents(@"


### PR DESCRIPTION
This was attempted in #5290 but we hit a hang in this test again this week (https://dev.azure.com/dnceng/public/_build/results?buildId=860511).