### PR TITLE
Provide MSB5009 error with project's name and it's GUID

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
@@ -1260,20 +1260,11 @@ namespace Microsoft.Build.UnitTests.Construction
                 EndGlobal
                 ";
 
-            try
-            {
-                ParseSolutionHelper(solutionFileContents);
-            }
-            catch (InvalidProjectFileException e)
-            {
-                Assert.Equal("MSB5009", e.ErrorCode);
-                Assert.Contains( "{1484A47E-F4C5-4700-B13F-A2BDB6ADD35E}", e.Message);
-                Assert.Contains("ConsoleApp1", e.Message);
-                return;
-            }
+            InvalidProjectFileException e = Should.Throw<InvalidProjectFileException>(() => ParseSolutionHelper(solutionFileContents));
 
-            // Should not get here
-            Assert.True(false);
+            e.ErrorCode.ShouldBe("MSB5009");
+            e.Message.ShouldContain( "{1484A47E-F4C5-4700-B13F-A2BDB6ADD35E}", e.Message);
+            e.Message.ShouldContain("ConsoleApp1", e.Message);
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
@@ -1263,8 +1263,8 @@ namespace Microsoft.Build.UnitTests.Construction
             InvalidProjectFileException e = Should.Throw<InvalidProjectFileException>(() => ParseSolutionHelper(solutionFileContents));
 
             e.ErrorCode.ShouldBe("MSB5009");
-            e.Message.ShouldContain( "{1484A47E-F4C5-4700-B13F-A2BDB6ADD35E}", e.Message);
-            e.Message.ShouldContain("ConsoleApp1", e.Message);
+            e.Message.ShouldContain("{1484A47E-F4C5-4700-B13F-A2BDB6ADD35E}");
+            e.Message.ShouldContain("ConsoleApp1");
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
@@ -1223,6 +1223,58 @@ namespace Microsoft.Build.UnitTests.Construction
             Assert.True(false);
         }
 
+        /// <summary>
+        /// Checks whether incorrect nesting found within the solution file is reported MSB5009 error
+        /// with the incorrectly nested project's name and it's GUID
+        /// </summary>
+        [Fact]
+        public void IncorrectlyNestedProjectErrorContainsProjectNameAndGuid()
+        {
+            string solutionFileContents =
+                @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'SolutionFolder', 'SolutionFolder', '{5EE89BD0-04E3-4600-9CF2-D083A77A9448}'
+                EndProject
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ConsoleApp1', 'ConsoleApp1\ConsoleApp1.csproj', '{1484A47E-F4C5-4700-B13F-A2BDB6ADD35E}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|Any CPU = Debug|Any CPU
+                        Release|Any CPU = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {1484A47E-F4C5-4700-B13F-A2BDB6ADD35E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {1484A47E-F4C5-4700-B13F-A2BDB6ADD35E}.Release|Any CPU.Build.0 = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                    GlobalSection(NestedProjects) = preSolution
+                        {1484A47E-F4C5-4700-B13F-A2BDB6ADD35E} = {5EE89BD0-04E3-4600-9CF2-D083A77A9448}
+                        {1484A47E-F4C5-4700-B13F-A2BDB6ADD35E} = {5EE89BD0-04E3-4600-9CF2-D083A77A9449}
+                    EndGlobalSection
+                    GlobalSection(ExtensibilityGlobals) = postSolution
+                        SolutionGuid = {AF600A67-B616-453E-9B27-4407D654F66E}
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+            try
+            {
+                ParseSolutionHelper(solutionFileContents);
+            }
+            catch (InvalidProjectFileException e)
+            {
+                Assert.Equal("MSB5009", e.ErrorCode);
+                Assert.Contains( "{1484A47E-F4C5-4700-B13F-A2BDB6ADD35E}", e.Message);
+                Assert.Contains("ConsoleApp1", e.Message);
+                return;
+            }
+
+            // Should not get here
+            Assert.True(false);
+        }
 
         /// <summary>
         /// Verifies that we correctly identify solution folders and mercury non-buildable projects both as

--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Build.Construction
                         if (!ParentSolution.ProjectsByGuid.TryGetValue(ParentProjectGuid, out ProjectInSolution proj))
                         {
                             ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(proj != null, "SubCategoryForSolutionParsingErrors",
-                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectError", ProjectName, ProjectGuid);
+                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectErrorWithNameAndGuid", ProjectName, ProjectGuid);
                         }
 
                         uniqueName = proj.GetUniqueProjectName() + "\\";
@@ -409,7 +409,7 @@ namespace Microsoft.Build.Construction
                         if (!ParentSolution.ProjectsByGuid.TryGetValue(ParentProjectGuid, out ProjectInSolution parent))
                         {
                             ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(parent != null, "SubCategoryForSolutionParsingErrors",
-                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectError");
+                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectErrorWithNameAndGuid", ProjectName, ProjectGuid);
                         }
 
                         projectName = parent.GetOriginalProjectName() + "\\";

--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Build.Construction
                         if (!ParentSolution.ProjectsByGuid.TryGetValue(ParentProjectGuid, out ProjectInSolution proj))
                         {
                             ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(proj != null, "SubCategoryForSolutionParsingErrors",
-                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectErrorWithNameAndGuid", ProjectName, ProjectGuid);
+                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectErrorWithNameAndGuid", ProjectName, ProjectGuid, ParentProjectGuid);
                         }
 
                         uniqueName = proj.GetUniqueProjectName() + "\\";
@@ -409,7 +409,7 @@ namespace Microsoft.Build.Construction
                         if (!ParentSolution.ProjectsByGuid.TryGetValue(ParentProjectGuid, out ProjectInSolution parent))
                         {
                             ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(parent != null, "SubCategoryForSolutionParsingErrors",
-                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectErrorWithNameAndGuid", ProjectName, ProjectGuid);
+                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectErrorWithNameAndGuid", ProjectName, ProjectGuid, ParentProjectGuid);
                         }
 
                         projectName = parent.GetOriginalProjectName() + "\\";

--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Build.Construction
                         if (!ParentSolution.ProjectsByGuid.TryGetValue(ParentProjectGuid, out ProjectInSolution proj))
                         {
                             ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(proj != null, "SubCategoryForSolutionParsingErrors",
-                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectError");
+                                new BuildEventFileInfo(ParentSolution.FullPath), "SolutionParseNestedProjectError", ProjectName, ProjectGuid);
                         }
 
                         uniqueName = proj.GetUniqueProjectName() + "\\";

--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -201,7 +201,7 @@
     <comment>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</comment>
   </data>
   <data name="SolutionParseNestedProjectError" Visibility="Public">
-    <value>MSB5009: Error parsing the nested project section in solution file.</value>
+    <value>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</value>
     <comment>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</comment>
   </data>
   <data name="SolutionParseNestedProjectUndefinedError" Visibility="Public">

--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -200,8 +200,12 @@
     <value>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</value>
     <comment>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</comment>
   </data>
-  <data name="SolutionParseNestedProjectError" Visibility="Public">
+  <data name="SolutionParseNestedProjectErrorWithNameAndGuid" Visibility="Public">
     <value>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</value>
+    <comment>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</comment>
+  </data>
+  <data name="SolutionParseNestedProjectError" Visibility="Public">
+    <value>MSB5009: Error parsing the nested project section in solution file.</value>
     <comment>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</comment>
   </data>
   <data name="SolutionParseNestedProjectUndefinedError" Visibility="Public">

--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -201,7 +201,7 @@
     <comment>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</comment>
   </data>
   <data name="SolutionParseNestedProjectErrorWithNameAndGuid" Visibility="Public">
-    <value>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</value>
+    <value>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</value>
     <comment>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</comment>
   </data>
   <data name="SolutionParseNestedProjectError" Visibility="Public">

--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: Soubor filtru řešení v {0} určuje, že v {1} se bude nacházet soubor řešení, ale tento soubor neexistuje.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: Verze nástrojů {0} je neznámá. Dostupné verze nástrojů jsou {1}.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: Při analýze vnořeného oddílu projektu v souboru řešení došlo k chybě.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: Die Projektmappenfilter-Datei unter "{0}" gibt an, dass eine Projektmappendatei unter "{1}" vorhanden ist. Diese Datei ist jedoch nicht vorhanden.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: Die Toolsversion "{0}" ist unbekannt. Verfügbare Toolversionen sind {1}.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: Fehler beim Analysieren des geschachtelten Projektabschnitts in der Projektmappendatei.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.en.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.en.xlf
@@ -226,8 +226,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.en.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.en.xlf
@@ -85,6 +85,11 @@
         <target state="new">MSB5026: The solution filter file at "{0}" specifies there will be a solution file at "{1}", but that file does not exist.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
@@ -226,8 +231,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.en.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.en.xlf
@@ -86,8 +86,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: Error al analizar la sección del proyecto anidado en el archivo de solución.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: El archivo de filtro de soluciones en "{0}" especifica que habrá un archivo de solución en "{1}", pero ese archivo no existe.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: No se reconoce la versión de herramientas "{0}". Las versiones de herramientas disponibles son {1}.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: le fichier de filtre de solution sur "{0}" spécifie l'existence d'un fichier solution sur "{1}", mais ce fichier n'existe pas.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: La version des outils "{0}" n'est pas reconnue. Les versions disponibles sont {1}.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: Erreur pendant l'analyse de la section du projet imbriqué dans le fichier solution.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: nel file di filtro della soluzione in "{0}" è indicata la presenza di un file di soluzione in "{1}", ma tale file non esiste.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: versione degli strumenti "{0}" non riconosciuta. Le versioni disponibili sono {1}.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: errore durante l'analisi della sezione del progetto annidato nel file di soluzione.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: "{0}" のソリューション フィルター ファイルでは、"{1}" にソリューション ファイルを配置するように指定されていますが、そのファイルは存在しません。</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: ツール バージョン "{0}" が認識されません。使用可能なツール バージョンは {1} です。</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: ソリューション ファイル内の入れ子にされたプロジェクト セクションを解析中にエラーが発生しました。</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: "{0}"의 솔루션 필터 파일이 "{1}"에 솔루션 파일이 있도록 지정하지만, 해당 파일이 없습니다.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: 도구 버전 "{0}"을(를) 인식할 수 없습니다. 사용할 수 있는 도구 버전은 {1}입니다.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: 솔루션 파일의 중첩된 프로젝트 섹션을 구문 분석하는 동안 오류가 발생했습니다.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: Błąd podczas analizowania zagnieżdżonej sekcji projektu w pliku rozwiązania.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: Plik filtru rozwiązania w lokalizacji „{0}” określa, że plik rozwiązania będzie się znajdował w lokalizacji „{1}”, ale ten plik nie istnieje.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: Wersja narzędzi „{0}” nie została rozpoznana. Dostępne wersje narzędzi to {1}.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: Erro ao analisar a seção do projeto aninhado no arquivo de solução.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: o arquivo de filtro da solução em "{0}" especifica que haverá um arquivo de solução em "{1}", mas esse arquivo não existe.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: A versão das ferramentas "{0}" não é reconhecida. As versões das ferramentas disponíveis são {1}.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: файл фильтра решения в "{0}" указывает на то, что в "{1}" будет находиться файл решения, однако этот файл отсутствует.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: версия инструментов "{0}" не распознана. Доступные версии инструментов: {1}.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: ошибка синтаксического анализа вложенного раздела проекта в файле решения.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: Çözüm dosyasındaki iç içe proje bölümünü ayrıştırma hatası oluştu.</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: "{0}" konumundaki çözüm filtresi dosyası, "{1}" konumunda bir çözüm dosyası olacağını belirtiyor, ancak bu dosya mevcut değil.</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: Araçlar sürümü "{0}" tanınmıyor. Kullanılabilir araç sürümleri şunlardır: {1}.</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: 分析解决方案文件中的嵌套项目节时出错。</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: 位于“{0}”的解决方案筛选器文件指定“{1}”处将存在一个解决方案文件，但该文件不存在。</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: 无法识别工具版本“{0}”。可用的工具版本为 {1}。</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -80,6 +80,11 @@
         <target state="translated">MSB5026: 位於 "{0}" 的解決方案篩選檔案指定將會有位於 "{1}" 的解決方案檔案，但該檔案並不存在。</target>
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
+        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: 工具版本 "{0}" 無法辨認。可用的工具版本為 {1}。</target>
@@ -216,8 +221,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -81,8 +81,8 @@
         <note>{StrBegin="MSB5026: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectErrorWithNameAndGuid">
-        <source>MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</source>
-        <target state="new">MSB5009: Error parsing the nested project "{0}" section with GUID: "{1}" in solution file.</target>
+        <source>MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</source>
+        <target state="new">MSB5009: Error parsing the project "{0}" section with GUID: "{1}". It is nested under "{2}" but that project is not found in the solution.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -216,8 +216,8 @@
         <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectError">
-        <source>MSB5009: Error parsing the nested project section in solution file.</source>
-        <target state="translated">MSB5009: 剖析方案檔中的巢狀專案區段時發生錯誤。</target>
+        <source>MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section, of project: {0} with GUID: {1} in solution file.</target>
         <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseNestedProjectUndefinedError">


### PR DESCRIPTION
This pull request fixes: #4836

Changes introduced in this delivery extends the *MSB5009* with additional information about the incorrectly nested project within the solution. Additional details are:
* incorrectly nested project's name (without the full path, unique name only),
* incorrectly nested project's GUID

**NOTE:** original *MSB5009* error is kept in the resources for backward compatibility (see commit messages) while the extended MSB5009 can be easily invoked with extended name.

---

Changes done in this delivery are:
* Create additional version of *MSB5009* error with modified error message - meaning stays the same as original *MSB5009* error, but incorrectly nested project's name and GUID is added as arguments.
* Replace the old *MSB5009* with the extended one for each place where this extended error should be used.
NOTE: `SolutionFile.ParseNestedProjects()` method has the original error kept, as it does specify at least the line of the solution file with the incorrect project. Moreover, at the moment of throwing the error, there's no possibility of getting the name of the project.
* Cover the incorrect nesting case with the unit test checking whether for an original reproduction solution (please check the commit message for link) proper error with both name and GUID is thrown.

For more details about each change please see the commit message.

---

Example
of original *MSB5009* error vs the extended version presented below. For both cases the same solution file was used, which is the solution file mentioned before available to get from the original [issue](https://github.com/dotnet/msbuild/issues/4835).

The original error:
![obraz](https://user-images.githubusercontent.com/70535775/97195157-4b978600-17ab-11eb-93d1-5297cc553360.png)
The extended version (the results of this following PR):
![obraz](https://user-images.githubusercontent.com/70535775/97195649-e1cbac00-17ab-11eb-9c68-a34bee728c3e.png)

