### PR TITLE
Fix ClickOnce signing bug where built assembly and final exe are not signed

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>16.8.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>16.8.1</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4015,6 +4015,24 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
         Condition="'$(_DeploymentSignClickOnceManifests)'=='true'" />
 
+    <!-- Sign the original ClickOnce entrypoint -->
+    <SignFile
+        CertificateThumbprint="$(_DeploymentResolvedManifestCertificateThumbprint)"
+        TimestampUrl="$(ManifestTimestampUrl)"
+        SigningTarget="@(_DeploymentManifestEntryPoint)"
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+        Condition="'$(_DeploymentSignClickOnceManifests)'=='true'" />
+
+    <!-- Sign apphost.exe if it's the entrypoint for the Launcher.exe. This is the case in loose file publish -->
+    <SignFile
+        CertificateThumbprint="$(_DeploymentResolvedManifestCertificateThumbprint)"
+        TimestampUrl="$(ManifestTimestampUrl)"
+        SigningTarget="$(AppHostIntermediatePath)"
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+        Condition="'$(_DeploymentSignClickOnceManifests)'=='true' and '$(UseAppHost)' == 'true' and '$(PublishSingleFile)' != 'true' and '$(_IsExecutable)' == 'true' and exists('$(AppHostIntermediatePath)')" />
+
     <!--
       Replace entry-point with Launcher and move original project's entry-point to content group.
     -->
@@ -4115,6 +4133,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <ClickOnceFiles Include="$(PublishedSingleFilePath)"/>
       <ClickOnceFiles Include="@(_FilesExcludedFromBundle)"/>
     </ItemGroup>
+
+    <!-- For single file publish in .net core app, sign the SF EXE if signing is enabled -->
+    <SignFile
+      CertificateThumbprint="$(_DeploymentResolvedManifestCertificateThumbprint)"
+      TimestampUrl="$(ManifestTimestampUrl)"
+      SigningTarget="$(PublishedSingleFilePath)"
+      TargetFrameworkVersion="$(TargetFrameworkVersion)"
+      TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+      Condition="'$(_DeploymentSignClickOnceManifests)'=='true' and '$(_DeploymentLauncherBased)' == 'true' and '$(PublishSingleFile)' == 'true'"
+      />
 
     <!-- Copy the application executable from Obj folder to app.publish folder.
     This is being done to avoid Windows Forms designer memory issues that can arise while operating directly on files located in Obj directory. -->


### PR DESCRIPTION
**Customer Impact**
Customers trying to deploy their .NET Core app w/ClickOnce will not have the application assembly and application EXE authenticode signed with the cert they set in their ClickOnce settings.

**Testing**
Core ClickOnce .NET Core scenarios for both .net 3.1 and .net 5.0 have been validated by sujitn;johnhart;ningli;yaya.
CTI team has completed full test validation.

**Risk**
Low. The changes are scoped to .NET Core ClickOnce deployment when signing is enabled in the ClickOnce settings.

**Code Reviewers**
johnhart

**Description of fix**
During ClickOnce publish, the application assembly DLL and wrapper EXE are not getting signed when signing is enabled in the ClickOnce settings. 

This change will invoke SignFile msbuild task to sign the built assembly dll and exe. For the PublishSingleFile=false case, it will sign apphost.exe (which gets copied to myapp.exe) and for the PublishSingleFile=true case, it will sign the final bundle EXE.
