### PR TITLE
OnlyCheckWhitespaceInsideParenthesis Fixes #5863

### DIFF
--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("$(x.StartsWith ('y'))")]
         [InlineData("$( x.StartsWith( $(SpacelessProperty) ) )")]
         [InlineData("$( x.StartsWith( $(_SpacelessProperty) ) )")]
+        [InlineData("$(x.StartsWith('Foo', StringComparison.InvariantCultureIgnoreCase))")]
         public void SpaceInMiddleOfProperty(string pattern)
         {
             Scanner lexer = new Scanner(pattern, ParserOptions.AllowProperties);

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -6,6 +6,7 @@ using System;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 
 
@@ -104,16 +105,27 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Tests the space errors case
         /// </summary>
-        [Fact]
-        public void SpaceProperty()
+        [Theory]
+        [InlineData("$(x )")]
+        [InlineData("$( x)")]
+        public void SpaceProperty(string pattern)
         {
-            Scanner lexer = new Scanner("$(x )", ParserOptions.AllowProperties);
+            Scanner lexer = new Scanner(pattern, ParserOptions.AllowProperties);
             AdvanceToScannerError(lexer);
             Assert.Equal("IllFormedPropertySpaceInCondition", lexer.GetErrorResource());
+        }
 
-            lexer = new Scanner("$( x)", ParserOptions.AllowProperties);
+        /// <summary>
+        /// Tests the space not next to end so no errors case
+        /// </summary>
+        [Theory]
+        [InlineData("$(x x)")]
+        [InlineData("$(y d f  ( hi ) sx)")]
+        public void SpaceInMiddleOfProperty(string pattern)
+        {
+            Scanner lexer = new Scanner(pattern, ParserOptions.AllowProperties);
             AdvanceToScannerError(lexer);
-            Assert.Equal("IllFormedPropertySpaceInCondition", lexer.GetErrorResource());
+            lexer._errorState.ShouldBeFalse();
         }
 
         [Fact]

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -68,11 +68,7 @@ namespace Microsoft.Build.UnitTests
         /// <param name="lexer"></param>
         private void AdvanceToScannerError(Scanner lexer)
         {
-            while (true)
-            {
-                if (!lexer.Advance()) break;
-                if (lexer.IsNext(Token.TokenType.EndOfInput)) break;
-            }
+            while (lexer.Advance() && !lexer.IsNext(Token.TokenType.EndOfInput)) ;
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Build.UnitTests
         /// <param name="lexer"></param>
         private void AdvanceToScannerError(Scanner lexer)
         {
-            while (lexer.Advance() && !lexer.IsNext(Token.TokenType.EndOfInput)) ;
+            while (lexer.Advance() && !lexer.IsNext(Token.TokenType.EndOfInput));
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -104,6 +104,8 @@ namespace Microsoft.Build.UnitTests
         [Theory]
         [InlineData("$(x )")]
         [InlineData("$( x)")]
+        [InlineData("$([MSBuild]::DoSomething($(space ))")]
+        [InlineData("$([MSBuild]::DoSomething($(_space ))")]
         public void SpaceProperty(string pattern)
         {
             Scanner lexer = new Scanner(pattern, ParserOptions.AllowProperties);
@@ -115,8 +117,10 @@ namespace Microsoft.Build.UnitTests
         /// Tests the space not next to end so no errors case
         /// </summary>
         [Theory]
-        [InlineData("$(x x)")]
-        [InlineData("$(y d f  ( hi ) sx)")]
+        [InlineData("$(x.StartsWith( 'y' ))")]
+        [InlineData("$(x.StartsWith ('y'))")]
+        [InlineData("$( x.StartsWith( $(SpacelessProperty) ) )")]
+        [InlineData("$( x.StartsWith( $(_SpacelessProperty) ) )")]
         public void SpaceInMiddleOfProperty(string pattern)
         {
             Scanner lexer = new Scanner(pattern, ParserOptions.AllowProperties);

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -325,26 +325,22 @@ namespace Microsoft.Build.Evaluation
             {
                 fixed (char* pchar = expression)
                 {
+                    if (expression.Length > 1 && pchar[0] == '(' && char.IsWhiteSpace(pchar[1]) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10))
+                    {
+                        indexResult = 1;
+                        return false;
+                    }
+
                     while (index < expression.Length)
                     {
                         char character = pchar[index];
                         if (character == '(')
                         {
                             nestLevel++;
-                            if (index + 1 < expression.Length && char.IsWhiteSpace(pchar[index + 1]) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10))
-                            {
-                                indexResult = index + 1;
-                                return false;
-                            }
                         }
                         else if (character == ')')
                         {
                             nestLevel--;
-                            if (index > 0 && char.IsWhiteSpace(pchar[index - 1]) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10))
-                            {
-                                indexResult = index - 1;
-                                return false;
-                            }
                         }
 
                         // We have reached the end of the parenthesis nesting
@@ -352,6 +348,12 @@ namespace Microsoft.Build.Evaluation
                         // If it is not then the calling code will determine that
                         if (nestLevel == 0)
                         {
+                            if (index > 0 && char.IsWhiteSpace(pchar[index - 1]) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10))
+                            {
+                                indexResult = index - 1;
+                                return false;
+                            }
+
                             indexResult = index;
                             return true;
                         }

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Evaluation
         private string _expression;
         private int _parsePoint;
         private Token _lookahead;
-        private bool _errorState;
+        internal bool _errorState;
         private int _errorPosition;
         // What we found instead of what we were looking for
         private string _unexpectedlyFound = null;

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Build.Evaluation
             {
                 fixed (char* pchar = expression)
                 {
-                    if (expression.Length > 1 && pchar[0] == '(' && char.IsWhiteSpace(pchar[1]) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10))
+                    if (expression.Length > index + 1 && pchar[index] == '(' && char.IsWhiteSpace(pchar[index + 1]) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10))
                     {
                         indexResult = 1;
                         return false;

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Build.Evaluation
                             whitespaceFound = true;
                             indexResult = index;
                         }
-                        else if (!char.IsLetterOrDigit(character) && character != '_')
+                        else if (!XmlUtilities.IsValidSubsequentElementNameCharacter(character))
                         {
                             nonIdentifierCharacterFound = true;
                         }

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Build.Evaluation
                             nonIdentifierCharacterFound = true;
                         }
 
-                        if (character == '$')
+                        if (character == '$' && index < expression.Length - 1 && pchar[index + 1] == '(')
                         {
                             if (!ScanForPropertyExpressionEnd(expression, index + 1, out index))
                             {


### PR DESCRIPTION
This weakens the check somewhat, since it only checks just inside parentheses, but that allows people to put spaces in, say, property conditions after a comma.

Fixes #5863