### PR TITLE
Update System.Collections.Immutable to 5.0.0

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -25,12 +25,12 @@
     <PackageReference Update="SourceLink.Create.CommandLine" Version="2.1.2" />
     <PackageReference Update="System.CodeDom" Version="4.4.0" />
     <PackageReference Update="System.Collections.Concurrent" Version="4.3.0" />
-    <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Update="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.0.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Update="System.Linq.Parallel" Version="4.0.1" />
-    <PackageReference Update="System.Memory" Version="4.5.3" />
+    <PackageReference Update="System.Memory" Version="4.5.4" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>16.8.1</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>16.8.2</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>


### PR DESCRIPTION
### Description
Some T4 template files fail at build time with a problem due to `System.Collections.Immutable` in MSBuild being older than Roslyn's copy.

```
An exception was thrown while trying to compile the transformation code. The following Exception was thrown:
System.MissingMethodException: Method not found: 'System.Collections.Immutable.ImmutableDictionary2<!!0,!!1> System.Collections.Immutable.ImmutableDictionary.ToImmutableDictionary(Builder<!!0,!!1>)'.
   at Microsoft.CodeAnalysis.CSharp.SyntaxAndDeclarationManager.AddSyntaxTrees(IEnumerable1 trees)
   at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.AddSyntaxTrees(IEnumerable1 trees)
   at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.CommonAddSyntaxTrees(IEnumerable1 trees)
   at Microsoft.VisualStudio.TextTemplating.CompilerBridge.PrepareNewCompilation()
   at Microsoft.VisualStudio.TextTemplating.CompilerBridge.Compile()
   at Microsoft.VisualStudio.TextTemplating.TransformationRunner.Compile(String source, String inputFile, IEnumerable1 references, Boolean debug, SupportedLanguage language, String compilerOptions). Line=0, Column=0
```

### Customer Impact
Some customers with T4 templates run during their build get a build failure. No workaround is currently known.

### Risk
Low.

### Code Reviewers
@Forgind 

### Description of fix
Update to GA version of the `System.Collections.Immutable` package that's already heavily dogfooded in VS via VS itself and Roslyn.

Fixes [AB#1245899](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1245899)
