### PR TITLE
ClickOnce publish does not publish certain runtime references in the correct destination folder

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>16.8.2</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>16.8.3</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Build.Shared
         internal const string redist = "Redist";
         internal const string resolvedFrom = "ResolvedFrom";
         internal const string destinationSubDirectory = "DestinationSubDirectory";
+        internal const string destinationSubPath = "DestinationSubPath";
         internal const string specificVersion = "SpecificVersion";
         internal const string link = "Link";
         internal const string subType = "SubType";

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4125,13 +4125,25 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Include the following files in clickonce manifest only if single file publish is false -->
     <ItemGroup Condition="'$(PublishSingleFile)' != 'true'">
-      <ClickOnceFiles Include="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce)"/>
+      <!-- 
+      _ClickOnceRuntimeCopyLocalItems group contains any runtimes folder assets of Nuget packages that are not included in 
+      _DeploymentReferencePaths (e.g. pdbs). They are populated from the RuntimeTargetsCopyLocalItems and NativeCopyLocalItems 
+      group that contain the RID-specific assets that go in runtimes folder on publish. They are output groups of the 
+      ResolvePackageAssets target in dotnet/sdk
+      -->
+      <_ClickOnceRuntimeCopyLocalItems Include="@(RuntimeTargetsCopyLocalItems)"
+                                      Condition="'%(RuntimeTargetsCopyLocalItems.CopyLocal)' == 'true'" />
+
+      <_ClickOnceRuntimeCopyLocalItems Include="@(NativeCopyLocalItems)" 
+                                      Condition="'%(NativeCopyLocalItems.CopyLocal)' == 'true'" />
+      <_ClickOnceRuntimeCopyLocalItems Remove="@(_DeploymentReferencePaths)" />
+      <_ClickOnceFiles Include="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce);@(_ClickOnceRuntimeCopyLocalItems)"/>
     </ItemGroup>
 
     <!-- For single file publish, we need to include the SF bundle EXE and files excluded from the bundle EXE in the clickonce manifest -->
     <ItemGroup Condition="'$(PublishSingleFile)' == 'true'">
-      <ClickOnceFiles Include="$(PublishedSingleFilePath)"/>
-      <ClickOnceFiles Include="@(_FilesExcludedFromBundle)"/>
+      <_ClickOnceFiles Include="$(PublishedSingleFilePath)"/>
+      <_ClickOnceFiles Include="@(_FilesExcludedFromBundle)"/>
     </ItemGroup>
 
     <!-- For single file publish in .net core app, sign the SF EXE if signing is enabled -->
@@ -4166,7 +4178,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         AssemblyName="$(_DeploymentApplicationManifestIdentity)"
         EntryPoint="@(_DeploymentClickOnceApplicationExecutable)"
         ExtraFiles="@(_DebugSymbolsIntermediatePath);$(IntermediateOutputPath)$(TargetName).xml;@(_ReferenceRelatedPaths)"
-        Files="@(ClickOnceFiles)"
+        Files="@(_ClickOnceFiles)"
         IsSelfContainedPublish="$(SelfContained)"
         IsSingleFilePublish="$(PublishSingleFile)"
         LauncherBasedDeployment="$(_DeploymentLauncherBased)"


### PR DESCRIPTION
**Customer Impact**
ClickOnce publish fails to publish runtime assets from the Runtimes sub-folder of Nuget package. The published app will then fail to launch after the install.

**Testing**
CTI team has completed ClickOnce Publish validation for Full FX, .NET Core 3.1 and .NET Core 5.0.

**Risk**
Low (limited to ClickOnce tasks/targets). The changes are scoped to a targets and task invoked for ClickOnce publish only and the new code is run only when certain metadata (DestinationSubDirectory) is present for any reference.

**Code Reviewers**
johnhart;nikolam;rainersigwald;forgind

**Description of fix**
Nuget packages can have a runtimes sub-folder that contain copylocal files that need to be available at runtime. These assets need to be published to a path that is specified in the DestinationSubDir metadata of the runtime asset. DestinationSubDir is set to the path of the runtime asset in the Nuget package (e.g. runtimes/win-x64/xyz.dll).

Without this fix, the legacy ClickOnce task which is not aware of this new metadata attempts to publishe these assets in the root publish folder. Also if there is another copylocal asset with the same name in the Nuget package, we now have 2 assets trying to publish to the same location and the second copy will get ignored due to the conflict.

In addition, Nuget packages can also have native DLLs as runtime assets which legacy ClickOnce task ignores.

A) Description of changes in ResolveManifestFiles ClickOnce task that resolves the files included in the ClickOnce manifest:

1. The TargetPath metadata (that ClickOnce uses as publish destination location) of the runtime asset is set to DestinationSubPath if the metadata value exists on the asset.

2. A dictionary used to track file entries that uses the filename as the key now prepends DestinationSubDirectory metadata to the key if a key with the filename already exists in the dictionary.

3. The filtering code that filters out native DLL references now excludes the filtering of native DLLs if the app is a .NET Core app.

4. The GetOuputFiles function that resolves ad-hoc Files for deployment also checks if the file is already included as a copylocal Reference in the OutputAssemblies list. If so, the File is skipped since otherwise the file would be duplicated in the ClickOnce manifest and the install will fail. The MongoDB.Driver.Core package is an example of such a package that need this special handling. It adds some of its runtime assets to the Content group via its targets file in the build folder of the NuGet package.

B) Changes in MS.Common.CurrentVersion.targets:

Runtimes assets in NuGet packages could also include assets that need be to be passed to ClickOnce tasks as ordinary files instead of references (e.g. pdbs). These need to be gathered from output groups of the ResolvePackageAssets SDK task and included  in ClickOnceFiles group.