### PR TITLE
Make matching case insensitive regardless of OS Fixes #5749

### DIFF
--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -2820,7 +2820,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void UpdateFromReferencedItemShouldBeCaseInsensitive()
         {
             string content = @"
-                              <from Include='a'>
+                              <from Include='A'>
                                   <metadata>m1_contents</metadata>
                               </from>
 

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -3177,28 +3177,15 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content);
 
-            if (FileUtilities.GetIsFileSystemCaseSensitive())
+            items.ShouldHaveSingleItem();
+
+            var expectedUpdated = new Dictionary<string, string>
             {
-                var expectedUpdated = new Dictionary<string, string>
-                {
-                    {"m1", "m1_contents"},
-                    {"m2", "m2_contents"},
-                };
+                {"m1", "m1_updated"},
+                {"m2", "m2_updated"},
+            };
 
-                ObjectModelHelpers.AssertItemHasMetadata(expectedUpdated, items[0]);
-            }
-            else
-            {
-                items.ShouldHaveSingleItem();
-
-                var expectedUpdated = new Dictionary<string, string>
-                {
-                    {"m1", "m1_updated"},
-                    {"m2", "m2_updated"},
-                };
-
-                ObjectModelHelpers.AssertItemHasMetadata(expectedUpdated, items[0]);
-            }
+            ObjectModelHelpers.AssertItemHasMetadata(expectedUpdated, items[0]);
         }
 
         public static IEnumerable<Object[]> UpdateAndRemoveShouldWorkWithEscapedCharactersTestData

--- a/src/Build/Utilities/FileSpecMatchTester.cs
+++ b/src/Build/Utilities/FileSpecMatchTester.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Shared;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -42,7 +43,7 @@ namespace Microsoft.Build.Internal
                 return _regex.IsMatch(normalizedFileToMatch);
             }
 
-            return FileUtilities.ComparePathsNoThrow(_unescapedFileSpec, fileToMatch, _currentDirectory);
+            return FileUtilities.ComparePathsNoThrow(_unescapedFileSpec, fileToMatch, _currentDirectory, alwaysIgnoreCase: true);
         }
 
         // this method parses the glob and extracts the fixed directory part in order to normalize it and make it absolute

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -735,11 +735,13 @@ namespace Microsoft.Build.Shared
         /// <param name="first"></param>
         /// <param name="second"></param>
         /// <param name="currentDirectory"></param>
+        /// <param name="alwaysIgnoreCase"></param>
         /// <returns></returns>
-        internal static bool ComparePathsNoThrow(string first, string second, string currentDirectory)
+        internal static bool ComparePathsNoThrow(string first, string second, string currentDirectory, bool alwaysIgnoreCase = false)
         {
+            StringComparison pathComparison = alwaysIgnoreCase ? StringComparison.OrdinalIgnoreCase : PathComparison;
             // perf: try comparing the bare strings first
-            if (string.Equals(first, second, PathComparison))
+            if (string.Equals(first, second, pathComparison))
             {
                 return true;
             }
@@ -747,7 +749,7 @@ namespace Microsoft.Build.Shared
             var firstFullPath = NormalizePathForComparisonNoThrow(first, currentDirectory);
             var secondFullPath = NormalizePathForComparisonNoThrow(second, currentDirectory);
 
-            return string.Equals(firstFullPath, secondFullPath, PathComparison);
+            return string.Equals(firstFullPath, secondFullPath, pathComparison);
         }
 
         /// <summary>


### PR DESCRIPTION
First commit: update a test such that it passes only if matching is case insensitive.
Second commit: modify FileUtilities.ComparePathsNoThrow such that it can be made to be always case sensitive or case insensitive. Note that this was changed about seven months ago in [#4997](https://github.com/dotnet/msbuild/pull/4997) where it had previously been a todo to make case sensitivity depend on OS but that implemented it.
Third commit: fix a test that theoretically ensured case insensitivity but in practice did not, changed to care about case in the same PR.

The second commit fixes #5749.