### PR TITLE
Binding redirect for Immutable upgrade; ngen in our context

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -52,6 +52,12 @@
           <codeBase version="16.8.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
+        <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
+        <dependentAssembly>
+          <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        </dependentAssembly>
+
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -41,6 +41,12 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
         </dependentAssembly>
 
+        <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
+        <dependentAssembly>
+          <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        </dependentAssembly>
+
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -48,7 +48,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)System.Resources.Extensions.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
-  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks


### PR DESCRIPTION
This addresses two problems with #5879:

1. Failures in VS RPS related to JITting at runtime. With no `ngenApplication` specified, our SCI got ngened in the context of the default VS application, which isn't `MSBuild.exe`. Then at runtime, it wasn't loaded because the MVID of the ngened assembly (VS's special optprof-augmented copy) didn't match the one located at runtime (the standard retail copy from our repo).
2. Added binding redirects for SCI. If a task depended on having access to our copy of SCI at our old version, updating our version would cause it to fail to load. Add a binding redirect like `devenv.exe` and Roslyn assemblies have to pull that reference to our copy.