### PR TITLE
Remove feedSource parameter from MicroBuild task

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -76,7 +76,6 @@ stages:
     - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
       inputs:
         dropName: $(VisualStudio.DropName)
-        feedSource: 'https://devdiv-test.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
     - script: eng/CIBuild.cmd
                 -configuration $(BuildConfiguration)


### PR DESCRIPTION
In a conversation between Rainer and Rick Krause

Rick mentions:
> You’re using the wrong package feed— https://devdiv-test.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json.
Change the feed source in your task to  https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json

And: 
>Actually, you could drop the feedSource value altogether, since it defaults to the value I said to use.
Thanks, Rick

It gets passed the step, but fails now at signing validation
![image](https://user-images.githubusercontent.com/4691428/99592311-e8150880-29a4-11eb-861a-f05e6b7f5f2f.png)

`[error].packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.20509.7\tools\SdkTasks\SigningValidation.proj(56,5): error : Signing validation failed. Check signcheck.errors.log for more information.`

Pipeline Build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4237997&view=results