### PR TITLE
Update NuGet and Roslyn versions

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-      <NuGetPackageVersion>5.7.0-rtm.6710</NuGetPackageVersion>
+      <NuGetPackageVersion>5.9.0-preview.1.6870</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
       <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>
       <NuGetProtocolVersion Condition="'$(NuGetProtocolVersion)' == ''">$(NuGetPackageVersion)</NuGetProtocolVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,6 +37,7 @@
   <!-- Toolset Dependencies -->
   <PropertyGroup>
     <DotNetCliVersion>3.1.100</DotNetCliVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.8.0</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386


### PR DESCRIPTION
The version of Arcade MSBuild currently uses uses Roslyn version 3.3.1. This updates that, but it should be removed when we've updated to a more modern version of arcade.

Also updates our version of NuGet.