### PR TITLE
Darc for bootstrap dependencies

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -3,7 +3,7 @@
     <PackageReference Update="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
     <PackageReference Update="LargeAddressAware" Version="1.0.3" />
     <PackageReference Update="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetBuildTasksVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-beta1-61516-01" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="$(MicrosoftNetCompilersToolsetVersion)" />
     <PackageReference Update="Microsoft.DotNet.BuildTools.GenAPI" Version="2.1.0-prerelease-02404-02" />
     <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,12 +1,4 @@
 <Project>
-
-  <PropertyGroup>
-      <NuGetPackageVersion>5.7.0-rtm.6710</NuGetPackageVersion>
-      <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
-      <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>
-      <NuGetProtocolVersion Condition="'$(NuGetProtocolVersion)' == ''">$(NuGetPackageVersion)</NuGetProtocolVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Update="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
     <PackageReference Update="LargeAddressAware" Version="1.0.3" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,5 +9,9 @@
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
       <Sha />
     </Dependency>
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha />
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,5 +5,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>6afe5f93699b6512ee07362fa451317a2ce34f7b</Sha>
     </Dependency>
+    <Dependency Name="NuGet.Build.Tasks" Version="">
+      <Uri>https://github.com/NuGet/NuGet.Client</Uri>
+      <Sha />
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,6 +37,7 @@
   <!-- Toolset Dependencies -->
   <PropertyGroup>
     <DotNetCliVersion>3.1.100</DotNetCliVersion>
+    <NuGetBuildTasksVersion>5.7.0-rtm.6710</NuGetBuildTasksVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,6 +37,7 @@
   <!-- Toolset Dependencies -->
   <PropertyGroup>
     <DotNetCliVersion>3.1.100</DotNetCliVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.3.1-beta3-final</MicrosoftNetCompilersToolsetVersion>
     <NuGetBuildTasksVersion>5.7.0-rtm.6710</NuGetBuildTasksVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">


### PR DESCRIPTION
Add the darc metadata for our dependencies on NuGet and Roslyn. These are toolset dependencies because we use them to construct our bootstrap folder/test environments, but we don't have product code dependencies here--`RoslynCodeTaskFactory` requires Roslyn but doesn't depend on it in the normal way to break cycles/allow floating versions.

This PR changes versions only for the Roslyn build task used for unit tests, making it match the toolset version used to make the bootstrap.