### PR TITLE
Don't hang builds on BuildManager internal errors

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -4094,6 +4094,32 @@ $@"<Project InitialTargets=`Sleep`>
         }
 
         [Fact]
+        public void BuildWithZeroConnectionTimeout()
+        {
+            string contents = CleanupFileContents(@"
+<Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
+ <Target Name='test'>
+    <Message Text='Text'/>
+ </Target>
+</Project>
+");
+            _env.SetEnvironmentVariable("MSBUILDNODECONNECTIONTIMEOUT", "0");
+
+            BuildRequestData data = GetBuildRequestData(contents);
+            try
+            {
+                BuildResult result = _buildManager.Build(_parameters, data);
+
+                // The build should either finish successfully (very unlikely).
+                result.OverallResult.ShouldBe(BuildResultCode.Success);
+            }
+            catch (InternalErrorException)
+            {
+                // Or it should throw InternalErrorException because the node didn't get connected within 0ms.
+            }
+        }
+
+        [Fact]
         [ActiveIssue("https://github.com/Microsoft/msbuild/issues/4368")]
         public void GraphBuildValid()
         {

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -4097,7 +4097,7 @@ $@"<Project InitialTargets=`Sleep`>
         public void BuildWithZeroConnectionTimeout()
         {
             string contents = CleanupFileContents(@"
-<Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
+<Project>
  <Target Name='test'>
     <Message Text='Text'/>
  </Target>

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -58,6 +58,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private readonly ITestOutputHelper _output;
 
         /// <summary>
+        /// The transient state corresponding to setting MSBUILDINPROCENVCHECK to 1.
+        /// </summary>
+        private readonly TransientTestState _inProcEnvCheckTransientEnvironmentVariable;
+
+        /// <summary>
         /// SetUp
         /// </summary>
         public BuildManager_Tests(ITestOutputHelper output)
@@ -77,7 +82,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _projectCollection = new ProjectCollection();
 
             _env = TestEnvironment.Create(output);
-            _env.SetEnvironmentVariable("MSBUILDINPROCENVCHECK", "1");
+            _inProcEnvCheckTransientEnvironmentVariable = _env.SetEnvironmentVariable("MSBUILDINPROCENVCHECK", "1");
         }
 
         /// <summary>
@@ -4103,6 +4108,8 @@ $@"<Project InitialTargets=`Sleep`>
  </Target>
 </Project>
 ");
+            // Do not use MSBUILDINPROCENVCHECK because this test case is expected to leave a defunct in-proc node behind.
+            _inProcEnvCheckTransientEnvironmentVariable.Revert();
             _env.SetEnvironmentVariable("MSBUILDNODECONNECTIONTIMEOUT", "0");
 
             BuildRequestData data = GetBuildRequestData(contents);

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -4113,9 +4113,10 @@ $@"<Project InitialTargets=`Sleep`>
                 // The build should either finish successfully (very unlikely).
                 result.OverallResult.ShouldBe(BuildResultCode.Success);
             }
-            catch (InternalErrorException)
+            catch (Exception e)
             {
                 // Or it should throw InternalErrorException because the node didn't get connected within 0ms.
+                e.ShouldBeOfType<InternalErrorException>();
             }
         }
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2184,20 +2184,13 @@ namespace Microsoft.Build.Execution
                             continue;
                         }
 
-                        submission.CompleteLogging(false);
-
                         // Attach the exception to this submission if it does not already have an exception associated with it
-                        if (submission.BuildResult?.Exception == null)
+                        if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
                         {
-                            if (submission.BuildResult == null)
-                            {
-                                submission.BuildResult = new BuildResult(submission.BuildRequest, e);
-                            }
-                            else
-                            {
-                                submission.BuildResult.Exception = _threadException.SourceException;
-                            }
+                            submission.BuildResult.Exception = e;
                         }
+                        submission.CompleteLogging(false);
+                        submission.CompleteResults(new BuildResult(submission.BuildRequest, e));
 
                         CheckSubmissionCompletenessAndRemove(submission);
                     }
@@ -2211,17 +2204,11 @@ namespace Microsoft.Build.Execution
                         }
 
                         // Attach the exception to this submission if it does not already have an exception associated with it
-                        if (submission.BuildResult?.Exception == null)
+                        if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
                         {
-                            if (submission.BuildResult == null)
-                            {
-                                submission.BuildResult = new GraphBuildResult(submission.SubmissionId, e);
-                            }
-                            else
-                            {
-                                submission.BuildResult.Exception = _threadException.SourceException;
-                            }
+                            submission.BuildResult.Exception = e;
                         }
+                        submission.CompleteResults(submission.BuildResult ?? new GraphBuildResult(submission.SubmissionId, e));
 
                         CheckSubmissionCompletenessAndRemove(submission);
                     }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2189,7 +2189,7 @@ namespace Microsoft.Build.Execution
                         {
                             submission.BuildResult.Exception = e;
                         }
-                        submission.CompleteLogging(false);
+                        submission.CompleteLogging(waitForLoggingThread: false);
                         submission.CompleteResults(new BuildResult(submission.BuildRequest, e));
 
                         CheckSubmissionCompletenessAndRemove(submission);


### PR DESCRIPTION
The logic to handle exceptions thrown on logging and communication threads was trying to make the build submission fail with the exception but it didn't always complete it. This manifested as the build hanging, for example when building with `MSBUILDNODECONNECTIONTIMEOUT = 0`, which is almost guaranteed to throw `InternalErrorException` in `InstantiateNode`.

This PR fixes it by making sure that all submissions are completed in `OnThreadException`. Unlike the original code, proper care is taken to avoid race conditions - i.e. the build result is mutated only if hasn't already been passed to the completion handler.

Fixes #5911 