### PR TITLE
Fix lazy string format

### DIFF
--- a/src/Framework/LazyFormattedBuildEventArgs.cs
+++ b/src/Framework/LazyFormattedBuildEventArgs.cs
@@ -199,45 +199,6 @@ namespace Microsoft.Build.Framework
             if ((args?.Length > 0))
             {
 #if DEBUG
-
-#if VALIDATERESOURCESTRINGS
-                // The code below reveals many places in our codebase where
-                // we're not using all of the data given to us to format
-                // strings -- but there are too many to presently fix.
-                // Rather than toss away the code, we should later build it
-                // and fix each offending resource (or the code processing
-                // the resource).
-
-                // String.Format() will throw a FormatException if args does
-                // not have enough elements to match each format parameter.
-                // However, it provides no feedback in the case when args contains
-                // more elements than necessary to replace each format 
-                // parameter.  We'd like to know if we're providing too much
-                // data in cases like these, so we'll fail if this code runs.
-                                                
-                // We create an array with one fewer element
-                object[] trimmedArgs = new object[args.Length - 1];
-                Array.Copy(args, 0, trimmedArgs, 0, args.Length - 1);
-
-                bool caughtFormatException = false;
-                try
-                {
-                    // This will throw if there aren't enough elements in trimmedArgs...
-                    String.Format(CultureInfo.CurrentCulture, unformatted, trimmedArgs);
-                }
-                catch (FormatException)
-                {
-                    caughtFormatException = true;
-                }
-
-                // If we didn't catch an exception above, then some of the elements
-                // of args were unnecessary when formatting unformatted...
-                Debug.Assert
-                (
-                    caughtFormatException,
-                    String.Format("The provided format string '{0}' had fewer format parameters than the number of format args, '{1}'.", unformatted, args.Length)
-                );
-#endif
                 // If you accidentally pass some random type in that can't be converted to a string, 
                 // FormatResourceString calls ToString() which returns the full name of the type!
                 foreach (object param in args)

--- a/src/Shared/ResourceUtilities.cs
+++ b/src/Shared/ResourceUtilities.cs
@@ -227,45 +227,6 @@ namespace Microsoft.Build.Shared
             if ((args?.Length > 0))
             {
 #if DEBUG
-
-#if VALIDATERESOURCESTRINGS
-                // The code below reveals many places in our codebase where
-                // we're not using all of the data given to us to format
-                // strings -- but there are too many to presently fix.
-                // Rather than toss away the code, we should later build it
-                // and fix each offending resource (or the code processing
-                // the resource).
-
-                // String.Format() will throw a FormatException if args does
-                // not have enough elements to match each format parameter.
-                // However, it provides no feedback in the case when args contains
-                // more elements than necessary to replace each format 
-                // parameter.  We'd like to know if we're providing too much
-                // data in cases like these, so we'll fail if this code runs.
-                                                
-                // We create an array with one fewer element
-                object[] trimmedArgs = new object[args.Length - 1];
-                Array.Copy(args, 0, trimmedArgs, 0, args.Length - 1);
-
-                bool caughtFormatException = false;
-                try
-                {
-                    // This will throw if there aren't enough elements in trimmedArgs...
-                    String.Format(CultureInfo.CurrentCulture, unformatted, trimmedArgs);
-                }
-                catch (FormatException)
-                {
-                    caughtFormatException = true;
-                }
-
-                // If we didn't catch an exception above, then some of the elements
-                // of args were unnecessary when formatting unformatted...
-                Debug.Assert
-                (
-                    caughtFormatException,
-                    String.Format("The provided format string '{0}' had fewer format parameters than the number of format args, '{1}'.", unformatted, args.Length)
-                );
-#endif
                 // If you accidentally pass some random type in that can't be converted to a string, 
                 // FormatResourceString calls ToString() which returns the full name of the type!
                 foreach (object param in args)

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -199,7 +199,14 @@ namespace Microsoft.Build.Utilities
         /// <exception cref="InvalidOperationException">Thrown when the <c>TaskResources</c> property of the owner task is not set.</exception>
         public virtual string FormatResourceString(string resourceName, params object[] args)
         {
-            return FormatString(GetResourceMessage(resourceName), args);
+            ErrorUtilities.VerifyThrowArgumentNull(resourceName, nameof(resourceName));
+            ErrorUtilities.VerifyThrowInvalidOperation(TaskResources != null, "Shared.TaskResourcesNotRegistered", TaskName);
+
+            string resourceString = TaskResources.GetString(resourceName, CultureInfo.CurrentUICulture);
+
+            ErrorUtilities.VerifyThrowArgument(resourceString != null, "Shared.TaskResourceNotFound", resourceName, TaskName);
+
+            return FormatString(resourceString, args);
         }
 
         /// <summary>
@@ -225,13 +232,7 @@ namespace Microsoft.Build.Utilities
         /// <returns>The message from resource.</returns>
         public virtual string GetResourceMessage(string resourceName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(resourceName, nameof(resourceName));
-            ErrorUtilities.VerifyThrowInvalidOperation(TaskResources != null, "Shared.TaskResourcesNotRegistered", TaskName);
-
-            string resourceString = TaskResources.GetString(resourceName, CultureInfo.CurrentUICulture);
-
-            ErrorUtilities.VerifyThrowArgument(resourceString != null, "Shared.TaskResourceNotFound", resourceName, TaskName);
-
+            string resourceString = FormatResourceString(resourceName, null);
             return resourceString;
         }
 #endregion
@@ -274,7 +275,7 @@ namespace Microsoft.Build.Utilities
 #if DEBUG
             if (messageArgs?.Length > 0)
             {
-                // Verify that message can be formated using given arguments
+                // Verify that message can be formatted using given arguments
                 ResourceUtilities.FormatString(message, messageArgs);
             }
 #endif

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -711,7 +711,7 @@ namespace Microsoft.Build.Utilities
             {
                 ErrorUtilities.VerifyThrowArgumentNull(messageResourceName, nameof(messageResourceName));
 
-                Log.LogMessage(importance, AssemblyResources.FormatResourceString(messageResourceName, messageArgs));
+                Log.LogMessage(importance, AssemblyResources.GetString(messageResourceName), messageArgs);
             }
         }
 


### PR DESCRIPTION
In couple of places we have not leveraged LazyFormattedBuildEventArgs properly.
With these changes strings would not be necessary to format, in cases when logging is limited like `/clp:PerformanceSummary`

Related issue #2700 