### PR TITLE
Allow overriding exp branch optprof sources

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -13,7 +13,8 @@ trigger:
 variables:
   - name: SourceBranch
     value: $(IbcSourceBranchName)
-  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/') }}:
+  - ${{ if and(eq(variables['Build.SourceBranch'], variables['IbcSourceBranchName']), startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/')) }}:
+    # For exp branches, get data from master unless explicitly specified
     - name: SourceBranch
       value: master
   - name: _DotNetArtifactsCategory


### PR DESCRIPTION
Before this change, the 'get optprof data from master for exp branches' logic always overrode the parameter that allows overriding the source branch, so if an exp branch needed data from non-master it broke.

Check to see that the passed-in value is the default (the real source branch name) before overriding it.