### PR TITLE
Revert "Modify ETW to capture the number of resolved references (#5923)"

### DIFF
--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -73,17 +73,16 @@ namespace Microsoft.Build.Eventing
             WriteEvent(6, projectPath, targets);
         }
 
-        [Event(7, Keywords = Keywords.All | Keywords.PerformanceLog)]
+        [Event(7, Keywords = Keywords.All)]
         public void RarComputeClosureStart()
         {
             WriteEvent(7);
         }
 
-        // If there are failures in ComputeClosure, this count may be inaccurate.
-        [Event(8, Keywords = Keywords.All | Keywords.PerformanceLog)]
-        public void RarComputeClosureStop(int referencesResolved)
+        [Event(8, Keywords = Keywords.All)]
+        public void RarComputeClosureStop()
         {
-            WriteEvent(8, referencesResolved);
+            WriteEvent(8);
         }
 
         /// <param name="condition">The condition being evaluated.</param>


### PR DESCRIPTION
This reverts commit f7111327ed928e28b3b57e1b4b83377a6299669b.

This was failing with F#'s older version of MSBuild.