### PR TITLE
Add timeout to hanging test

### DIFF
--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Graph.UnitTests
             }
         }
 
-        [Theory]
+        [Theory(Timeout = 20_000)]
         [MemberData(nameof(GraphsWithUniformSolutionConfigurations))]
         public void GraphConstructionCanLoadEntryPointsFromSolution(
             Dictionary<int, int[]> edges,

--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Graph.UnitTests
             }
         }
 
-        [Theory(Timeout = 20_000)]
+        [Theory(Timeout = 20_000)] // Test hangs intermittently: https://github.com/dotnet/msbuild/issues/5520
         [MemberData(nameof(GraphsWithUniformSolutionConfigurations))]
         public void GraphConstructionCanLoadEntryPointsFromSolution(
             Dictionary<int, int[]> edges,


### PR DESCRIPTION
This has hung several times lately, including [here](https://dev.azure.com/dnceng/public/_build/results?buildId=910820&view=logs&j=20125c81-7edb-551b-693a-61efae016b74&t=7ce25265-aabe-59d3-d73c-06619cfcc3c4). Adding a timeout to make that a bit better.