### PR TITLE
Have ProjectInSolution.AbsolutePath return a normalized path

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
@@ -2400,5 +2400,42 @@ EndGlobal
 
             exception.Message.ShouldStartWith(message);
         }
+
+        /// <summary>
+        /// A test where paths contain ..\ segments to ensure the paths are normalized.
+        /// </summary>
+        [Fact]
+        public void ParseSolutionWithParentedPaths()
+        {
+            string solutionFileContents =
+                @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{749ABBD6-B803-4DA5-8209-498127164114}')  = 'ProjectA',  '..\ProjectA\ProjectA.csproj', '{0ABED153-9451-483C-8140-9E8D7306B216}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|AnyCPU = Debug|AnyCPU
+                        Release|AnyCPU = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.Build.0 = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+            SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+            string expectedRelativePath = Path.Combine("..", "ProjectA", "ProjectA.csproj");
+            Assert.Equal("ProjectA", solution.ProjectsInOrder[0].ProjectName);
+            Assert.Equal(expectedRelativePath, solution.ProjectsInOrder[0].RelativePath);
+            Assert.Equal(Path.GetFullPath(Path.Combine(Path.GetDirectoryName(solution.FullPath), expectedRelativePath)), solution.ProjectsInOrder[0].AbsolutePath);
+            Assert.Equal("{0ABED153-9451-483C-8140-9E8D7306B216}", solution.ProjectsInOrder[0].ProjectGuid);
+        }
     }
 }

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -740,10 +740,10 @@ EndGlobal
             string solutionConfigurationContents = msbuildProject.GetPropertyValue("CurrentSolutionConfigurationContents");
 
             // Only the specified solution configuration is represented in THE BLOB: nothing for x64 in this case
-            string expected = @"<SolutionConfiguration>
-  <ProjectConfiguration Project=`{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}` AbsolutePath=`##temp##Project1\A.csproj` BuildProjectInSolution=`True`>Debug|AnyCPU</ProjectConfiguration>
-  <ProjectConfiguration Project=`{881C1674-4ECA-451D-85B6-D7C59B7F16FA}` AbsolutePath=`##temp##Project2\B.csproj` BuildProjectInSolution=`True`>Debug|AnyCPU<ProjectDependency Project=`{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}` /></ProjectConfiguration>
-  <ProjectConfiguration Project=`{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}` AbsolutePath=`##temp##Project3\C.csproj` BuildProjectInSolution=`True`>Debug|AnyCPU</ProjectConfiguration>
+            string expected = $@"<SolutionConfiguration>
+  <ProjectConfiguration Project=`{{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}}` AbsolutePath=`##temp##{Path.Combine("Project1", "A.csproj")}` BuildProjectInSolution=`True`>Debug|AnyCPU</ProjectConfiguration>
+  <ProjectConfiguration Project=`{{881C1674-4ECA-451D-85B6-D7C59B7F16FA}}` AbsolutePath=`##temp##{Path.Combine("Project2", "B.csproj")}` BuildProjectInSolution=`True`>Debug|AnyCPU<ProjectDependency Project=`{{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}}` /></ProjectConfiguration>
+  <ProjectConfiguration Project=`{{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}}` AbsolutePath=`##temp##{Path.Combine("Project3", "C.csproj")}` BuildProjectInSolution=`True`>Debug|AnyCPU</ProjectConfiguration>
 </SolutionConfiguration>".Replace("`", "\"").Replace("##temp##", Path.GetTempPath());
 
             Helpers.VerifyAssertLineByLine(expected, solutionConfigurationContents);
@@ -953,14 +953,14 @@ EndGlobal
             msbuildProject.ReevaluateIfNecessary();
 
             string solutionConfigurationContents = msbuildProject.GetPropertyValue("CurrentSolutionConfigurationContents");
-            string tempProjectPath = Path.Combine(Path.GetTempPath(), "ClassLibrary1\\ClassLibrary1.csproj");
+            string tempProjectPath = Path.Combine(Path.GetTempPath(), "ClassLibrary1", "ClassLibrary1.csproj");
 
             Assert.Contains("{6185CC21-BE89-448A-B3C0-D1C27112E595}", solutionConfigurationContents);
             tempProjectPath = Path.GetFullPath(tempProjectPath);
             Assert.True(solutionConfigurationContents.IndexOf(tempProjectPath, StringComparison.OrdinalIgnoreCase) > 0);
             Assert.Contains("CSConfig1|AnyCPU", solutionConfigurationContents);
 
-            tempProjectPath = Path.Combine(Path.GetTempPath(), "MainApp\\MainApp.vcxproj");
+            tempProjectPath = Path.Combine(Path.GetTempPath(), "MainApp", "MainApp.vcxproj");
             tempProjectPath = Path.GetFullPath(tempProjectPath);
             Assert.Contains("{A6F99D27-47B9-4EA4-BFC9-25157CBDC281}", solutionConfigurationContents);
             Assert.True(solutionConfigurationContents.IndexOf(tempProjectPath, StringComparison.OrdinalIgnoreCase) > 0);

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -210,6 +210,8 @@ namespace Microsoft.Build.Construction
                 {
                     _solutionFile = value;
                     _solutionFilter = null;
+
+                    SolutionFileDirectory = Path.GetDirectoryName(_solutionFile);
                 }
             }
         }
@@ -381,6 +383,9 @@ namespace Microsoft.Build.Construction
                         _solutionFile
                     );
                 }
+
+                SolutionFileDirectory = Path.GetDirectoryName(_solutionFile);
+
                 _solutionFilter = new HashSet<string>(NativeMethodsShared.OSUsesCaseSensitivePaths ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
                 foreach (JsonElement project in solution.GetProperty("projects").EnumerateArray())
                 {
@@ -475,8 +480,6 @@ namespace Microsoft.Build.Construction
             {
                 // Open the file
                 fileStream = File.OpenRead(_solutionFile);
-                // Store the directory of the file as the current directory may change while we are processes the file
-                SolutionFileDirectory = Path.GetDirectoryName(_solutionFile);
                 SolutionReader = new StreamReader(fileStream, Encoding.GetEncoding(0)); // HIGHCHAR: If solution files have no byte-order marks, then assume ANSI rather than ASCII.
                 ParseSolution();
             }

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Build.Graph
                 {
                     newEntryPoints.Add(
                         new ProjectGraphEntryPoint(
-                            FileUtilities.NormalizePath(project.AbsolutePath),
+                            project.AbsolutePath,
                             solutionGlobalProperties
                                 .SetItem("Configuration", projectConfiguration.ConfigurationName)
                                 .SetItem("Platform", projectConfiguration.PlatformName)
@@ -344,7 +344,7 @@ namespace Microsoft.Build.Graph
 
                 foreach (var projectWithDependencies in solutionFile.ProjectsInOrder.Where(p => p.Dependencies.Count != 0))
                 {
-                    solutionDependencies[FileUtilities.NormalizePath(projectWithDependencies.AbsolutePath)] = projectWithDependencies.Dependencies.Select(
+                    solutionDependencies[projectWithDependencies.AbsolutePath] = projectWithDependencies.Dependencies.Select(
                         dependencyGuid =>
                         {
                             // code snippet cloned from SolutionProjectGenerator.AddPropertyGroupForSolutionConfiguration
@@ -365,7 +365,7 @@ namespace Microsoft.Build.Graph
                             // (If a project is not selected for build in the solution configuration, it won't build even if it's depended on by something that IS selected for build)
                             // .. and only if it's known to be MSBuild format, as projects can't use the information otherwise 
                             return dependencyProject?.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat
-                                ? FileUtilities.NormalizePath(dependencyProject.AbsolutePath)
+                                ? dependencyProject.AbsolutePath
                                 : null;
                         })
                         .Where(p => p != null)


### PR DESCRIPTION
This change updates `ProjectInSolution.AbsolutePath` to return a normalized path.  At the moment it simply returns the result of a `Path.Combine()` which leaves `..\` path segments in place and does not contain OS-specific path separators.

Fixes #5949 and https://github.com/NuGet/Home/issues/10307