### PR TITLE
[Don't Merge] Run target to ensure OutputPath has a trailing slash

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -797,6 +797,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
       
     <PropertyGroup>
+      <BaseOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseOutputPath)', 'bin'))))</BaseOutputPath>
+      <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseOutputPath)', '$(Configuration)'))</OutputPath>
+      <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseOutputPath)', '$(PlatformName)', '$(Configuration)'))</OutputPath>
       <OutputPath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))</OutputPath>
     </PropertyGroup>
   </Target>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -792,6 +792,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
   </Target>
 
+  <Target
+      Name="_EnsureOutputPathHasTrailingSlash"
+      BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
+      
+    <PropertyGroup>
+      <OutputPath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))</OutputPath>
+    </PropertyGroup>
+  </Target>
+
   <!--
     ============================================================
                                         _CheckForInvalidConfigurationAndPlatform


### PR DESCRIPTION
Creating as a PR to workaround `exp/` pipeline issues