### PR TITLE
HasLoggedError Respects MSBuildWarningsAsErrors

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -211,6 +211,29 @@ namespace Microsoft.Build.BackEnd.Logging
         internal void LogWarning(string subcategoryResourceName, BuildEventFileInfo file, string messageResourceName, params object[] messageArgs)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            // PROBLEM WITH THIS CHUNK:
+            // LoggingContext has no idea if LoggingService actually interpreted the warning as an error, and logged it as so.
+            // It's a problem because TaskBuilder checks _THIS FILE'S _HASLOGGEDERRORS_ boolean to see if it logged errors.
+            // But loggingservice does not expose this info!
+
+            //doesn't work if the submission had already logged an error. unless we count the number of logged errors.
+
+            // Another problem is you need the warning code. Okay we can get that from resourceutilities.
+
+            // The fix: Have LoggingContext see if what we were about to log as an warning is actually an error.
+            // Prev code path: LogWarning -> _loggingService.LogWarning -> RouteBuildEvent -> LoggingService.RouteBuildEvent "Oh should we ACTUALLY log it as an error? -> Replace with error args.
+            // New code path: LogWarning "Oh are we actually going to log that as an error?" -> _loggingService.LogWarning -> LoggingService.RouteBuildEvent -> done.
+
+            string warningCode;
+            string helpKeyword;
+            string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out warningCode, out helpKeyword, messageResourceName, messageArgs);
+
+            if(_loggingService.WarningsAsErrors.Contains(warningCode))
+            {
+                LogError(file, messageResourceName, messageArgs);
+                return;
+            }
+
             _loggingService.LogWarning(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
         }
 
@@ -225,6 +248,12 @@ namespace Microsoft.Build.BackEnd.Logging
         internal void LogWarningFromText(string subcategoryResourceName, string warningCode, string helpKeyword, BuildEventFileInfo file, string message)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+
+            if(_loggingService.WarningsAsErrors.Contains(warningCode))
+            {
+                LogErrorFromText(subcategoryResourceName, warningCode, helpKeyword, file, message);
+            }
+
             _loggingService.LogWarningFromText(_eventContext, subcategoryResourceName, warningCode, helpKeyword, file, message);
         }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
             // Log an error if the warning we were about to log is listed as a WarningAsError
             // https://github.com/dotnet/msbuild/issues/5511
-            if(_loggingService.WarningsAsErrors != null)
+            if(_loggingService.WarningsAsErrors != null && _loggingService.WarningsAsErrors.Count > 0)
             {
                 string warningCode;
                 string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out warningCode, out _, messageResourceName, messageArgs);
@@ -243,9 +243,13 @@ namespace Microsoft.Build.BackEnd.Logging
 
             // Log an error if the warning we were about to log is listed as a WarningAsError
             // https://github.com/dotnet/msbuild/issues/5511
-            if (_loggingService.WarningsAsErrors.Contains(warningCode))
+            if (_loggingService.WarningsAsErrors != null && _loggingService.WarningsAsErrors.Count > 0)
             {
-                LogErrorFromText(subcategoryResourceName, warningCode, helpKeyword, file, message);
+                if (_loggingService.WarningsAsErrors.Contains(warningCode))
+                {
+                    LogErrorFromText(subcategoryResourceName, warningCode, helpKeyword, file, message);
+                    return;
+                }
             }
 
             _loggingService.LogWarningFromText(_eventContext, subcategoryResourceName, warningCode, helpKeyword, file, message);

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -211,22 +211,11 @@ namespace Microsoft.Build.BackEnd.Logging
         internal void LogWarning(string subcategoryResourceName, BuildEventFileInfo file, string messageResourceName, params object[] messageArgs)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            // PROBLEM WITH THIS CHUNK:
-            // LoggingContext has no idea if LoggingService actually interpreted the warning as an error, and logged it as so.
-            // It's a problem because TaskBuilder checks _THIS FILE'S _HASLOGGEDERRORS_ boolean to see if it logged errors.
-            // But loggingservice does not expose this info!
 
-            //doesn't work if the submission had already logged an error. unless we count the number of logged errors.
-
-            // Another problem is you need the warning code. Okay we can get that from resourceutilities.
-
-            // The fix: Have LoggingContext see if what we were about to log as an warning is actually an error.
-            // Prev code path: LogWarning -> _loggingService.LogWarning -> RouteBuildEvent -> LoggingService.RouteBuildEvent "Oh should we ACTUALLY log it as an error? -> Replace with error args.
-            // New code path: LogWarning "Oh are we actually going to log that as an error?" -> _loggingService.LogWarning -> LoggingService.RouteBuildEvent -> done.
-
+            // Log an error if the warning we were about to log is listed as a WarningAsError
+            // https://github.com/dotnet/msbuild/issues/5511
             string warningCode;
-            string helpKeyword;
-            string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out warningCode, out helpKeyword, messageResourceName, messageArgs);
+            string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out warningCode, out _, messageResourceName, messageArgs);
 
             if(_loggingService.WarningsAsErrors.Contains(warningCode))
             {
@@ -249,7 +238,9 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
 
-            if(_loggingService.WarningsAsErrors.Contains(warningCode))
+            // Log an error if the warning we were about to log is listed as a WarningAsError
+            // https://github.com/dotnet/msbuild/issues/5511
+            if (_loggingService.WarningsAsErrors.Contains(warningCode))
             {
                 LogErrorFromText(subcategoryResourceName, warningCode, helpKeyword, file, message);
             }

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -214,13 +214,16 @@ namespace Microsoft.Build.BackEnd.Logging
 
             // Log an error if the warning we were about to log is listed as a WarningAsError
             // https://github.com/dotnet/msbuild/issues/5511
-            string warningCode;
-            string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out warningCode, out _, messageResourceName, messageArgs);
-
-            if(_loggingService.WarningsAsErrors.Contains(warningCode))
+            if(_loggingService.WarningsAsErrors != null)
             {
-                LogError(file, messageResourceName, messageArgs);
-                return;
+                string warningCode;
+                string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out warningCode, out _, messageResourceName, messageArgs);
+
+                if (_loggingService.WarningsAsErrors.Contains(warningCode))
+                {
+                    LogError(file, messageResourceName, messageArgs);
+                    return;
+                }
             }
 
             _loggingService.LogWarning(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1333,6 +1333,7 @@ namespace Microsoft.Build.BackEnd.Logging
                         BuildEventContext = warningEvent.BuildEventContext,
                         ProjectFile = warningEvent.ProjectFile,
                     };
+                    
                 }
             }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1008,7 +1008,26 @@ namespace Microsoft.Build.BackEnd.Logging
                 BuildErrorEventArgs errorEvent = null;
                 BuildMessageEventArgs messageEvent = null;
 
-                if ((warningEvent = buildEvent as BuildWarningEventArgs) != null && warningEvent.BuildEventContext != null && warningEvent.BuildEventContext.ProjectContextId != BuildEventContext.InvalidProjectContextId)
+                bool shouldLogWarningAsError = WarningsAsErrors != null && (warningEvent = buildEvent as BuildWarningEventArgs) != null && WarningsAsErrors.Contains(warningEvent.Code);
+
+                if(shouldLogWarningAsError)
+                {
+                    errorEvent = new BuildErrorEventArgs(warningEvent.Subcategory,
+                                     warningEvent.Code,
+                                     warningEvent.File,
+                                     warningEvent.LineNumber,
+                                     warningEvent.ColumnNumber,
+                                     warningEvent.EndLineNumber,
+                                     warningEvent.EndColumnNumber,
+                                     warningEvent.Message,
+                                     warningEvent.HelpKeyword,
+                                     warningEvent.SenderName)
+                    {
+                        BuildEventContext = warningEvent.BuildEventContext
+                    };
+                }
+                
+                if (!shouldLogWarningAsError && (warningEvent = buildEvent as BuildWarningEventArgs) != null && warningEvent.BuildEventContext != null && warningEvent.BuildEventContext.ProjectContextId != BuildEventContext.InvalidProjectContextId)
                 {
                     warningEvent.ProjectFile = GetAndVerifyProjectFileFromContext(warningEvent.BuildEventContext);
                 }
@@ -1037,7 +1056,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 else
                 {
                     // Log all events if OnlyLogCriticalEvents is false
-                    ProcessLoggingEvent(buildEvent);
+                     ProcessLoggingEvent(buildEvent);
                 }
             }
         }

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             lock (_lockObject)
             {
+                _buildSubmissionIdsThatHaveLoggedErrors.Add(location.SubmissionId);
                 LogError(location, null, file, messageResourceName, messageArgs);
             }
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -433,7 +433,6 @@ namespace Microsoft.Build.BackEnd
                                 e.HelpKeyword,
                                 e.SenderName
                             );
-
                     warningEvent.BuildEventContext = _taskLoggingContext.BuildEventContext;
                     _taskLoggingContext.LoggingService.LogBuildEvent(warningEvent);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/5511

## Context
Custom tasks have a `Log.HasLoggedErrors` property that does not respect thrown warnings that are listed under `MSBuildWarningsAsErrors`.

## The Solution
Before logging the warning, check if the warning code is listed under `MSBuildWarningsAsErrors`. If so, log as an error instead.

## Notes
Some comments I wrote as I was investigating this, in all its unformatted glory
```
            // LoggingContext has no idea if LoggingService actually interpreted the warning as an error, and logged it as so.
            // It's a problem because TaskBuilder checks _THIS FILE'S _HASLOGGEDERRORS_ boolean to see if it logged errors.
            // But loggingservice does not expose this info!

            //doesn't work if the submission had already logged an error. unless we count the number of logged errors.

            // Another problem is you need the warning code. Okay we can get that from resourceutilities.

            // The fix: Have LoggingContext see if what we were about to log as an warning is actually an error.
            // Prev code path: LogWarning -> _loggingService.LogWarning -> LoggingService.RouteBuildEvent "Oh should we ACTUALLY log it as an error? -> Replace with error args.
            // New code path: LogWarning "oh wait actually log it as an error" -> _loggingService.LogWarning -> RouteBuildEvent -> LoggingService.RouteBuildEvent -> log.
```

## To-Do
- [ ] See if this works locally
- [ ] Tests