### PR TITLE
Exec: take EchoOff into account when command fails

### DIFF
--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -336,17 +336,23 @@ namespace Microsoft.Build.Tasks
         {
             if (IgnoreExitCode)
             {
-                Log.LogMessageFromResources(MessageImportance.Normal, "Exec.CommandFailedNoErrorCode", Command, ExitCode);
+                if (!EchoOff)
+                {
+                    Log.LogMessageFromResources(MessageImportance.Normal, "Exec.CommandFailedNoErrorCode", Command, ExitCode);
+                }
                 return true;
             }
 
-            if (ExitCode == NativeMethods.SE_ERR_ACCESSDENIED)
+            if (!EchoOff)
             {
-                Log.LogErrorWithCodeFromResources("Exec.CommandFailedAccessDenied", Command, ExitCode);
-            }
-            else
-            {
-                Log.LogErrorWithCodeFromResources("Exec.CommandFailed", Command, ExitCode);
+                if (ExitCode == NativeMethods.SE_ERR_ACCESSDENIED)
+                {
+                    Log.LogErrorWithCodeFromResources("Exec.CommandFailedAccessDenied", Command, ExitCode);
+                }
+                else
+                {
+                    Log.LogErrorWithCodeFromResources("Exec.CommandFailed", Command, ExitCode);
+                }
             }
             return false;
         }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -345,14 +345,14 @@ namespace Microsoft.Build.Tasks
             }
 
             // Don't emit expanded form of Command when EchoOff is set.
-            string commandForLogging = EchoOff ? nameof(EchoOff) : Command;
+            string commandForLog = EchoOff ? "..." : Command;
             if (ExitCode == NativeMethods.SE_ERR_ACCESSDENIED)
             {
-                Log.LogErrorWithCodeFromResources("Exec.CommandFailedAccessDenied", commandForLogging, ExitCode);
+                Log.LogErrorWithCodeFromResources("Exec.CommandFailedAccessDenied", commandForLog, ExitCode);
             }
             else
             {
-                Log.LogErrorWithCodeFromResources("Exec.CommandFailed", commandForLogging, ExitCode);
+                Log.LogErrorWithCodeFromResources("Exec.CommandFailed", commandForLog, ExitCode);
             }
             return false;
         }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -336,6 +336,7 @@ namespace Microsoft.Build.Tasks
         {
             if (IgnoreExitCode)
             {
+                // Don't log when EchoOff and IgnoreExitCode.
                 if (!EchoOff)
                 {
                     Log.LogMessageFromResources(MessageImportance.Normal, "Exec.CommandFailedNoErrorCode", Command, ExitCode);
@@ -343,16 +344,15 @@ namespace Microsoft.Build.Tasks
                 return true;
             }
 
-            if (!EchoOff)
+            // Don't emit expanded form of Command when EchoOff is set.
+            string commandForLogging = EchoOff ? nameof(EchoOff) : Command;
+            if (ExitCode == NativeMethods.SE_ERR_ACCESSDENIED)
             {
-                if (ExitCode == NativeMethods.SE_ERR_ACCESSDENIED)
-                {
-                    Log.LogErrorWithCodeFromResources("Exec.CommandFailedAccessDenied", Command, ExitCode);
-                }
-                else
-                {
-                    Log.LogErrorWithCodeFromResources("Exec.CommandFailed", Command, ExitCode);
-                }
+                Log.LogErrorWithCodeFromResources("Exec.CommandFailedAccessDenied", commandForLogging, ExitCode);
+            }
+            else
+            {
+                Log.LogErrorWithCodeFromResources("Exec.CommandFailed", commandForLogging, ExitCode);
             }
             return false;
         }


### PR DESCRIPTION
@rainersigwald 

EchoOff is documented to:

> If true, the task will not emit the expanded form of Command to the MSBuild log.