### PR TITLE
Allow redundant specification of MSBuild assemblies in inline tasks

### DIFF
--- a/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
+++ b/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
@@ -1101,6 +1101,36 @@ namespace Microsoft.Build.UnitTests
                 FileUtilities.DeleteDirectoryNoThrow(newTempPath, true);
             }
         }
+
+        /// <summary>
+        /// Test the simple case where we have a string parameter and we want to log that.
+        /// </summary>
+        [Fact]
+        public void RedundantMSBuildReferences()
+        {
+            string projectFileContents = @"
+                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                        <UsingTask TaskName=`CustomTaskFromCodeFactory_RedundantMSBuildReferences` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
+                         <ParameterGroup>     
+                             <Text/>
+                          </ParameterGroup>
+                            <Task>
+                              <Reference Include='$(MSBuildToolsPath)\Microsoft.Build.Framework.dll' />
+                              <Reference Include='$(MSBuildToolsPath)\Microsoft.Build.Utilities.Core.dll' />
+
+                                <Code>
+                                     Log.LogMessage(MessageImportance.High, Text);
+                                </Code>
+                            </Task>
+                        </UsingTask>
+                        <Target Name=`Build`>
+                            <CustomTaskFromCodeFactory_RedundantMSBuildReferences Text=`Hello, World!` />
+                        </Target>
+                    </Project>";
+
+            MockLogger mockLogger = Helpers.BuildProjectWithNewOMExpectSuccess(projectFileContents);
+            mockLogger.AssertLogContains("Hello, World!");
+        }
     }
 #else
     public sealed class CodeTaskFactoryTests

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -666,13 +666,13 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            static string GetPathFromPartialAssemblyName(string referenceAssembly, string candidateAssemblyLocation)
+            static string GetPathFromPartialAssemblyName(string partialName, string candidateAssemblyLocation)
             {
 #pragma warning disable 618, 612
                 // Unfortunately Assembly.Load is not an alternative to LoadWithPartialName, since
                 // Assembly.Load requires the full assembly name to be passed to it.
                 // Therefore we must ignore the deprecated warning.
-                Assembly candidateAssembly = Assembly.LoadWithPartialName(referenceAssembly);
+                Assembly candidateAssembly = Assembly.LoadWithPartialName(partialName);
                 if (candidateAssembly != null)
                 {
                     candidateAssemblyLocation = candidateAssembly.Location;
@@ -682,7 +682,7 @@ namespace Microsoft.Build.Tasks
                     string path = Path.Combine(
                         NativeMethodsShared.FrameworkCurrentPath,
                         "Facades",
-                        Path.GetFileName(referenceAssembly));
+                        Path.GetFileName(partialName));
                     if (!FileSystems.Default.FileExists(path))
                     {
                         var newPath = path + ".dll";
@@ -698,11 +698,11 @@ namespace Microsoft.Build.Tasks
                 return candidateAssemblyLocation;
             }
 
-            string CacheAssemblyIdentityFromPath(string referenceAssembly, string candidateAssemblyLocation)
+            string CacheAssemblyIdentityFromPath(string assemblyFile, string candidateAssemblyLocation)
             {
                 try
                 {
-                    Assembly candidateAssembly = Assembly.UnsafeLoadFrom(referenceAssembly);
+                    Assembly candidateAssembly = Assembly.UnsafeLoadFrom(assemblyFile);
                     if (candidateAssembly != null)
                     {
                         candidateAssemblyLocation = candidateAssembly.Location;
@@ -712,9 +712,9 @@ namespace Microsoft.Build.Tasks
                 catch (BadImageFormatException e)
                 {
                     Debug.Assert(e.Message.Contains("0x80131058"), "Expected Message to contain 0x80131058");
-                    AssemblyName.GetAssemblyName(referenceAssembly);
-                    candidateAssemblyLocation = referenceAssembly;
-                    _log.LogMessageFromResources(MessageImportance.Low, "CodeTaskFactory.HaveReflectionOnlyAssembly", referenceAssembly);
+                    AssemblyName.GetAssemblyName(assemblyFile);
+                    candidateAssemblyLocation = assemblyFile;
+                    _log.LogMessageFromResources(MessageImportance.Low, "CodeTaskFactory.HaveReflectionOnlyAssembly", assemblyFile);
                 }
 
                 return candidateAssemblyLocation;

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -692,13 +692,8 @@ namespace Microsoft.Build.Tasks
                             }
                         }
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
                     {
-                        if (ExceptionHandling.IsCriticalException(e))
-                        {
-                            throw;
-                        }
-
                         _log.LogErrorWithCodeFromResources("CodeTaskFactory.ReferenceAssemblyIsInvalid", referenceAssembly, e.Message);
                     }
                 }

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -647,22 +647,7 @@ namespace Microsoft.Build.Tasks
                         }
                         else
                         {
-                            try
-                            {
-                                Assembly candidateAssembly = Assembly.UnsafeLoadFrom(referenceAssembly);
-                                if (candidateAssembly != null)
-                                {
-                                    candidateAssemblyLocation = candidateAssembly.Location;
-                                    s_knownReferenceAssemblies[candidateAssembly.FullName] = candidateAssembly;
-                                }
-                            }
-                            catch (BadImageFormatException e)
-                            {
-                                Debug.Assert(e.Message.Contains("0x80131058"), "Expected Message to contain 0x80131058");
-                                AssemblyName.GetAssemblyName(referenceAssembly);
-                                candidateAssemblyLocation = referenceAssembly;
-                                _log.LogMessageFromResources(MessageImportance.Low, "CodeTaskFactory.HaveReflectionOnlyAssembly", referenceAssembly);
-                            }
+                            candidateAssemblyLocation = CacheAssemblyIdentityFromPath(referenceAssembly, candidateAssemblyLocation);
                         }
                     }
                     catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
@@ -710,6 +695,28 @@ namespace Microsoft.Build.Tasks
                     }
                 }
 #pragma warning restore 618, 612
+                return candidateAssemblyLocation;
+            }
+
+            string CacheAssemblyIdentityFromPath(string referenceAssembly, string candidateAssemblyLocation)
+            {
+                try
+                {
+                    Assembly candidateAssembly = Assembly.UnsafeLoadFrom(referenceAssembly);
+                    if (candidateAssembly != null)
+                    {
+                        candidateAssemblyLocation = candidateAssembly.Location;
+                        s_knownReferenceAssemblies[candidateAssembly.FullName] = candidateAssembly;
+                    }
+                }
+                catch (BadImageFormatException e)
+                {
+                    Debug.Assert(e.Message.Contains("0x80131058"), "Expected Message to contain 0x80131058");
+                    AssemblyName.GetAssemblyName(referenceAssembly);
+                    candidateAssemblyLocation = referenceAssembly;
+                    _log.LogMessageFromResources(MessageImportance.Low, "CodeTaskFactory.HaveReflectionOnlyAssembly", referenceAssembly);
+                }
+
                 return candidateAssemblyLocation;
             }
         }

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -732,8 +732,7 @@ namespace Microsoft.Build.Tasks
         private Assembly CompileInMemoryAssembly()
         {
             // Combine our default assembly references with those specified
-            var finalReferencedAssemblies = new List<string>();
-            CombineReferencedAssemblies(finalReferencedAssemblies);
+            var finalReferencedAssemblies = CombineReferencedAssemblies();
 
             // Combine our default using's with those specified
             string[] finalUsingNamespaces = CombineUsingNamespaces();
@@ -862,8 +861,10 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Combine our default referenced assemblies with those explicitly specified
         /// </summary>
-        private void CombineReferencedAssemblies(List<string> finalReferenceList)
+        private List<string> CombineReferencedAssemblies()
         {
+            List<string> finalReferenceList = new List<string>(s_defaultReferencedFrameworkAssemblyNames.Length + 2 + _referencedAssemblies.Count);
+
             foreach (string defaultReference in DefaultReferencedAssemblies)
             {
                 AddReferenceAssemblyToReferenceList(finalReferenceList, defaultReference);
@@ -876,6 +877,8 @@ namespace Microsoft.Build.Tasks
                     AddReferenceAssemblyToReferenceList(finalReferenceList, referenceAssembly);
                 }
             }
+
+            return finalReferenceList;
         }
 
         /// <summary>

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -642,12 +642,12 @@ namespace Microsoft.Build.Tasks
                         {
                             if (!referenceAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || !referenceAssembly.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                             {
-                                candidateAssemblyLocation = GetPathFromPartialAssemblyName(referenceAssembly, candidateAssemblyLocation);
+                                candidateAssemblyLocation = GetPathFromPartialAssemblyName(referenceAssembly);
                             }
                         }
                         else
                         {
-                            candidateAssemblyLocation = CacheAssemblyIdentityFromPath(referenceAssembly, candidateAssemblyLocation);
+                            candidateAssemblyLocation = CacheAssemblyIdentityFromPath(referenceAssembly);
                         }
                     }
                     catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
@@ -666,8 +666,10 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            static string GetPathFromPartialAssemblyName(string partialName, string candidateAssemblyLocation)
+            static string GetPathFromPartialAssemblyName(string partialName)
             {
+                string candidateAssemblyLocation = null;
+
 #pragma warning disable 618, 612
                 // Unfortunately Assembly.Load is not an alternative to LoadWithPartialName, since
                 // Assembly.Load requires the full assembly name to be passed to it.
@@ -698,8 +700,10 @@ namespace Microsoft.Build.Tasks
                 return candidateAssemblyLocation;
             }
 
-            string CacheAssemblyIdentityFromPath(string assemblyFile, string candidateAssemblyLocation)
+            string CacheAssemblyIdentityFromPath(string assemblyFile)
             {
+                string candidateAssemblyLocation = null;
+
                 try
                 {
                     Assembly candidateAssembly = Assembly.UnsafeLoadFrom(assemblyFile);

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -606,7 +606,11 @@ namespace Microsoft.Build.Tasks
                         }
                         else
                         {
-                            candidateAssemblyLocation = CacheAssemblyIdentityFromPath(referenceAssembly);
+                            if (!TryCacheAssemblyIdentityFromPath(referenceAssembly, out candidateAssemblyLocation))
+                            {
+                                // Assembly should be skipped; return
+                                return;
+                            }
                         }
                     }
                     catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
@@ -659,15 +663,23 @@ namespace Microsoft.Build.Tasks
                 return candidateAssemblyLocation;
             }
 
-            string CacheAssemblyIdentityFromPath(string assemblyFile)
+            bool TryCacheAssemblyIdentityFromPath(string assemblyFile, out string candidateAssemblyLocation)
             {
-                string candidateAssemblyLocation = null;
+                candidateAssemblyLocation = null;
 
                 try
                 {
                     Assembly candidateAssembly = Assembly.UnsafeLoadFrom(assemblyFile);
                     if (candidateAssembly != null)
                     {
+                        if (candidateAssembly.FullName == typeof(Task).Assembly.FullName ||
+                            candidateAssembly.FullName == typeof(ITask).Assembly.FullName)
+                        {
+                            // Framework and Utilities are default references but are often
+                            // specified in the UsingTask anyway; if so just ignore them.
+                            return false;
+                        }
+
                         candidateAssemblyLocation = candidateAssembly.Location;
                         s_knownReferenceAssemblies[candidateAssembly.FullName] = candidateAssembly;
                     }
@@ -680,7 +692,7 @@ namespace Microsoft.Build.Tasks
                     _log.LogMessageFromResources(MessageImportance.Low, "CodeTaskFactory.HaveReflectionOnlyAssembly", assemblyFile);
                 }
 
-                return candidateAssemblyLocation;
+                return true;
             }
         }
 

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -71,11 +71,6 @@ namespace Microsoft.Build.Tasks
         private static readonly ConcurrentDictionary<FullTaskSpecification, Assembly> s_compiledTaskCache = new ConcurrentDictionary<FullTaskSpecification, Assembly>();
 
         /// <summary>
-        /// The default assemblies to reference when compiling inline code.
-        /// </summary>
-        private static List<string> s_defaultReferencedAssemblies;
-
-        /// <summary>
         /// Merged set of assembly reference paths (default + specified)
         /// </summary>
         private List<string> _referencedAssemblies;
@@ -149,42 +144,6 @@ namespace Microsoft.Build.Tasks
         /// Gets the type of the generated task.
         /// </summary>
         public Type TaskType { get; private set; }
-
-        /// <summary>
-        /// The assemblies that the codetaskfactory should reference by default.
-        /// </summary>
-        private static List<string> DefaultReferencedAssemblies
-        {
-            get
-            {
-                if (s_defaultReferencedAssemblies == null)
-                {
-                    s_defaultReferencedAssemblies = new List<string>();
-
-                    // Loading with the partial name is fine for framework assemblies -- we'll always get the correct one 
-                    // through the magic of unification
-                    foreach (string frameworkAssembly in s_defaultReferencedFrameworkAssemblyNames)
-                    {
-                        s_defaultReferencedAssemblies.Add(frameworkAssembly);
-                    }
-
-                    // We also want to add references to two MSBuild assemblies: Microsoft.Build.Framework.dll and 
-                    // Microsoft.Build.Utilities.Core.dll.  If we just let the CLR unify the simple name, it will 
-                    // pick the highest version on the machine, which means that in hosts with restrictive binding 
-                    // redirects, or no binding redirects, we'd end up creating an inline task that could not be 
-                    // run.  Instead, to make sure that we can actually use what we're building, just use the Framework
-                    // and Utilities currently loaded into this process -- Since we're in Microsoft.Build.Tasks.Core.dll
-                    // right now, by definition both of them are always already loaded. 
-                    string msbuildFrameworkPath = Assembly.GetAssembly(typeof(ITask)).Location;
-                    string msbuildUtilitiesPath = Assembly.GetAssembly(typeof(Task)).Location;
-
-                    s_defaultReferencedAssemblies.Add(msbuildFrameworkPath);
-                    s_defaultReferencedAssemblies.Add(msbuildUtilitiesPath);
-                }
-
-                return s_defaultReferencedAssemblies;
-            }
-        }
 
         /// <summary>
         /// Get the type information for all task parameters
@@ -865,11 +824,33 @@ namespace Microsoft.Build.Tasks
         {
             List<string> finalReferenceList = new List<string>(s_defaultReferencedFrameworkAssemblyNames.Length + 2 + _referencedAssemblies.Count);
 
-            foreach (string defaultReference in DefaultReferencedAssemblies)
+            // Set some default references:
+
+            // Loading with the partial name is fine for framework assemblies -- we'll always get the correct one 
+            // through the magic of unification
+            foreach (string defaultReference in s_defaultReferencedFrameworkAssemblyNames)
             {
                 AddReferenceAssemblyToReferenceList(finalReferenceList, defaultReference);
             }
 
+            // We also want to add references to two MSBuild assemblies: Microsoft.Build.Framework.dll and 
+            // Microsoft.Build.Utilities.Core.dll.  If we just let the CLR unify the simple name, it will 
+            // pick the highest version on the machine, which means that in hosts with restrictive binding 
+            // redirects, or no binding redirects, we'd end up creating an inline task that could not be 
+            // run.  Instead, to make sure that we can actually use what we're building, just use the Framework
+            // and Utilities currently loaded into this process -- Since we're in Microsoft.Build.Tasks.Core.dll
+            // right now, by definition both of them are always already loaded.
+            //
+            // NOTE Dec 2020: I don't think the above really applies given the eternally-15.1.0.0 version policy
+            // we are currently using. But loading these from an explicit path seems fine so I'm not changing
+            // that.
+            string msbuildFrameworkPath = Assembly.GetAssembly(typeof(ITask)).Location;
+            string msbuildUtilitiesPath = Assembly.GetAssembly(typeof(Task)).Location;
+
+            finalReferenceList.Add(msbuildFrameworkPath);
+            finalReferenceList.Add(msbuildUtilitiesPath);
+
+            // Now for the explicitly-specified references:
             if (_referencedAssemblies != null)
             {
                 foreach (string referenceAssembly in _referencedAssemblies)

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -643,33 +643,7 @@ namespace Microsoft.Build.Tasks
                         {
                             if (!referenceAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || !referenceAssembly.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                             {
-#pragma warning disable 618, 612
-                                // Unfortunately Assembly.Load is not an alternative to LoadWithPartialName, since
-                                // Assembly.Load requires the full assembly name to be passed to it.
-                                // Therefore we must ignore the deprecated warning.
-                                Assembly candidateAssembly = Assembly.LoadWithPartialName(referenceAssembly);
-                                if (candidateAssembly != null)
-                                {
-                                    candidateAssemblyLocation = candidateAssembly.Location;
-                                }
-                                else if (NativeMethodsShared.IsMono)
-                                {
-                                    string path = Path.Combine(
-                                        NativeMethodsShared.FrameworkCurrentPath,
-                                        "Facades",
-                                        Path.GetFileName(referenceAssembly));
-                                    if (!FileSystems.Default.FileExists(path))
-                                    {
-                                        var newPath = path + ".dll";
-                                        path = !FileSystems.Default.FileExists(newPath) ? path + ".exe" : newPath;
-                                    }
-                                    candidateAssembly = Assembly.UnsafeLoadFrom(path);
-                                    if (candidateAssembly != null)
-                                    {
-                                        candidateAssemblyLocation = candidateAssembly.Location;
-                                    }
-                                }
-#pragma warning restore 618, 612
+                                candidateAssemblyLocation = GetPathFromPartialAssemblyName(referenceAssembly, candidateAssemblyLocation);
                             }
                         }
                         else
@@ -706,6 +680,38 @@ namespace Microsoft.Build.Tasks
                 {
                     _log.LogErrorWithCodeFromResources("CodeTaskFactory.CouldNotFindReferenceAssembly", referenceAssembly);
                 }
+            }
+
+            static string GetPathFromPartialAssemblyName(string referenceAssembly, string candidateAssemblyLocation)
+            {
+#pragma warning disable 618, 612
+                // Unfortunately Assembly.Load is not an alternative to LoadWithPartialName, since
+                // Assembly.Load requires the full assembly name to be passed to it.
+                // Therefore we must ignore the deprecated warning.
+                Assembly candidateAssembly = Assembly.LoadWithPartialName(referenceAssembly);
+                if (candidateAssembly != null)
+                {
+                    candidateAssemblyLocation = candidateAssembly.Location;
+                }
+                else if (NativeMethodsShared.IsMono)
+                {
+                    string path = Path.Combine(
+                        NativeMethodsShared.FrameworkCurrentPath,
+                        "Facades",
+                        Path.GetFileName(referenceAssembly));
+                    if (!FileSystems.Default.FileExists(path))
+                    {
+                        var newPath = path + ".dll";
+                        path = !FileSystems.Default.FileExists(newPath) ? path + ".exe" : newPath;
+                    }
+                    candidateAssembly = Assembly.UnsafeLoadFrom(path);
+                    if (candidateAssembly != null)
+                    {
+                        candidateAssemblyLocation = candidateAssembly.Location;
+                    }
+                }
+#pragma warning restore 618, 612
+                return candidateAssemblyLocation;
             }
         }
 

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -638,8 +638,7 @@ namespace Microsoft.Build.Tasks
                 {
                     try
                     {
-                        bool fileExists = FileSystems.Default.FileExists(referenceAssembly);
-                        if (!fileExists)
+                        if (!FileSystems.Default.FileExists(referenceAssembly))
                         {
                             if (!referenceAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || !referenceAssembly.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                             {

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Build.Tasks
                     return null;
                 }
 
-                references.Add(attribute.Value);
+                references.Add(FileUtilities.MaybeAdjustFilePath(attribute.Value));
             }
 
             return references;

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -39,6 +39,15 @@ namespace Microsoft.Build.Tasks
 
         static CodeTaskFactory()
         {
+            // Populate default-reference-assembly information
+            Assembly frameworkAssembly = Assembly.GetAssembly(typeof(ITask));
+            _msbuildFrameworkName = frameworkAssembly.FullName;
+            _msbuildFrameworkPath = frameworkAssembly.Location;
+
+            Assembly utilitiesAssembly = Assembly.GetAssembly(typeof(Task));
+            _msbuildUtilitiesName = utilitiesAssembly.FullName;
+            _msbuildUtilitiesPath = utilitiesAssembly.Location;
+
             // The handler is not detached because it only returns assemblies for custom references that cannot be found in the normal Load context
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomainOnAssemblyResolve;
         }
@@ -53,6 +62,11 @@ namespace Microsoft.Build.Tasks
 
             return assembly;
         }
+
+        private static readonly string _msbuildFrameworkName;
+        private static readonly string _msbuildFrameworkPath;
+        private static readonly string _msbuildUtilitiesName;
+        private static readonly string _msbuildUtilitiesPath;
 
         /// <summary>
         /// Default assemblies names to reference during inline code compilation - from the .NET Framework
@@ -672,8 +686,9 @@ namespace Microsoft.Build.Tasks
                     Assembly candidateAssembly = Assembly.UnsafeLoadFrom(assemblyFile);
                     if (candidateAssembly != null)
                     {
-                        if (candidateAssembly.FullName == typeof(Task).Assembly.FullName ||
-                            candidateAssembly.FullName == typeof(ITask).Assembly.FullName)
+                        string name = candidateAssembly.FullName;
+                        if (name == _msbuildFrameworkName ||
+                            name == _msbuildUtilitiesName)
                         {
                             // Framework and Utilities are default references but are often
                             // specified in the UsingTask anyway; if so just ignore them.
@@ -856,11 +871,9 @@ namespace Microsoft.Build.Tasks
             // NOTE Dec 2020: I don't think the above really applies given the eternally-15.1.0.0 version policy
             // we are currently using. But loading these from an explicit path seems fine so I'm not changing
             // that.
-            string msbuildFrameworkPath = Assembly.GetAssembly(typeof(ITask)).Location;
-            string msbuildUtilitiesPath = Assembly.GetAssembly(typeof(Task)).Location;
 
-            finalReferenceList.Add(msbuildFrameworkPath);
-            finalReferenceList.Add(msbuildUtilitiesPath);
+            finalReferenceList.Add(_msbuildFrameworkPath);
+            finalReferenceList.Add(_msbuildUtilitiesPath);
 
             // Now for the explicitly-specified references:
             if (_referencedAssemblies != null)


### PR DESCRIPTION
Fixes #5822 by filtering out the default MSBuild assemblies from the UsingTask list.


9bfc622 is the real work but there were a bunch of refactorings to make that clear. I recommend going commit-by-commit.