### PR TITLE
Skip hanging test

### DIFF
--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Graph.UnitTests
             }
         }
 
-        [Theory(Timeout = 20_000)] // Test hangs intermittently: https://github.com/dotnet/msbuild/issues/5520
+        [Theory(Skip = "hangs in CI, can't repro locally: https://github.com/dotnet/msbuild/issues/5520")]
         [MemberData(nameof(GraphsWithUniformSolutionConfigurations))]
         public void GraphConstructionCanLoadEntryPointsFromSolution(
             Dictionary<int, int[]> edges,

--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Graph.UnitTests
             }
         }
 
-        [Theory(Skip = "hangs in CI, can't repro locally: https://github.com/dotnet/msbuild/issues/5520")]
+        [Theory(Skip = "hangs in CI, can't repro locally: https://github.com/dotnet/msbuild/issues/5453")]
         [MemberData(nameof(GraphsWithUniformSolutionConfigurations))]
         public void GraphConstructionCanLoadEntryPointsFromSolution(
             Dictionary<int, int[]> edges,


### PR DESCRIPTION
This test has been hanging repeatedly lately. See, for example:
https://dev.azure.com/dnceng/public/_build/results?buildId=934918&view=logs&j=1522e9b9-b859-5e5f-ec86-a68fc9508baf&t=a8d37b2d-1a39-51d6-c11e-8665c8c9811e