### PR TITLE
Pass CurrentTaskContext as ParentBuildEventContext

### DIFF
--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1160,7 +1160,7 @@ namespace Microsoft.Build.BackEnd
                             configurationId: matchingConfig.ConfigurationId,
                             escapedTargets: request.Targets,
                             hostServices: issuingEntry.Request.HostServices,
-                            parentBuildEventContext: issuingEntry.Request.BuildEventContext,
+                            parentBuildEventContext: issuingEntry.Request.CurrentTaskContext ?? issuingEntry.Request.BuildEventContext,
                             parentRequest: issuingEntry.Request,
                             buildRequestDataFlags: buildRequestDataFlags,
                             requestedProjectState: null,


### PR DESCRIPTION
We missed a case when the MSBuild task is starting a project build where we didn't pass the parent context if we already had a configuration.

https://github.com/dotnet/msbuild/pull/5013 was the initial fix, but it only fixed the case when matchingConfig was null. This fixes the other case.

Just copying this line:
https://github.com/dotnet/msbuild/blob/a2c42ce9fc8d6fbd4a8cd600073803b8687c9341/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs#L1134

Fixes https://github.com/dotnet/msbuild/issues/5473

