### PR TITLE
RoslynCodeTaskFactory: Fix caching of assemblies

### DIFF
--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryTaskInfo.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryTaskInfo.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Build.Tasks
                 return true;
             }
 
-            return References.Equals(other.References) && String.Equals(SourceCode, other.SourceCode, StringComparison.OrdinalIgnoreCase);
+            return String.Equals(SourceCode, other.SourceCode, StringComparison.OrdinalIgnoreCase) && References.SetEquals(other.References);
         }
 
         public override bool Equals(object obj)
@@ -66,7 +66,8 @@ namespace Microsoft.Build.Tasks
 
         public override int GetHashCode()
         {
-            return 0;
+            // This is good enough to avoid most collisions, no need to hash References
+            return SourceCode.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
Equals() method on RoslynCodeTaskFactoryTaskInfo was using reference equality to compare hashsets, and thus always returned false. So we never could reuse existing compilations from the dictionary, always compiling the task from scratch.

Use SetEquals instead and add a unit-test that verifies that there's only one compilation happening now (instead of two).

Fixes https://github.com/dotnet/msbuild/issues/5948