### PR TITLE
Fix AssemblyUtilities.CultureInfoHasGetCultures

### DIFF
--- a/src/Shared/AssemblyUtilities.cs
+++ b/src/Shared/AssemblyUtilities.cs
@@ -100,6 +100,8 @@ namespace Microsoft.Build.Shared
 #if !FEATURE_CULTUREINFO_GETCULTURES
         public static bool CultureInfoHasGetCultures()
         {
+            Initialize();
+
             return s_cultureInfoGetCultureMethod != null;
         }
 #endif // !FEATURE_CULTUREINFO_GETCULTURES
@@ -109,8 +111,6 @@ namespace Microsoft.Build.Shared
 #if FEATURE_CULTUREINFO_GETCULTURES
             return CultureInfo.GetCultures(CultureTypes.AllCultures);
 #else
-            Initialize();
-
             if (!CultureInfoHasGetCultures())
             {
                 throw new NotSupportedException("CultureInfo does not have the method GetCultures");


### PR DESCRIPTION
The `Initialize()` method must be called before testing the `s_cultureInfoGetCultureMethod` static field.

This might go unnoticed if the `Initialize` method was called earlier through some other code path but the result of calling `CultureInfoHasGetCultures()` would be wrong if `Initialize()` was not called beforehand. For example, in the static constructor of `Microsoft.Build.Tasks.CultureInfoCache`.

Note: I stumbled on this when [diagnosing an issue][1] with the AssignCulture task.

[1]: https://github.com/Humanizr/Humanizer/issues/1021#issuecomment-753682963