### PR TITLE
Warnings-as-errors fail BuildSubmission results

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -693,8 +693,6 @@ namespace Microsoft.Build.Execution
             BuildSubmission submission = PendBuildRequest(requestData);
             BuildResult result = submission.Execute();
 
-            SetOverallResultIfWarningsAsErrors(result);
-
             return result;
         }
 
@@ -2084,8 +2082,6 @@ namespace Microsoft.Build.Execution
                 // If the submission has completed or never started, remove it.
                 if (submission.IsCompleted || submission.BuildRequest == null)
                 {
-                    SetOverallResultIfWarningsAsErrors(submission.BuildResult);
-
                     _buildSubmissions.Remove(submission.SubmissionId);
 
                     // Clear all cached SDKs for the submission
@@ -2343,25 +2339,6 @@ namespace Microsoft.Build.Execution
             }
 
             return castPacket;
-        }
-
-        /// <summary>
-        /// Sets the overall result of a build only if the user had specified /warnaserror and there were any errors.
-        /// This ensures the old behavior stays intact where builds could succeed even if a failure was logged.
-        /// </summary>
-        private void SetOverallResultIfWarningsAsErrors(BuildResult result)
-        {
-            if (result?.OverallResult == BuildResultCode.Success)
-            {
-                ILoggingService loggingService = ((IBuildComponentHost)this).LoggingService;
-
-                if (loggingService.HasBuildSubmissionLoggedErrors(result.SubmissionId))
-                {
-                    result.SetOverallResult(overallResult: false);
-
-                    _overallBuildSuccess = false;
-                }
-            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildSubmission.cs
+++ b/src/Build/BackEnd/BuildManager/BuildSubmission.cs
@@ -198,6 +198,13 @@ namespace Microsoft.Build.Execution
                 bool hasCompleted = (Interlocked.Exchange(ref _completionInvoked, 1) == 1);
                 if (!hasCompleted)
                 {
+                    // Did this submission have warnings elevated to errors? If so, mark it as
+                    // failed even though it succeeded (with warnings--but they're errors).
+                    if (((IBuildComponentHost)BuildManager).LoggingService.HasBuildSubmissionLoggedErrors(BuildResult.SubmissionId))
+                    {
+                        BuildResult.SetOverallResult(overallResult: false);
+                    }
+
                     _completionEvent.Set();
 
                     if (_completionCallback != null)

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2215,6 +2215,29 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+        [Fact]
+        public void EndToEndWarnAsErrors()
+        {
+            using TestEnvironment testEnvironment = UnitTests.TestEnvironment.Create();
+
+            string projectContents = ObjectModelHelpers.CleanupFileContents(@"<Project>
+
+  <Target Name=""IssueWarning"">
+    <Warning Text=""Warning!"" />
+  </Target>
+  
+</Project>");
+
+
+            TransientTestProjectWithFiles testProject = testEnvironment.CreateTestProjectWithFiles(projectContents, new string[0]);
+
+            bool success;
+
+            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" -warnaserror", out success, _output);
+
+            success.ShouldBeFalse(() => output);
+        }
+
 #if FEATURE_ASSEMBLYLOADCONTEXT
         /// <summary>
         /// Ensure that tasks get loaded into their own <see cref="System.Runtime.Loader.AssemblyLoadContext"/>.

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2230,7 +2230,7 @@ namespace Microsoft.Build.UnitTests
 
             TransientTestProjectWithFiles testProject = testEnvironment.CreateTestProjectWithFiles(projectContents);
 
-            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" -warnaserror", out bool success, _output);
+            RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" -warnaserror", out bool success, _output);
 
             success.ShouldBeFalse();
         }

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2228,14 +2228,11 @@ namespace Microsoft.Build.UnitTests
   
 </Project>");
 
+            TransientTestProjectWithFiles testProject = testEnvironment.CreateTestProjectWithFiles(projectContents);
 
-            TransientTestProjectWithFiles testProject = testEnvironment.CreateTestProjectWithFiles(projectContents, new string[0]);
+            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" -warnaserror", out bool success, _output);
 
-            bool success;
-
-            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" -warnaserror", out success, _output);
-
-            success.ShouldBeFalse(() => output);
+            success.ShouldBeFalse();
         }
 
 #if FEATURE_ASSEMBLYLOADCONTEXT


### PR DESCRIPTION
Fix #5837 by moving the promotion of warnings to build failures to the `BuildSubmission` level instead of doing it in `BuildManager` (where the result change happened at `EndBuild()` time and thus wasn't visible when checking the result after the submission completed:

https://github.com/dotnet/msbuild/blob/c70d520b5b8df990f651f0d00cd186a68cb277c6/src/MSBuild/XMake.cs#L1256-L1268