### PR TITLE
Deduplicate strings in binlogs

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1591,9 +1591,10 @@ namespace Microsoft.Build.Logging
         public void Replay(string sourceFilePath) { }
         public void Replay(string sourceFilePath, System.Threading.CancellationToken cancellationToken) { }
     }
-    public partial class BuildEventArgsReader
+    public partial class BuildEventArgsReader : System.IDisposable
     {
         public BuildEventArgsReader(System.IO.BinaryReader binaryReader, int fileFormatVersion) { }
+        public void Dispose() { }
         public Microsoft.Build.Framework.BuildEventArgs Read() { throw null; }
     }
     public delegate void ColorResetter();

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1585,9 +1585,10 @@ namespace Microsoft.Build.Logging
         public void Replay(string sourceFilePath) { }
         public void Replay(string sourceFilePath, System.Threading.CancellationToken cancellationToken) { }
     }
-    public partial class BuildEventArgsReader
+    public partial class BuildEventArgsReader : System.IDisposable
     {
         public BuildEventArgsReader(System.IO.BinaryReader binaryReader, int fileFormatVersion) { }
+        public void Dispose() { }
         public Microsoft.Build.Framework.BuildEventArgs Read() { throw null; }
     }
     public delegate void ColorResetter();

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -513,7 +513,7 @@ namespace Microsoft.Build.UnitTests
                 memoryStream.Position = 0;
 
                 var binaryReader = new BinaryReader(memoryStream);
-                var buildEventArgsReader = new BuildEventArgsReader(binaryReader, BinaryLogger.FileFormatVersion);
+                using var buildEventArgsReader = new BuildEventArgsReader(binaryReader, BinaryLogger.FileFormatVersion);
 
                 Assert.Throws<EndOfStreamException>(() => buildEventArgsReader.Read());
             }
@@ -570,7 +570,7 @@ namespace Microsoft.Build.UnitTests
             memoryStream.Position = 0;
 
             var binaryReader = new BinaryReader(memoryStream);
-            var buildEventArgsReader = new BuildEventArgsReader(binaryReader, BinaryLogger.FileFormatVersion);
+            using var buildEventArgsReader = new BuildEventArgsReader(binaryReader, BinaryLogger.FileFormatVersion);
             var deserializedArgs = (T)buildEventArgsReader.Read();
 
             Assert.Equal(length, memoryStream.Position);

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -25,5 +25,7 @@
         UninitializedPropertyRead,
         EnvironmentVariableRead,
         PropertyInitialValueSet,
+        NameValueList,
+        String,
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -33,7 +33,12 @@ namespace Microsoft.Build.Logging
             using (var stream = new FileStream(sourceFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 var gzipStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
-                var binaryReader = new BinaryReader(gzipStream);
+
+                // wrapping the GZipStream in a buffered stream significantly improves performance
+                // and the max throughput is reached with a 32K buffer. See details here:
+                // https://github.com/dotnet/runtime/issues/39233#issuecomment-745598847
+                var bufferedStream = new BufferedStream(gzipStream, 32768);
+                var binaryReader = new BinaryReader(bufferedStream);
 
                 int fileFormatVersion = binaryReader.ReadInt32();
 
@@ -45,7 +50,7 @@ namespace Microsoft.Build.Logging
                     throw new NotSupportedException(text);
                 }
 
-                var reader = new BuildEventArgsReader(binaryReader, fileFormatVersion);
+                using var reader = new BuildEventArgsReader(binaryReader, fileFormatVersion);
                 while (true)
                 {
                     if (cancellationToken.IsCancellationRequested)

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -143,6 +143,10 @@ namespace Microsoft.Build.Logging
             }
 
             stream = new GZipStream(stream, CompressionLevel.Optimal);
+
+            // wrapping the GZipStream in a buffered stream significantly improves performance
+            // and the max throughput is reached with a 32K buffer. See details here:
+            // https://github.com/dotnet/runtime/issues/39233#issuecomment-745598847
             stream = new BufferedStream(stream, bufferSize: 32768);
             binaryWriter = new BinaryWriter(stream);
             eventArgsWriter = new BuildEventArgsWriter(binaryWriter);

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -35,7 +35,13 @@ namespace Microsoft.Build.Logging
         //   - This was used in a now-reverted change but is the same as 9.
         // version 9:
         //   - new record kinds: EnvironmentVariableRead, PropertyReassignment, UninitializedPropertyRead
-        internal const int FileFormatVersion = 9;
+        // version 10:
+        //   - new record kinds:
+        //      * String - deduplicate strings by hashing and write a string record before it's used
+        //      * NameValueList - deduplicate arrays of name-value pairs such as properties, items and metadata
+        //                        in a separate record and refer to those records from regular records
+        //                        where a list used to be written in-place
+        internal const int FileFormatVersion = 10;
 
         private Stream stream;
         private BinaryWriter binaryWriter;
@@ -137,6 +143,7 @@ namespace Microsoft.Build.Logging
             }
 
             stream = new GZipStream(stream, CompressionLevel.Optimal);
+            stream = new BufferedStream(stream, bufferSize: 32768);
             binaryWriter = new BinaryWriter(stream);
             eventArgsWriter = new BuildEventArgsWriter(binaryWriter);
 
@@ -175,8 +182,8 @@ namespace Microsoft.Build.Logging
                 {
                     eventArgsWriter.WriteBlob(BinaryLogRecordKind.ProjectImportArchive, projectImportsCollector.GetAllBytes());
                 }
-                projectImportsCollector.Close();
 
+                projectImportsCollector.Close();
                 projectImportsCollector = null;
             }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Build.Logging
     {
         private readonly BinaryReader binaryReader;
         private readonly int fileFormatVersion;
+        private long recordNumber = 0;
 
         /// <summary>
         /// A list of string records we've encountered so far. If it's a small string, it will be the string directly.
@@ -96,6 +97,8 @@ namespace Microsoft.Build.Logging
                     ReadBlob(recordKind);
                 }
 
+                recordNumber += 1;
+
                 recordKind = (BinaryLogRecordKind)ReadInt32();
             }
 
@@ -171,6 +174,8 @@ namespace Microsoft.Build.Logging
                     break;
             }
 
+            recordNumber += 1;
+
             return result;
         }
 
@@ -224,7 +229,9 @@ namespace Microsoft.Build.Logging
                 return dictionary;
             }
 
-            return new Dictionary<string, string>();
+            // this should never happen for valid binlogs
+            throw new InvalidDataException(
+                $"NameValueList record number {recordNumber} is invalid: index {id} is not within {stringRecords.Count}.");
         }
 
         private void ReadStringRecord()
@@ -1065,7 +1072,9 @@ namespace Microsoft.Build.Logging
                 return result;
             }
 
-            return string.Empty;
+            // this should never happen for valid binlogs
+            throw new InvalidDataException(
+                $"String record number {recordNumber} is invalid: string index {index} is not within {stringRecords.Count}.");
         }
 
         private int ReadInt32()

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -1200,8 +1200,11 @@ namespace Microsoft.Build.Logging
                         FileMode.OpenOrCreate,
                         FileAccess.ReadWrite,
                         FileShare.None,
-                        bufferSize: 4096,
+                        bufferSize: 4096, // 4096 seems to have the best performance on SSD
                         FileOptions.RandomAccess | FileOptions.DeleteOnClose);
+
+                    // 65536 has no particular significance, and maybe could be tuned
+                    // but 65536 performs well enough and isn't a lot of memory for a singleton
                     streamWriter = new StreamWriter(stream, utf8noBom, 65536);
                     streamWriter.AutoFlush = true;
                     streamReader = new StreamReader(stream, utf8noBom);

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
 
@@ -11,10 +12,29 @@ namespace Microsoft.Build.Logging
     /// <summary>
     /// Deserializes and returns BuildEventArgs-derived objects from a BinaryReader
     /// </summary>
-    public class BuildEventArgsReader
+    public class BuildEventArgsReader : IDisposable
     {
         private readonly BinaryReader binaryReader;
         private readonly int fileFormatVersion;
+
+        /// <summary>
+        /// A list of string records we've encountered so far. If it's a small string, it will be the string directly.
+        /// If it's a large string, it will be a pointer into a temporary page file where the string content will be
+        /// written out to. This is necessary so we don't keep all the strings in memory when reading large binlogs.
+        /// We will OOM otherwise.
+        /// </summary>
+        private readonly List<object> stringRecords = new List<object>();
+
+        /// <summary>
+        /// A list of dictionaries we've encountered so far. Dictionaries are referred to by their order in this list.
+        /// </summary>
+        private readonly List<(int keyIndex, int valueIndex)[]> nameValueListRecords = new List<(int, int)[]>();
+
+        /// <summary>
+        /// A "page-file" for storing strings we've read so far. Keeping them in memory would OOM the 32-bit MSBuild
+        /// when reading large binlogs. This is a no-op in a 64-bit process.
+        /// </summary>
+        private StringStorage stringStorage = new StringStorage();
 
         // reflection is needed to set these three fields because public constructors don't provide
         // a way to set these from the outside
@@ -36,6 +56,15 @@ namespace Microsoft.Build.Logging
             this.fileFormatVersion = fileFormatVersion;
         }
 
+        public void Dispose()
+        {
+            if (stringStorage != null)
+            {
+                stringStorage.Dispose();
+                stringStorage = null;
+            }
+        }
+
         /// <summary>
         /// Raised when the log reader encounters a binary blob embedded in the stream.
         /// The arguments include the blob kind and the byte buffer with the contents.
@@ -49,9 +78,23 @@ namespace Microsoft.Build.Logging
         {
             BinaryLogRecordKind recordKind = (BinaryLogRecordKind)ReadInt32();
 
-            while (IsBlob(recordKind))
+            // Skip over data storage records since they don't result in a BuildEventArgs.
+            // just ingest their data and continue.
+            while (IsAuxiliaryRecord(recordKind))
             {
-                ReadBlob(recordKind);
+                // these are ordered by commonality
+                if (recordKind == BinaryLogRecordKind.String)
+                {
+                    ReadStringRecord();
+                }
+                else if (recordKind == BinaryLogRecordKind.NameValueList)
+                {
+                    ReadNameValueList();
+                }
+                else if (recordKind == BinaryLogRecordKind.ProjectImportArchive)
+                {
+                    ReadBlob(recordKind);
+                }
 
                 recordKind = (BinaryLogRecordKind)ReadInt32();
             }
@@ -131,12 +174,11 @@ namespace Microsoft.Build.Logging
             return result;
         }
 
-        /// <summary>
-        /// For now it's just the ProjectImportArchive.
-        /// </summary>
-        private static bool IsBlob(BinaryLogRecordKind recordKind)
+        private static bool IsAuxiliaryRecord(BinaryLogRecordKind recordKind)
         {
-            return recordKind == BinaryLogRecordKind.ProjectImportArchive;
+            return recordKind == BinaryLogRecordKind.String
+                || recordKind == BinaryLogRecordKind.NameValueList
+                || recordKind == BinaryLogRecordKind.ProjectImportArchive;
         }
 
         private void ReadBlob(BinaryLogRecordKind kind)
@@ -144,6 +186,52 @@ namespace Microsoft.Build.Logging
             int length = ReadInt32();
             byte[] bytes = binaryReader.ReadBytes(length);
             OnBlobRead?.Invoke(kind, bytes);
+        }
+
+        private void ReadNameValueList()
+        {
+            int count = ReadInt32();
+
+            var list = new (int, int)[count];
+            for (int i = 0; i < count; i++)
+            {
+                int key = ReadInt32();
+                int value = ReadInt32();
+                list[i] = (key, value);
+            }
+
+            nameValueListRecords.Add(list);
+        }
+
+        private IDictionary<string, string> GetNameValueList(int id)
+        {
+            id -= BuildEventArgsWriter.NameValueRecordStartIndex;
+            if (id >= 0 && id < nameValueListRecords.Count)
+            {
+                var list = nameValueListRecords[id];
+
+                var dictionary = new Dictionary<string, string>(list.Length);
+                for (int i = 0; i < list.Length; i++)
+                {
+                    string key = GetStringFromRecord(list[i].keyIndex);
+                    string value = GetStringFromRecord(list[i].valueIndex);
+                    if (key != null)
+                    {
+                        dictionary[key] = value;
+                    }
+                }
+
+                return dictionary;
+            }
+
+            return new Dictionary<string, string>();
+        }
+
+        private void ReadStringRecord()
+        {
+            string text = ReadString();
+            object storedString = stringStorage.Add(text);
+            stringRecords.Add(storedString);
         }
 
         private BuildEventArgs ReadProjectImportedEventArgs()
@@ -232,7 +320,7 @@ namespace Microsoft.Build.Logging
         private BuildEventArgs ReadProjectEvaluationStartedEventArgs()
         {
             var fields = ReadBuildEventArgsFields();
-            var projectFile = ReadString();
+            var projectFile = ReadDeduplicatedString();
 
             var e = new ProjectEvaluationStartedEventArgs(fields.Message)
             {
@@ -245,7 +333,7 @@ namespace Microsoft.Build.Logging
         private BuildEventArgs ReadProjectEvaluationFinishedEventArgs()
         {
             var fields = ReadBuildEventArgsFields();
-            var projectFile = ReadString();
+            var projectFile = ReadDeduplicatedString();
 
             var e = new ProjectEvaluationFinishedEventArgs(fields.Message)
             {
@@ -264,8 +352,11 @@ namespace Microsoft.Build.Logging
                     var d = new Dictionary<EvaluationLocation, ProfiledLocation>(count);
                     for (int i = 0; i < count; i++)
                     {
-                        d.Add(ReadEvaluationLocation(), ReadProfiledLocation());
+                        var evaluationLocation = ReadEvaluationLocation();
+                        var profiledLocation = ReadProfiledLocation();
+                        d[evaluationLocation] = profiledLocation;
                     }
+
                     e.ProfilerResult = new ProfilerResult(d);
                 }
             }
@@ -284,10 +375,10 @@ namespace Microsoft.Build.Logging
 
             var projectFile = ReadOptionalString();
             var projectId = ReadInt32();
-            var targetNames = ReadString();
+            var targetNames = ReadDeduplicatedString();
             var toolsVersion = ReadOptionalString();
 
-            Dictionary<string, string> globalProperties = null;
+            IDictionary<string, string> globalProperties = null;
 
             if (fileFormatVersion > 6)
             {
@@ -298,7 +389,7 @@ namespace Microsoft.Build.Logging
             }
 
             var propertyList = ReadPropertyList();
-            var itemList = ReadItems();
+            var itemList = ReadProjectItems();
 
             var e = new ProjectStartedEventArgs(
                 projectId,
@@ -361,7 +452,7 @@ namespace Microsoft.Build.Logging
             var projectFile = ReadOptionalString();
             var targetFile = ReadOptionalString();
             var targetName = ReadOptionalString();
-            var targetOutputItemList = ReadItemList();
+            var targetOutputItemList = ReadTaskItemList();
 
             var e = new TargetFinishedEventArgs(
                 fields.Message,
@@ -525,7 +616,7 @@ namespace Microsoft.Build.Logging
             var fields = ReadBuildEventArgsFields();
             var importance = (MessageImportance)ReadInt32();
 
-            var environmentVariableName = ReadString();
+            var environmentVariableName = ReadDeduplicatedString();
 
             var e = new EnvironmentVariableReadEventArgs(
                 environmentVariableName,
@@ -542,10 +633,10 @@ namespace Microsoft.Build.Logging
         {
             var fields = ReadBuildEventArgsFields();
             var importance = (MessageImportance)ReadInt32();
-            string propertyName = ReadString();
-            string previousValue = ReadString();
-            string newValue = ReadString();
-            string location = ReadString();
+            string propertyName = ReadDeduplicatedString();
+            string previousValue = ReadDeduplicatedString();
+            string newValue = ReadDeduplicatedString();
+            string location = ReadDeduplicatedString();
 
             var e = new PropertyReassignmentEventArgs(
                 propertyName,
@@ -565,7 +656,7 @@ namespace Microsoft.Build.Logging
         {
             var fields = ReadBuildEventArgsFields();
             var importance = (MessageImportance)ReadInt32();
-            string propertyName = ReadString();
+            string propertyName = ReadDeduplicatedString();
 
             var e = new UninitializedPropertyReadEventArgs(
                 propertyName,
@@ -582,9 +673,9 @@ namespace Microsoft.Build.Logging
         {
             var fields = ReadBuildEventArgsFields();
             var importance = (MessageImportance)ReadInt32();
-            string propertyName = ReadString();
-            string propertyValue = ReadString();
-            string propertySource = ReadString();
+            string propertyName = ReadDeduplicatedString();
+            string propertyValue = ReadDeduplicatedString();
+            string propertySource = ReadDeduplicatedString();
 
             var e = new PropertyInitialValueSetEventArgs(
                 propertyName,
@@ -625,7 +716,7 @@ namespace Microsoft.Build.Logging
 
             if ((flags & BuildEventArgsFieldFlags.Message) != 0)
             {
-                result.Message = ReadString();
+                result.Message = ReadDeduplicatedString();
             }
 
             if ((flags & BuildEventArgsFieldFlags.BuildEventContext) != 0)
@@ -640,12 +731,12 @@ namespace Microsoft.Build.Logging
 
             if ((flags & BuildEventArgsFieldFlags.HelpHeyword) != 0)
             {
-                result.HelpKeyword = ReadString();
+                result.HelpKeyword = ReadDeduplicatedString();
             }
 
             if ((flags & BuildEventArgsFieldFlags.SenderName) != 0)
             {
-                result.SenderName = ReadString();
+                result.SenderName = ReadDeduplicatedString();
             }
 
             if ((flags & BuildEventArgsFieldFlags.Timestamp) != 0)
@@ -655,22 +746,22 @@ namespace Microsoft.Build.Logging
 
             if ((flags & BuildEventArgsFieldFlags.Subcategory) != 0)
             {
-                result.Subcategory = ReadString();
+                result.Subcategory = ReadDeduplicatedString();
             }
 
             if ((flags & BuildEventArgsFieldFlags.Code) != 0)
             {
-                result.Code = ReadString();
+                result.Code = ReadDeduplicatedString();
             }
 
             if ((flags & BuildEventArgsFieldFlags.File) != 0)
             {
-                result.File = ReadString();
+                result.File = ReadDeduplicatedString();
             }
 
             if ((flags & BuildEventArgsFieldFlags.ProjectFile) != 0)
             {
-                result.ProjectFile = ReadString();
+                result.ProjectFile = ReadDeduplicatedString();
             }
 
             if ((flags & BuildEventArgsFieldFlags.LineNumber) != 0)
@@ -761,16 +852,33 @@ namespace Microsoft.Build.Logging
             return result;
         }
 
-        private Dictionary<string, string> ReadStringDictionary()
+        private IDictionary<string, string> ReadStringDictionary()
+        {
+            if (fileFormatVersion < 10)
+            {
+                return ReadLegacyStringDictionary();
+            }
+
+            int index = ReadInt32();
+            if (index == 0)
+            {
+                return null;
+            }
+
+            var record = GetNameValueList(index);
+            return record;
+        }
+
+        private IDictionary<string, string> ReadLegacyStringDictionary()
         {
             int count = ReadInt32();
-
             if (count == 0)
             {
                 return null;
             }
 
-            Dictionary<string, string> result = new Dictionary<string, string>(count);
+            var result = new Dictionary<string, string>(count);
+
             for (int i = 0; i < count; i++)
             {
                 string key = ReadString();
@@ -783,16 +891,29 @@ namespace Microsoft.Build.Logging
 
         private class TaskItem : ITaskItem
         {
+            private static readonly Dictionary<string, string> emptyMetadata = new Dictionary<string, string>();
+
             public string ItemSpec { get; set; }
-            public Dictionary<string, string> Metadata { get; } = new Dictionary<string, string>();
+            public IDictionary<string, string> Metadata { get; }
+
+            public TaskItem()
+            {
+                Metadata = new Dictionary<string, string>();
+            }
+
+            public TaskItem(string itemSpec, IDictionary<string, string> metadata)
+            {
+                ItemSpec = itemSpec;
+                Metadata = metadata ?? emptyMetadata;
+            }
 
             public int MetadataCount => Metadata.Count;
 
-            public ICollection MetadataNames => Metadata.Keys;
+            public ICollection MetadataNames => (ICollection)Metadata.Keys;
 
             public IDictionary CloneCustomMetadata()
             {
-                return Metadata;
+                return (IDictionary)Metadata;
             }
 
             public void CopyMetadataTo(ITaskItem destinationItem)
@@ -814,25 +935,23 @@ namespace Microsoft.Build.Logging
             {
                 throw new NotImplementedException();
             }
-        }
 
-        private ITaskItem ReadItem()
-        {
-            var item = new TaskItem();
-            item.ItemSpec = ReadString();
-
-            int count = ReadInt32();
-            for (int i = 0; i < count; i++)
+            public override string ToString()
             {
-                string name = ReadString();
-                string value = ReadString();
-                item.Metadata[name] = value;
+                return $"{ItemSpec} Metadata: {MetadataCount}";
             }
-
-            return item;
         }
 
-        private IEnumerable ReadItems()
+        private ITaskItem ReadTaskItem()
+        {
+            string itemSpec = ReadDeduplicatedString();
+            var metadata = ReadStringDictionary();
+
+            var taskItem = new TaskItem(itemSpec, metadata);
+            return taskItem;
+        }
+
+        private IEnumerable ReadProjectItems()
         {
             int count = ReadInt32();
             if (count == 0)
@@ -840,19 +959,40 @@ namespace Microsoft.Build.Logging
                 return null;
             }
 
-            var list = new List<DictionaryEntry>(count);
+            List<DictionaryEntry> list;
 
-            for (int i = 0; i < count; i++)
+            // starting with format version 10 project items are grouped by name
+            // so we only have to write the name once, and then the count of items
+            // with that name. When reading a legacy binlog we need to read the
+            // old style flat list where the name is duplicated for each item.
+            if (fileFormatVersion < 10)
             {
-                string key = ReadString();
-                ITaskItem item = ReadItem();
-                list.Add(new DictionaryEntry(key, item));
+                list = new List<DictionaryEntry>(count);
+                for (int i = 0; i < count; i++)
+                {
+                    string itemName = ReadString();
+                    ITaskItem item = ReadTaskItem();
+                    list.Add(new DictionaryEntry(itemName, item));
+                }
+            }
+            else
+            {
+                list = new List<DictionaryEntry>();
+                for (int i = 0; i < count; i++)
+                {
+                    string itemName = ReadDeduplicatedString();
+                    var items = ReadTaskItemList();
+                    foreach (var item in items)
+                    {
+                        list.Add(new DictionaryEntry(itemName, item));
+                    }
+                }
             }
 
             return list;
         }
 
-        private IEnumerable ReadItemList()
+        private IEnumerable ReadTaskItemList()
         {
             int count = ReadInt32();
             if (count == 0)
@@ -864,28 +1004,68 @@ namespace Microsoft.Build.Logging
 
             for (int i = 0; i < count; i++)
             {
-                ITaskItem item = ReadItem();
+                ITaskItem item = ReadTaskItem();
                 list.Add(item);
             }
 
             return list;
         }
 
-        private string ReadOptionalString()
-        {
-            if (ReadBoolean())
-            {
-                return ReadString();
-            }
-            else
-            {
-                return null;
-            }
-        }
-
         private string ReadString()
         {
             return binaryReader.ReadString();
+        }
+
+        private string ReadOptionalString()
+        {
+            if (fileFormatVersion < 10)
+            {
+                if (ReadBoolean())
+                {
+                    return ReadString();
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            return ReadDeduplicatedString();
+        }
+
+        private string ReadDeduplicatedString()
+        {
+            if (fileFormatVersion < 10)
+            {
+                return ReadString();
+            }
+
+            int index = ReadInt32();
+            return GetStringFromRecord(index);
+        }
+
+        private string GetStringFromRecord(int index)
+        {
+            if (index == 0)
+            {
+                return null;
+            }
+            else if (index == 1)
+            {
+                return string.Empty;
+            }
+
+            // we reserve numbers 2-9 for future use.
+            // the writer assigns 10 as the index of the first string
+            index -= BuildEventArgsWriter.StringStartIndex;
+            if (index >= 0 && index < this.stringRecords.Count)
+            {
+                object storedString = stringRecords[index];
+                string result = stringStorage.Get(storedString);
+                return result;
+            }
+
+            return string.Empty;
         }
 
         private int ReadInt32()
@@ -972,10 +1152,149 @@ namespace Microsoft.Build.Logging
                 {
                     parentId = ReadInt64();
                 }
+
                 return new EvaluationLocation(id, parentId, evaluationPass, evaluationDescription, file, line, elementName, description, kind);
             }
 
             return new EvaluationLocation(0, null, evaluationPass, evaluationDescription, file, line, elementName, description, kind);
+        }
+
+        /// <summary>
+        /// Locates the string in the page file.
+        /// </summary>
+        internal class StringPosition
+        {
+            /// <summary>
+            /// Offset in the file.
+            /// </summary>
+            public long FilePosition;
+
+            /// <summary>
+            /// The length of the string in chars (not bytes).
+            /// </summary>
+            public int StringLength;
+        }
+
+        /// <summary>
+        /// Stores large strings in a temp file on disk, to avoid keeping all strings in memory.
+        /// Only creates a file for 32-bit MSBuild.exe, just returns the string directly on 64-bit.
+        /// </summary>
+        internal class StringStorage : IDisposable
+        {
+            private string filePath;
+            private FileStream stream;
+            private StreamWriter streamWriter;
+            private StreamReader streamReader;
+            private StringBuilder stringBuilder;
+
+            public const int StringSizeThreshold = 1024;
+
+            public StringStorage()
+            {
+                if (!Environment.Is64BitProcess)
+                {
+                    filePath = Path.GetTempFileName();
+                    var utf8noBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                    stream = new FileStream(
+                        filePath,
+                        FileMode.OpenOrCreate,
+                        FileAccess.ReadWrite,
+                        FileShare.None,
+                        bufferSize: 4096,
+                        FileOptions.RandomAccess | FileOptions.DeleteOnClose);
+                    streamWriter = new StreamWriter(stream, utf8noBom, 65536);
+                    streamWriter.AutoFlush = true;
+                    streamReader = new StreamReader(stream, utf8noBom);
+                    stringBuilder = new StringBuilder();
+                }
+            }
+
+            private long totalAllocatedShortStrings = 0;
+
+            public object Add(string text)
+            {
+                if (filePath == null)
+                {
+                    // on 64-bit, we have as much memory as we want
+                    // so no need to write to the file at all
+                    return text;
+                }
+
+                // Tradeoff between not crashing with OOM on large binlogs and
+                // keeping the playback of smaller binlogs relatively fast.
+                // It is slow to store all small strings in the file and constantly
+                // seek to retrieve them. Instead we'll keep storing small strings
+                // in memory until we allocate 2 GB. After that, all strings go to
+                // the file.
+                // Win-win: small binlog playback is fast and large binlog playback
+                // doesn't OOM.
+                if (text.Length <= StringSizeThreshold && totalAllocatedShortStrings < 2_000_000_000)
+                {
+                    // note that we write strings in UTF8 so we don't need to multiply by 2 as chars
+                    // will be 1 byte on average
+                    totalAllocatedShortStrings += text.Length;
+                    return text;
+                }
+
+                var stringPosition = new StringPosition();
+
+                stringPosition.FilePosition = stream.Position;
+
+                streamWriter.Write(text);
+
+                stringPosition.StringLength = text.Length;
+                return stringPosition;
+            }
+
+            public string Get(object storedString)
+            {
+                if (storedString is string text)
+                {
+                    return text;
+                }
+
+                var position = (StringPosition)storedString;
+
+                stream.Position = position.FilePosition;
+                stringBuilder.Length = position.StringLength;
+                for (int i = 0; i < position.StringLength; i++)
+                {
+                    char ch = (char)streamReader.Read();
+                    stringBuilder[i] = ch;
+                }
+
+                stream.Position = stream.Length;
+                streamReader.DiscardBufferedData();
+
+                string result = stringBuilder.ToString();
+                stringBuilder.Clear();
+                return result;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    if (streamWriter != null)
+                    {
+                        streamWriter.Dispose();
+                        streamWriter = null;
+                    }
+
+                    if (stream != null)
+                    {
+                        stream.Dispose();
+                        stream = null;
+                    }
+                }
+                catch
+                {
+                    // The StringStorage class is not crucial for other functionality and if 
+                    // there are exceptions when closing the temp file, it's too late to do anything about it.
+                    // Since we don't want to disrupt anything and the file is in the TEMP directory, it will
+                    // get cleaned up at some point anyway.
+                }
+            }
         }
     }
 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -1190,11 +1190,11 @@ namespace Microsoft.Build.Logging
         /// </summary>
         internal class StringStorage : IDisposable
         {
-            private string filePath;
+            private readonly string filePath;
             private FileStream stream;
             private StreamWriter streamWriter;
-            private StreamReader streamReader;
-            private StringBuilder stringBuilder;
+            private readonly StreamReader streamReader;
+            private readonly StringBuilder stringBuilder;
 
             public const int StringSizeThreshold = 1024;
 
@@ -1240,10 +1240,8 @@ namespace Microsoft.Build.Logging
                 // the file.
                 // Win-win: small binlog playback is fast and large binlog playback
                 // doesn't OOM.
-                if (text.Length <= StringSizeThreshold && totalAllocatedShortStrings < 2_000_000_000)
+                if (text.Length <= StringSizeThreshold && totalAllocatedShortStrings < 1_000_000_000)
                 {
-                    // note that we write strings in UTF8 so we don't need to multiply by 2 as chars
-                    // will be 1 byte on average
                     totalAllocatedShortStrings += text.Length;
                     return text;
                 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -725,10 +725,7 @@ namespace Microsoft.Build.Logging
         {
             WriteDeduplicatedString(item.ItemSpec);
 
-            if (nameValueListBuffer.Count > 0)
-            {
-                nameValueListBuffer.Clear();
-            }
+            nameValueListBuffer.Clear();
 
             IDictionary customMetadata = item.CloneCustomMetadata();
 
@@ -768,10 +765,7 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            if (nameValueListBuffer.Count > 0)
-            {
-                nameValueListBuffer.Clear();
-            }
+            nameValueListBuffer.Clear();
 
             // there are no guarantees that the properties iterator won't change, so 
             // take a snapshot and work with the readonly copy
@@ -806,10 +800,7 @@ namespace Microsoft.Build.Logging
 
         private void Write(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
         {
-            if (nameValueListBuffer.Count > 0)
-            {
-                nameValueListBuffer.Clear();
-            }
+            nameValueListBuffer.Clear();
 
             if (keyValuePairs != null)
             {

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -200,13 +200,37 @@ namespace Microsoft.Build.Logging
         {
             // write the blob directly to the underlying writer,
             // bypassing the memory stream
-            binaryWriter = originalBinaryWriter;
+            using var redirection = RedirectWritesToOriginalWriter();
 
             Write(kind);
             Write(bytes.Length);
             Write(bytes);
+        }
 
-            binaryWriter = currentRecordWriter;
+        /// <summary>
+        /// Switches the binaryWriter used by the Write* methods to the direct underlying stream writer
+        /// until the disposable is disposed. Useful to bypass the currentRecordWriter to write a string,
+        /// blob or NameValueRecord that should precede the record being currently written.
+        /// </summary>
+        private IDisposable RedirectWritesToOriginalWriter()
+        {
+            binaryWriter = originalBinaryWriter;
+            return new RedirectionScope(this);
+        }
+
+        private struct RedirectionScope : IDisposable
+        {
+            private readonly BuildEventArgsWriter _writer;
+
+            public RedirectionScope(BuildEventArgsWriter buildEventArgsWriter)
+            {
+                _writer = buildEventArgsWriter;
+            }
+
+            public void Dispose()
+            {
+                _writer.binaryWriter = _writer.currentRecordWriter;
+            }
         }
 
         private void Write(BuildStartedEventArgs e)
@@ -833,7 +857,7 @@ namespace Microsoft.Build.Logging
             // Switch the binaryWriter used by the Write* methods to the direct underlying stream writer.
             // We want this record to precede the record we're currently writing to currentRecordWriter
             // which is backed by a MemoryStream buffer
-            binaryWriter = this.originalBinaryWriter;
+            using var redirectionScope = RedirectWritesToOriginalWriter();
 
             Write(BinaryLogRecordKind.NameValueList);
             Write(nameValueIndexListBuffer.Count);
@@ -843,9 +867,6 @@ namespace Microsoft.Build.Logging
                 Write(kvp.Key);
                 Write(kvp.Value);
             }
-
-            // switch back to continue writing the current record to the memory stream
-            binaryWriter = this.currentRecordWriter;
         }
 
         /// <summary>
@@ -954,16 +975,10 @@ namespace Microsoft.Build.Logging
 
         private void WriteStringRecord(string text)
         {
-            // Switch the binaryWriter used by the Write* methods to the direct underlying stream writer.
-            // We want this record to precede the record we're currently writing to currentRecordWriter
-            // which is backed by a MemoryStream buffer
-            binaryWriter = this.originalBinaryWriter;
+            using var redirectionScope = RedirectWritesToOriginalWriter();
 
             Write(BinaryLogRecordKind.String);
             binaryWriter.Write(text);
-
-            // switch back to continue writing the current record to the memory stream
-            binaryWriter = this.currentRecordWriter;
         }
 
         private void Write(DateTime timestamp)

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
+using Microsoft.Build.Internal;
 
 namespace Microsoft.Build.Logging
 {
@@ -15,7 +16,85 @@ namespace Microsoft.Build.Logging
     /// </summary>
     internal class BuildEventArgsWriter
     {
-        private readonly BinaryWriter binaryWriter;
+        private readonly Stream originalStream;
+
+        /// <summary>
+        /// When writing the current record, first write it to a memory stream,
+        /// then flush to the originalStream. This is needed so that if we discover
+        /// that we need to write a string record in the middle of writing the
+        /// current record, we will write the string record to the original stream
+        /// and the current record will end up after the string record.
+        /// </summary>
+        private readonly MemoryStream currentRecordStream;
+
+        /// <summary>
+        /// The binary writer around the originalStream.
+        /// </summary>
+        private readonly BinaryWriter originalBinaryWriter;
+
+        /// <summary>
+        /// The binary writer around the currentRecordStream.
+        /// </summary>
+        private readonly BinaryWriter currentRecordWriter;
+
+        /// <summary>
+        /// The binary writer we're currently using. Is pointing at the currentRecordWriter usually,
+        /// but sometimes we repoint it to the originalBinaryWriter temporarily, when writing string
+        /// and name-value records.
+        /// </summary>
+        private BinaryWriter binaryWriter;
+
+        /// <summary>
+        /// Hashtable used for deduplicating strings. When we need to write a string,
+        /// we check in this hashtable first, and if we've seen the string before,
+        /// just write out its index. Otherwise write out a string record, and then
+        /// write the string index. A string record is guaranteed to precede its first
+        /// usage.
+        /// The reader will read the string records first and then be able to retrieve
+        /// a string by its index. This allows us to keep the format streaming instead
+        /// of writing one giant string table at the end. If a binlog is interrupted
+        /// we'll be able to use all the information we've discovered thus far.
+        /// </summary>
+        private readonly Dictionary<HashKey, int> stringHashes = new Dictionary<HashKey, int>();
+
+        /// <summary>
+        /// Hashtable used for deduplicating name-value lists. Same as strings.
+        /// </summary>
+        private readonly Dictionary<HashKey, int> nameValueListHashes = new Dictionary<HashKey, int>();
+
+        /// <summary>
+        /// Index 0 is null, Index 1 is the empty string.
+        /// Reserve indices 2-9 for future use. Start indexing actual strings at 10.
+        /// </summary>
+        internal const int StringStartIndex = 10;
+
+        /// <summary>
+        /// Let's reserve a few indices for future use.
+        /// </summary>
+        internal const int NameValueRecordStartIndex = 10;
+
+        /// <summary>
+        /// 0 is null, 1 is empty string
+        /// 2-9 are reserved for future use.
+        /// Start indexing at 10.
+        /// </summary>
+        private int stringRecordId = StringStartIndex;
+
+        /// <summary>
+        /// The index of the next record to be written.
+        /// </summary>
+        private int nameValueRecordId = NameValueRecordStartIndex;
+
+        /// <summary>
+        /// A temporary buffer we use when writing a NameValueList record. Avoids allocating a list each time.
+        /// </summary>
+        private readonly List<KeyValuePair<string, string>> nameValueListBuffer = new List<KeyValuePair<string, string>>(1024);
+
+        /// <summary>
+        /// A temporary buffer we use when hashing a NameValueList record. Stores the indices of hashed strings
+        /// instead of the actual names and values.
+        /// </summary>
+        private readonly List<KeyValuePair<int, int>> nameValueIndexListBuffer = new List<KeyValuePair<int, int>>(1024);
 
         /// <summary>
         /// Initializes a new instance of BuildEventArgsWriter with a BinaryWriter
@@ -23,13 +102,31 @@ namespace Microsoft.Build.Logging
         /// <param name="binaryWriter">A BinaryWriter to write the BuildEventArgs instances to</param>
         public BuildEventArgsWriter(BinaryWriter binaryWriter)
         {
-            this.binaryWriter = binaryWriter;
+            this.originalStream = binaryWriter.BaseStream;
+
+            // this doesn't exceed 30K for smaller binlogs so seems like a reasonable
+            // starting point to avoid reallocations in the common case
+            this.currentRecordStream = new MemoryStream(65536);
+
+            this.originalBinaryWriter = binaryWriter;
+            this.currentRecordWriter = new BinaryWriter(currentRecordStream);
+
+            this.binaryWriter = currentRecordWriter;
         }
 
         /// <summary>
         /// Write a provided instance of BuildEventArgs to the BinaryWriter
         /// </summary>
         public void Write(BuildEventArgs e)
+        {
+            WriteCore(e);
+
+            // flush the current record and clear the MemoryStream to prepare for next use
+            currentRecordStream.WriteTo(originalStream);
+            currentRecordStream.SetLength(0);
+        }
+
+        private void WriteCore(BuildEventArgs e)
         {
             // the cases are ordered by most used first for performance
             if (e is BuildMessageEventArgs)
@@ -101,9 +198,15 @@ namespace Microsoft.Build.Logging
 
         public void WriteBlob(BinaryLogRecordKind kind, byte[] bytes)
         {
+            // write the blob directly to the underlying writer,
+            // bypassing the memory stream
+            binaryWriter = originalBinaryWriter;
+
             Write(kind);
             Write(bytes.Length);
             Write(bytes);
+
+            binaryWriter = currentRecordWriter;
         }
 
         private void Write(BuildStartedEventArgs e)
@@ -124,15 +227,15 @@ namespace Microsoft.Build.Logging
         {
             Write(BinaryLogRecordKind.ProjectEvaluationStarted);
             WriteBuildEventArgsFields(e);
-            Write(e.ProjectFile);
+            WriteDeduplicatedString(e.ProjectFile);
         }
 
         private void Write(ProjectEvaluationFinishedEventArgs e)
         {
             Write(BinaryLogRecordKind.ProjectEvaluationFinished);
-            
+
             WriteBuildEventArgsFields(e);
-            Write(e.ProjectFile);
+            WriteDeduplicatedString(e.ProjectFile);
 
             Write(e.ProfilerResult.HasValue);
             if (e.ProfilerResult.HasValue)
@@ -162,11 +265,11 @@ namespace Microsoft.Build.Logging
                 Write(e.ParentProjectBuildEventContext);
             }
 
-            WriteOptionalString(e.ProjectFile);
+            WriteDeduplicatedString(e.ProjectFile);
 
             Write(e.ProjectId);
-            Write(e.TargetNames);
-            WriteOptionalString(e.ToolsVersion);
+            WriteDeduplicatedString(e.TargetNames);
+            WriteDeduplicatedString(e.ToolsVersion);
 
             if (e.GlobalProperties == null)
             {
@@ -180,14 +283,14 @@ namespace Microsoft.Build.Logging
 
             WriteProperties(e.Properties);
 
-            WriteItems(e.Items);
+            WriteProjectItems(e.Items);
         }
 
         private void Write(ProjectFinishedEventArgs e)
         {
             Write(BinaryLogRecordKind.ProjectFinished);
             WriteBuildEventArgsFields(e);
-            WriteOptionalString(e.ProjectFile);
+            WriteDeduplicatedString(e.ProjectFile);
             Write(e.Succeeded);
         }
 
@@ -195,11 +298,11 @@ namespace Microsoft.Build.Logging
         {
             Write(BinaryLogRecordKind.TargetStarted);
             WriteBuildEventArgsFields(e);
-            WriteOptionalString(e.TargetName);
-            WriteOptionalString(e.ProjectFile);
-            WriteOptionalString(e.TargetFile);
-            WriteOptionalString(e.ParentTarget);
-            Write((int) e.BuildReason);
+            WriteDeduplicatedString(e.TargetName);
+            WriteDeduplicatedString(e.ProjectFile);
+            WriteDeduplicatedString(e.TargetFile);
+            WriteDeduplicatedString(e.ParentTarget);
+            Write((int)e.BuildReason);
         }
 
         private void Write(TargetFinishedEventArgs e)
@@ -207,19 +310,19 @@ namespace Microsoft.Build.Logging
             Write(BinaryLogRecordKind.TargetFinished);
             WriteBuildEventArgsFields(e);
             Write(e.Succeeded);
-            WriteOptionalString(e.ProjectFile);
-            WriteOptionalString(e.TargetFile);
-            WriteOptionalString(e.TargetName);
-            WriteItemList(e.TargetOutputs);
+            WriteDeduplicatedString(e.ProjectFile);
+            WriteDeduplicatedString(e.TargetFile);
+            WriteDeduplicatedString(e.TargetName);
+            WriteTaskItemList(e.TargetOutputs);
         }
 
         private void Write(TaskStartedEventArgs e)
         {
             Write(BinaryLogRecordKind.TaskStarted);
             WriteBuildEventArgsFields(e);
-            WriteOptionalString(e.TaskName);
-            WriteOptionalString(e.ProjectFile);
-            WriteOptionalString(e.TaskFile);
+            WriteDeduplicatedString(e.TaskName);
+            WriteDeduplicatedString(e.ProjectFile);
+            WriteDeduplicatedString(e.TaskFile);
         }
 
         private void Write(TaskFinishedEventArgs e)
@@ -227,19 +330,19 @@ namespace Microsoft.Build.Logging
             Write(BinaryLogRecordKind.TaskFinished);
             WriteBuildEventArgsFields(e);
             Write(e.Succeeded);
-            WriteOptionalString(e.TaskName);
-            WriteOptionalString(e.ProjectFile);
-            WriteOptionalString(e.TaskFile);
+            WriteDeduplicatedString(e.TaskName);
+            WriteDeduplicatedString(e.ProjectFile);
+            WriteDeduplicatedString(e.TaskFile);
         }
 
         private void Write(BuildErrorEventArgs e)
         {
             Write(BinaryLogRecordKind.Error);
             WriteBuildEventArgsFields(e);
-            WriteOptionalString(e.Subcategory);
-            WriteOptionalString(e.Code);
-            WriteOptionalString(e.File);
-            WriteOptionalString(e.ProjectFile);
+            WriteDeduplicatedString(e.Subcategory);
+            WriteDeduplicatedString(e.Code);
+            WriteDeduplicatedString(e.File);
+            WriteDeduplicatedString(e.ProjectFile);
             Write(e.LineNumber);
             Write(e.ColumnNumber);
             Write(e.EndLineNumber);
@@ -250,10 +353,10 @@ namespace Microsoft.Build.Logging
         {
             Write(BinaryLogRecordKind.Warning);
             WriteBuildEventArgsFields(e);
-            WriteOptionalString(e.Subcategory);
-            WriteOptionalString(e.Code);
-            WriteOptionalString(e.File);
-            WriteOptionalString(e.ProjectFile);
+            WriteDeduplicatedString(e.Subcategory);
+            WriteDeduplicatedString(e.Code);
+            WriteDeduplicatedString(e.File);
+            WriteDeduplicatedString(e.ProjectFile);
             Write(e.LineNumber);
             Write(e.ColumnNumber);
             Write(e.EndLineNumber);
@@ -319,17 +422,17 @@ namespace Microsoft.Build.Logging
             Write(BinaryLogRecordKind.ProjectImported);
             WriteMessageFields(e);
             Write(e.ImportIgnored);
-            WriteOptionalString(e.ImportedProjectFile);
-            WriteOptionalString(e.UnexpandedProject);
+            WriteDeduplicatedString(e.ImportedProjectFile);
+            WriteDeduplicatedString(e.UnexpandedProject);
         }
 
         private void Write(TargetSkippedEventArgs e)
         {
             Write(BinaryLogRecordKind.TargetSkipped);
             WriteMessageFields(e);
-            WriteOptionalString(e.TargetFile);
-            WriteOptionalString(e.TargetName);
-            WriteOptionalString(e.ParentTarget);
+            WriteDeduplicatedString(e.TargetFile);
+            WriteDeduplicatedString(e.TargetName);
+            WriteDeduplicatedString(e.ParentTarget);
             Write((int)e.BuildReason);
         }
 
@@ -343,41 +446,41 @@ namespace Microsoft.Build.Logging
         {
             Write(BinaryLogRecordKind.PropertyReassignment);
             WriteMessageFields(e);
-            Write(e.PropertyName);
-            Write(e.PreviousValue);
-            Write(e.NewValue);
-            Write(e.Location);
+            WriteDeduplicatedString(e.PropertyName);
+            WriteDeduplicatedString(e.PreviousValue);
+            WriteDeduplicatedString(e.NewValue);
+            WriteDeduplicatedString(e.Location);
         }
 
         private void Write(UninitializedPropertyReadEventArgs e)
         {
             Write(BinaryLogRecordKind.UninitializedPropertyRead);
             WriteMessageFields(e);
-            Write(e.PropertyName);
+            WriteDeduplicatedString(e.PropertyName);
         }
 
         private void Write(PropertyInitialValueSetEventArgs e)
         {
             Write(BinaryLogRecordKind.PropertyInitialValueSet);
             WriteMessageFields(e);
-            Write(e.PropertyName);
-            Write(e.PropertyValue);
-            Write(e.PropertySource);
+            WriteDeduplicatedString(e.PropertyName);
+            WriteDeduplicatedString(e.PropertyValue);
+            WriteDeduplicatedString(e.PropertySource);
         }
 
         private void Write(EnvironmentVariableReadEventArgs e)
         {
             Write(BinaryLogRecordKind.EnvironmentVariableRead);
             WriteMessageFields(e);
-            Write(e.EnvironmentVariableName);
+            WriteDeduplicatedString(e.EnvironmentVariableName);
         }
 
         private void Write(TaskCommandLineEventArgs e)
         {
             Write(BinaryLogRecordKind.TaskCommandLine);
             WriteMessageFields(e);
-            WriteOptionalString(e.CommandLine);
-            WriteOptionalString(e.TaskName);
+            WriteDeduplicatedString(e.CommandLine);
+            WriteDeduplicatedString(e.TaskName);
         }
 
         private void WriteBuildEventArgsFields(BuildEventArgs e)
@@ -391,7 +494,7 @@ namespace Microsoft.Build.Logging
         {
             if ((flags & BuildEventArgsFieldFlags.Message) != 0)
             {
-                Write(e.Message);
+                WriteDeduplicatedString(e.Message);
             }
 
             if ((flags & BuildEventArgsFieldFlags.BuildEventContext) != 0)
@@ -406,12 +509,12 @@ namespace Microsoft.Build.Logging
 
             if ((flags & BuildEventArgsFieldFlags.HelpHeyword) != 0)
             {
-                Write(e.HelpKeyword);
+                WriteDeduplicatedString(e.HelpKeyword);
             }
 
             if ((flags & BuildEventArgsFieldFlags.SenderName) != 0)
             {
-                Write(e.SenderName);
+                WriteDeduplicatedString(e.SenderName);
             }
 
             if ((flags & BuildEventArgsFieldFlags.Timestamp) != 0)
@@ -431,22 +534,22 @@ namespace Microsoft.Build.Logging
 
             if ((flags & BuildEventArgsFieldFlags.Subcategory) != 0)
             {
-                Write(e.Subcategory);
+                WriteDeduplicatedString(e.Subcategory);
             }
 
             if ((flags & BuildEventArgsFieldFlags.Code) != 0)
             {
-                Write(e.Code);
+                WriteDeduplicatedString(e.Code);
             }
 
             if ((flags & BuildEventArgsFieldFlags.File) != 0)
             {
-                Write(e.File);
+                WriteDeduplicatedString(e.File);
             }
 
             if ((flags & BuildEventArgsFieldFlags.ProjectFile) != 0)
             {
-                Write(e.ProjectFile);
+                WriteDeduplicatedString(e.ProjectFile);
             }
 
             if ((flags & BuildEventArgsFieldFlags.LineNumber) != 0)
@@ -554,25 +657,24 @@ namespace Microsoft.Build.Logging
             return flags;
         }
 
-        private void WriteItemList(IEnumerable items)
+        private void WriteTaskItemList(IEnumerable items)
         {
             var taskItems = items as IEnumerable<ITaskItem>;
-            if (taskItems != null)
+            if (taskItems == null)
             {
-                Write(taskItems.Count());
-
-                foreach (var item in taskItems)
-                {
-                    Write(item);
-                }
-
+                Write(false);
                 return;
             }
 
-            Write(0);
+            Write(taskItems.Count());
+
+            foreach (var item in taskItems)
+            {
+                Write(item);
+            }
         }
 
-        private void WriteItems(IEnumerable items)
+        private void WriteProjectItems(IEnumerable items)
         {
             if (items == null)
             {
@@ -580,29 +682,34 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            var entries = items.OfType<DictionaryEntry>()
-                .Where(e => e.Key is string && e.Value is ITaskItem)
+            var groups = items
+                .OfType<DictionaryEntry>()
+                .GroupBy(entry => entry.Key as string, entry => entry.Value as ITaskItem)
+                .Where(group => !string.IsNullOrEmpty(group.Key))
                 .ToArray();
-            Write(entries.Length);
 
-            foreach (DictionaryEntry entry in entries)
+            Write(groups.Length);
+
+            foreach (var group in groups)
             {
-                string key = entry.Key as string;
-                ITaskItem item = entry.Value as ITaskItem;
-                Write(key);
-                Write(item);
+                WriteDeduplicatedString(group.Key);
+                WriteTaskItemList(group);
             }
         }
 
         private void Write(ITaskItem item)
         {
-            Write(item.ItemSpec);
+            WriteDeduplicatedString(item.ItemSpec);
+
+            if (nameValueListBuffer.Count > 0)
+            {
+                nameValueListBuffer.Clear();
+            }
+
             IDictionary customMetadata = item.CloneCustomMetadata();
-            Write(customMetadata.Count);
 
             foreach (string metadataName in customMetadata.Keys)
             {
-                Write(metadataName);
                 string valueOrError;
 
                 try
@@ -623,8 +730,10 @@ namespace Microsoft.Build.Logging
                     Debug.Fail(e.ToString());
                 }
 
-                Write(valueOrError);
+                nameValueListBuffer.Add(new KeyValuePair<string, string>(metadataName, valueOrError));
             }
+
+            WriteNameValueList();
         }
 
         private void WriteProperties(IEnumerable properties)
@@ -635,26 +744,29 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
+            if (nameValueListBuffer.Count > 0)
+            {
+                nameValueListBuffer.Clear();
+            }
+
             // there are no guarantees that the properties iterator won't change, so 
             // take a snapshot and work with the readonly copy
             var propertiesArray = properties.OfType<DictionaryEntry>().ToArray();
 
-            Write(propertiesArray.Length);
-
-            foreach (DictionaryEntry entry in propertiesArray)
+            for (int i = 0; i < propertiesArray.Length; i++)
             {
-                if (entry.Key is string && entry.Value is string)
+                DictionaryEntry entry = propertiesArray[i];
+                if (entry.Key is string key && entry.Value is string value)
                 {
-                    Write((string)entry.Key);
-                    Write((string)entry.Value);
+                    nameValueListBuffer.Add(new KeyValuePair<string, string>(key, value));
                 }
                 else
                 {
-                    // to keep the count accurate
-                    Write("");
-                    Write("");
+                    nameValueListBuffer.Add(new KeyValuePair<string, string>(string.Empty, string.Empty));
                 }
             }
+
+            WriteNameValueList();
         }
 
         private void Write(BuildEventContext buildEventContext)
@@ -668,21 +780,98 @@ namespace Microsoft.Build.Logging
             Write(buildEventContext.EvaluationId);
         }
 
-        private void Write<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> keyValuePairs)
+        private void Write(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
         {
-            if (keyValuePairs?.Any() == true)
+            if (nameValueListBuffer.Count > 0)
             {
-                Write(keyValuePairs.Count());
+                nameValueListBuffer.Clear();
+            }
+
+            if (keyValuePairs != null)
+            {
                 foreach (var kvp in keyValuePairs)
                 {
-                    Write(kvp.Key.ToString());
-                    Write(kvp.Value.ToString());
+                    nameValueListBuffer.Add(kvp);
                 }
             }
-            else
+
+            WriteNameValueList();
+        }
+
+        private void WriteNameValueList()
+        {
+            if (nameValueListBuffer.Count == 0)
             {
-                Write(false);
+                Write((byte)0);
+                return;
             }
+
+            HashKey hash = HashAllStrings(nameValueListBuffer);
+            if (!nameValueListHashes.TryGetValue(hash, out var recordId))
+            {
+                recordId = nameValueRecordId;
+                nameValueListHashes[hash] = nameValueRecordId;
+
+                WriteNameValueListRecord();
+
+                nameValueRecordId += 1;
+            }
+
+            Write(recordId);
+        }
+
+        /// <summary>
+        /// In the middle of writing the current record we may discover that we want to write another record
+        /// preceding the current one, specifically the list of names and values we want to reuse in the
+        /// future. As we are writing the current record to a MemoryStream first, it's OK to temporarily
+        /// switch to the direct underlying stream and write the NameValueList record first.
+        /// When the current record is done writing, the MemoryStream will flush to the underlying stream
+        /// and the current record will end up after the NameValueList record, as desired.
+        /// </summary>
+        private void WriteNameValueListRecord()
+        {
+            // Switch the binaryWriter used by the Write* methods to the direct underlying stream writer.
+            // We want this record to precede the record we're currently writing to currentRecordWriter
+            // which is backed by a MemoryStream buffer
+            binaryWriter = this.originalBinaryWriter;
+
+            Write(BinaryLogRecordKind.NameValueList);
+            Write(nameValueIndexListBuffer.Count);
+            for (int i = 0; i < nameValueListBuffer.Count; i++)
+            {
+                var kvp = nameValueIndexListBuffer[i];
+                Write(kvp.Key);
+                Write(kvp.Value);
+            }
+
+            // switch back to continue writing the current record to the memory stream
+            binaryWriter = this.currentRecordWriter;
+        }
+
+        /// <summary>
+        /// Compute the total hash of all items in the nameValueList
+        /// while simultaneously filling the nameValueIndexListBuffer with the individual
+        /// hashes of the strings, mirroring the strings in the original nameValueList.
+        /// This helps us avoid hashing strings twice (once to hash the string individually
+        /// and the second time when hashing it as part of the nameValueList)
+        /// </summary>
+        private HashKey HashAllStrings(List<KeyValuePair<string, string>> nameValueList)
+        {
+            HashKey hash = new HashKey();
+
+            nameValueIndexListBuffer.Clear();
+
+            for (int i = 0; i < nameValueList.Count; i++)
+            {
+                var kvp = nameValueList[i];
+                var (keyIndex, keyHash) = HashString(kvp.Key);
+                var (valueIndex, valueHash) = HashString(kvp.Value);
+                hash = hash.Add(keyHash);
+                hash = hash.Add(valueHash);
+                nameValueIndexListBuffer.Add(new KeyValuePair<int, int>(keyIndex, valueIndex));
+            }
+
+            return hash;
         }
 
         private void Write(BinaryLogRecordKind kind)
@@ -718,34 +907,63 @@ namespace Microsoft.Build.Logging
             binaryWriter.Write(bytes);
         }
 
+        private void Write(byte b)
+        {
+            binaryWriter.Write(b);
+        }
+
         private void Write(bool boolean)
         {
             binaryWriter.Write(boolean);
         }
 
-        private void Write(string text)
+        private void WriteDeduplicatedString(string text)
         {
-            if (text != null)
-            {
-                binaryWriter.Write(text);
-            }
-            else
-            {
-                binaryWriter.Write(false);
-            }
+            var (recordId, _) = HashString(text);
+            Write(recordId);
         }
 
-        private void WriteOptionalString(string text)
+        /// <summary>
+        /// Hash the string and write a String record if not already hashed.
+        /// </summary>
+        /// <returns>Returns the string record index as well as the hash.</returns>
+        private (int index, HashKey hash) HashString(string text)
         {
             if (text == null)
             {
-                Write(false);
+                return (0, default);
             }
-            else
+            else if (text.Length == 0)
             {
-                Write(true);
-                Write(text);
+                return (1, default);
             }
+
+            var hash = new HashKey(text);
+            if (!stringHashes.TryGetValue(hash, out var recordId))
+            {
+                recordId = stringRecordId;
+                stringHashes[hash] = stringRecordId;
+
+                WriteStringRecord(text);
+
+                stringRecordId += 1;
+            }
+
+            return (recordId, hash);
+        }
+
+        private void WriteStringRecord(string text)
+        {
+            // Switch the binaryWriter used by the Write* methods to the direct underlying stream writer.
+            // We want this record to precede the record we're currently writing to currentRecordWriter
+            // which is backed by a MemoryStream buffer
+            binaryWriter = this.originalBinaryWriter;
+
+            Write(BinaryLogRecordKind.String);
+            binaryWriter.Write(text);
+
+            // switch back to continue writing the current record to the memory stream
+            binaryWriter = this.currentRecordWriter;
         }
 
         private void Write(DateTime timestamp)
@@ -761,10 +979,10 @@ namespace Microsoft.Build.Logging
 
         private void Write(EvaluationLocation item)
         {
-            WriteOptionalString(item.ElementName);
-            WriteOptionalString(item.ElementDescription);
-            WriteOptionalString(item.EvaluationPassDescription);
-            WriteOptionalString(item.File);
+            WriteDeduplicatedString(item.ElementName);
+            WriteDeduplicatedString(item.ElementDescription);
+            WriteDeduplicatedString(item.EvaluationPassDescription);
+            WriteDeduplicatedString(item.File);
             Write((int)item.Kind);
             Write((int)item.EvaluationPass);
 
@@ -787,6 +1005,90 @@ namespace Microsoft.Build.Logging
             Write(e.NumberOfHits);
             Write(e.ExclusiveTime);
             Write(e.InclusiveTime);
+        }
+
+        internal readonly struct HashKey : IEquatable<HashKey>
+        {
+            private readonly ulong value;
+
+            private HashKey(ulong i)
+            {
+                value = i;
+            }
+
+            public HashKey(string text)
+            {
+                if (text == null)
+                {
+                    value = 0;
+                }
+                else
+                {
+                    value = FnvHash64.GetHashCode(text);
+                }
+            }
+
+            public static HashKey Combine(HashKey left, HashKey right)
+            {
+                return new HashKey(FnvHash64.Combine(left.value, right.value));
+            }
+
+            public HashKey Add(HashKey other) => Combine(this, other);
+
+            public bool Equals(HashKey other)
+            {
+                return value == other.value;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is HashKey other)
+                {
+                    return Equals(other);
+                }
+
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return unchecked((int)value);
+            }
+
+            public override string ToString()
+            {
+                return value.ToString();
+            }
+        }
+
+        internal static class FnvHash64
+        {
+            public const ulong Offset = 14695981039346656037;
+            public const ulong Prime = 1099511628211;
+
+            public static ulong GetHashCode(string text)
+            {
+                ulong hash = Offset;
+
+                unchecked
+                {
+                    for (int i = 0; i < text.Length; i++)
+                    {
+                        char ch = text[i];
+                        hash = (hash ^ ch) * Prime;
+                    }
+                }
+
+                return hash;
+            }
+
+            public static ulong Combine(ulong left, ulong right)
+            {
+                unchecked
+                {
+                    return (left ^ right) * Prime;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
When writing out a binary log we now deduplicate strings and dictionaries. This results in a significant performance increase and binlog size reduction. Performance increase is about 2x on average, size reduction is about 4x on average, but up to 30x for large binlogs.

Add two new record kinds: String and NameValueList. A string record is written the first time we encounter a string we need to serialize. The next time we see the string we only write its index in the total list of strings.

Similarly, NameValueList is a list of key and value strings, used for Properties, environment variables and Item metadata. The first time we're writing out a list we write a record, and subsequent times just the index.

This keeps the binlog format streaming, so if the logging is interrupted midway, we will be able to read everything up to that point.

We do not hold on to strings we encountered. Instead we hash them and only preserve the hash code. We rely on the hash function resulting in no collisions, otherwise it could happen that a random string in a binlog would be substituted instead of another one. The hashtables do not significantly add to MSBuild memory usage (20-30 MB for our largest binlogs).

FNV-1a (64-bit hash size) was a carefully chosen hash function for its simplicity, performance, and lack of collisions on all binlogs tested so far. 32-bit hash size (such as string.GetHashCode() was not sufficient and resulted in ~800 collisions for our largest binlog with 2.7 million strings.

This change includes other performance improvements such as inserting a BufferedStream around the stream we're reading or writing. This results in a significant performance improvement.

We introduce a new StringStorage data structure in the binlog reader, for storing the strings on disk instead of reading them all into memory. Strings are loaded into memory on demand. This prevents OOM in 32-bit MSBuild processes when playing back large binlogs. This keeps the memory usage relatively flat when reading.

### Testing

I've done extensive testing for correctness, performance, and hash collisions and performance.

Hash function selection is documented here:
https://github.com/KirillOsenkov/MSBuildStructuredLog/wiki/String-Hashing
In summary, Fnv-1a provides no collisions with 64-bit hash size, and very decent performance (11 seconds to hash all the strings in our largest binlog, 2.7 million strings). Additionally it's very simple and minimal code.

Playback:
I've tested various scenarios for playback:
 1. binlog format
   - playing back a legacy binlog (format version < 10), with no String or NameValueList records
   - playing back version 10 binlog
 2. process bitness
   - on 32-bit we need to use the StringStorage helper class when reading new binlogs, to avoid OOM
   - on 32-bit we're fine when reading legacy binlogs as they're fully streaming
   - on 64-bit we just store all strings in memory, and it results in much faster performance
 
The data looks good:
![image](https://user-images.githubusercontent.com/679326/104138799-5f3e9b80-535b-11eb-8362-3dcfd3d73ed8.png)

### Binlog size reduction:

Strings: | Binlog: | Legacy binlog size (KB) | New binlog size (KB)
-- | -- | -- | --
2,744,490 | vswin.binlog | 703,863 | 274,714
2,711,714 | 790.binlog | 791,488 | 283,364
1,633,734 | 23GB.binlog | 22,558,820 | 172,617
681,346 | mmitche.binlog | 590,938 | 157,915
302,685 | roslyn.binlog | 194,354 | 49,277
288,136 | dotnet.binlog | 64,577 | 24,599
220,177 | vsmac.binlog | 143,178 | 35,095
42,658 | Ide.binlog | 20,753 | 12,334

Playback of binlog into binlog, perf improvement:
Playback of legacy vswin.binlog by legacy: 6:54
Playback of legacy vswin.binlog by new: 2:56
Playback of new vswin.binlog on 32-bit: 3:17
Playback of new vswin.binlog on 64-bit: 2:13

In summary, I expect builds to be faster (up to 4 minutes improvement for really large builds) and binlogs to be smaller (up to 50% for small binlogs, 2-4x for medium size, and 131x (from 23 GB to 172 MB) for our most extreme binlog.


