### PR TITLE
Added Include/Exclude filtering capability to Unzip Task (#5169)

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1217,6 +1217,8 @@ namespace Microsoft.Build.Tasks
         public Unzip() { }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+        public string Exclude { get { throw null; } set { } }
+        public string Include { get { throw null; } set { } }
         public bool OverwriteReadOnlyFiles { get { throw null; } set { } }
         public bool SkipUnchangedFiles { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -894,6 +894,8 @@ namespace Microsoft.Build.Tasks
         public Unzip() { }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+        public string Exclude { get { throw null; } set { } }
+        public string Include { get { throw null; } set { } }
         public bool OverwriteReadOnlyFiles { get { throw null; } set { } }
         public bool SkipUnchangedFiles { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Shared
         private static readonly char[] s_wildcardCharacters = { '*', '?' };
         private static readonly char[] s_wildcardAndSemicolonCharacters = { '*', '?', ';' };
 
-        private static readonly string[] s_propertyReferences = { "$(", "@(" };
+        private static readonly string[] s_propertyAndItemReferences = { "$(", "@(" };
 
         // on OSX both System.IO.Path separators are '/', so we have to use the literals
         internal static readonly char[] directorySeparatorCharacters = { '/', '\\' };
@@ -195,16 +195,16 @@ namespace Microsoft.Build.Shared
             return
 
                 (-1 != filespec.IndexOfAny(s_wildcardAndSemicolonCharacters)) ||
-                HasPropertyReferences(filespec)
+                HasPropertyOrItemReferences(filespec)
                 ;
         }
 
         /// <summary>
         /// Determines whether the given path has any property references.
         /// </summary>
-        internal static bool HasPropertyReferences(string filespec)
+        internal static bool HasPropertyOrItemReferences(string filespec)
         {
-            return s_propertyReferences.Aggregate(false, (current, propertyReference) => current | filespec.Contains(propertyReference));
+            return s_propertyAndItemReferences.Aggregate(false, (current, propertyReference) => current | filespec.Contains(propertyReference));
         }
 
         /// <summary>

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Build.Shared
         private static readonly char[] s_wildcardCharacters = { '*', '?' };
         private static readonly char[] s_wildcardAndSemicolonCharacters = { '*', '?', ';' };
 
+        private static readonly string[] s_propertyReferences = { "$(", "@(" };
+
         // on OSX both System.IO.Path separators are '/', so we have to use the literals
         internal static readonly char[] directorySeparatorCharacters = { '/', '\\' };
         internal static readonly string[] directorySeparatorStrings = directorySeparatorCharacters.Select(c => c.ToString()).ToArray();
@@ -166,8 +168,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Determines whether the given path has any wild card characters.
         /// </summary>
-        /// <param name="filespec"></param>
-        /// <returns></returns>
         internal static bool HasWildcards(string filespec)
         {
             // Perf Note: Doing a [Last]IndexOfAny(...) is much faster than compiling a
@@ -180,16 +180,31 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
-        /// Determines whether the given path has any wild card characters or any semicolons.
+        /// Determines whether the given path has any wild card characters or semicolons.
+        /// </summary>
+        internal static bool HasWildcardsOrSemicolon(string filespec)
+        {
+            return -1 != filespec.LastIndexOfAny(s_wildcardAndSemicolonCharacters);
+        }
+
+        /// <summary>
+        /// Determines whether the given path has any wild card characters, any semicolons or any property references.
         /// </summary>
         internal static bool HasWildcardsSemicolonItemOrPropertyReferences(string filespec)
         {
             return
 
                 (-1 != filespec.IndexOfAny(s_wildcardAndSemicolonCharacters)) ||
-                filespec.Contains("$(") ||
-                filespec.Contains("@(")
+                HasPropertyReferences(filespec)
                 ;
+        }
+
+        /// <summary>
+        /// Determines whether the given path has any property references.
+        /// </summary>
+        internal static bool HasPropertyReferences(string filespec)
+        {
+            return s_propertyReferences.Aggregate(false, (current, propertyReference) => current | filespec.Contains(propertyReference));
         }
 
         /// <summary>

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static bool HasPropertyOrItemReferences(string filespec)
         {
-            return s_propertyAndItemReferences.Any(ref=> filespec.Contains(ref));
+            return s_propertyAndItemReferences.Any(filespec.Contains);
         }
 
         /// <summary>

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static bool HasPropertyOrItemReferences(string filespec)
         {
-            return s_propertyAndItemReferences.Aggregate(false, (current, propertyReference) => current | filespec.Contains(propertyReference));
+            return s_propertyAndItemReferences.Any(ref=> filespec.Contains(ref));
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -245,6 +245,35 @@ namespace Microsoft.Build.Tasks.UnitTests
         }
 
         [Fact]
+        public void CanUnzip_WithExcludeFilter()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                testEnvironment.CreateFile(source, "BE78A17D30144B549D21F71D5C633F7D.txt", "file1");
+                testEnvironment.CreateFile(source, "A04FF4B88DF14860B7C73A8E75A4FB76.txt", "file2");
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
+
+                Unzip unzip = new Unzip
+                                  {
+                                      BuildEngine = _mockEngine,
+                                      DestinationFolder = new TaskItem(destination.Path),
+                                      OverwriteReadOnlyFiles = true,
+                                      SkipUnchangedFiles = false,
+                                      SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
+                                      Exclude = "BE78A17D30144B549D21F71D5C633F7D"
+                                  };
+
+                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
         public void CanUnzip_WithIncludeAndExcludeFilter()
         {
             using (TestEnvironment testEnvironment = TestEnvironment.Create())

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                                       OverwriteReadOnlyFiles = true,
                                       SkipUnchangedFiles = false,
                                       SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
-                                      Include = "<BE78A17D30144B549D21F71D5C633F7D/.txt"
+                                      Include = "<BE78A17D30144B|549D21F71D5C633F7D/.txt"
                                   };
 
                 unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
@@ -387,7 +387,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                                       OverwriteReadOnlyFiles = true,
                                       SkipUnchangedFiles = false,
                                       SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
-                                      Exclude = "<BE78A17D30144B549D21F71D5C633F7D/.txt"
+                                      Exclude = "<BE78A17D30144B|549D21F71D5C633F7D/.txt"
                                   };
 
                 unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                                       OverwriteReadOnlyFiles = true,
                                       SkipUnchangedFiles = false,
                                       SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
-                                      Include = "<BE78A17D30144B549D21F71D5C633F7D>.txt"
+                                      Include = "<BE78A17D30144B549D21F71D5C633F7D/.txt"
                                   };
 
                 unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
@@ -385,7 +385,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                                       OverwriteReadOnlyFiles = true,
                                       SkipUnchangedFiles = false,
                                       SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
-                                      Exclude = "<BE78A17D30144B549D21F71D5C633F7D>.txt"
+                                      Exclude = "<BE78A17D30144B549D21F71D5C633F7D/.txt"
                                   };
 
                 unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -309,5 +309,117 @@ namespace Microsoft.Build.Tasks.UnitTests
                 _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "sub", "subfile.js"), () => _mockEngine.Log);
             }
         }
+
+        [Fact]
+        public void LogsErrorIfIncludeContainsInvalidPathCharacters()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                testEnvironment.CreateFile(source, "BE78A17D30144B549D21F71D5C633F7D.txt", "file1");
+                testEnvironment.CreateFile(source, "A04FF4B88DF14860B7C73A8E75A4FB76.txt", "file2");
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
+
+                Unzip unzip = new Unzip
+                                  {
+                                      BuildEngine = _mockEngine,
+                                      DestinationFolder = new TaskItem(destination.Path),
+                                      OverwriteReadOnlyFiles = true,
+                                      SkipUnchangedFiles = false,
+                                      SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
+                                      Include = "<BE78A17D30144B549D21F71D5C633F7D>.txt"
+                                  };
+
+                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain("MSB3937", () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
+        public void LogsErrorIfIncludeContainsPropertyReferences()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                testEnvironment.CreateFile(source, "BE78A17D30144B549D21F71D5C633F7D.txt", "file1");
+                testEnvironment.CreateFile(source, "A04FF4B88DF14860B7C73A8E75A4FB76.txt", "file2");
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
+
+                Unzip unzip = new Unzip
+                                  {
+                                      BuildEngine = _mockEngine,
+                                      DestinationFolder = new TaskItem(destination.Path),
+                                      OverwriteReadOnlyFiles = true,
+                                      SkipUnchangedFiles = false,
+                                      SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
+                                      Include = "$(Include)"
+                                  };
+
+                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain("MSB3938", () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
+        public void LogsErrorIfExcludeContainsInvalidPathCharacters()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                testEnvironment.CreateFile(source, "BE78A17D30144B549D21F71D5C633F7D.txt", "file1");
+                testEnvironment.CreateFile(source, "A04FF4B88DF14860B7C73A8E75A4FB76.txt", "file2");
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
+
+                Unzip unzip = new Unzip
+                                  {
+                                      BuildEngine = _mockEngine,
+                                      DestinationFolder = new TaskItem(destination.Path),
+                                      OverwriteReadOnlyFiles = true,
+                                      SkipUnchangedFiles = false,
+                                      SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
+                                      Exclude = "<BE78A17D30144B549D21F71D5C633F7D>.txt"
+                                  };
+
+                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain("MSB3937", () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
+        public void LogsErrorIfExcludeContainsPropertyReferences()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                testEnvironment.CreateFile(source, "BE78A17D30144B549D21F71D5C633F7D.txt", "file1");
+                testEnvironment.CreateFile(source, "A04FF4B88DF14860B7C73A8E75A4FB76.txt", "file2");
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
+
+                Unzip unzip = new Unzip
+                                  {
+                                      BuildEngine = _mockEngine,
+                                      DestinationFolder = new TaskItem(destination.Path),
+                                      OverwriteReadOnlyFiles = true,
+                                      SkipUnchangedFiles = false,
+                                      SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
+                                      Exclude = "$(Include)"
+                                  };
+
+                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain("MSB3938", () => _mockEngine.Log);
+            }
+        }
     }
 }

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -310,6 +310,7 @@ namespace Microsoft.Build.Tasks.UnitTests
             }
         }
 
+        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
         public void LogsErrorIfIncludeContainsInvalidPathCharacters()
         {
@@ -366,6 +367,7 @@ namespace Microsoft.Build.Tasks.UnitTests
             }
         }
 
+        [PlatformSpecific(TestPlatforms.Windows)] 
         [Fact]
         public void LogsErrorIfExcludeContainsInvalidPathCharacters()
         {

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -280,9 +280,10 @@ namespace Microsoft.Build.Tasks.UnitTests
             {
                 TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
                 TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
-                testEnvironment.CreateFile(source, "BE78A17D30144B549D21F71D5C633F7D.txt", "file1");
-                testEnvironment.CreateFile(source, "A04FF4B88DF14860B7C73A8E75A4FB76.txt", "file2");
-                testEnvironment.CreateFile(source, "191CD39C4DCF4749A29887E496D0F141.txt", "file3");
+                testEnvironment.CreateFile(source, "file1.js", "file1");
+                testEnvironment.CreateFile(source, "file1.js.map", "file2");
+                testEnvironment.CreateFile(source, "file2.js", "file3");
+                testEnvironment.CreateFile(source, "readme.txt", "file4");
 
                 TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
 
@@ -293,15 +294,16 @@ namespace Microsoft.Build.Tasks.UnitTests
                                       OverwriteReadOnlyFiles = true,
                                       SkipUnchangedFiles = false,
                                       SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
-                                      Include = "BE78A17D30144B549D21F71D5C633F7D",
-                                      Exclude = "A04FF4B88DF14860B7C73A8E75A4FB76"
+                                      Include = ".*?\\.js",
+                                      Exclude = ".*?\\.js\\.map"
                                   };
 
                 unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "191CD39C4DCF4749A29887E496D0F141.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "file1.js"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "file1.js.map"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "file2.js"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "readme.txt"), () => _mockEngine.Log);
             }
         }
     }

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                                       OverwriteReadOnlyFiles = true,
                                       SkipUnchangedFiles = false,
                                       SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
-                                      Include = "BE78A17D30144B549D21F71D5C633F7D"
+                                      Include = "BE78A17D30144B549D21F71D5C633F7D.txt"
                                   };
 
                 unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
@@ -263,7 +263,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                                       OverwriteReadOnlyFiles = true,
                                       SkipUnchangedFiles = false,
                                       SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
-                                      Exclude = "BE78A17D30144B549D21F71D5C633F7D"
+                                      Exclude = "BE78A17D30144B549D21F71D5C633F7D.txt"
                                   };
 
                 unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
@@ -280,10 +280,12 @@ namespace Microsoft.Build.Tasks.UnitTests
             {
                 TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
                 TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                TransientTestFolder sub = source.CreateDirectory("sub");
                 testEnvironment.CreateFile(source, "file1.js", "file1");
                 testEnvironment.CreateFile(source, "file1.js.map", "file2");
                 testEnvironment.CreateFile(source, "file2.js", "file3");
                 testEnvironment.CreateFile(source, "readme.txt", "file4");
+                testEnvironment.CreateFile(sub, "subfile.js", "File5");
 
                 TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
 
@@ -294,8 +296,8 @@ namespace Microsoft.Build.Tasks.UnitTests
                                       OverwriteReadOnlyFiles = true,
                                       SkipUnchangedFiles = false,
                                       SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
-                                      Include = ".*?\\.js",
-                                      Exclude = ".*?\\.js\\.map"
+                                      Include = "*.js",
+                                      Exclude = "*.js.map;sub\\*.js"
                                   };
 
                 unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
@@ -304,6 +306,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "file1.js.map"), () => _mockEngine.Log);
                 _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "file2.js"), () => _mockEngine.Log);
                 _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "readme.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "sub", "subfile.js"), () => _mockEngine.Log);
             }
         }
     }

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -310,7 +310,6 @@ namespace Microsoft.Build.Tasks.UnitTests
             }
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
         public void LogsErrorIfIncludeContainsInvalidPathCharacters()
         {
@@ -367,7 +366,6 @@ namespace Microsoft.Build.Tasks.UnitTests
             }
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)] 
         [Fact]
         public void LogsErrorIfExcludeContainsInvalidPathCharacters()
         {

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -214,5 +214,66 @@ namespace Microsoft.Build.Tasks.UnitTests
                 _mockEngine.Log.ShouldContain("MSB3932", () => _mockEngine.Log);
             }
         }
+
+        [Fact]
+        public void CanUnzip_WithIncludeFilter()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                testEnvironment.CreateFile(source, "BE78A17D30144B549D21F71D5C633F7D.txt", "file1");
+                testEnvironment.CreateFile(source, "A04FF4B88DF14860B7C73A8E75A4FB76.txt", "file2");
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
+
+                Unzip unzip = new Unzip
+                                  {
+                                      BuildEngine = _mockEngine,
+                                      DestinationFolder = new TaskItem(destination.Path),
+                                      OverwriteReadOnlyFiles = true,
+                                      SkipUnchangedFiles = false,
+                                      SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
+                                      Include = "BE78A17D30144B549D21F71D5C633F7D"
+                                  };
+
+                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
+        public void CanUnzip_WithIncludeAndExcludeFilter()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                testEnvironment.CreateFile(source, "BE78A17D30144B549D21F71D5C633F7D.txt", "file1");
+                testEnvironment.CreateFile(source, "A04FF4B88DF14860B7C73A8E75A4FB76.txt", "file2");
+                testEnvironment.CreateFile(source, "191CD39C4DCF4749A29887E496D0F141.txt", "file3");
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
+
+                Unzip unzip = new Unzip
+                                  {
+                                      BuildEngine = _mockEngine,
+                                      DestinationFolder = new TaskItem(destination.Path),
+                                      OverwriteReadOnlyFiles = true,
+                                      SkipUnchangedFiles = false,
+                                      SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
+                                      Include = "BE78A17D30144B549D21F71D5C633F7D",
+                                      Exclude = "A04FF4B88DF14860B7C73A8E75A4FB76"
+                                  };
+
+                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "191CD39C4DCF4749A29887E496D0F141.txt"), () => _mockEngine.Log);
+            }
+        }
     }
 }

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2789,6 +2789,14 @@
     <value>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</value>
     <comment>{StrBegin="MSB3936: "}</comment>
   </data>
+  <data name="Unzip.ErrorParsingPatternInvalidPath">
+    <value>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</value>
+    <comment>{StrBegin="MSB3937: "}</comment>
+  </data>
+  <data name="Unzip.ErrorParsingPatternPropertyReferences">
+    <value>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</value>
+    <comment>{StrBegin="MSB3938: "}</comment>
+  </data>
   <data name="Unzip.DidNotUnzipBecauseOfFileMatch">
     <value>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</value>
   </data>

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2793,7 +2793,7 @@
     <value>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</value>
   </data>
   <data name="Unzip.DidNotUnzipBecauseOfFilter">
-    <value>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</value>
+    <value>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</value>
   </data>
   <data name="Unzip.FileComment">
     <value>Unzipping file "{0}" to "{1}".</value>

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2792,6 +2792,9 @@
   <data name="Unzip.DidNotUnzipBecauseOfFileMatch">
     <value>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</value>
   </data>
+  <data name="Unzip.DidNotUnzipBecauseOfFilter">
+    <value>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</value>
+  </data>
   <data name="Unzip.FileComment">
     <value>Unzipping file "{0}" to "{1}".</value>
   </data>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: Soubor {0} se nepodařilo rozzipovat, protože neexistuje nebo není přístupný.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">Soubor {0} se rozzipovává do {1}.</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">Rozzipování ze souboru {0} do souboru {1} neproběhlo, protože parametr {2} byl v projektu nastaven na hodnotu {3} a velikosti souborů a časová razítka se shodují.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: Rozzipování do adresáře {0} se nepodařilo, protože ho nebylo možné vytvořit. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">Die Datei "{0}" wurde nicht in die Datei "{1}" entzippt, weil der Parameter "{2}" im Projekt auf "{3}" festgelegt war und die Größen und Zeitstempel der Dateien übereinstimmen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: Fehler beim Entzippen in das Verzeichnis "{0}", weil dieses nicht erstellt werden konnte.  {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: Die Datei "{0}" konnte nicht entzippt werden, weil sie nicht vorhanden ist oder nicht darauf zugegriffen werden kann.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">Die Datei "{0}" wird in "{1}" entzippt.</target>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -2530,6 +2530,11 @@
         <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -2531,8 +2531,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -2565,6 +2565,16 @@
         <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="new">Unzipping file "{0}" to "{1}".</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: No se pudo descomprimir el archivo "{0}" porque no existe o no se puede tener acceso a él.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">Descomprimiendo el archivo "{0}" en "{1}".</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">No se descomprimió del archivo "{0}" en el archivo "{1}" porque el parámetro "{2}" se estableció como "{3}" en el proyecto y los tamaños y las marcas de tiempo de los archivos coinciden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: No se pudo descomprimir en el directorio "{0}" porque no se pudo crear.  {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: Échec de la décompression du fichier "{0}", car le fichier n'existe pas ou est inaccessible.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">Décompression du fichier "{0}" dans "{1}".</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">Impossible de décompresser le fichier "{0}" vers le fichier "{1}", car le paramètre "{2}" a la valeur "{3}" dans le projet, et les tailles et horodatages des fichiers correspondent.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: Échec de la décompression dans le répertoire "{0}", car il n'a pas pu être créé. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">Non è stato possibile decomprimere il file "{0}" nel file "{1}". Il parametro "{2}" è stato impostato su "{3}" nel progetto e le dimensioni e il timestamp dei file corrispondono.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: non è stato possibile decomprimere nella directory "{0}" perché non è stato possibile crearla. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: non è stato possibile decomprimere il file "{0}" perché non esiste oppure è inaccessibile.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">Decompressione del file "{0}" in "{1}".</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">"{2}" パラメーターがプロジェクトで "{3}" に設定されているため、またファイルのサイズとタイムスタンプが一致するため、ファイル "{0}" からファイル "{1}" に解凍しませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: ディレクトリ "{0}" への解凍は、そのディレクトリを作成できなかったため、失敗しました。{1}</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: ファイルが存在しないか、アクセスできないため、ファイル "{0}" を解凍できませんでした。</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">ファイル "{0}" を "{1}" に解凍しています。</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: 파일이 존재하지 않거나 액세스할 수 없기 때문에 파일 "{0}"의 압축을 풀지 못했습니다.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">파일 "{0}"의 압축을 "{1}"에 푸는 중입니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">"{2}" 매개 변수가 프로젝트에 "{3}"(으)로 설정되었고 파일 크기와 타임스탬프가 일치하기 때문에 "{0}" 파일에서 "{1}" 파일로 압축을 풀 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: "{0}" 디렉터리를 생성할 수 없기 때문에 이 디렉터리에 압축을 풀지 못했습니다.  {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: Nie można rozpakować pliku „{0}”, ponieważ plik nie istnieje lub jest niedostępny.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">Rozpakowywanie pliku „{0}” do pliku „{1}”.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">Nie wykonano rozpakowywania z pliku „{0}” do pliku „{1}”, ponieważ parametr „{2}” w projekcie został ustawiony na wartość „{3}”, a rozmiary plików i sygnatury czasowe pasują do siebie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: Nie można rozpakować do katalogu „{0}”, ponieważ nie można go utworzyć. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">Não foi possível descompactar o arquivo "{0}" para o arquivo "{1}", pois o parâmetro "{2}" foi definido como "{3}" no projeto, e os tamanhos de arquivos e os carimbos de data/hora não correspondem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: Falha ao descompactar no diretório "{0}" porque ele não pôde ser criado. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: Falha ao descompactar o arquivo "{0}" porque ele não existe ou está inacessível.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">Descompactando o arquivo "{0}" em "{1}".</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: не удалось распаковать файл "{0}", так как он не существует или недоступен.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">Распаковка файла "{0}" в"{1}".</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">Не удалось выполнить распаковку из файла "{0}" в файл "{1}", так как для параметра "{2}" в проекте было задано значение "{3}", а размеры файлов и отметки времени совпадают.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: не удалось выполнить распаковку в каталог "{0}", так как создать его не удалось. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">Projede "{2}" parametresi "{3}" olarak ayarlandığından ve dosya boyutlarıyla zaman damgaları eşleştiğinden "{0}" dosyasını "{1}" dosyasına çıkarma işlemi gerçekleştirilmedi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: "{0}" dizini oluşturulamadığından bu dizine çıkarılamadı. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: Dosya mevcut olmadığından veya erişilebilir olmadığından "{0}" dosyasının sıkıştırması açılamadı.</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">"{0}" dosyasının sıkıştırması "{1}" hedefine açılıyor.</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">未从文件“{0}”解压缩到文件“{1}”，因为“{2}”参数在项目中设置为“{3}”，而两个文件的大小及时间戳一致。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: 未能解压缩到目录“{0}”，因为无法创建它。{1}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: 未能解压缩文件“{0}”，因为该文件不存在或无法访问。</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">将文件“{0}”解压缩到“{1}”。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -2481,8 +2481,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
-        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
-        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <source>Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include filter or because it matched the exclude filter.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -2480,6 +2480,11 @@
         <target state="translated">並未從檔案 "{0}" 解壓縮到檔案 "{1}"，因為在專案中的 "{2}" 參數原先設定為 "{3}"，且檔案的大小與時間戳記相符。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFilter">
+        <source>Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</source>
+        <target state="new">Did not unzip file "{0}" because it didn't match the include or matched the exclude filter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
         <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
         <target state="translated">MSB3931: 因為無法建立目錄 "{0}"，所以無法解壓縮至該目錄。{1}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -2515,6 +2515,16 @@
         <target state="translated">MSB3932: 因為檔案不存在或無法存取，所以無法解壓縮檔案 "{0}"。</target>
         <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternInvalidPath">
+        <source>MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</source>
+        <target state="new">MSB3937: Failed to parse pattern "{0}" because it contains an invalid path character.</target>
+        <note>{StrBegin="MSB3937: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorParsingPatternPropertyReferences">
+        <source>MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</source>
+        <target state="new">MSB3938: Failed to parse pattern "{0}" because it contains a property reference which isn't supported.</target>
+        <note>{StrBegin="MSB3938: "}</note>
+      </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
         <target state="translated">正在將檔案 "{0}" 解壓縮到 "{1}"。</target>

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Build.Tasks
         public string Include { get; set; }
 
         /// <summary>
-        /// Gets or sets a glob expression that will be used to determine which files to exclude from being unzipped from the archive.
+        /// Gets or sets an MSBuild glob expression that will be used to determine which files to exclude from being unzipped from the archive.
         /// </summary>
         public string Exclude { get; set; }
 

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -246,12 +246,7 @@ namespace Microsoft.Build.Tasks
 
             if (_excludePatterns.Length > 0)
             {
-                result |= _excludePatterns.Aggregate(
-                    false,
-                    (current, pattern) => current | FileMatcher.IsMatch(
-                                              FileMatcher.Normalize(zipArchiveEntry.FullName),
-                                              pattern,
-                                              true));
+                result |= _excludePatterns.Any(pattern => FileMatcher.IsMatch(FileMatcher.Normalize(zipArchiveEntry.FullName), pattern, true));
             }
 
             return result;

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -241,12 +241,7 @@ namespace Microsoft.Build.Tasks
 
             if (_includePatterns.Length > 0)
             {
-                result |= _includePatterns.Aggregate(
-                    false,
-                    (current, pattern) => current | !FileMatcher.IsMatch(
-                                              FileMatcher.Normalize(zipArchiveEntry.FullName),
-                                              pattern,
-                                              true));
+                result = _includePatterns.All(pattern => !FileMatcher.IsMatch(FileMatcher.Normalize(zipArchiveEntry.FullName), pattern, true));
             }
 
             if (_excludePatterns.Length > 0)

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -53,12 +53,12 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Gets or sets a regular expression that will be used to include files to be unzipped.
         /// </summary>
-        public string Include { get; set; }
+        public string IncludePattern { get; set; }
 
         /// <summary>
         /// Gets or sets a regular expression that will be used to exclude files to be unzipped.
         /// </summary>
-        public string Exclude { get; set; }
+        public string ExcludePattern { get; set; }
 
         /// <inheritdoc cref="ICancelableTask.Cancel"/>
         public void Cancel()

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Build.Tasks
                             // Should only be thrown if the archive could not be opened (Access denied, corrupt file, etc)
                             Log.LogErrorWithCodeFromResources("Unzip.ErrorCouldNotOpenFile", sourceFile.ItemSpec, e.Message);
                         }
-                    } 
+                    }
                 }
             }
             finally
@@ -294,19 +294,17 @@ namespace Microsoft.Build.Tasks
                 // Supporting property references would require access to Expander which is unavailable in Microsoft.Build.Tasks
                 Log.LogErrorWithCodeFromResources("Unzip.ErrorParsingPatternPropertyReferences", pattern);
             }
+            else if (pattern.IndexOfAny(FileUtilities.InvalidPathChars) != -1)
+            {
+                Log.LogErrorWithCodeFromResources("Unzip.ErrorParsingPatternInvalidPath", pattern);
+            }
             else
             {
                 patterns = pattern.Contains(';')
                                ? pattern.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(FileMatcher.Normalize).ToArray()
                                : new[] { pattern };
-                if (patterns.Any(p => p.IndexOfAny(Path.GetInvalidPathChars()) != -1))
-                {
-                    Log.LogErrorWithCodeFromResources("Unzip.ErrorParsingPatternInvalidPath", pattern);
-                }
-                else
-                {
-                    result = true;
-                }
+
+                result = true;
             }
 
             return result;

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Tasks
         public ITaskItem[] SourceFiles { get; set; }
 
         /// <summary>
-        /// Gets or sets a glob expression that will be used to determine which files to include being unzipped from the archive.
+        /// Gets or sets an MSBuild glob expression that will be used to determine which files to include being unzipped from the archive.
         /// </summary>
         public string Include { get; set; }
 

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Build.Tasks
             {
                 result = true;
             }
-            else if (FileMatcher.HasPropertyReferences(pattern))
+            else if (FileMatcher.HasPropertyOrItemReferences(pattern))
             {
                 // Supporting property references would require access to Expander which is unavailable in Microsoft.Build.Tasks
                 Log.LogErrorWithCodeFromResources("Unzip.ErrorParsingPatternPropertyReferences", pattern);


### PR DESCRIPTION
Fixes #5169

### Context
See #5169

### Changes Made
Unzip Task now has "Include" and "Exclude" optional properties to pass a pattern to filter archive entries to be unzipped.

### Testing
Added following tests:
- CanUnzip_WithIncludeFilter
- CanUnzip_WithExcludeFilter
- CanUnzip_WithIncludeAndExcludeFilter

These 3 test the ability to include/exclude files from the archive unzip.

### Notes
Unable to translate the resources to all languages. Can someone provide guidance/translations?