### PR TITLE
Remove myget feed references

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,9 +5,6 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="arcade" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
-    <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />


### PR DESCRIPTION
These have been deprecated and are now failing--see
https://github.com/dotnet/core-eng/wiki/MyGet-Migration-New-Homes
