### PR TITLE
Switch eng/common to linguist-vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,7 +20,7 @@ src/Tasks/*.targets linguist-detectable=true
 src/Tasks/*.tasks linguist-detectable=true
 
 # Don't include Arcade-owned path
-eng/common/** linguist-vendored
+eng/common/** linguist-vendored linguist-generated
 
 # Display XLF files collapsed by default in PR diffs
 *.xlf linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,7 +20,7 @@ src/Tasks/*.targets linguist-detectable=true
 src/Tasks/*.tasks linguist-detectable=true
 
 # Don't include Arcade-owned path
-eng/common/** linguist-detectable=false
+eng/common/** linguist-vendored
 
 # Display XLF files collapsed by default in PR diffs
 *.xlf linguist-generated=true


### PR DESCRIPTION
This is a more accurate description of what's going on here; the code canonically lives in `dotnet/arcade` and so is [vendored](https://github.com/github/linguist/blob/master/README.md#vendored-code) here.