### PR TITLE
Reduce byte array allocations when reading/writing packets

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -622,7 +622,7 @@ namespace Microsoft.Build.BackEnd
             /// <summary>
             /// A BinaryWriter to assist writing bytes to the buffer.
             /// </summary>
-            private BinaryWriter _writeBufferStreamWriter;
+            private BinaryWriter _writeBufferBinaryWriter;
 
             /// <summary>
             /// Event indicating the node has terminated.
@@ -654,9 +654,9 @@ namespace Microsoft.Build.BackEnd
                 _headerByte = new byte[5]; // 1 for the packet type, 4 for the body length
 
                 // packets get this large so avoid reallocations
-                _readBufferMemoryStream = new MemoryStream(MaxPacketWriteSize);
-                _writeBufferMemoryStream = new MemoryStream(MaxPacketWriteSize);
-                _writeBufferStreamWriter = new BinaryWriter(_writeBufferMemoryStream);
+                _readBufferMemoryStream = new MemoryStream();
+                _writeBufferMemoryStream = new MemoryStream();
+                _writeBufferBinaryWriter = new BinaryWriter(_writeBufferMemoryStream);
                 _nodeTerminated = new ManualResetEvent(false);
                 _terminateDelegate = terminateDelegate;
                 _sharedReadBuffer = InterningBinaryReader.CreateSharedBuffer();
@@ -750,14 +750,14 @@ namespace Microsoft.Build.BackEnd
                     _writeBufferMemoryStream.WriteByte((byte)packet.Type);
 
                     // Pad for the packet length
-                    _writeBufferStreamWriter.Write(0);
+                    _writeBufferBinaryWriter.Write(0);
                     packet.Translate(writeTranslator);
 
                     int writeStreamLength = (int)_writeBufferMemoryStream.Position;
 
                     // Now plug in the real packet length
                     _writeBufferMemoryStream.Position = 1;
-                    _writeBufferStreamWriter.Write(writeStreamLength - 5);
+                    _writeBufferBinaryWriter.Write(writeStreamLength - 5);
 
                     byte[] writeStreamBuffer = _writeBufferMemoryStream.GetBuffer();
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -764,25 +764,27 @@ namespace Microsoft.Build.BackEnd
 
             private void SendDataCore(INodePacket packet)
             {
-                // clear the buffer but keep the underlying capacity to avoid reallocations
-                _writeBufferMemoryStream.SetLength(0);
+                MemoryStream writeStream = _writeBufferMemoryStream;
 
-                ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(_writeBufferMemoryStream);
+                // clear the buffer but keep the underlying capacity to avoid reallocations
+                writeStream.SetLength(0);
+
+                ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(writeStream);
                 try
                 {
-                    _writeBufferMemoryStream.WriteByte((byte)packet.Type);
+                    writeStream.WriteByte((byte)packet.Type);
 
                     // Pad for the packet length
-                    WriteInt32(_writeBufferMemoryStream, 0);
+                    WriteInt32(writeStream, 0);
                     packet.Translate(writeTranslator);
 
-                    int writeStreamLength = (int)_writeBufferMemoryStream.Position;
+                    int writeStreamLength = (int)writeStream.Position;
 
                     // Now plug in the real packet length
-                    _writeBufferMemoryStream.Position = 1;
-                    WriteInt32(_writeBufferMemoryStream, writeStreamLength - 5);
+                    writeStream.Position = 1;
+                    WriteInt32(writeStream, writeStreamLength - 5);
 
-                    byte[] writeStreamBuffer = _writeBufferMemoryStream.GetBuffer();
+                    byte[] writeStreamBuffer = writeStream.GetBuffer();
 
                     for (int i = 0; i < writeStreamLength; i += MaxPacketWriteSize)
                     {

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -609,8 +609,20 @@ namespace Microsoft.Build.BackEnd
 
             /// <summary>
             /// A buffer typically big enough to handle a packet body.
+            /// We use this as a convenient way to manage and cache a byte[] that's resized
+            /// automatically to fit our payload.
             /// </summary>
-            private byte[] _smallReadBuffer;
+            private MemoryStream _readBufferMemoryStream;
+
+            /// <summary>
+            /// A buffer for writing packets.
+            /// </summary>
+            private MemoryStream _writeBufferMemoryStream;
+
+            /// <summary>
+            /// A BinaryWriter to assist writing bytes to the buffer.
+            /// </summary>
+            private BinaryWriter _writeBufferStreamWriter;
 
             /// <summary>
             /// Event indicating the node has terminated.
@@ -640,7 +652,11 @@ namespace Microsoft.Build.BackEnd
                 _serverToClientStream = nodePipe;
                 _packetFactory = factory;
                 _headerByte = new byte[5]; // 1 for the packet type, 4 for the body length
-                _smallReadBuffer = new byte[1000]; // 1000 was just an average seen on one profile run.
+
+                // packets get this large so avoid reallocations
+                _readBufferMemoryStream = new MemoryStream(MaxPacketWriteSize);
+                _writeBufferMemoryStream = new MemoryStream(MaxPacketWriteSize);
+                _writeBufferStreamWriter = new BinaryWriter(_writeBufferMemoryStream);
                 _nodeTerminated = new ManualResetEvent(false);
                 _terminateDelegate = terminateDelegate;
                 _sharedReadBuffer = InterningBinaryReader.CreateSharedBuffer();
@@ -685,16 +701,8 @@ namespace Microsoft.Build.BackEnd
                     NodePacketType packetType = (NodePacketType)_headerByte[0];
                     int packetLength = BitConverter.ToInt32(_headerByte, 1);
 
-                    byte[] packetData;
-                    if (packetLength < _smallReadBuffer.Length)
-                    {
-                        packetData = _smallReadBuffer;
-                    }
-                    else
-                    {
-                        // Preallocated buffer is not large enough to hold the body. Allocate now, but don't hold it forever.
-                        packetData = new byte[packetLength];
-                    }
+                    _readBufferMemoryStream.SetLength(packetLength);
+                    byte[] packetData = _readBufferMemoryStream.GetBuffer();
 
                     try
                     {
@@ -733,26 +741,30 @@ namespace Microsoft.Build.BackEnd
             /// <param name="packet">The packet to send.</param>
             public void SendData(INodePacket packet)
             {
-                MemoryStream writeStream = new MemoryStream();
-                ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(writeStream);
+                // clear the buffer but keep the underlying capacity to avoid reallocations
+                _writeBufferMemoryStream.SetLength(0);
+
+                ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(_writeBufferMemoryStream);
                 try
                 {
-                    writeStream.WriteByte((byte)packet.Type);
+                    _writeBufferMemoryStream.WriteByte((byte)packet.Type);
 
                     // Pad for the packet length
-                    writeStream.Write(BitConverter.GetBytes((int)0), 0, 4);
+                    _writeBufferStreamWriter.Write(0);
                     packet.Translate(writeTranslator);
 
+                    int writeStreamLength = (int)_writeBufferMemoryStream.Position;
+
                     // Now plug in the real packet length
-                    writeStream.Position = 1;
-                    writeStream.Write(BitConverter.GetBytes((int)writeStream.Length - 5), 0, 4);
+                    _writeBufferMemoryStream.Position = 1;
+                    _writeBufferStreamWriter.Write(writeStreamLength - 5);
 
-                    byte[] writeStreamBuffer = writeStream.GetBuffer();
+                    byte[] writeStreamBuffer = _writeBufferMemoryStream.GetBuffer();
 
-                    for (int i = 0; i < writeStream.Length; i += MaxPacketWriteSize)
+                    for (int i = 0; i < writeStreamLength; i += MaxPacketWriteSize)
                     {
-                        int lengthToWrite = Math.Min((int)writeStream.Length - i, MaxPacketWriteSize);
-                        if ((int)writeStream.Length - i <= MaxPacketWriteSize)
+                        int lengthToWrite = Math.Min(writeStreamLength - i, MaxPacketWriteSize);
+                        if (writeStreamLength - i <= MaxPacketWriteSize)
                         {
                             // We are done, write the last bit asynchronously.  This is actually the general case for
                             // most packets in the build, and the asynchronous behavior here is desirable.
@@ -770,7 +782,7 @@ namespace Microsoft.Build.BackEnd
                             // might want to send data immediately afterward, and that could result in overlapping writes
                             // to the pipe on different threads.
 #if FEATURE_APM
-                            IAsyncResult result = _serverToClientStream.BeginWrite(writeStream.GetBuffer(), i, lengthToWrite, null, null);
+                            IAsyncResult result = _serverToClientStream.BeginWrite(writeStreamBuffer, i, lengthToWrite, null, null);
                             _serverToClientStream.EndWrite(result);
 #else
                             _serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
@@ -887,16 +899,10 @@ namespace Microsoft.Build.BackEnd
                 int packetLength = BitConverter.ToInt32(_headerByte, 1);
                 MSBuildEventSource.Log.PacketReadSize(packetLength);
 
-                byte[] packetData;
-                if (packetLength < _smallReadBuffer.Length)
-                {
-                    packetData = _smallReadBuffer;
-                }
-                else
-                {
-                    // Preallocated buffer is not large enough to hold the body. Allocate now, but don't hold it forever.
-                    packetData = new byte[packetLength];
-                }
+                // Ensures the buffer is at least this length.
+                // It avoids reallocations if the buffer is already large enough.
+                _readBufferMemoryStream.SetLength(packetLength);
+                byte[] packetData = _readBufferMemoryStream.GetBuffer();
 
                 _clientToServerStream.BeginRead(packetData, 0, packetLength, BodyReadComplete, new Tuple<byte[], int>(packetData, packetLength));
             }

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Diagnostics;
 using System.Threading;
-#if !FEATURE_APM
 using System.Threading.Tasks;
-#endif
 using System.Runtime.InteropServices;
 #if FEATURE_PIPE_SECURITY
 using System.Security.Principal;
@@ -742,6 +741,29 @@ namespace Microsoft.Build.BackEnd
             /// <param name="packet">The packet to send.</param>
             public void SendData(INodePacket packet)
             {
+                _packetQueue.Add(packet);
+                DrainPacketQueue();
+            }
+
+            private BlockingCollection<INodePacket> _packetQueue = new BlockingCollection<INodePacket>();
+            private Task _packetDrainTask = Task.CompletedTask;
+
+            private void DrainPacketQueue()
+            {
+                lock (_packetQueue)
+                {
+                    _packetDrainTask = _packetDrainTask.ContinueWith(_ =>
+                    {
+                        while (_packetQueue.TryTake(out var packet))
+                        {
+                            SendDataCore(packet);
+                        }
+                    }, TaskScheduler.Default);
+                }
+            }
+
+            private void SendDataCore(INodePacket packet)
+            {
                 // clear the buffer but keep the underlying capacity to avoid reallocations
                 _writeBufferMemoryStream.SetLength(0);
 
@@ -765,30 +787,7 @@ namespace Microsoft.Build.BackEnd
                     for (int i = 0; i < writeStreamLength; i += MaxPacketWriteSize)
                     {
                         int lengthToWrite = Math.Min(writeStreamLength - i, MaxPacketWriteSize);
-                        if (writeStreamLength - i <= MaxPacketWriteSize)
-                        {
-                            // We are done, write the last bit asynchronously.  This is actually the general case for
-                            // most packets in the build, and the asynchronous behavior here is desirable.
-#if FEATURE_APM
-                            _serverToClientStream.BeginWrite(writeStreamBuffer, i, lengthToWrite, PacketWriteComplete, null);
-#else
-                            _serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
-#endif
-                            return;
-                        }
-                        else
-                        {
-                            // If this packet is longer that we can write in one go, then we need to break it up.  We can't
-                            // return out of this function and let the rest of the system continue because another operation
-                            // might want to send data immediately afterward, and that could result in overlapping writes
-                            // to the pipe on different threads.
-#if FEATURE_APM
-                            IAsyncResult result = _serverToClientStream.BeginWrite(writeStreamBuffer, i, lengthToWrite, null, null);
-                            _serverToClientStream.EndWrite(result);
-#else
-                            _serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
-#endif
-                        }
+                        _serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
                     }
                 }
                 catch (IOException e)

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -771,7 +771,7 @@ namespace Microsoft.Build.BackEnd
 #if FEATURE_APM
                             _serverToClientStream.BeginWrite(writeStreamBuffer, i, lengthToWrite, PacketWriteComplete, null);
 #else
-                            _serverToClientStream.WriteAsync(writeStreamBuffer, i, lengthToWrite);
+                            _serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
 #endif
                             return;
                         }

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -743,7 +743,8 @@ namespace Microsoft.Build.BackEnd
             /// Sends the specified packet to this node asynchronously.
             /// The method enqueues a task to write the packet and returns
             /// immediately. This is because SendData() is on a hot path
-            /// under the primary lock and we want to minimize our time there.
+            /// under the primary lock (BuildManager's _syncLock)
+            /// and we want to minimize our time there.
             /// </summary>
             /// <param name="packet">The packet to send.</param>
             public void SendData(INodePacket packet)

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -199,7 +199,6 @@ namespace Microsoft.Build.BackEnd
             _asyncDataMonitor = new object();
             _sharedReadBuffer = InterningBinaryReader.CreateSharedBuffer();
 
-            // packets get at least this large
             _packetStream = new MemoryStream();
             _binaryWriter = new BinaryWriter(_packetStream);
 

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Build.BackEnd
             _sharedReadBuffer = InterningBinaryReader.CreateSharedBuffer();
 
             // packets get at least this large
-            _packetStream = new MemoryStream(1048576);
+            _packetStream = new MemoryStream();
             _binaryWriter = new BinaryWriter(_packetStream);
 
 #if FEATURE_PIPE_SECURITY && FEATURE_NAMED_PIPE_SECURITY_CONSTRUCTOR

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -99,6 +99,16 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private SharedReadBuffer _sharedReadBuffer;
 
+        /// <summary>
+        /// A way to cache a byte array when writing out packets
+        /// </summary>
+        private MemoryStream _packetStream;
+
+        /// <summary>
+        /// A binary writer to help write into <see cref="_packetStream"/>
+        /// </summary>
+        private BinaryWriter _binaryWriter;
+
 #endregion
 
 #region INodeEndpoint Events
@@ -188,6 +198,10 @@ namespace Microsoft.Build.BackEnd
             _status = LinkStatus.Inactive;
             _asyncDataMonitor = new object();
             _sharedReadBuffer = InterningBinaryReader.CreateSharedBuffer();
+
+            // packets get at least this large
+            _packetStream = new MemoryStream(1048576);
+            _binaryWriter = new BinaryWriter(_packetStream);
 
 #if FEATURE_PIPE_SECURITY && FEATURE_NAMED_PIPE_SECURITY_CONSTRUCTOR
             if (!NativeMethodsShared.IsMono)
@@ -584,22 +598,26 @@ namespace Microsoft.Build.BackEnd
                             INodePacket packet;
                             while (localPacketQueue.TryDequeue(out packet))
                             {
-                                MemoryStream packetStream = new MemoryStream();
+                                var packetStream = _packetStream;
+                                packetStream.SetLength(0);
+
                                 ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(packetStream);
 
                                 packetStream.WriteByte((byte)packet.Type);
 
                                 // Pad for packet length
-                                packetStream.Write(BitConverter.GetBytes((int)0), 0, 4);
+                                _binaryWriter.Write(0);
 
                                 // Reset the position in the write buffer.
                                 packet.Translate(writeTranslator);
 
+                                int packetStreamLength = (int)packetStream.Position;
+
                                 // Now write in the actual packet length
                                 packetStream.Position = 1;
-                                packetStream.Write(BitConverter.GetBytes((int)packetStream.Length - 5), 0, 4);
+                                _binaryWriter.Write(packetStreamLength - 5);
 
-                                localWritePipe.Write(packetStream.GetBuffer(), 0, (int)packetStream.Length);
+                                localWritePipe.Write(packetStream.GetBuffer(), 0, packetStreamLength);
                             }
                         }
                         catch (Exception e)


### PR DESCRIPTION
Byte arrays are a major source of LOH allocations when streaming logging events across nodes. Allocating a large MemoryStream once and then growing it as needed almost completely removes allocations for byte arrays.

This should significantly improve memory traffic during large builds.

### Before:
![image](https://user-images.githubusercontent.com/679326/104253706-ff62f600-5429-11eb-892a-ff8747038347.png)

### After:
![image](https://user-images.githubusercontent.com/679326/104253730-0f7ad580-542a-11eb-9d1b-d84df5b1c6a4.png)
