### PR TITLE
Sync comment changes from docs

### DIFF
--- a/src/Build/Construction/ProjectItemElement.cs
+++ b/src/Build/Construction/ProjectItemElement.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Gets of sets the MatchOnMetadata value.
+        /// Gets or sets the MatchOnMetadata value.
         /// Returns empty string if it is not present.
         /// Removes the attribute if the value to set is empty or null.
         /// </summary>
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Gets of sets the MatchOnMetadataOptions value.
+        /// Gets or sets the MatchOnMetadataOptions value.
         /// Returns empty string if it is not present.
         /// Removes the attribute if the value to set is empty or null.
         /// </summary>

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -42,9 +42,7 @@ namespace Microsoft.Build.Evaluation
     /// Always backed by XML; can be built directly, or an instance can be cloned off to add virtual items/properties and build.
     /// Edits to this project always update the backing XML.
     /// </summary>
-    /// <remarks>
-    /// UNDONE: (Multiple configurations.) Protect against problems when attempting to edit, after edits were made to the same ProjectRootElement either directly or through other projects evaluated from that ProjectRootElement.
-    /// </remarks>
+    // UNDONE: (Multiple configurations.) Protect against problems when attempting to edit, after edits were made to the same ProjectRootElement either directly or through other projects evaluated from that ProjectRootElement.
     [DebuggerDisplay("{FullPath} EffectiveToolsVersion={ToolsVersion} #GlobalProperties={_data.GlobalPropertiesDictionary.Count} #Properties={_data.Properties.Count} #ItemTypes={_data.ItemTypes.Count} #ItemDefinitions={_data.ItemDefinitions.Count} #Items={_data.Items.Count} #Targets={_data.Targets.Count}")]
     public class Project : ILinkableObject
     {
@@ -1331,7 +1329,7 @@ namespace Microsoft.Build.Evaluation
         /// access concurrently from multiple threads.
         /// </summary>
         /// <param name="settings">The project instance creation settings.</param>
-        /// <returns>the created project instance.</returns>
+        /// <returns>The created project instance.</returns>
         public ProjectInstance CreateProjectInstance(ProjectInstanceSettings settings)
         {
             return CreateProjectInstance(settings, null);
@@ -1342,7 +1340,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="settings">The project instance creation settings.</param>
         /// <param name="evaluationContext">The evaluation context to use in case reevaluation is required.</param>
-        /// <returns>the created project instance.</returns>
+        /// <returns>The created project instance.</returns>
         public ProjectInstance CreateProjectInstance(ProjectInstanceSettings settings, EvaluationContext evaluationContext)
         {
             return implementation.CreateProjectInstance(settings, evaluationContext);

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -582,9 +582,9 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Loggers that all contained projects will use for their builds.
         /// Loggers are added with the <see cref="RegisterLogger"/>.
-        /// UNDONE: Currently they cannot be removed.
         /// Returns an empty collection if there are no loggers.
         /// </summary>
+        // UNDONE: Currently loggers cannot be removed.
         public ICollection<ILogger> Loggers
         {
             [DebuggerStepThrough]
@@ -1465,10 +1465,10 @@ namespace Microsoft.Build.Evaluation
 
         /// <summary>
         /// Called when a host is completely done with the project collection.
-        /// UNDONE: This is a hack to make sure the logging thread shuts down if the build used the logging service
-        /// off the ProjectCollection. After CTP we need to rationalize this and see if we can remove the logging service from
-        /// the project collection entirely so this isn't necessary.
         /// </summary>
+        // UNDONE: This is a hack to make sure the logging thread shuts down if the build used the logging service
+        // off the ProjectCollection. After CTP we need to rationalize this and see if we can remove the logging service from
+        // the project collection entirely so this isn't necessary.
         public void Dispose()
         {
             Dispose(true);

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -35,9 +35,7 @@ namespace Microsoft.Build.Evaluation
     /// Aggregation of a toolset version (eg. "2.0"), tools path, and optional set of associated properties.
     /// Toolset is immutable.
     /// </summary>
-    /// <remarks>
-    /// UNDONE: Review immutability. If this is not immutable, add a mechanism to notify the project collection/s owning it to increment their toolsetVersion.
-    /// </remarks>
+    // UNDONE: Review immutability. If this is not immutable, add a mechanism to notify the project collection/s owning it to increment their toolsetVersion.
     [DebuggerDisplay("ToolsVersion={ToolsVersion} ToolsPath={ToolsPath} #Properties={_properties.Count}")]
     public class Toolset : ITranslatable
     {

--- a/src/Build/Errors/InternalLoggerException.cs
+++ b/src/Build/Errors/InternalLoggerException.cs
@@ -16,11 +16,9 @@ namespace Microsoft.Build.Exceptions
     /// This exception is used to wrap an unhandled exception from a logger. This exception aborts the build, and it can only be
     /// thrown by the MSBuild engine.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both forward and backward compatibility
     [Serializable]
     public sealed class InternalLoggerException : Exception
     {

--- a/src/Build/Errors/InvalidProjectFileException.cs
+++ b/src/Build/Errors/InvalidProjectFileException.cs
@@ -15,11 +15,9 @@ namespace Microsoft.Build.Exceptions
     /// This exception is thrown whenever there is a problem with the user's XML project file. The problem might be semantic or
     /// syntactical. The latter would be of a type typically caught by XSD validation (if it was performed by the project writer).
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both forward and backward compatibility
     [Serializable]
     public sealed class InvalidProjectFileException : Exception
     {

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Execution
     /// and call it several times to build it.
     /// </summary>
     /// <comments>
-    /// Neither this class nor none of its constituents are allowed to have
+    /// Neither this class nor any of its constituents are allowed to have
     /// references to any of the Construction or Evaluation objects.
     /// This class is immutable except for adding instance items and setting instance properties.
     /// It only exposes items and properties: targets, host services, and the task registry are not exposed as they are only the concern of build.

--- a/src/Build/Instance/ProjectItemGroupTaskItemInstance.cs
+++ b/src/Build/Instance/ProjectItemGroupTaskItemInstance.cs
@@ -74,47 +74,47 @@ namespace Microsoft.Build.Execution
         private ElementLocation _location;
 
         /// <summary>
-        /// Location of the include, if any
+        /// Location of the include, if any.
         /// </summary>
         private ElementLocation _includeLocation;
 
         /// <summary>
-        /// Location of the exclude, if any
+        /// Location of the exclude, if any.
         /// </summary>
         private ElementLocation _excludeLocation;
 
         /// <summary>
-        /// Location of the remove, if any
+        /// Location of the remove, if any.
         /// </summary>
         private ElementLocation _removeLocation;
 
         /// <summary>
-        /// Location of matchOnMetadata, if any
+        /// Location of matchOnMetadata, if any.
         /// </summary>
         private ElementLocation _matchOnMetadataLocation;
 
         /// <summary>
-        /// Location of metadataMatchingSchema, if any
+        /// Location of metadataMatchingSchema, if any.
         /// </summary>
         private ElementLocation _matchOnMetadataOptionsLocation;
 
         /// <summary>
-        /// Location of keepMetadata, if any
+        /// Location of keepMetadata, if any.
         /// </summary>
         private ElementLocation _keepMetadataLocation;
 
         /// <summary>
-        /// Location of removeMetadata, if any
+        /// Location of removeMetadata, if any.
         /// </summary>
         private ElementLocation _removeMetadataLocation;
 
         /// <summary>
-        /// Location of keepDuplicates, if any
+        /// Location of keepDuplicates, if any.
         /// </summary>
         private ElementLocation _keepDuplicatesLocation;
 
         /// <summary>
-        /// Location of the condition, if any
+        /// Location of the condition, if any.
         /// </summary>
         private ElementLocation _conditionLocation;
 
@@ -258,7 +258,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Unevaluated MatchOnMetadata value
+        /// Unevaluated MatchOnMetadata value.
         /// </summary>
         public string MatchOnMetadata
         {
@@ -268,7 +268,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Unevaluated MatchOnMetadataOptions value
+        /// Unevaluated MatchOnMetadataOptions value.
         /// </summary>
         public string MatchOnMetadataOptions
         {
@@ -278,7 +278,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Unevaluated keepMetadata value
+        /// Unevaluated keepMetadata value.
         /// </summary>
         public string KeepMetadata
         {
@@ -288,7 +288,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Unevaluated removeMetadata value
+        /// Unevaluated removeMetadata value.
         /// </summary>
         public string RemoveMetadata
         {
@@ -298,7 +298,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Unevaluated keepDuplicates value
+        /// Unevaluated keepDuplicates value.
         /// </summary>
         public string KeepDuplicates
         {
@@ -308,7 +308,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Unevaluated condition value
+        /// Unevaluated condition value.
         /// </summary>
         public string Condition
         {
@@ -333,7 +333,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the element
+        /// Location of the element.
         /// </summary>
         public ElementLocation Location
         {
@@ -343,7 +343,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the include attribute, if any
+        /// Location of the include attribute, if any.
         /// </summary>
         public ElementLocation IncludeLocation
         {
@@ -353,7 +353,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the exclude attribute, if any
+        /// Location of the exclude attribute, if any.
         /// </summary>
         public ElementLocation ExcludeLocation
         {
@@ -363,7 +363,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the remove attribute, if any
+        /// Location of the remove attribute, if any.
         /// </summary>
         public ElementLocation RemoveLocation
         {
@@ -373,7 +373,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the matchOnMetadata attribute, if any
+        /// Location of the matchOnMetadata attribute, if any.
         /// </summary>
         public ElementLocation MatchOnMetadataLocation
         {
@@ -383,7 +383,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the matchOnMetadataOptions attribute, if any
+        /// Location of the matchOnMetadataOptions attribute, if any.
         /// </summary>
         public ElementLocation MatchOnMetadataOptionsLocation
         {
@@ -393,7 +393,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the keepMetadata attribute, if any
+        /// Location of the keepMetadata attribute, if any.
         /// </summary>
         public ElementLocation KeepMetadataLocation
         {
@@ -403,7 +403,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the removeMetadata attribute, if any
+        /// Location of the removeMetadata attribute, if any.
         /// </summary>
         public ElementLocation RemoveMetadataLocation
         {
@@ -413,7 +413,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the keepDuplicates attribute, if any
+        /// Location of the keepDuplicates attribute, if any.
         /// </summary>
         public ElementLocation KeepDuplicatesLocation
         {
@@ -423,7 +423,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Location of the condition attribute if any
+        /// Location of the condition attribute if any.
         /// </summary>
         public ElementLocation ConditionLocation
         {

--- a/src/Deprecated/Engine/Errors/InternalLoggerException.cs
+++ b/src/Deprecated/Engine/Errors/InternalLoggerException.cs
@@ -14,12 +14,10 @@ namespace Microsoft.Build.BuildEngine
     /// This exception is used to wrap an unhandled exception from a logger. This exception aborts the build, and it can only be
     /// thrown by the MSBuild engine.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both forward and backward compatibility
-    /// </remarks>
     /// <owner>SumedhK</owner>
+    // WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both forward and backward compatibility
     [Serializable]
     public sealed class InternalLoggerException : Exception
     {

--- a/src/Deprecated/Engine/Errors/InvalidProjectFileException.cs
+++ b/src/Deprecated/Engine/Errors/InvalidProjectFileException.cs
@@ -14,12 +14,11 @@ namespace Microsoft.Build.BuildEngine
     /// This exception is thrown whenever there is a problem with the user's XML project file. The problem might be semantic or
     /// syntactical. The latter would be of a type typically caught by XSD validation (if it was performed by the project writer).
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both forward and backward compatibility
-    /// </remarks>
     /// <owner>RGoel</owner>
+    // WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both forward and backward compatibility
+
     [Serializable]
     public sealed class InvalidProjectFileException : Exception
     {

--- a/src/Framework/BuildErrorEventArgs.cs
+++ b/src/Framework/BuildErrorEventArgs.cs
@@ -10,14 +10,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for error events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class BuildErrorEventArgs : LazyFormattedBuildEventArgs
     {

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -12,14 +12,12 @@ namespace Microsoft.Build.Framework
     /// This class encapsulates the default data associated with build events. 
     /// It is intended to be extended/sub-classed.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public abstract class BuildEventArgs : EventArgs
     {

--- a/src/Framework/BuildFinishedEventArgs.cs
+++ b/src/Framework/BuildFinishedEventArgs.cs
@@ -9,14 +9,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// This class represents the event arguments for build finished events.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class BuildFinishedEventArgs : BuildStatusEventArgs
     {

--- a/src/Framework/BuildMessageEventArgs.cs
+++ b/src/Framework/BuildMessageEventArgs.cs
@@ -33,14 +33,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for message events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class BuildMessageEventArgs : LazyFormattedBuildEventArgs
     {

--- a/src/Framework/BuildStartedEventArgs.cs
+++ b/src/Framework/BuildStartedEventArgs.cs
@@ -9,14 +9,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for build started events.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class BuildStartedEventArgs : BuildStatusEventArgs
     {

--- a/src/Framework/BuildWarningEventArgs.cs
+++ b/src/Framework/BuildWarningEventArgs.cs
@@ -10,14 +10,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for warning events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class BuildWarningEventArgs : LazyFormattedBuildEventArgs
     {

--- a/src/Framework/CriticalBuildMessageEventArgs.cs
+++ b/src/Framework/CriticalBuildMessageEventArgs.cs
@@ -8,14 +8,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for critical message events. These always have High importance.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class CriticalBuildMessageEventArgs : BuildMessageEventArgs
     {

--- a/src/Framework/CustomBuildEventArgs.cs
+++ b/src/Framework/CustomBuildEventArgs.cs
@@ -8,14 +8,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for custom build events.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public abstract class CustomBuildEventArgs : LazyFormattedBuildEventArgs
     {

--- a/src/Framework/ExternalProjectFinishedEventArgs.cs
+++ b/src/Framework/ExternalProjectFinishedEventArgs.cs
@@ -8,14 +8,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for external project finished events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class ExternalProjectFinishedEventArgs : CustomBuildEventArgs
     {

--- a/src/Framework/ExternalProjectStartedEventArgs.cs
+++ b/src/Framework/ExternalProjectStartedEventArgs.cs
@@ -8,14 +8,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for external project started events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class ExternalProjectStartedEventArgs : CustomBuildEventArgs
     {

--- a/src/Framework/ILogger.cs
+++ b/src/Framework/ILogger.cs
@@ -19,11 +19,12 @@ namespace Microsoft.Build.Framework
     /// 3) Normal -- display all errors, warnings, high importance events, some status events, and a build summary
     /// 4) Detailed -- display all errors, warnings, high and normal importance events, all status events, and a build summary
     /// 5) Diagnostic -- display all events, and a build summary
-    /// 
-    /// WARNING: VS Automation code for the Tools/Options MSBuild build verbosity setting will be broken
-    /// by changes to this enum (not to mention existing MSBuild clients and vsproject code). 
-    /// Please make sure to talk to automation devs before changing it.
     /// </remarks>
+    // 
+    // WARNING: VS Automation code for the Tools/Options MSBuild build verbosity setting will be broken
+    // by changes to this enum (not to mention existing MSBuild clients and vsproject code). 
+    // Please make sure to talk to automation devs before changing it.
+
     [ComVisible(true)]
     public enum LoggerVerbosity
     {

--- a/src/Framework/LoggerException.cs
+++ b/src/Framework/LoggerException.cs
@@ -14,11 +14,9 @@ namespace Microsoft.Build.Framework
     /// Allows a logger to force the build to stop in an explicit way, when, for example, it 
     /// receives invalid parameters, or cannot write to disk.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both forward and backward compatibility
     [Serializable]
     public class LoggerException : Exception
     {

--- a/src/Framework/ProjectFinishedEventArgs.cs
+++ b/src/Framework/ProjectFinishedEventArgs.cs
@@ -10,14 +10,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for project finished events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class ProjectFinishedEventArgs : BuildStatusEventArgs
     {

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -14,14 +14,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for project started events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class ProjectStartedEventArgs : BuildStatusEventArgs
     {

--- a/src/Framework/TargetFinishedEventArgs.cs
+++ b/src/Framework/TargetFinishedEventArgs.cs
@@ -11,14 +11,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for target finished events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class TargetFinishedEventArgs : BuildStatusEventArgs
     {

--- a/src/Framework/TargetStartedEventArgs.cs
+++ b/src/Framework/TargetStartedEventArgs.cs
@@ -10,14 +10,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for target started events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>    
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility    
     [Serializable]
     public class TargetStartedEventArgs : BuildStatusEventArgs
     {

--- a/src/Framework/TaskFinishedEventArgs.cs
+++ b/src/Framework/TaskFinishedEventArgs.cs
@@ -10,14 +10,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for task finished events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class TaskFinishedEventArgs : BuildStatusEventArgs
     {

--- a/src/Framework/TaskStartedEventArgs.cs
+++ b/src/Framework/TaskStartedEventArgs.cs
@@ -10,14 +10,12 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for task started events
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing
+    // ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is
+    // immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both
+    // forward and backward compatibility
     [Serializable]
     public class TaskStartedEventArgs : BuildStatusEventArgs
     {

--- a/src/Tasks/ComReferenceResolutionException.cs
+++ b/src/Tasks/ComReferenceResolutionException.cs
@@ -10,11 +10,9 @@ namespace Microsoft.Build.Tasks
     /// Internal exception thrown when there's an unrecoverable failure resolving a COM reference and we should 
     /// move on to the next one, if it makes sense.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both forward and backward compatibility
     [Serializable]
     internal class ComReferenceResolutionException : Exception
     {

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -17,9 +17,7 @@ namespace Microsoft.Build.Tasks
     /// This class defines an "Exec" MSBuild task, which simply invokes the specified process with the specified arguments, waits
     /// for it to complete, and then returns True if the process completed successfully, and False if an error occurred.
     /// </summary>
-    /// <comments>
-    /// UNDONE: ToolTask has a "UseCommandProcessor" flag that duplicates much of the code in this class. Remove the duplication.
-    /// </comments>
+    // UNDONE: ToolTask has a "UseCommandProcessor" flag that duplicates much of the code in this class. Remove the duplication.
     public class Exec : ToolTaskExtension
     {
         #region Constructors

--- a/src/Tasks/StrongNameException.cs
+++ b/src/Tasks/StrongNameException.cs
@@ -9,11 +9,9 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Internal exception thrown when there's an unrecoverable failure extracting public/private keys.
     /// </summary>
-    /// <remarks>
-    /// WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both forward and backward compatibility
-    /// </remarks>
+    // WARNING: marking a type [Serializable] without implementing ISerializable imposes a serialization contract -- it is a
+    // promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
+    // without following certain special FX guidelines, can break both forward and backward compatibility
     [Serializable]
     internal class StrongNameException : Exception
     {

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Build.Utilities
     ///     At this point we will look up the success state of the project finished event for the submission ID and log a build finished event to the logger.
     ///     The event source will be cleaned up.  This may be interesting because the unregister will come from a thread other than what is doing the logging.
     ///     This may create a Synchronization issue, if unregister is called while events are being logged.
-    ///     
-    /// UNDONE: If we can use ErrorUtilities, replace all InvalidOperation and Argument exceptions with the appropriate calls.
-    /// 
     /// </summary>
+    //     
+    // UNDONE: If we can use ErrorUtilities, replace all InvalidOperation and Argument exceptions with the appropriate calls.
+    // 
     public class MuxLogger : INodeLogger
     {
         /// <summary>

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -54,10 +54,8 @@ namespace Microsoft.Build.Utilities
     /// Base class used for tasks that spawn an executable. This class implements the ToolPath property which can be used to
     /// override the default path.
     /// </summary>
-    /// <remarks>
-    /// INTERNAL WARNING: DO NOT USE the Log property in this class! Log points to resources in the task assembly itself, and 
-    /// we want to use resources from Utilities. Use LogPrivate (for private Utilities resources) and LogShared (for shared MSBuild resources)
-    /// </remarks>
+    // INTERNAL WARNING: DO NOT USE the Log property in this class! Log points to resources in the task assembly itself, and 
+    // we want to use resources from Utilities. Use LogPrivate (for private Utilities resources) and LogShared (for shared MSBuild resources)
     public abstract class ToolTask : Task, ICancelableTask
     {
         private static readonly bool s_preserveTempFiles = string.Equals(Environment.GetEnvironmentVariable("MSBUILDPRESERVETOOLTEMPFILES"), "1", StringComparison.Ordinal);


### PR DESCRIPTION
Fixes #6027 

### Context
This synchronizes changes to the docs in the docs repo and brings those changes into the /// comments.

### Changes Made

Comments only
Internal comments such as UNDONE, etc.., changed from public triple-slash comments to normal comments.

