### PR TITLE
Remove RestoreSources from Versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,19 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
-  <Import Project="$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''" />
-  <PropertyGroup>
-    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
-    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
-        $(RestoreSources);
-        https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-        https://dotnet.myget.org/F/roslyn/api/v3/index.json;
-        https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
-        https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-        https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json
-    </RestoreSources>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>16.9.0</VersionPrefix>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
This has been obsolete for some time per https://github.com/dotnet/arcade/blob/ca7fab569267ed3bc73360882d652d119aae5653/Documentation/RestoreSourcesUpdateStatus.md

(thanks for pointing this out @ladipro!)

While I was there I removed `MSBuildAllProjects` since _it's_ been obsolete since #3605.