### PR TITLE
Assign Blank Issues the Untriaged Label

### DIFF
--- a/.github/ISSUE_TEMPLATE/04_blankissue.md
+++ b/.github/ISSUE_TEMPLATE/04_blankissue.md
@@ -1,0 +1,6 @@
+---
+name: 📄 Blank Issue
+about: Doesn't fit the other categories? File a blank ticket here.
+title: ''
+labels: untriaged
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Issue with .NET (Core) SDK
     url:  https://github.com/dotnet/sdk/issues/new/choose


### PR DESCRIPTION
### Context
Issues filed with no template don't get the untriaged label assigned to them, this makes it slightly more annoying to track things in our bug review meeting (separate query for issues we need to get back to).

### Changes Made
Disabled blank issues, and created a template that contains a blank issue, but assigns the `untriaged` label to it.

### Notes
`untriaged` essentially means: "Get to this during bug triage, until we've assigned this out and determined what kind of issue this is."