### PR TITLE
Update branding for 16.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ MSBuild 16.4 builds from the branch [`vs16.4`](https://github.com/Microsoft/msbu
 
 [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.4)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.4)
 
-MSBuild 16.0 builds from the branch [`vs16.0`](https://github.com/Microsoft/msbuild/tree/vs16.0). Only high-priority bugfixes will be considered for servicing 16.0.
-
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.0)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.0)
-
 MSBuild 15.9 builds from the branch [`vs15.9`](https://github.com/Microsoft/msbuild/tree/vs15.9). Only very-high-priority bugfixes will be considered for servicing 15.9.
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ For more information on MSBuild, see the [MSBuild documentation](https://docs.mi
 
 ### Build Status
 
-The current development branch is `master`. Changes in `master` will go into a future update of MSBuild, which will release with Visual Studio 16.9 and a corresponding version of the .NET Core SDK.
+The current development branch is `master`. Changes in `master` will go into a future update of MSBuild, which will release with Visual Studio 16.10 and a corresponding version of the .NET Core SDK.
 
 [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=master)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=master)
 
-We have forked for MSBuild 16.8 in the branch [`vs16.8`](https://github.com/Microsoft/msbuild/tree/vs16.8). Changes to that branch need special approval.
+We have forked for MSBuild 16.9 in the branch [`vs16.9`](https://github.com/Microsoft/msbuild/tree/vs16.9). Changes to that branch need special approval.
 
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.8)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.8)
+[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.9)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.9)
 
 MSBuild 16.7 builds from the branch [`vs16.7`](https://github.com/Microsoft/msbuild/tree/vs16.7). Only high-priority bugfixes will be considered for servicing 16.7.
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.9.0</VersionPrefix>
+    <VersionPrefix>16.10.0</VersionPrefix>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -48,8 +48,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.9.0.0" newVersion="16.9.0.0" />
-          <codeBase version="16.9.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.10.0.0" newVersion="16.10.0.0" />
+          <codeBase version="16.10.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -60,8 +60,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.9.0.0" newVersion="16.9.0.0" />
-          <codeBase version="16.9.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.10.0.0" newVersion="16.10.0.0" />
+          <codeBase version="16.10.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->


### PR DESCRIPTION
Not until vs16.9 is brought up-to-date.

Also, for the binding redirects/code bases, is it a string comparison, a version comparison, or a number comparison? Wondering if it would interpret 16.9 as greater or less than 16.10.