### PR TITLE
Optimize FileExists lookup

### DIFF
--- a/src/Shared/FileDelegates.cs
+++ b/src/Shared/FileDelegates.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Build.Shared
     internal delegate string[] DirectoryGetFiles(string path, string searchPattern);
 
     /// <summary>
-    /// delegate for optimized looking up files in directory
-    /// designed to be used for testing and to verify file existence by directory listing
+    /// Delegate for optimized looking up files in directory.
+    /// Designed to be used for testing and to verify file existence by cached directory listing.
     /// </summary>
-    /// <param name="path">Directory path to start search for files in</param>
+    /// <param name="path">Directory path to search files in</param>
     /// <param name="fileName">name of file</param>
-    /// <returns>return full path file name or null if file do not exists</returns>
-    internal delegate string DirectoryFile(string path, string fileName);
+    /// <returns>true if file exists</returns>
+    internal delegate bool FileExistsInDirectory(string path, string fileName);
 
     /// <summary>
     /// delegate for Directory.GetDirectories.

--- a/src/Shared/FileDelegates.cs
+++ b/src/Shared/FileDelegates.cs
@@ -6,12 +6,21 @@ using System.IO;
 namespace Microsoft.Build.Shared
 {
     /// <summary>
-    /// delegate for System.IO.Directory.GetFiles, used for testing
+    /// delegate for System.IO.Directory.GetFiles
     /// </summary>
     /// <param name="path">Directory path to start search for files in</param>
     /// <param name="searchPattern">pattern of files to match</param>
     /// <returns>string array of files which match search pattern</returns>
     internal delegate string[] DirectoryGetFiles(string path, string searchPattern);
+
+    /// <summary>
+    /// delegate for optimized looking up files in directory
+    /// designed to be used for testing and to verify file existence by directory listing
+    /// </summary>
+    /// <param name="path">Directory path to start search for files in</param>
+    /// <param name="fileName">name of file</param>
+    /// <returns>return full path file name or null if file do not exists</returns>
+    internal delegate string DirectoryFile(string path, string fileName);
 
     /// <summary>
     /// delegate for Directory.GetDirectories.

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -969,10 +969,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Get all files from directory matching pattern
         /// </summary>
-        /// <param name="path"></param>
-        /// <param name="pattern"></param>
-        /// <param name="fileSystem"></param>
-        /// <returns>list of files or null if it is impossible to get files</returns>
         internal static string[] DirectoryGetFiles(string path, string pattern = "*", IFileSystem fileSystem = null)
         {
             path = AttemptToShortenPath(path);

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -971,6 +971,11 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string[] DirectoryGetFiles(string path, string pattern = "*", IFileSystem fileSystem = null)
         {
+            if (path is null)
+                throw new ArgumentNullException(nameof(path));
+            if (path.Length == 0)
+                throw new ArgumentException("Unexpected empty string", nameof(path));
+
             path = AttemptToShortenPath(path);
             return (fileSystem ?? DefaultFileSystem).EnumerateFiles(path, pattern).ToArray();
         }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -967,6 +967,19 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
+        /// Get all files from directory matching pattern
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="pattern"></param>
+        /// <param name="fileSystem"></param>
+        /// <returns>list of files or null if it is impossible to get files</returns>
+        internal static string[] DirectoryGetFiles(string path, string pattern = "*", IFileSystem fileSystem = null)
+        {
+            path = AttemptToShortenPath(path);
+            return (fileSystem ?? DefaultFileSystem).EnumerateFiles(path, pattern).ToArray();
+        }
+
+        /// <summary>
         /// If there is a directory or file at the specified path, returns true.
         /// Otherwise, returns false.
         /// Does not throw IO exceptions, to match Directory.Exists and File.Exists.

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -549,6 +549,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.False(FileUtilities.FileOrDirectoryExistsNoThrow("||"));
             Assert.False(FileUtilities.FileOrDirectoryExistsNoThrow(isWindows ? @"c:\doesnot_exist" : "/doesnot_exist"));
+            Assert.False(FileUtilities.FileOrDirectoryExistsNoThrow(string.Empty));
             Assert.True(FileUtilities.FileOrDirectoryExistsNoThrow(isWindows ? @"c:\" : "/"));
             Assert.True(FileUtilities.FileOrDirectoryExistsNoThrow(Path.GetTempPath()));
 
@@ -665,6 +666,35 @@ namespace Microsoft.Build.UnitTests
                 Directory.SetCurrentDirectory(currentDirectory);
             }
         }
+
+        [Fact]
+        public void DirectoryGetFilesThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => FileUtilities.DirectoryGetFiles(null));
+        }
+
+        [Fact]
+        public void DirectoryGetFilesThrowsOnEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => FileUtilities.DirectoryGetFiles(string.Empty));
+        }
+
+        [ConditionalFact(nameof(RunTestsThatDependOnWindowsShortPathBehavior_Workaround4241))]
+        public void DirectoryGetFilesTooLongWithDots()
+        {
+            Assert.Throws<ArgumentNullException>(() => FileUtilities.DirectoryGetFiles(null));
+
+            string systemDirectoryPath = Path.Combine(Environment.SystemDirectory) + Path.DirectorySeparatorChar;
+            string longPart = new string('x', NativeMethodsShared.MAX_PATH - systemDirectoryPath.Length); // We want the shortest that is > max path.
+
+            string inputPath = Path.Combine(new[] { Environment.SystemDirectory, longPart, "..", });
+
+            Console.WriteLine(inputPath.Length);
+
+            // "c:\windows\system32\<verylong>\.." > MAX_PATH
+            var files = FileUtilities.DirectoryGetFiles(inputPath);
+            Assert.NotEmpty(files);
+        }     
 
         public static bool RunTestsThatDependOnWindowsShortPathBehavior_Workaround4241()
         {

--- a/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
@@ -288,6 +288,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     fileExists,
                     directoryExists,
                     getDirectories,
+                    getDirectoryFiles,
                     getAssemblyName,
                     getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -316,6 +317,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     fileExists,
                     directoryExists,
                     getDirectories,
+                    getDirectoryFiles,
                     getAssemblyName,
                     getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -364,6 +366,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     fileExists,
                     directoryExists,
                     getDirectories,
+                    getDirectoryFiles,
                     getAssemblyName,
                     getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -391,6 +394,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     fileExists,
                     directoryExists,
                     getDirectories,
+                    getDirectoryFiles,
                     getAssemblyName,
                     getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -438,6 +442,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     fileExists,
                     directoryExists,
                     getDirectories,
+                    getDirectoryFiles,
                     getAssemblyName,
                     getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -465,6 +470,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     fileExists,
                     directoryExists,
                     getDirectories,
+                    getDirectoryFiles,
                     getAssemblyName,
                     getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -509,6 +515,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -532,6 +539,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -572,6 +580,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -595,6 +604,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -636,6 +646,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -659,6 +670,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -702,6 +714,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -725,6 +738,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -768,6 +782,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -792,6 +807,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -838,6 +854,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -862,6 +879,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 fileExists,
                 directoryExists,
                 getDirectories,
+                getDirectoryFiles,
                 getAssemblyName,
                 getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3312,7 +3312,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <returns></returns>
         private ReferenceTable GenerateTableWithAssemblyFromTheGlobalLocation(string location)
         {
-            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, getDirectoryFile, null, null, null, null,
+            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, fileExistsInDirectory, null, null, null, null,
 #if FEATURE_WIN32_REGISTRY
                 null, null, null,
 #endif
@@ -6795,7 +6795,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void ReferenceTableDependentItemsInBlackList4()
         {
-            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, getDirectoryFile, null, null, null,
+            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, fileExistsInDirectory, null, null, null,
 #if FEATURE_WIN32_REGISTRY
                 null, null, null,
 #endif
@@ -6973,7 +6973,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
         private static ReferenceTable MakeEmptyReferenceTable(TaskLoggingHelper log)
         {
-            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, getDirectoryFile, null, null, null, null,
+            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, fileExistsInDirectory, null, null, null, null,
 #if FEATURE_WIN32_REGISTRY
                 null, null, null,
 #endif

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -7638,7 +7638,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         }
 
         [Fact]
-        [Trait("Category", "netcore-linux-failing")]
+        [Trait("Category", "mono-osx-failing")]
         public void HandleFilesInSearchPathsWhichDiffersOnlyInCasing()
         {
             string redistListPath = CreateGenericRedistList();

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -7637,6 +7637,73 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
         }
 
+        [Fact]
+        [Trait("Category", "netcore-linux-failing")]
+        public void HandleFilesInSearchPathsWhichDiffersOnlyInCasing()
+        {
+            string redistListPath = CreateGenericRedistList();
+            try
+            {
+                ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+                t.BuildEngine = new MockEngine(_output);
+
+                t.Assemblies = new ITaskItem[]
+                {
+                    new TaskItem("System.Xml")
+                };
+
+                t.SearchPaths = new string[]
+                {
+                        @"{TargetFrameworkDirectory}"
+                };
+
+                t.TargetFrameworkDirectories = new string[] { Path.Combine(ObjectModelHelpers.TempProjectDir, "v3.5") };
+                string systemXmlPath = Path.Combine(ObjectModelHelpers.TempProjectDir, "v3.5\\System.Xml.dll");
+                string aFile = Path.Combine(ObjectModelHelpers.TempProjectDir, "v3.5\\A.File.dll");
+                string aFileLowercase = Path.Combine(ObjectModelHelpers.TempProjectDir, "v3.5\\a.file.dll");
+
+                t.InstalledAssemblyTables = new ITaskItem[] { new TaskItem(redistListPath) };
+
+                GetAssemblyName cachedGetAssemblyName = getAssemblyName;
+                List<string> preservedExistentFiles = s_existentFiles;
+                s_existentFiles = new List<string>(s_existentFiles);
+
+                s_existentFiles.Add(systemXmlPath);
+                s_existentFiles.Add(aFile);
+                s_existentFiles.Add(aFileLowercase);
+
+                getAssemblyName = new GetAssemblyName(delegate (string path)
+                {
+                    if (String.Equals(path, systemXmlPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new AssemblyNameExtension("System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+                    }
+
+                    return null;
+                });
+
+                bool success;
+                try
+                {
+                    success = Execute(t);
+                }
+                finally
+                {
+                    s_existentFiles = preservedExistentFiles;
+                    getAssemblyName = cachedGetAssemblyName;
+                }
+
+                Assert.True(success); // "Expected no errors."
+                Assert.Single(t.ResolvedFiles); // "Expected one resolved assembly."
+                Assert.Contains("System.Xml", t.ResolvedFiles[0].ItemSpec); // "Expected System.Xml to resolve."
+            }
+            finally
+            {
+                File.Delete(redistListPath);
+            }
+        }
+
         /// <summary>
         /// Here's how you get into this situation:
         ///

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -7655,7 +7655,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 t.SearchPaths = new string[]
                 {
-                        @"{TargetFrameworkDirectory}"
+                    @"{TargetFrameworkDirectory}"
                 };
 
                 t.TargetFrameworkDirectories = new string[] { Path.Combine(ObjectModelHelpers.TempProjectDir, "v3.5") };

--- a/src/Tasks.UnitTests/AssemblyDependency/Perf.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Perf.cs
@@ -76,9 +76,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 Assert.True(succeeded);
                 
-                uniqueFileExists[s_dependsOnNuGet_NWinMdPath].ShouldBe(1);
-                uniqueFileExists[s_dependsOnNuGet_NDllPath].ShouldBe(1);
-                uniqueFileExists[s_dependsOnNuGet_NExePath].ShouldBe(1);
+                uniqueGetDirectoryFiles[s_dependsOnNuGet_Path].ShouldBe(1);
             }
             finally
             {
@@ -121,9 +119,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 Assert.True(succeeded);
 
-                uniqueFileExists.ShouldNotContainKey(@"C:\DependsOnNuget\N.winmd");
-                uniqueFileExists.ShouldNotContainKey(@"C:\DependsOnNuget\N.dll");
-                uniqueFileExists.ShouldNotContainKey(@"C:\DependsOnNuget\N.exe");
+                uniqueGetDirectoryFiles.ShouldNotContainKey(s_dependsOnNuGet_Path);
             }
             finally
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         // Performance checks.
         internal static Dictionary<string, int> uniqueFileExists = null;
         internal static Dictionary<string, int> uniqueGetAssemblyName = null;
-        internal static ConcurrentDictionary<string, int> uniqueGetDirectoryFiles = null;
+        internal static Dictionary<string, int> uniqueGetDirectoryFiles = null;
 
         internal static bool useFrameworkFileExists = false;
         internal const string REDISTLIST = @"<FileList  Redist=""Microsoft-Windows-CLRCoreComp.4.0"" Name="".NET Framework 4"" RuntimeVersion=""4.0"" ToolsVersion=""12.0"">
@@ -305,7 +305,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             // If tables are present then the corresponding IO function will do some monitoring.
             uniqueFileExists = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             uniqueGetAssemblyName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            uniqueGetDirectoryFiles = new ConcurrentDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            uniqueGetDirectoryFiles = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -891,7 +891,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             // Do IO monitoring if needed.
             if (uniqueGetDirectoryFiles != null)
             {
-                uniqueGetDirectoryFiles.AddOrUpdate(path, 1, (_, n) => n+1);
+                uniqueGetDirectoryFiles.TryGetValue(path, out int count);
+                uniqueGetDirectoryFiles[path] = count + 1;
             }
 
             return s_existentFiles

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -13,6 +13,7 @@ using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 using Xunit;
 using Xunit.Abstractions;
+using System.Linq;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -20,7 +21,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     {
         // Create the mocks.
         internal static Microsoft.Build.Shared.FileExists fileExists = new Microsoft.Build.Shared.FileExists(FileExists);
+        internal static Microsoft.Build.Shared.DirectoryFile getDirectoryFile = new Microsoft.Build.Shared.DirectoryFile(GetDirectoryFile);
         internal static Microsoft.Build.Shared.DirectoryExists directoryExists = new Microsoft.Build.Shared.DirectoryExists(DirectoryExists);
+        internal static Microsoft.Build.Shared.DirectoryGetFiles getDirectoryFiles = new Microsoft.Build.Shared.DirectoryGetFiles(GetDirectoryFiles);
         internal static Microsoft.Build.Tasks.GetDirectories getDirectories = new Microsoft.Build.Tasks.GetDirectories(GetDirectories);
         internal static Microsoft.Build.Tasks.GetAssemblyName getAssemblyName = new Microsoft.Build.Tasks.GetAssemblyName(GetAssemblyName);
         internal static Microsoft.Build.Tasks.GetAssemblyMetadata getAssemblyMetadata = new Microsoft.Build.Tasks.GetAssemblyMetadata(GetAssemblyMetadata);
@@ -41,6 +44,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         // Performance checks.
         internal static Dictionary<string, int> uniqueFileExists = null;
         internal static Dictionary<string, int> uniqueGetAssemblyName = null;
+        internal static ConcurrentDictionary<string, int> uniqueGetDirectoryFiles = null;
 
         internal static bool useFrameworkFileExists = false;
         internal const string REDISTLIST = @"<FileList  Redist=""Microsoft-Windows-CLRCoreComp.4.0"" Name="".NET Framework 4"" RuntimeVersion=""4.0"" ToolsVersion=""12.0"">
@@ -256,6 +260,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         protected static readonly string s_portableDllPath = Path.Combine(s_rootPathPrefix, "SystemRuntime", "Portable.dll");
         protected static readonly string s_systemRuntimeDllPath = Path.Combine(s_rootPathPrefix, "SystemRuntime", "System.Runtime.dll");
 
+        protected static readonly string s_dependsOnNuGet_Path = Path.Combine(s_rootPathPrefix, "DependsOnNuget");
         protected static readonly string s_dependsOnNuGet_ADllPath = Path.Combine(s_rootPathPrefix, "DependsOnNuget", "A.dll");
         protected static readonly string s_dependsOnNuGet_NDllPath = Path.Combine(s_rootPathPrefix, "DependsOnNuget", "N.dll");
         protected static readonly string s_dependsOnNuGet_NExePath = Path.Combine(s_rootPathPrefix, "DependsOnNuget", "N.exe");
@@ -300,6 +305,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             // If tables are present then the corresponding IO function will do some monitoring.
             uniqueFileExists = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             uniqueGetAssemblyName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            uniqueGetDirectoryFiles = new ConcurrentDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -859,6 +865,52 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             // Everything else doesn't exist.
             return false;
+        }
+
+        /// <summary>
+        /// Mock the Directory.GetFiles method.
+        /// </summary>
+        /// <param name="path">The path to directory.</param>
+        /// <returns>'true' if the file is supposed to exist</returns>
+
+        internal static string[] GetDirectoryFiles(string path, string pattern)
+        {
+            if (!Path.IsPathRooted(path))
+            {
+                path = Path.GetFullPath(path);
+            }
+
+            // remove trailing path separator
+            path = Path.GetDirectoryName(Path.Combine(path, "a.txt"));
+
+            if (pattern != "*")
+            {
+                throw new InvalidOperationException("In this context, directory listing with pattern is neither supported not expected to be used.");
+            }
+
+            // Do IO monitoring if needed.
+            if (uniqueGetDirectoryFiles != null)
+            {
+                uniqueGetDirectoryFiles.AddOrUpdate(path, 1, (_, n) => n+1);
+            }
+
+            return s_existentFiles
+                .Where(fn => Path.GetDirectoryName(fn).Equals(path, StringComparison.OrdinalIgnoreCase))
+                .Select(fn => Path.Combine(path, Path.GetFileName(fn)))
+                .Distinct()
+                .ToArray();
+        }
+
+        internal static string GetDirectoryFile(string path, string fileName)
+        {
+            string fullName = Path.Combine(path, fileName);
+
+            if (!FileExists(fullName))
+            {
+                return null;
+            }
+
+            return fullName;
         }
 
         /// <summary>
@@ -3006,6 +3058,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 	                    fileExists,
 	                    directoryExists,
 	                    getDirectories,
+                        getDirectoryFiles,
 	                    getAssemblyName,
 	                    getAssemblyMetadata,
 	#if FEATURE_WIN32_REGISTRY
@@ -3068,7 +3121,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 	                        fileExists,
 	                        directoryExists,
 	                        getDirectories,
-	                        getAssemblyName,
+                            getDirectoryFiles,
+                            getAssemblyName,
 	                        getAssemblyMetadata,
 	#if FEATURE_WIN32_REGISTRY
 	                        getRegistrySubKeyNames,

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -3053,27 +3053,27 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     t.FindSerializationAssemblies = false;
                     t.FindRelatedFiles = false;
                     t.StateFile = null;
-	                t.Execute
-	                (
-	                    fileExists,
-	                    directoryExists,
-	                    getDirectories,
-                        getDirectoryFiles,
-	                    getAssemblyName,
-	                    getAssemblyMetadata,
-	#if FEATURE_WIN32_REGISTRY
-	                    getRegistrySubKeyNames,
-	                    getRegistrySubKeyDefaultValue,
-	#endif
-	                    getLastWriteTime,
-	                    getRuntimeVersion,
-	#if FEATURE_WIN32_REGISTRY
-	                    openBaseKey,
-	#endif
-	                    checkIfAssemblyIsInGac,
-	                    isWinMDFile,
-	                    readMachineTypeFromPEHeader
-	                );
+                    t.Execute
+                    (
+                        fileExists,
+                        directoryExists,
+                        getDirectories,
+                            getDirectoryFiles,
+                        getAssemblyName,
+                        getAssemblyMetadata,
+    #if FEATURE_WIN32_REGISTRY
+                        getRegistrySubKeyNames,
+                        getRegistrySubKeyDefaultValue,
+    #endif
+                        getLastWriteTime,
+                        getRuntimeVersion,
+    #if FEATURE_WIN32_REGISTRY
+                        openBaseKey,
+    #endif
+                        checkIfAssemblyIsInGac,
+                        isWinMDFile,
+                        readMachineTypeFromPEHeader
+                );
 
                     // A few checks. These should always be true or it may be a perf issue for project load.
                     ITaskItem[] loadModeResolvedFiles = new TaskItem[0];
@@ -3115,28 +3115,28 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     string cache = rarCacheFile;
                     t.StateFile = cache;
                     File.Delete(t.StateFile);
-	                succeeded =
-	                    t.Execute
-	                    (
-	                        fileExists,
-	                        directoryExists,
-	                        getDirectories,
+                    succeeded =
+                        t.Execute
+                        (
+                            fileExists,
+                            directoryExists,
+                            getDirectories,
                             getDirectoryFiles,
                             getAssemblyName,
-	                        getAssemblyMetadata,
-	#if FEATURE_WIN32_REGISTRY
-	                        getRegistrySubKeyNames,
-	                        getRegistrySubKeyDefaultValue,
-	#endif
-	                        getLastWriteTime,
-	                        getRuntimeVersion,
-	#if FEATURE_WIN32_REGISTRY
-	                        openBaseKey,
-	#endif
-	                        checkIfAssemblyIsInGac,
-	                        isWinMDFile,
-	                        readMachineTypeFromPEHeader
-	                    );
+                            getAssemblyMetadata,
+    #if FEATURE_WIN32_REGISTRY
+                            getRegistrySubKeyNames,
+                            getRegistrySubKeyDefaultValue,
+    #endif
+                            getLastWriteTime,
+                            getRuntimeVersion,
+    #if FEATURE_WIN32_REGISTRY
+                            openBaseKey,
+    #endif
+                            checkIfAssemblyIsInGac,
+                            isWinMDFile,
+                            readMachineTypeFromPEHeader
+                        );
                     if (FileUtilities.FileExistsNoThrow(t.StateFile))
                     {
                         Assert.Single(t.FilesWritten);

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     {
         // Create the mocks.
         internal static Microsoft.Build.Shared.FileExists fileExists = new Microsoft.Build.Shared.FileExists(FileExists);
-        internal static Microsoft.Build.Shared.DirectoryFile getDirectoryFile = new Microsoft.Build.Shared.DirectoryFile(GetDirectoryFile);
+        internal static Microsoft.Build.Shared.FileExistsInDirectory fileExistsInDirectory = new Microsoft.Build.Shared.FileExistsInDirectory(FileExistsInDirectory);
         internal static Microsoft.Build.Shared.DirectoryExists directoryExists = new Microsoft.Build.Shared.DirectoryExists(DirectoryExists);
         internal static Microsoft.Build.Shared.DirectoryGetFiles getDirectoryFiles = new Microsoft.Build.Shared.DirectoryGetFiles(GetDirectoryFiles);
         internal static Microsoft.Build.Tasks.GetDirectories getDirectories = new Microsoft.Build.Tasks.GetDirectories(GetDirectories);
@@ -901,16 +901,11 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 .ToArray();
         }
 
-        internal static string GetDirectoryFile(string path, string fileName)
+        internal static bool FileExistsInDirectory(string path, string fileName)
         {
             string fullName = Path.Combine(path, fileName);
 
-            if (!FileExists(fullName))
-            {
-                return null;
-            }
-
-            return fullName;
+            return FileExists(fullName);
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -872,7 +872,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// </summary>
         /// <param name="path">The path to directory.</param>
         /// <returns>'true' if the file is supposed to exist</returns>
-
         internal static string[] GetDirectoryFiles(string path, string pattern)
         {
             if (!Path.IsPathRooted(path))
@@ -3054,7 +3053,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                         fileExists,
                         directoryExists,
                         getDirectories,
-                            getDirectoryFiles,
+                        getDirectoryFiles,
                         getAssemblyName,
                         getAssemblyMetadata,
     #if FEATURE_WIN32_REGISTRY

--- a/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkAttribute.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkAttribute.cs
@@ -372,6 +372,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     fileExists,
                     directoryExists,
                     getDirectories,
+                    getDirectoryFiles,
                     getAssemblyName,
                     getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY

--- a/src/Tasks.UnitTests/HintPathResolver_Tests.cs
+++ b/src/Tasks.UnitTests/HintPathResolver_Tests.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 searchPathElement: "{HintPathFromItem}",
                 getAssemblyName: (path) => throw new NotImplementedException(), // not called in this code path
                 fileExists: p => FileUtilities.FileExistsNoThrow(p),
+                getDirectoryFile: null, // not used
                 getRuntimeVersion: (path) => throw new NotImplementedException(), // not called in this code path
                 targetedRuntimeVesion: Version.Parse("4.0.30319"));
 

--- a/src/Tasks.UnitTests/HintPathResolver_Tests.cs
+++ b/src/Tasks.UnitTests/HintPathResolver_Tests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 searchPathElement: "{HintPathFromItem}",
                 getAssemblyName: (path) => throw new NotImplementedException(), // not called in this code path
                 fileExists: p => FileUtilities.FileExistsNoThrow(p),
-                getDirectoryFile: null, // not used
+                fileExistsInDirectory: null, // not used
                 getRuntimeVersion: (path) => throw new NotImplementedException(), // not called in this code path
                 targetedRuntimeVesion: Version.Parse("4.0.30319"));
 

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
@@ -99,8 +99,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public AssemblyFoldersExResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetRegistrySubKeyNames getRegistrySubKeyNames, GetRegistrySubKeyDefaultValue getRegistrySubKeyDefaultValue, GetAssemblyRuntimeVersion getRuntimeVersion, OpenBaseKey openBaseKey, Version targetedRuntimeVesion, ProcessorArchitecture targetProcessorArchitecture, bool compareProcessorArchitecture, IBuildEngine buildEngine)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, targetProcessorArchitecture, compareProcessorArchitecture)
+        public AssemblyFoldersExResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetRegistrySubKeyNames getRegistrySubKeyNames, GetRegistrySubKeyDefaultValue getRegistrySubKeyDefaultValue, GetAssemblyRuntimeVersion getRuntimeVersion, OpenBaseKey openBaseKey, Version targetedRuntimeVesion, ProcessorArchitecture targetProcessorArchitecture, bool compareProcessorArchitecture, IBuildEngine buildEngine)
+            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, targetProcessorArchitecture, compareProcessorArchitecture)
         {
             _buildEngine = buildEngine as IBuildEngine4;
             _getRegistrySubKeyNames = getRegistrySubKeyNames;

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
@@ -99,8 +99,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public AssemblyFoldersExResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetRegistrySubKeyNames getRegistrySubKeyNames, GetRegistrySubKeyDefaultValue getRegistrySubKeyDefaultValue, GetAssemblyRuntimeVersion getRuntimeVersion, OpenBaseKey openBaseKey, Version targetedRuntimeVesion, ProcessorArchitecture targetProcessorArchitecture, bool compareProcessorArchitecture, IBuildEngine buildEngine)
-            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, targetProcessorArchitecture, compareProcessorArchitecture)
+        public AssemblyFoldersExResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetRegistrySubKeyNames getRegistrySubKeyNames, GetRegistrySubKeyDefaultValue getRegistrySubKeyDefaultValue, GetAssemblyRuntimeVersion getRuntimeVersion, OpenBaseKey openBaseKey, Version targetedRuntimeVesion, ProcessorArchitecture targetProcessorArchitecture, bool compareProcessorArchitecture, IBuildEngine buildEngine)
+            : base(searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion, targetProcessorArchitecture, compareProcessorArchitecture)
         {
             _buildEngine = buildEngine as IBuildEngine4;
             _getRegistrySubKeyNames = getRegistrySubKeyNames;

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
         /// Construct.
         /// </summary>
         public AssemblyFoldersFromConfigResolver(string searchPathElement, GetAssemblyName getAssemblyName,
-            FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion,
+            FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion,
             ProcessorArchitecture targetProcessorArchitecture, bool compareProcessorArchitecture,
             IBuildEngine buildEngine, TaskLoggingHelper log)
             : base(
-                searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion,
+                searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion,
                 targetProcessorArchitecture, compareProcessorArchitecture)
         {
             _buildEngine = buildEngine as IBuildEngine4;

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
         /// Construct.
         /// </summary>
         public AssemblyFoldersFromConfigResolver(string searchPathElement, GetAssemblyName getAssemblyName,
-            FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion,
+            FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion,
             ProcessorArchitecture targetProcessorArchitecture, bool compareProcessorArchitecture,
             IBuildEngine buildEngine, TaskLoggingHelper log)
             : base(
-                searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion,
+                searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion,
                 targetProcessorArchitecture, compareProcessorArchitecture)
         {
             _buildEngine = buildEngine as IBuildEngine4;

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="searchPathElement">The corresponding element from the search path.</param>
         /// <param name="getAssemblyName">Delegate that gets the assembly name.</param>
         /// <param name="fileExists">Delegate that returns if the file exists.</param>
-        /// <param name="getDirectoryFile">Delegate to test if file exists in directory and return fill file name</param>
+        /// <param name="getDirectoryFile">Delegate to test if file exists in directory and return full file name</param>
         /// <param name="getRuntimeVersion">Delegate that returns the clr runtime version for the file.</param>
         /// <param name="targetedRuntimeVesion">The targeted runtime version.</param>
         public AssemblyFoldersResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Build.Tasks
         /// <param name="searchPathElement">The corresponding element from the search path.</param>
         /// <param name="getAssemblyName">Delegate that gets the assembly name.</param>
         /// <param name="fileExists">Delegate that returns if the file exists.</param>
-        /// <param name="getDirectoryFile">Delegate to test if file exists in directory and return full file name</param>
+        /// <param name="fileExistsInDirectory">Delegate to test if file exists in directory.</param>
         /// <param name="getRuntimeVersion">Delegate that returns the clr runtime version for the file.</param>
         /// <param name="targetedRuntimeVesion">The targeted runtime version.</param>
-        public AssemblyFoldersResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
+        public AssemblyFoldersResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
         {
         }
 

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
@@ -18,10 +18,11 @@ namespace Microsoft.Build.Tasks
         /// <param name="searchPathElement">The corresponding element from the search path.</param>
         /// <param name="getAssemblyName">Delegate that gets the assembly name.</param>
         /// <param name="fileExists">Delegate that returns if the file exists.</param>
+        /// <param name="getDirectoryFile">Delegate to test if file exists in directory and return fill file name</param>
         /// <param name="getRuntimeVersion">Delegate that returns the clr runtime version for the file.</param>
         /// <param name="targetedRuntimeVesion">The targeted runtime version.</param>
-        public AssemblyFoldersResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
+        public AssemblyFoldersResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
         {
         }
 

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="targetProcessorArchitecture">Like x86 or IA64\AMD64, the processor architecture being targetted.</param>
         /// <param name="frameworkPaths">Paths to FX folders.</param>
         /// <param name="fileExists"></param>
+        /// <param name="getDirectoryFile"></param>
         /// <param name="getAssemblyName"></param>
         /// <param name="getRegistrySubKeyNames"></param>
         /// <param name="getRegistrySubKeyDefaultValue"></param>
@@ -129,6 +130,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="targetProcessorArchitecture">Like x86 or IA64\AMD64, the processor architecture being targetted.</param>
         /// <param name="frameworkPaths">Paths to FX folders.</param>
         /// <param name="fileExists"></param>
+        /// <param name="getDirectoryFile"></param>
         /// <param name="getAssemblyName"></param>
         /// <param name="installedAssemblies"></param>
         /// <param name="getRuntimeVersion"></param>
@@ -145,6 +147,7 @@ namespace Microsoft.Build.Tasks
             System.Reflection.ProcessorArchitecture targetProcessorArchitecture,
             string[] frameworkPaths,
             FileExists fileExists,
+            DirectoryFile getDirectoryFile,
             GetAssemblyName getAssemblyName,
 #if FEATURE_WIN32_REGISTRY
             GetRegistrySubKeyNames getRegistrySubKeyNames,
@@ -168,44 +171,44 @@ namespace Microsoft.Build.Tasks
                 // HintPath property.
                 if (String.Equals(basePath, AssemblyResolutionConstants.hintPathSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new HintPathResolver(searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new HintPathResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
                 }
                 else if (String.Equals(basePath, AssemblyResolutionConstants.frameworkPathSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new FrameworkPathResolver(frameworkPaths, installedAssemblies, searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new FrameworkPathResolver(frameworkPaths, installedAssemblies, searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
                 }
                 else if (String.Equals(basePath, AssemblyResolutionConstants.rawFileNameSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new RawFilenameResolver(searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new RawFilenameResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
                 }
                 else if (String.Equals(basePath, AssemblyResolutionConstants.candidateAssemblyFilesSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new CandidateAssemblyFilesResolver(candidateAssemblyFiles, searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new CandidateAssemblyFilesResolver(candidateAssemblyFiles, searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
                 }
 #if FEATURE_GAC
                 else if (String.Equals(basePath, AssemblyResolutionConstants.gacSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new GacResolver(targetProcessorArchitecture, searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, getAssemblyPathInGac);
+                    resolvers[p] = new GacResolver(targetProcessorArchitecture, searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion, getAssemblyPathInGac);
                 }
 #endif
                 else if (String.Equals(basePath, AssemblyResolutionConstants.assemblyFoldersSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new AssemblyFoldersResolver(searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new AssemblyFoldersResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
                 }
 #if FEATURE_WIN32_REGISTRY
                 // Check for AssemblyFoldersEx sentinel.
                 else if (0 == String.Compare(basePath, 0, AssemblyResolutionConstants.assemblyFoldersExSentinel, 0, AssemblyResolutionConstants.assemblyFoldersExSentinel.Length, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new AssemblyFoldersExResolver(searchPaths[p], getAssemblyName, fileExists, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getRuntimeVersion, openBaseKey, targetedRuntimeVersion, targetProcessorArchitecture, true, buildEngine);
+                    resolvers[p] = new AssemblyFoldersExResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getRuntimeVersion, openBaseKey, targetedRuntimeVersion, targetProcessorArchitecture, true, buildEngine);
                 }
 #endif
                 else if (0 == String.Compare(basePath, 0, AssemblyResolutionConstants.assemblyFoldersFromConfigSentinel, 0, AssemblyResolutionConstants.assemblyFoldersFromConfigSentinel.Length, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new AssemblyFoldersFromConfigResolver(searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, targetProcessorArchitecture, true, buildEngine, log);
+                    resolvers[p] = new AssemblyFoldersFromConfigResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion, targetProcessorArchitecture, true, buildEngine, log);
                 }
                 else
                 {
-                    resolvers[p] = new DirectoryResolver(searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new DirectoryResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
                 }
             }
             return resolvers;
@@ -218,6 +221,7 @@ namespace Microsoft.Build.Tasks
         (
             List<string> directories,
             FileExists fileExists,
+            DirectoryFile getDirectoryFile,
             GetAssemblyName getAssemblyName,
             GetAssemblyRuntimeVersion getRuntimeVersion,
             Version targetedRuntimeVersion
@@ -226,7 +230,7 @@ namespace Microsoft.Build.Tasks
             var resolvers = new Resolver[directories.Count];
             for (int i = 0; i < directories.Count; i++)
             {
-                resolvers[i] = new DirectoryResolver(directories[i], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
+                resolvers[i] = new DirectoryResolver(directories[i], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
             }
 
             return resolvers;

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="targetProcessorArchitecture">Like x86 or IA64\AMD64, the processor architecture being targetted.</param>
         /// <param name="frameworkPaths">Paths to FX folders.</param>
         /// <param name="fileExists"></param>
-        /// <param name="getDirectoryFile"></param>
+        /// <param name="fileExistsInDirectory"></param>
         /// <param name="getAssemblyName"></param>
         /// <param name="getRegistrySubKeyNames"></param>
         /// <param name="getRegistrySubKeyDefaultValue"></param>
@@ -130,7 +130,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="targetProcessorArchitecture">Like x86 or IA64\AMD64, the processor architecture being targetted.</param>
         /// <param name="frameworkPaths">Paths to FX folders.</param>
         /// <param name="fileExists"></param>
-        /// <param name="getDirectoryFile"></param>
+        /// <param name="fileExistsInDirectory"></param>
         /// <param name="getAssemblyName"></param>
         /// <param name="installedAssemblies"></param>
         /// <param name="getRuntimeVersion"></param>
@@ -147,7 +147,7 @@ namespace Microsoft.Build.Tasks
             System.Reflection.ProcessorArchitecture targetProcessorArchitecture,
             string[] frameworkPaths,
             FileExists fileExists,
-            DirectoryFile getDirectoryFile,
+            FileExistsInDirectory fileExistsInDirectory,
             GetAssemblyName getAssemblyName,
 #if FEATURE_WIN32_REGISTRY
             GetRegistrySubKeyNames getRegistrySubKeyNames,
@@ -171,44 +171,44 @@ namespace Microsoft.Build.Tasks
                 // HintPath property.
                 if (String.Equals(basePath, AssemblyResolutionConstants.hintPathSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new HintPathResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new HintPathResolver(searchPaths[p], getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVersion);
                 }
                 else if (String.Equals(basePath, AssemblyResolutionConstants.frameworkPathSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new FrameworkPathResolver(frameworkPaths, installedAssemblies, searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new FrameworkPathResolver(frameworkPaths, installedAssemblies, searchPaths[p], getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVersion);
                 }
                 else if (String.Equals(basePath, AssemblyResolutionConstants.rawFileNameSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new RawFilenameResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new RawFilenameResolver(searchPaths[p], getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVersion);
                 }
                 else if (String.Equals(basePath, AssemblyResolutionConstants.candidateAssemblyFilesSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new CandidateAssemblyFilesResolver(candidateAssemblyFiles, searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new CandidateAssemblyFilesResolver(candidateAssemblyFiles, searchPaths[p], getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVersion);
                 }
 #if FEATURE_GAC
                 else if (String.Equals(basePath, AssemblyResolutionConstants.gacSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new GacResolver(targetProcessorArchitecture, searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion, getAssemblyPathInGac);
+                    resolvers[p] = new GacResolver(targetProcessorArchitecture, searchPaths[p], getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVersion, getAssemblyPathInGac);
                 }
 #endif
                 else if (String.Equals(basePath, AssemblyResolutionConstants.assemblyFoldersSentinel, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new AssemblyFoldersResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new AssemblyFoldersResolver(searchPaths[p], getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVersion);
                 }
 #if FEATURE_WIN32_REGISTRY
                 // Check for AssemblyFoldersEx sentinel.
                 else if (0 == String.Compare(basePath, 0, AssemblyResolutionConstants.assemblyFoldersExSentinel, 0, AssemblyResolutionConstants.assemblyFoldersExSentinel.Length, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new AssemblyFoldersExResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getRuntimeVersion, openBaseKey, targetedRuntimeVersion, targetProcessorArchitecture, true, buildEngine);
+                    resolvers[p] = new AssemblyFoldersExResolver(searchPaths[p], getAssemblyName, fileExists, fileExistsInDirectory, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getRuntimeVersion, openBaseKey, targetedRuntimeVersion, targetProcessorArchitecture, true, buildEngine);
                 }
 #endif
                 else if (0 == String.Compare(basePath, 0, AssemblyResolutionConstants.assemblyFoldersFromConfigSentinel, 0, AssemblyResolutionConstants.assemblyFoldersFromConfigSentinel.Length, StringComparison.OrdinalIgnoreCase))
                 {
-                    resolvers[p] = new AssemblyFoldersFromConfigResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion, targetProcessorArchitecture, true, buildEngine, log);
+                    resolvers[p] = new AssemblyFoldersFromConfigResolver(searchPaths[p], getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVersion, targetProcessorArchitecture, true, buildEngine, log);
                 }
                 else
                 {
-                    resolvers[p] = new DirectoryResolver(searchPaths[p], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new DirectoryResolver(searchPaths[p], getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVersion);
                 }
             }
             return resolvers;
@@ -221,7 +221,7 @@ namespace Microsoft.Build.Tasks
         (
             List<string> directories,
             FileExists fileExists,
-            DirectoryFile getDirectoryFile,
+            FileExistsInDirectory fileExistsInDirectory,
             GetAssemblyName getAssemblyName,
             GetAssemblyRuntimeVersion getRuntimeVersion,
             Version targetedRuntimeVersion
@@ -230,7 +230,7 @@ namespace Microsoft.Build.Tasks
             var resolvers = new Resolver[directories.Count];
             for (int i = 0; i < directories.Count; i++)
             {
-                resolvers[i] = new DirectoryResolver(directories[i], getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVersion);
+                resolvers[i] = new DirectoryResolver(directories[i], getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVersion);
             }
 
             return resolvers;

--- a/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
+++ b/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
@@ -26,10 +26,11 @@ namespace Microsoft.Build.Tasks
         /// <param name="searchPathElement">The corresponding element from the search path.</param>
         /// <param name="getAssemblyName">Delegate that gets the assembly name.</param>
         /// <param name="fileExists">Delegate that returns if the file exists.</param>
+        /// <param name="getDirectoryFile">Delegate to test if file exists in directory and return fill file name</param>
         /// <param name="getRuntimeVersion">Delegate that returns the clr runtime version for the file.</param>
         /// <param name="targetedRuntimeVesion">The targeted runtime version.</param>
-        public CandidateAssemblyFilesResolver(string[] candidateAssemblyFiles, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
+        public CandidateAssemblyFilesResolver(string[] candidateAssemblyFiles, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
         {
             _candidateAssemblyFiles = candidateAssemblyFiles;
         }

--- a/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
+++ b/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="searchPathElement">The corresponding element from the search path.</param>
         /// <param name="getAssemblyName">Delegate that gets the assembly name.</param>
         /// <param name="fileExists">Delegate that returns if the file exists.</param>
-        /// <param name="getDirectoryFile">Delegate to test if file exists in directory and return fill file name</param>
+        /// <param name="getDirectoryFile">Delegate to test if file exists in directory and return full file name</param>
         /// <param name="getRuntimeVersion">Delegate that returns the clr runtime version for the file.</param>
         /// <param name="targetedRuntimeVesion">The targeted runtime version.</param>
         public CandidateAssemblyFilesResolver(string[] candidateAssemblyFiles, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)

--- a/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
+++ b/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Build.Tasks
         /// <param name="searchPathElement">The corresponding element from the search path.</param>
         /// <param name="getAssemblyName">Delegate that gets the assembly name.</param>
         /// <param name="fileExists">Delegate that returns if the file exists.</param>
-        /// <param name="getDirectoryFile">Delegate to test if file exists in directory and return full file name</param>
+        /// <param name="fileExistsInDirectory">Delegate to test if file exists in directory and return full file name</param>
         /// <param name="getRuntimeVersion">Delegate that returns the clr runtime version for the file.</param>
         /// <param name="targetedRuntimeVesion">The targeted runtime version.</param>
-        public CandidateAssemblyFilesResolver(string[] candidateAssemblyFiles, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
+        public CandidateAssemblyFilesResolver(string[] candidateAssemblyFiles, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
         {
             _candidateAssemblyFiles = candidateAssemblyFiles;
         }

--- a/src/Tasks/AssemblyDependency/DirectoryResolver.cs
+++ b/src/Tasks/AssemblyDependency/DirectoryResolver.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public DirectoryResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
+        public DirectoryResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
         {
         }
 

--- a/src/Tasks/AssemblyDependency/DirectoryResolver.cs
+++ b/src/Tasks/AssemblyDependency/DirectoryResolver.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public DirectoryResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
+        public DirectoryResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
         {
         }
 

--- a/src/Tasks/AssemblyDependency/FrameworkPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/FrameworkPathResolver.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public FrameworkPathResolver(string[] frameworkPaths, InstalledAssemblies installedAssemblies, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
+        public FrameworkPathResolver(string[] frameworkPaths, InstalledAssemblies installedAssemblies, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
         {
             _frameworkPaths = frameworkPaths;
             _installedAssemblies = installedAssemblies;

--- a/src/Tasks/AssemblyDependency/FrameworkPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/FrameworkPathResolver.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public FrameworkPathResolver(string[] frameworkPaths, InstalledAssemblies installedAssemblies, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
+        public FrameworkPathResolver(string[] frameworkPaths, InstalledAssemblies installedAssemblies, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
         {
             _frameworkPaths = frameworkPaths;
             _installedAssemblies = installedAssemblies;

--- a/src/Tasks/AssemblyDependency/GacResolver.cs
+++ b/src/Tasks/AssemblyDependency/GacResolver.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Build.Tasks
         /// <param name="searchPathElement">The search path element.</param>
         /// <param name="getAssemblyName">Delegate to get the assembly name object.</param>
         /// <param name="fileExists">Delegate to check if the file exists.</param>
-        /// <param name="getDirectoryFile">Delegate to check if the file exists by cached list of files of directory.</param>
+        /// <param name="fileExistsInDirectory">Delegate to check if the file exists by cached list of files of directory.</param>
         /// <param name="getRuntimeVersion">Delegate to get the runtime version.</param>
         /// <param name="targetedRuntimeVesion">The targeted runtime version.</param>
         /// <param name="getAssemblyPathInGac">Delegate to get assembly path in the GAC.</param>
-        public GacResolver(System.Reflection.ProcessorArchitecture targetProcessorArchitecture, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion, GetAssemblyPathInGac getAssemblyPathInGac)
-            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, targetProcessorArchitecture, true)
+        public GacResolver(System.Reflection.ProcessorArchitecture targetProcessorArchitecture, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion, GetAssemblyPathInGac getAssemblyPathInGac)
+            : base(searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion, targetProcessorArchitecture, true)
         {
             _getAssemblyPathInGac = getAssemblyPathInGac;
         }

--- a/src/Tasks/AssemblyDependency/GacResolver.cs
+++ b/src/Tasks/AssemblyDependency/GacResolver.cs
@@ -24,11 +24,12 @@ namespace Microsoft.Build.Tasks
         /// <param name="searchPathElement">The search path element.</param>
         /// <param name="getAssemblyName">Delegate to get the assembly name object.</param>
         /// <param name="fileExists">Delegate to check if the file exists.</param>
+        /// <param name="getDirectoryFile">Delegate to check if the file exists by cached list of files of directory.</param>
         /// <param name="getRuntimeVersion">Delegate to get the runtime version.</param>
         /// <param name="targetedRuntimeVesion">The targeted runtime version.</param>
         /// <param name="getAssemblyPathInGac">Delegate to get assembly path in the GAC.</param>
-        public GacResolver(System.Reflection.ProcessorArchitecture targetProcessorArchitecture, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion, GetAssemblyPathInGac getAssemblyPathInGac)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, targetProcessorArchitecture, true)
+        public GacResolver(System.Reflection.ProcessorArchitecture targetProcessorArchitecture, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion, GetAssemblyPathInGac getAssemblyPathInGac)
+            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, targetProcessorArchitecture, true)
         {
             _getAssemblyPathInGac = getAssemblyPathInGac;
         }

--- a/src/Tasks/AssemblyDependency/HintPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/HintPathResolver.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public HintPathResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
+        public HintPathResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
         {
         }
 

--- a/src/Tasks/AssemblyDependency/HintPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/HintPathResolver.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public HintPathResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
+        public HintPathResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
         {
         }
 

--- a/src/Tasks/AssemblyDependency/RawFilenameResolver.cs
+++ b/src/Tasks/AssemblyDependency/RawFilenameResolver.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public RawFilenameResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
+        public RawFilenameResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
         {
         }
 

--- a/src/Tasks/AssemblyDependency/RawFilenameResolver.cs
+++ b/src/Tasks/AssemblyDependency/RawFilenameResolver.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public RawFilenameResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
+        public RawFilenameResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, ProcessorArchitecture.None, false)
         {
         }
 

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -79,6 +79,8 @@ namespace Microsoft.Build.Tasks
         private readonly DirectoryExists _directoryExists;
         /// <summary>Delegate used for getting directories.</summary>
         private readonly GetDirectories _getDirectories;
+        /// <summary>Delegate used for verify file in directories.</summary>
+        private readonly DirectoryFile _getDirectoryFile;
         /// <summary>Delegate used for getting assembly names.</summary>
         private readonly GetAssemblyName _getAssemblyName;
         /// <summary>Delegate used for finding dependencies of a file.</summary>
@@ -175,6 +177,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="installedAssemblies">Installed assembly XML tables.</param>
         /// <param name="targetProcessorArchitecture">Like x86 or IA64\AMD64, the processor architecture being targetted.</param>
         /// <param name="fileExists">Delegate used for checking for the existence of a file.</param>
+        /// <param name="getDirectoryFile">Delegate used for checking for the existence of a file in a directory and mapping it to full path.</param>
         /// <param name="directoryExists">Delegate used for files.</param>
         /// <param name="getDirectories">Delegate used for getting directories.</param>
         /// <param name="getAssemblyName">Delegate used for getting assembly names.</param>
@@ -216,6 +219,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="installedAssemblies">Installed assembly XML tables.</param>
         /// <param name="targetProcessorArchitecture">Like x86 or IA64\AMD64, the processor architecture being targetted.</param>
         /// <param name="fileExists">Delegate used for checking for the existence of a file.</param>
+        /// <param name="getDirectoryFile">Delegate used for checking for the existence of a file in a directory and mapping it to full path.</param>
         /// <param name="directoryExists">Delegate used for files.</param>
         /// <param name="getDirectories">Delegate used for getting directories.</param>
         /// <param name="getAssemblyName">Delegate used for getting assembly names.</param>
@@ -254,6 +258,7 @@ namespace Microsoft.Build.Tasks
             InstalledAssemblies installedAssemblies,
             System.Reflection.ProcessorArchitecture targetProcessorArchitecture,
             FileExists fileExists,
+            DirectoryFile getDirectoryFile,
             DirectoryExists directoryExists,
             GetDirectories getDirectories,
             GetAssemblyName getAssemblyName,
@@ -293,6 +298,7 @@ namespace Microsoft.Build.Tasks
             _fileExists = fileExists;
             _directoryExists = directoryExists;
             _getDirectories = getDirectories;
+            _getDirectoryFile = getDirectoryFile;
             _getAssemblyName = getAssemblyName;
             _getAssemblyMetadata = getAssemblyMetadata;
             _getRuntimeVersion = getRuntimeVersion;
@@ -348,6 +354,7 @@ namespace Microsoft.Build.Tasks
                     targetProcessorArchitecture,
                     frameworkPaths,
                     fileExists,
+                    getDirectoryFile,
                     getAssemblyName,
 #if FEATURE_WIN32_REGISTRY
                     getRegistrySubKeyNames,
@@ -1302,14 +1309,14 @@ namespace Microsoft.Build.Tasks
             // If a reference has the SDKName metadata on it then we will only search using a single resolver, that is the InstalledSDKResolver.
             if (reference.SDKName.Length > 0)
             {
-                jaggedResolvers.Add(new Resolver[] { new InstalledSDKResolver(_resolvedSDKReferences, "SDKResolver", _getAssemblyName, _fileExists, _getRuntimeVersion, _targetedRuntimeVersion) });
+                jaggedResolvers.Add(new Resolver[] { new InstalledSDKResolver(_resolvedSDKReferences, "SDKResolver", _getAssemblyName, _fileExists, _getDirectoryFile, _getRuntimeVersion, _targetedRuntimeVersion) });
             }
             else
             {
                 // Do not probe near dependees if the reference is primary and resolved externally. If resolved externally, the search paths should have been specified in such a way to point to the assembly file.
                 if (assemblyName == null || !_externallyResolvedPrimaryReferences.Contains(assemblyName.Name))
                 {
-                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceFolders, _fileExists, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion));
+                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceFolders, _fileExists, _getDirectoryFile, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion));
                 }
 
                 jaggedResolvers.Add(Resolvers);

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Tasks
         private readonly DirectoryExists _directoryExists;
         /// <summary>Delegate used for getting directories.</summary>
         private readonly GetDirectories _getDirectories;
-        /// <summary>Delegate used for verify file in directories.</summary>
+        /// <summary>Delegate used for checking for the existence of a file in a directory and mapping it to full path.</summary>
         private readonly DirectoryFile _getDirectoryFile;
         /// <summary>Delegate used for getting assembly names.</summary>
         private readonly GetAssemblyName _getAssemblyName;

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Build.Tasks
         private readonly DirectoryExists _directoryExists;
         /// <summary>Delegate used for getting directories.</summary>
         private readonly GetDirectories _getDirectories;
-        /// <summary>Delegate used for checking for the existence of a file in a directory and mapping it to full path.</summary>
-        private readonly DirectoryFile _getDirectoryFile;
+        /// <summary>Delegate used for checking for the existence of a file in a directory.</summary>
+        private readonly FileExistsInDirectory _fileExistsInDirectory;
         /// <summary>Delegate used for getting assembly names.</summary>
         private readonly GetAssemblyName _getAssemblyName;
         /// <summary>Delegate used for finding dependencies of a file.</summary>
@@ -177,7 +177,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="installedAssemblies">Installed assembly XML tables.</param>
         /// <param name="targetProcessorArchitecture">Like x86 or IA64\AMD64, the processor architecture being targetted.</param>
         /// <param name="fileExists">Delegate used for checking for the existence of a file.</param>
-        /// <param name="getDirectoryFile">Delegate used for checking for the existence of a file in a directory and mapping it to full path.</param>
+        /// <param name="fileExistsInDirectory">Delegate used for checking for the existence of a file in a directory.</param>
         /// <param name="directoryExists">Delegate used for files.</param>
         /// <param name="getDirectories">Delegate used for getting directories.</param>
         /// <param name="getAssemblyName">Delegate used for getting assembly names.</param>
@@ -219,7 +219,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="installedAssemblies">Installed assembly XML tables.</param>
         /// <param name="targetProcessorArchitecture">Like x86 or IA64\AMD64, the processor architecture being targetted.</param>
         /// <param name="fileExists">Delegate used for checking for the existence of a file.</param>
-        /// <param name="getDirectoryFile">Delegate used for checking for the existence of a file in a directory and mapping it to full path.</param>
+        /// <param name="fileExistsInDirectory">Delegate used for checking for the existence of a file in a directory.</param>
         /// <param name="directoryExists">Delegate used for files.</param>
         /// <param name="getDirectories">Delegate used for getting directories.</param>
         /// <param name="getAssemblyName">Delegate used for getting assembly names.</param>
@@ -258,7 +258,7 @@ namespace Microsoft.Build.Tasks
             InstalledAssemblies installedAssemblies,
             System.Reflection.ProcessorArchitecture targetProcessorArchitecture,
             FileExists fileExists,
-            DirectoryFile getDirectoryFile,
+            FileExistsInDirectory fileExistsInDirectory,
             DirectoryExists directoryExists,
             GetDirectories getDirectories,
             GetAssemblyName getAssemblyName,
@@ -298,7 +298,7 @@ namespace Microsoft.Build.Tasks
             _fileExists = fileExists;
             _directoryExists = directoryExists;
             _getDirectories = getDirectories;
-            _getDirectoryFile = getDirectoryFile;
+            _fileExistsInDirectory = fileExistsInDirectory;
             _getAssemblyName = getAssemblyName;
             _getAssemblyMetadata = getAssemblyMetadata;
             _getRuntimeVersion = getRuntimeVersion;
@@ -354,7 +354,7 @@ namespace Microsoft.Build.Tasks
                     targetProcessorArchitecture,
                     frameworkPaths,
                     fileExists,
-                    getDirectoryFile,
+                    fileExistsInDirectory,
                     getAssemblyName,
 #if FEATURE_WIN32_REGISTRY
                     getRegistrySubKeyNames,
@@ -1309,14 +1309,14 @@ namespace Microsoft.Build.Tasks
             // If a reference has the SDKName metadata on it then we will only search using a single resolver, that is the InstalledSDKResolver.
             if (reference.SDKName.Length > 0)
             {
-                jaggedResolvers.Add(new Resolver[] { new InstalledSDKResolver(_resolvedSDKReferences, "SDKResolver", _getAssemblyName, _fileExists, _getDirectoryFile, _getRuntimeVersion, _targetedRuntimeVersion) });
+                jaggedResolvers.Add(new Resolver[] { new InstalledSDKResolver(_resolvedSDKReferences, "SDKResolver", _getAssemblyName, _fileExists, _fileExistsInDirectory, _getRuntimeVersion, _targetedRuntimeVersion) });
             }
             else
             {
                 // Do not probe near dependees if the reference is primary and resolved externally. If resolved externally, the search paths should have been specified in such a way to point to the assembly file.
                 if (assemblyName == null || !_externallyResolvedPrimaryReferences.Contains(assemblyName.Name))
                 {
-                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceFolders, _fileExists, _getDirectoryFile, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion));
+                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceFolders, _fileExists, _fileExistsInDirectory, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion));
                 }
 
                 jaggedResolvers.Add(Resolvers);

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1934,6 +1934,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="fileExists">Delegate used for checking for the existence of a file.</param>
         /// <param name="directoryExists">Delegate used for checking for the existence of a directory.</param>
         /// <param name="getDirectories">Delegate used for finding directories.</param>
+        /// <param name="getDirectoryFiles">Delegate used to get files from directories.</param>
         /// <param name="getAssemblyName">Delegate used for finding fusion names of assemblyFiles.</param>
         /// <param name="getAssemblyMetadata">Delegate used for finding dependencies of a file.</param>
         /// <param name="getRegistrySubKeyNames">Used to get registry subkey names.</param>
@@ -1952,6 +1953,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="fileExists">Delegate used for checking for the existence of a file.</param>
         /// <param name="directoryExists">Delegate used for checking for the existence of a directory.</param>
         /// <param name="getDirectories">Delegate used for finding directories.</param>
+        /// <param name="getDirectoryFiles">Delegate used to get files from directories.</param>
         /// <param name="getAssemblyName">Delegate used for finding fusion names of assemblyFiles.</param>
         /// <param name="getAssemblyMetadata">Delegate used for finding dependencies of a file.</param>
         /// <param name="getLastWriteTime">Delegate used to get the last write time.</param>
@@ -1966,6 +1968,7 @@ namespace Microsoft.Build.Tasks
             FileExists fileExists,
             DirectoryExists directoryExists,
             GetDirectories getDirectories,
+            DirectoryGetFiles getDirectoryFiles,
             GetAssemblyName getAssemblyName,
             GetAssemblyMetadata getAssemblyMetadata,
 #if FEATURE_WIN32_REGISTRY
@@ -2141,6 +2144,7 @@ namespace Microsoft.Build.Tasks
                     getAssemblyMetadata = _cache.CacheDelegate(getAssemblyMetadata);
                     fileExists = _cache.CacheDelegate(fileExists);
                     directoryExists = _cache.CacheDelegate(directoryExists);
+                    DirectoryFile getDirectoryFile = _cache.CacheDelegate(getDirectoryFiles);
                     getDirectories = _cache.CacheDelegate(getDirectories);
                     getRuntimeVersion = _cache.CacheDelegate(getRuntimeVersion);
 
@@ -2188,6 +2192,7 @@ namespace Microsoft.Build.Tasks
                         installedAssemblies,
                         processorArchitecture,
                         fileExists,
+                        getDirectoryFile,
                         directoryExists,
                         getDirectories,
                         getAssemblyName,
@@ -3023,6 +3028,7 @@ namespace Microsoft.Build.Tasks
                 new FileExists(p => FileUtilities.FileExistsNoThrow(p)),
                 new DirectoryExists(p => FileUtilities.DirectoryExistsNoThrow(p)),
                 new GetDirectories(Directory.GetDirectories),
+                new DirectoryGetFiles((d, p) => FileUtilities.DirectoryGetFiles(d, p)),
                 new GetAssemblyName(AssemblyNameExtension.GetAssemblyNameEx),
                 new GetAssemblyMetadata(AssemblyInformation.GetAssemblyMetadata),
 #if FEATURE_WIN32_REGISTRY

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2144,7 +2144,7 @@ namespace Microsoft.Build.Tasks
                     getAssemblyMetadata = _cache.CacheDelegate(getAssemblyMetadata);
                     fileExists = _cache.CacheDelegate(fileExists);
                     directoryExists = _cache.CacheDelegate(directoryExists);
-                    DirectoryFile getDirectoryFile = _cache.CacheDelegate(getDirectoryFiles);
+                    FileExistsInDirectory fileExistsInDirectory = _cache.CacheDelegate(getDirectoryFiles);
                     getDirectories = _cache.CacheDelegate(getDirectories);
                     getRuntimeVersion = _cache.CacheDelegate(getRuntimeVersion);
 
@@ -2192,7 +2192,7 @@ namespace Microsoft.Build.Tasks
                         installedAssemblies,
                         processorArchitecture,
                         fileExists,
-                        getDirectoryFile,
+                        fileExistsInDirectory,
                         directoryExists,
                         getDirectories,
                         getAssemblyName,

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -116,7 +116,9 @@ namespace Microsoft.Build.Tasks
             bool wantSpecificVersion,
             bool allowMismatchBetweenFusionNameAndFileName,
             List<ResolutionSearchLocation> assembliesConsideredAndRejected,
-            bool isFileExistenceVerified = false
+            bool useDirectoryCache = false,
+            string directory = null,
+            string fileName = null
         )
         {
             ResolutionSearchLocation considered = null;
@@ -129,7 +131,7 @@ namespace Microsoft.Build.Tasks
                 };
             }
 
-            if (FileMatchesAssemblyName(assemblyName, isPrimaryProjectReference, wantSpecificVersion, allowMismatchBetweenFusionNameAndFileName, fullPath, considered, isFileExistenceVerified))
+            if (FileMatchesAssemblyName(assemblyName, isPrimaryProjectReference, wantSpecificVersion, allowMismatchBetweenFusionNameAndFileName, fullPath, considered, useDirectoryCache, directory, fileName))
             {
                 return true;
             }
@@ -149,7 +151,9 @@ namespace Microsoft.Build.Tasks
         /// <param name="allowMismatchBetweenFusionNameAndFileName">Whether to allow naming mismatch.</param>
         /// <param name="pathToCandidateAssembly">Path to a possible file.</param>
         /// <param name="searchLocation">Information about why the candidate file didn't match</param>
-        /// <param name="isFileExistenceVerified">Set it to true if file existence is guaranteed, to improve performance by avoiding unnecessary fileExists()</param>
+        /// <param name="useDirectoryCache">Set it to true if file existence is verified by cached list of files in directory.</param>
+        /// <param name="directory">Directory of directory cache. Required if useDirectoryCache.</param>
+        /// <param name="fileName">Name of file in directory cache. Required if useDirectoryCache.</param>
         protected bool FileMatchesAssemblyName
         (
             AssemblyNameExtension assemblyName,
@@ -158,7 +162,9 @@ namespace Microsoft.Build.Tasks
             bool allowMismatchBetweenFusionNameAndFileName,
             string pathToCandidateAssembly,
             ResolutionSearchLocation searchLocation,
-            bool isFileExistenceVerified = false
+            bool useDirectoryCache = false,
+            string directory = null,
+            string fileName = null
         )
         {
             if (searchLocation != null)
@@ -190,7 +196,27 @@ namespace Microsoft.Build.Tasks
 
             bool isSimpleAssemblyName = assemblyName?.IsSimpleName == true;
 
-            if (isFileExistenceVerified || fileExists(pathToCandidateAssembly))
+            bool fileFound;
+            if (useDirectoryCache && Utilities.ChangeWaves.AreFeaturesEnabled(Utilities.ChangeWaves.Wave16_10))
+            {
+                // this verifies file existence using getDirectoryFile delegate which internally used cached list of all files in a particular directory
+                // if some cases it render better performance than one by one FileExists
+                try
+                {
+                    fileFound = getDirectoryFile(directory, fileName) != null;
+                }
+                catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+                {
+                    // Assuming it's the search path that's bad. But combine them both so the error is visible if it's the reference itself.
+                    throw new InvalidParameterValueException("SearchPaths", directory + (directory.EndsWith("\\", StringComparison.OrdinalIgnoreCase) ? String.Empty : "\\") + fileName, e.Message);
+                }
+            }
+            else
+            {
+                fileFound = fileExists(pathToCandidateAssembly);
+            }
+
+            if (fileFound)
             {
                 // If the resolver we are using is targeting a given processor architecture then we must crack open the assembly and make sure the architecture is compatible
                 // We cannot do these simple name matches.
@@ -322,33 +348,10 @@ namespace Microsoft.Build.Tasks
             {
                 string weakNameBase = assemblyName.Name;
 
-                // feature flag by ChangeWaves 
-                bool useFileEnumerationOptimization = Utilities.ChangeWaves.AreFeaturesEnabled(Utilities.ChangeWaves.Wave17_0);
-
                 foreach (string executableExtension in executableExtensions)
                 {
+                    string fileName = weakNameBase + executableExtension;
                     string fullPath;
-                    bool fileExistenceVerified = false;
-
-                    string fileName = $"{weakNameBase}{executableExtension}";
-                    if (useFileEnumerationOptimization)
-                    {
-                        try
-                        {
-                            fileExistenceVerified = getDirectoryFile(directory, fileName) != null;
-                        }
-                        catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
-                        {
-                            // Assuming it's the search path that's bad. But combine them both so the error is visible if it's the reference itself.
-                            throw new InvalidParameterValueException("SearchPaths", directory + (directory.EndsWith("\\", StringComparison.OrdinalIgnoreCase) ? String.Empty : "\\") + fileName, e.Message);
-                        }
-
-                        if (!fileExistenceVerified)
-                        {
-                            // file do not exists, try next file extension
-                            continue;
-                        }
-                    }
 
                     try
                     {
@@ -361,7 +364,8 @@ namespace Microsoft.Build.Tasks
                     }
 
                     // We have a full path returned
-                    if (ResolveAsFile(fullPath, assemblyName, isPrimaryProjectReference, wantSpecificVersion, false, assembliesConsideredAndRejected, isFileExistenceVerified: fileExistenceVerified))
+                    if (ResolveAsFile(fullPath, assemblyName, isPrimaryProjectReference, wantSpecificVersion, false, assembliesConsideredAndRejected,
+                        useDirectoryCache: true, directory: directory, fileName: fileName))
                     {
                         if (candidateFullPath == null)
                         {
@@ -408,31 +412,11 @@ namespace Microsoft.Build.Tasks
                         {
                             if (String.Equals(executableExtension, weakNameBaseExtension, StringComparison.CurrentCultureIgnoreCase))
                             {
-                                bool fileExistenceVerified = false;
-
-                                if (useFileEnumerationOptimization)
-                                {
-                                    try
-                                    {
-                                        fileExistenceVerified = getDirectoryFile(directory, weakNameBase) != null;
-                                    }
-                                    catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
-                                    {
-                                        // Assuming it's the search path that's bad. But combine them both so the error is visible if it's the reference itself.
-                                        throw new InvalidParameterValueException("SearchPaths", directory + (directory.EndsWith("\\", StringComparison.OrdinalIgnoreCase) ? String.Empty : "\\") + weakNameBase, e.Message);
-                                    }
-
-                                    if (!fileExistenceVerified)
-                                    {
-                                        // file do not exists, try next file extension
-                                        continue;
-                                    }
-                                }
-
                                 string fullPath = Path.Combine(directory, weakNameBase);
                                 var extensionlessAssemblyName = new AssemblyNameExtension(weakNameBaseFileName);
 
-                                if (ResolveAsFile(fullPath, extensionlessAssemblyName, isPrimaryProjectReference, wantSpecificVersion, false, assembliesConsideredAndRejected, isFileExistenceVerified: fileExistenceVerified))
+                                if (ResolveAsFile(fullPath, extensionlessAssemblyName, isPrimaryProjectReference, wantSpecificVersion, false, assembliesConsideredAndRejected,
+                                    useDirectoryCache: true, directory: directory, fileName: weakNameBase))
                                 {
                                     return fullPath;
                                 }

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Build.Tasks
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {
                     // Assuming it's the search path that's bad. But combine them both so the error is visible if it's the reference itself.
-                    throw new InvalidParameterValueException("SearchPaths", directory + (directory.EndsWith("\\", StringComparison.OrdinalIgnoreCase) ? String.Empty : "\\") + fileName, e.Message);
+                    throw new InvalidParameterValueException("SearchPaths", $"{directory.TrimEnd(Path.DirectorySeparatorChar)}{Path.DirectorySeparatorChar}{fileName}", e.Message);
                 }
             }
             else
@@ -360,7 +360,7 @@ namespace Microsoft.Build.Tasks
                     catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                     {
                         // Assuming it's the search path that's bad. But combine them both so the error is visible if it's the reference itself.
-                        throw new InvalidParameterValueException("SearchPaths", directory + (directory.EndsWith("\\", StringComparison.OrdinalIgnoreCase) ? String.Empty : "\\") + fileName, e.Message);
+                        throw new InvalidParameterValueException("SearchPaths", $"{directory.TrimEnd(Path.DirectorySeparatorChar)}{Path.DirectorySeparatorChar}{fileName}", e.Message);
                     }
 
                     // We have a full path returned

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Delegate.
         /// </summary>
-        private readonly DirectoryFile getDirectoryFile;
+        private readonly FileExistsInDirectory fileExistsInDirectory;
 
         /// <summary>
         /// Delegate
@@ -57,12 +57,12 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        protected Resolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion, ProcessorArchitecture targetedProcessorArchitecture, bool compareProcessorArchitecture)
+        protected Resolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion, ProcessorArchitecture targetedProcessorArchitecture, bool compareProcessorArchitecture)
         {
             this.searchPathElement = searchPathElement;
             this.getAssemblyName = getAssemblyName;
             this.fileExists = fileExists;
-            this.getDirectoryFile = getDirectoryFile;
+            this.fileExistsInDirectory = fileExistsInDirectory;
             this.getRuntimeVersion = getRuntimeVersion;
             this.targetedRuntimeVersion = targetedRuntimeVesion;
             this.targetProcessorArchitecture = targetedProcessorArchitecture;
@@ -199,11 +199,11 @@ namespace Microsoft.Build.Tasks
             bool fileFound;
             if (useDirectoryCache && Utilities.ChangeWaves.AreFeaturesEnabled(Utilities.ChangeWaves.Wave16_10))
             {
-                // this verifies file existence using getDirectoryFile delegate which internally used cached list of all files in a particular directory
+                // this verifies file existence using fileExistsInDirectory delegate which internally used cached set of all files in a particular directory
                 // if some cases it render better performance than one by one FileExists
                 try
                 {
-                    fileFound = getDirectoryFile(directory, fileName) != null;
+                    fileFound = fileExistsInDirectory(directory, fileName);
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {

--- a/src/Tasks/InstalledSDKResolver.cs
+++ b/src/Tasks/InstalledSDKResolver.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public InstalledSDKResolver(Dictionary<string, ITaskItem> resolvedSDKs, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
+        public InstalledSDKResolver(Dictionary<string, ITaskItem> resolvedSDKs, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, FileExistsInDirectory fileExistsInDirectory, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, fileExistsInDirectory, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
         {
             _resolvedSDKs = resolvedSDKs;
         }

--- a/src/Tasks/InstalledSDKResolver.cs
+++ b/src/Tasks/InstalledSDKResolver.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public InstalledSDKResolver(Dictionary<string, ITaskItem> resolvedSDKs, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
+        public InstalledSDKResolver(Dictionary<string, ITaskItem> resolvedSDKs, string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, DirectoryFile getDirectoryFile, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
+            : base(searchPathElement, getAssemblyName, fileExists, getDirectoryFile, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
         {
             _resolvedSDKs = resolvedSDKs;
         }

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -601,7 +601,6 @@ namespace Microsoft.Build.Tasks
         /// <returns>file full path or null if file do not exists</returns>
         private string GetDirectoryFile(string path, string fileName)
         {
-
             instanceLocalDirectoryFiles.TryGetValue(path, out Dictionary<string, string> cached);
             if (cached == null)
             {
@@ -610,13 +609,13 @@ namespace Microsoft.Build.Tasks
                 {
                     files = getFiles(path, "*");
                 }
-                catch(DirectoryNotFoundException)
+                catch (DirectoryNotFoundException)
                 {
                     files = Array.Empty<string>();
                 }
 
                 cached = new Dictionary<string, string>(files.Length, StringComparer.OrdinalIgnoreCase);
-                foreach(var file in files)
+                foreach (var file in files)
                 {
                     // this will not throw if there are files which differs only by case
                     cached[Path.GetFileName(file)] = file;

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -615,7 +615,13 @@ namespace Microsoft.Build.Tasks
                     files = Array.Empty<string>();
                 }
 
-                cached = files.ToDictionary(fn => Path.GetFileName(fn), StringComparer.OrdinalIgnoreCase);
+                cached = new Dictionary<string, string>(files.Length, StringComparer.OrdinalIgnoreCase);
+                foreach(var file in files)
+                {
+                    // this will not throw if there are files which differs only by case
+                    cached[Path.GetFileName(file)] = file;
+                }
+
                 instanceLocalDirectoryFiles[path] = cached;
             }
 

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -601,6 +601,12 @@ namespace Microsoft.Build.Tasks
         /// <returns>true if file exists</returns>
         private bool FileExistsInDirectory(string path, string fileName)
         {
+            // to behave same as File.Exists(Path.Combine("","file.cs") we have to map empty string to current directory
+            if (path.Length == 0)
+            {
+                path = ".";
+            }
+
             instanceLocalDirectoryFiles.TryGetValue(path, out HashSet<string> cached);
             if (cached == null)
             {

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -594,7 +594,7 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// Cached implementation of GetFiles aimed to verify existence of a file in a directory.
-        /// It does not throw if directory do not exists.
+        /// It does not throw if directory does not exists.
         /// </summary>
         /// <param name="path"></param>
         /// <param name="fileName"></param>

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -625,6 +625,9 @@ namespace Microsoft.Build.Tasks
                 instanceLocalDirectoryFiles[path] = cached;
             }
 
+            // At this point we have all files from directory loaded into dictionary.
+            // It TryGetValue do not found file as key in dictionary it will set fullPathFileName to default(string) i.e. null
+            // which is exactly what we need as null indicate that given file does not exists
             cached.TryGetValue(fileName, out string fullPathFileName);
 
             return fullPathFileName;


### PR DESCRIPTION
### Performance
https://github.com/dotnet/msbuild/issues/5018

### Context
Optimize FileExists lookup for Resolver.ResolveFromDirectory used cases, by caching list of files in the lookup directory and verify its existence against it.

### Changes Made
RAR Resolver.ResolveFromDirectory, changes needed to propagate new FileIO delegate and fixing related unit tests

### Testing
Tested to build OrchadCore and Roslyn

### Notes
Performance saving:
- OrchardCore - none, this project has all references externally resolved and Resolver.ResolveFromDirectory is not called
- Roslyn t:Rebuild - 6% or RAR execution time
- dotnet new mvc; dotnet build - none, seems like all SDK based projects have all references externally resolved

I am not 100% sure if increased code complexity and introduced risk is worth the potential saving.