### PR TITLE
Optimize Match-on-metadata

### DIFF
--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -2231,7 +2231,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 <I1 Include='c1' M1='foo/bar.vb' M2='y'/>
                 <I1 Include='d1' M1='foo\foo\foo' M2='b'/>
                 <I1 Include='e1' M1='a/b/../c/./d' M2='1'/>
-                <I1 Include='f1' M1='{ ObjectModelHelpers.TempProjectDir }\b\c' M2='6'/>
+                <I1 Include='f1' M1='{ Environment.CurrentDirectory }\b\c' M2='6'/>
 
                 <I2 Include='a2' M1='FOO.TXT' m2='c'/>
                 <I2 Include='b2' M1='foo/bar.txt' m2='x'/>
@@ -2403,7 +2403,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         [Fact]
-        public void FailWithMatchingMultipleMetadata()
+        public void RemoveMatchingMultipleMetadata()
         {
             string content = ObjectModelHelpers.FormatProjectContentsWithItemGroupFragment(
                 @"<I1 Include='a1' M1='1' M2='a'/>
@@ -2421,10 +2421,13 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             Project project = ObjectModelHelpers.CreateInMemoryProject(content);
             IEnumerable<ProjectItem> items = project.ItemsIgnoringCondition.Where(i => i.ItemType.Equals("I2"));
             items.Count().ShouldBe(3);
+            items.ElementAt(0).EvaluatedInclude.ShouldBe("a2");
+            items.ElementAt(1).EvaluatedInclude.ShouldBe("c2");
+            items.ElementAt(2).EvaluatedInclude.ShouldBe("d2");
         }
 
         [Fact]
-        public void FailWithMultipleItemReferenceOnMatchingMetadata()
+        public void RemoveMultipleItemReferenceOnMatchingMetadata()
         {
             string content = ObjectModelHelpers.FormatProjectContentsWithItemGroupFragment(
                 @"<I1 Include='a1' M1='1' M2='a'/>
@@ -2465,7 +2468,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 <I2 Remove='%(I1.M1)' MatchOnMetadata='M1' />");
             Should.Throw<InvalidProjectFileException>(() => ObjectModelHelpers.CreateInMemoryProject(content))
-                .HelpKeyword.ShouldBe("MSBuild.OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem");
+                .HelpKeyword.ShouldBe("MSBuild.OM_MatchOnMetadataIsRestrictedToReferencedItems");
         }
 
         [Fact]

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -2418,8 +2418,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 <I2 Remove='@(I1)' MatchOnMetadata='M1;M2'/>");
 
-            Should.Throw<InvalidProjectFileException>(() => ObjectModelHelpers.CreateInMemoryProject(content))
-                .HelpKeyword.ShouldBe("MSBuild.OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem");
+            Project project = ObjectModelHelpers.CreateInMemoryProject(content);
+            IEnumerable<ProjectItem> items = project.ItemsIgnoringCondition.Where(i => i.ItemType.Equals("I2"));
+            items.Count().ShouldBe(3);
         }
 
         [Fact]
@@ -2443,8 +2444,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 <I3 Remove='@(I1);@(I2)' MatchOnMetadata='M1' />");
 
-            Should.Throw<InvalidProjectFileException>(() => ObjectModelHelpers.CreateInMemoryProject(content))
-                .HelpKeyword.ShouldBe("MSBuild.OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem");
+            Project project = ObjectModelHelpers.CreateInMemoryProject(content);
+            IEnumerable<ProjectItem> items = project.ItemsIgnoringCondition.Where(i => i.ItemType.Equals("I3"));
+            items.ShouldBeEmpty();
         }
 
         [Fact]
@@ -2462,7 +2464,6 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 <I2 Include='d2' M1='y' m2='d'/>
 
                 <I2 Remove='%(I1.M1)' MatchOnMetadata='M1' />");
-
             Should.Throw<InvalidProjectFileException>(() => ObjectModelHelpers.CreateInMemoryProject(content))
                 .HelpKeyword.ShouldBe("MSBuild.OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem");
         }

--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -1989,6 +1989,68 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact]
+        public void RemoveWithMatchingMultipleMetadata()
+        {
+            string content = ObjectModelHelpers.CleanupFileContents(
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
+                    <Target Name='t'>
+                        <ItemGroup>
+                            <I1 Include='a1' M1='1' M2='a'/>
+                            <I1 Include='b1' M1='2' M2='x'/>
+                            <I1 Include='c1' M1='3' M2='y'/>
+                            <I1 Include='d1' M1='4' M2='b'/>
+
+                            <I2 Include='a2' M1='x' m2='c'/>
+                            <I2 Include='b2' M1='2' m2='x'/>
+                            <I2 Include='c2' M1='3' m2='Y'/>
+                            <I2 Include='d2' M1='y' m2='d'/>
+
+                            <I2 Remove='@(I1)' MatchOnMetadata='M1;M2' />
+                        </ItemGroup>
+                    </Target></Project>");
+            IntrinsicTask task = CreateIntrinsicTask(content);
+            Lookup lookup = LookupHelpers.CreateEmptyLookup();
+            ExecuteTask(task, lookup);
+            ICollection<ProjectItemInstance> items = lookup.GetItems("I2");
+            items.Count().ShouldBe(3);
+            items.ElementAt(0).EvaluatedInclude.ShouldBe("a2");
+            items.ElementAt(1).EvaluatedInclude.ShouldBe("c2");
+            items.ElementAt(2).EvaluatedInclude.ShouldBe("d2");
+        }
+
+        [Fact]
+        public void RemoveWithMultipleItemReferenceOnMatchingMetadata()
+        {
+            string content = ObjectModelHelpers.CleanupFileContents(
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
+                    <Target Name='t'>
+                        <ItemGroup>
+                            <I1 Include='a1' M1='1' M2='a'/>
+                            <I1 Include='b1' M1='2' M2='x'/>
+                            <I1 Include='c1' M1='3' M2='y'/>
+                            <I1 Include='d1' M1='4' M2='b'/>
+
+                            <I2 Include='a2' M1='x' m2='c'/>
+                            <I2 Include='b2' M1='2' m2='x'/>
+                            <I2 Include='c2' M1='3' m2='Y'/>
+                            <I2 Include='d2' M1='y' m2='d'/>
+
+                            <I3 Include='a3' M1='1' m2='b'/>
+                            <I3 Include='b3' M1='x' m2='a'/>
+                            <I3 Include='c3' M1='3' m2='2'/>
+                            <I3 Include='d3' M1='y' m2='d'/>
+
+                            <I3 Remove='@(I1);@(I2)' MatchOnMetadata='M1' />
+                        </ItemGroup>
+                    </Target></Project>");
+            IntrinsicTask task = CreateIntrinsicTask(content);
+            Lookup lookup = LookupHelpers.CreateEmptyLookup();
+            ExecuteTask(task, lookup);
+            ICollection<ProjectItemInstance> items = lookup.GetItems("I3");
+            items.ShouldBeEmpty();
+        }
+
+        [Fact]
         public void FailWithMetadataItemReferenceOnMatchingMetadata()
         {
             string content = ObjectModelHelpers.CleanupFileContents(
@@ -2011,7 +2073,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             IntrinsicTask task = CreateIntrinsicTask(content);
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             Assert.ThrowsAny<InvalidProjectFileException>(() => ExecuteTask(task, lookup))
-                .HelpKeyword.ShouldBe("MSBuild.OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem");
+                .HelpKeyword.ShouldBe("MSBuild.OM_MatchOnMetadataIsRestrictedToReferencedItems");
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -1989,63 +1989,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact]
-        public void FailWithMatchingMultipleMetadata()
-        {
-            string content = ObjectModelHelpers.CleanupFileContents(
-                @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
-                    <Target Name='t'>
-                        <ItemGroup>
-                            <I1 Include='a1' M1='1' M2='a'/>
-                            <I1 Include='b1' M1='2' M2='x'/>
-                            <I1 Include='c1' M1='3' M2='y'/>
-                            <I1 Include='d1' M1='4' M2='b'/>
-
-                            <I2 Include='a2' M1='x' m2='c'/>
-                            <I2 Include='b2' M1='2' m2='x'/>
-                            <I2 Include='c2' M1='3' m2='Y'/>
-                            <I2 Include='d2' M1='y' m2='d'/>
-
-                            <I2 Remove='@(I1)' MatchOnMetadata='M1;M2' />
-                        </ItemGroup>
-                    </Target></Project>");
-            IntrinsicTask task = CreateIntrinsicTask(content);
-            Lookup lookup = LookupHelpers.CreateEmptyLookup();
-            Assert.ThrowsAny<InvalidProjectFileException>(() => ExecuteTask(task, lookup))
-                .HelpKeyword.ShouldBe("MSBuild.OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem");
-        }
-
-        [Fact]
-        public void FailWithMultipleItemReferenceOnMatchingMetadata()
-        {
-            string content = ObjectModelHelpers.CleanupFileContents(
-                @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
-                    <Target Name='t'>
-                        <ItemGroup>
-                            <I1 Include='a1' M1='1' M2='a'/>
-                            <I1 Include='b1' M1='2' M2='x'/>
-                            <I1 Include='c1' M1='3' M2='y'/>
-                            <I1 Include='d1' M1='4' M2='b'/>
-
-                            <I2 Include='a2' M1='x' m2='c'/>
-                            <I2 Include='b2' M1='2' m2='x'/>
-                            <I2 Include='c2' M1='3' m2='Y'/>
-                            <I2 Include='d2' M1='y' m2='d'/>
-
-                            <I3 Include='a3' M1='1' m2='b'/>
-                            <I3 Include='b3' M1='x' m2='a'/>
-                            <I3 Include='c3' M1='3' m2='2'/>
-                            <I3 Include='d3' M1='y' m2='d'/>
-
-                            <I3 Remove='@(I1);@(I2)' MatchOnMetadata='M1' />
-                        </ItemGroup>
-                    </Target></Project>");
-            IntrinsicTask task = CreateIntrinsicTask(content);
-            Lookup lookup = LookupHelpers.CreateEmptyLookup();
-            Assert.ThrowsAny<InvalidProjectFileException>(() => ExecuteTask(task, lookup))
-                .HelpKeyword.ShouldBe("MSBuild.OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem");
-        }
-
-        [Fact]
         public void FailWithMetadataItemReferenceOnMatchingMetadata()
         {
             string content = ObjectModelHelpers.CleanupFileContents(

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -588,7 +588,7 @@ namespace Microsoft.Build.BackEnd
                 "OM_MatchOnMetadataIsRestrictedToReferencedItems",
                 child.RemoveLocation,
                 child.Remove);
-            MetadataSet<ProjectPropertyInstance, ProjectItemInstance> metadataSet = new(matchingOptions, matchOnMetadata, itemSpec);
+            MetadataTrie<ProjectPropertyInstance, ProjectItemInstance> metadataSet = new(matchingOptions, matchOnMetadata, itemSpec);
             return group.Where(item => metadataSet.Contains(matchOnMetadata.Select(m => item.GetMetadataValue(m)))).ToList();
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -250,8 +250,16 @@ namespace Microsoft.Build.BackEnd
             else
             {
                 ImmutableList<string> metadataList = matchOnMetadata.ToImmutableList();
-                MetadataSet<ProjectPropertyInstance, ProjectItemInstance> metadataSet = new(matchingOptions, metadataList,
-                    new ItemSpec<ProjectPropertyInstance, ProjectItemInstance>(child.Remove, bucket.Expander, child.RemoveLocation, Project.Directory, true));
+                ItemSpec<ProjectPropertyInstance, ProjectItemInstance> itemSpec = new(child.Remove, bucket.Expander, child.RemoveLocation, Project.Directory, true);
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(
+                    itemSpec.Fragments.Count == 1
+                    && itemSpec.Fragments.First() is ItemSpec<ProjectPropertyInstance, ProjectItemInstance>.ItemExpressionFragment
+                    && matchOnMetadata.Count == 1,
+                    new BuildEventFileInfo(string.Empty),
+                    "OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem",
+                    child.RemoveLocation,
+                    child.Remove);
+                MetadataSet<ProjectPropertyInstance, ProjectItemInstance> metadataSet = new(matchingOptions, metadataList, itemSpec);
                 itemsToRemove = group.Where(item => metadataSet.Contains(metadataList.Select(m => item.GetMetadataValue(m)))).ToList();
             }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Build.BackEnd
                 ImmutableList<string> metadataList = matchOnMetadata.ToImmutableList();
                 MetadataSet<ProjectPropertyInstance, ProjectItemInstance> metadataSet = new(matchingOptions, metadataList,
                     new ItemSpec<ProjectPropertyInstance, ProjectItemInstance>(child.Remove, bucket.Expander, child.RemoveLocation, Project.Directory, true));
-                itemsToRemove = group.Where(item => metadataSet.Contains(metadataList.Select(m => item.GetMetadata(m).EvaluatedValue))).ToList();
+                itemsToRemove = group.Where(item => metadataSet.Contains(metadataList.Select(m => item.GetMetadataValue(m)))).ToList();
             }
 
             if (itemsToRemove != null)

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -585,7 +585,7 @@ namespace Microsoft.Build.BackEnd
             ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(
                 itemSpec.Fragments.All(f => f is ItemSpec<ProjectPropertyInstance, ProjectItemInstance>.ItemExpressionFragment),
                 new BuildEventFileInfo(string.Empty),
-                "OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem",
+                "OM_MatchOnMetadataIsRestrictedToReferencedItems",
                 child.RemoveLocation,
                 child.Remove);
             MetadataSet<ProjectPropertyInstance, ProjectItemInstance> metadataSet = new(matchingOptions, matchOnMetadata, itemSpec);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -581,7 +581,7 @@ namespace Microsoft.Build.BackEnd
             HashSet<string> matchOnMetadata,
             MatchOnMetadataOptions matchingOptions)
         {
-            ItemSpec<ProjectPropertyInstance, ProjectItemInstance> itemSpec = new(child.Remove, expander, child.RemoveLocation, Project.Directory, true);
+            ItemSpec<ProjectPropertyInstance, ProjectItemInstance> itemSpec = new ItemSpec<ProjectPropertyInstance, ProjectItemInstance>(child.Remove, expander, child.RemoveLocation, Project.Directory, true);
             ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(
                 itemSpec.Fragments.All(f => f is ItemSpec<ProjectPropertyInstance, ProjectItemInstance>.ItemExpressionFragment),
                 new BuildEventFileInfo(string.Empty),

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -588,7 +588,7 @@ namespace Microsoft.Build.BackEnd
                 "OM_MatchOnMetadataIsRestrictedToReferencedItems",
                 child.RemoveLocation,
                 child.Remove);
-            MetadataTrie<ProjectPropertyInstance, ProjectItemInstance> metadataSet = new(matchingOptions, matchOnMetadata, itemSpec);
+            MetadataTrie<ProjectPropertyInstance, ProjectItemInstance> metadataSet = new MetadataTrie<ProjectPropertyInstance, ProjectItemInstance>(matchingOptions, matchOnMetadata, itemSpec);
             return group.Where(item => metadataSet.Contains(matchOnMetadata.Select(m => item.GetMetadataValue(m)))).ToList();
         }
 

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -459,15 +459,52 @@ namespace Microsoft.Build.Evaluation
             && FileUtilities.IsAnySlash(TextFragment[3]);
     }
 
-    internal sealed class MetadataSet<P, I> where P : class, IProperty where I : class, IItem, IMetadataTable
+    /// <summary>
+    /// A Trie representing the sets of values of specified metadata taken on by the referenced items.
+    /// A single flat list or set of metadata values would not work in this case because we are matching
+    /// on multiple metadata. If one item specifies NotTargetFramework to be net46 and TargetFramework to
+    /// be netcoreapp3.1, we wouldn't want to match that to an item with TargetFramework 46 and
+    /// NotTargetFramework netcoreapp3.1.
+    /// 
+    /// Implementing this as a list of sets where each metadatum key has its own set also would not work
+    /// because different items could match on different metadata, and we want to check to see if any
+    /// single item matches on all the metadata. As an example, consider this scenario:
+    /// Item Baby has metadata GoodAt="eating" BadAt="talking" OkAt="sleeping"
+    /// Item Child has metadata GoodAt="sleeping" BadAt="eating" OkAt="talking"
+    /// Item Adolescent has metadata GoodAt="talking" BadAt="sleeping" OkAt="eating"
+    /// Specifying these three metadata:
+    /// Item Forgind with metadata GoodAt="sleeping" BadAt="talking" OkAt="eating"
+    /// should match none of them because Forgind doesn't match all three metadata of any of the items.
+    /// With a list of sets, Forgind would match Baby on BadAt, Child on GoodAt, and Adolescent on OkAt,
+    /// and Forgind would be erroneously removed.
+    /// 
+    /// With a Trie as below, Items specify paths in the tree, so going to any child node eliminates all
+    /// items that don't share that metadatum. This ensures the match is proper.
+    /// 
+    /// Todo: Tries naturally can have different shapes depending on in what order the metadata are considered.
+    /// Specifically, if all the items share a single metadata value for the one metadatum and have different
+    /// values for a second metadatum, it will have only one node more than the number of items if the first
+    /// metadatum is considered first. If the metadatum is considered first, it will have twice that number.
+    /// Users can theoretically specify the order in which metadata should be considered by reordering them
+    /// on the line invoking this, but that is extremely nonobvious from a user's perspective.
+    /// It would be nice to detect poorly-ordered metadata and account for it to avoid making more nodes than
+    /// necessary. This would need to order if appropriately both in creating the MetadataTrie and in using it,
+    /// so it could best be done as a preprocessing step. For now, wait to find out if it's necessary (users'
+    /// computers run out of memory) before trying to implement it.
+    /// </summary>
+    /// <typeparam name="P">Property type</typeparam>
+    /// <typeparam name="I">Item type</typeparam>
+    internal sealed class MetadataTrie<P, I> where P : class, IProperty where I : class, IItem, IMetadataTable
     {
-        private readonly Dictionary<string, MetadataSet<P, I>> _children;
+        private readonly Dictionary<string, MetadataTrie<P, I>> _children;
         private readonly Func<string, string> _normalize;
 
-        internal MetadataSet(MatchOnMetadataOptions options, IEnumerable<string> metadata, ItemSpec<P, I> itemSpec)
+        internal MetadataTrie(MatchOnMetadataOptions options, IEnumerable<string> metadata, ItemSpec<P, I> itemSpec)
         {
-            StringComparer comparer = options == MatchOnMetadataOptions.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
-            _children = new Dictionary<string, MetadataSet<P, I>>(comparer);
+            StringComparer comparer = options == MatchOnMetadataOptions.CaseSensitive ? StringComparer.Ordinal :
+                options == MatchOnMetadataOptions.CaseInsensitive || FileUtilities.PathComparison == StringComparison.OrdinalIgnoreCase ? StringComparer.OrdinalIgnoreCase :
+                StringComparer.Ordinal;
+            _children = new Dictionary<string, MetadataTrie<P, I>>(comparer);
             _normalize = options == MatchOnMetadataOptions.PathLike ? p => FileUtilities.NormalizePathForComparisonNoThrow(p, Environment.CurrentDirectory) : p => p;
             foreach (ItemSpec<P, I>.ItemExpressionFragment frag in itemSpec.Fragments)
             {
@@ -478,21 +515,21 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        private MetadataSet(StringComparer comparer)
+        private MetadataTrie(StringComparer comparer)
         {
-            _children = new Dictionary<string, MetadataSet<P, I>>(comparer);
+            _children = new Dictionary<string, MetadataTrie<P, I>>(comparer);
         }
 
         // Relies on IEnumerable returning the metadata in a reasonable order. Reasonable?
         private void Add(IEnumerable<string> metadata, StringComparer comparer)
         {
-            MetadataSet<P, I> current = this;
+            MetadataTrie<P, I> current = this;
             foreach (string m in metadata)
             {
                 string normalizedString = _normalize(m);
-                if (!current._children.TryGetValue(normalizedString, out MetadataSet<P, I> child))
+                if (!current._children.TryGetValue(normalizedString, out MetadataTrie<P, I> child))
                 {
-                    child = new MetadataSet<P, I>(comparer);
+                    child = new MetadataTrie<P, I>(comparer);
                     current._children.Add(normalizedString, child);
                 }
                 current = child;
@@ -501,7 +538,7 @@ namespace Microsoft.Build.Evaluation
 
         internal bool Contains(IEnumerable<string> metadata)
         {
-            MetadataSet<P, I> current = this;
+            MetadataTrie<P, I> current = this;
             foreach (string m in metadata)
             {
                 if (String.IsNullOrEmpty(m))

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -467,9 +467,9 @@ namespace Microsoft.Build.Evaluation
 
         internal MetadataSet(MatchOnMetadataOptions options, ImmutableList<string> metadata, ItemSpec<P, I> itemSpec)
         {
-            StringComparer comparer = options == MatchOnMetadataOptions.CaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            StringComparer comparer = options == MatchOnMetadataOptions.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
             children = new Dictionary<string, MetadataSet<P, I>>(comparer);
-            normalize = options == MatchOnMetadataOptions.PathLike ? FileUtilities.NormalizeForPathComparison : s => s;
+            normalize = options == MatchOnMetadataOptions.PathLike ? p => FileUtilities.NormalizePathForComparisonNoThrow(p, Environment.CurrentDirectory) : p => p;
             foreach (ItemSpec<P, I>.ItemExpressionFragment frag in itemSpec.Fragments)
             {
                 foreach (ItemSpec<P, I>.ReferencedItem referencedItem in frag.ReferencedItems)
@@ -488,9 +488,9 @@ namespace Microsoft.Build.Evaluation
         private void Add(IEnumerable<string> metadata, StringComparer comparer)
         {
             MetadataSet<P, I> current = this;
-            foreach (string s in metadata)
+            foreach (string m in metadata)
             {
-                string normalizedString = normalize(s);
+                string normalizedString = normalize(m);
                 if (current.children.TryGetValue(normalizedString, out MetadataSet<P, I> child))
                 {
                     current = child;
@@ -513,6 +513,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     nonEmptyFound = true;
                 }
+                string normalizedString = normalize(m);
                 if (!curr.children.TryGetValue(normalize(m), out curr))
                 {
                     return false;

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -513,7 +513,6 @@ namespace Microsoft.Build.Evaluation
                 {
                     nonEmptyFound = true;
                 }
-                string normalizedString = normalize(m);
                 if (!curr.children.TryGetValue(normalize(m), out curr))
                 {
                     return false;

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Build.Globbing;
 using Microsoft.Build.Internal;
@@ -83,24 +84,6 @@ namespace Microsoft.Build.Evaluation
             public override bool IsMatch(string itemToMatch)
             {
                 return ReferencedItems.Any(v => v.ItemAsValueFragment.IsMatch(itemToMatch));
-            }
-
-            public override bool IsMatchOnMetadata(IItem item, IEnumerable<string> metadata, MatchOnMetadataOptions options)
-            {
-                return ReferencedItems.Any(referencedItem =>
-                        metadata.All(m => !item.GetMetadataValue(m).Equals(string.Empty) && MetadataComparer(options, item.GetMetadataValue(m), referencedItem.Item.GetMetadataValue(m))));
-            }
-
-            private bool MetadataComparer(MatchOnMetadataOptions options, string itemMetadata, string referencedItemMetadata)
-            {
-                if (options.Equals(MatchOnMetadataOptions.PathLike))
-                {
-                    return FileUtilities.ComparePathsNoThrow(itemMetadata, referencedItemMetadata, ProjectDirectory);
-                }
-                else 
-                {
-                    return String.Equals(itemMetadata, referencedItemMetadata, options.Equals(MatchOnMetadataOptions.CaseInsensitive) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
-                }
             }
 
             public override IMSBuildGlob ToMSBuildGlob()
@@ -311,26 +294,6 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        ///     Return true if any of the given <paramref name="metadata" /> matches the metadata on <paramref name="item" />
-        /// </summary>
-        /// <param name="item">The item to attempt to find a match for based on matching metadata</param>
-        /// <param name="metadata">Names of metadata to look for matches for</param>
-        /// <param name="options">metadata option matching</param>
-        /// <returns></returns>
-        public bool MatchesItemOnMetadata(IItem item, IEnumerable<string> metadata, MatchOnMetadataOptions options)
-        {
-            foreach (var fragment in Fragments)
-            {
-                if (fragment.IsMatchOnMetadata(item, metadata, options))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
         ///     Return the fragments that match against the given <paramref name="itemToMatch" />
         /// </summary>
         /// <param name="itemToMatch">The item to match.</param>
@@ -456,14 +419,6 @@ namespace Microsoft.Build.Evaluation
             return FileMatcher.IsMatch(itemToMatch);
         }
 
-        /// <summary>
-        /// Returns true if <paramref name="itemToMatch" /> matches any ReferencedItems based on <paramref name="metadata" /> and <paramref name="options" />.
-        /// </summary>
-        public virtual bool IsMatchOnMetadata(IItem itemToMatch, IEnumerable<string> metadata, MatchOnMetadataOptions options)
-        {
-            return false;
-        }
-
         public virtual IMSBuildGlob ToMSBuildGlob()
         {
             return MsBuildGlob;
@@ -503,5 +458,88 @@ namespace Microsoft.Build.Evaluation
             && TextFragment[1] == '*'
             && TextFragment[2] == '*'
             && FileUtilities.IsAnySlash(TextFragment[3]);
+    }
+
+    internal class MetadataSet<P, I> where P : class, IProperty where I : class, IItem, IMetadataTable
+    {
+        private Dictionary<string, MetadataSet<P, I>> children;
+        MatchOnMetadataOptions options;
+
+        internal MetadataSet(MatchOnMetadataOptions options, ImmutableList<string> metadata, ItemSpec<P, I> itemSpec)
+        {
+            StringComparer comparer = options == MatchOnMetadataOptions.CaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            children = new Dictionary<string, MetadataSet<P, I>>(comparer);
+            this.options = options;
+            foreach (ItemSpec<P, I>.ItemExpressionFragment frag in itemSpec.Fragments)
+            {
+                foreach (ItemSpec<P, I>.ReferencedItem referencedItem in frag.ReferencedItems)
+                {
+                    this.Add(metadata.Select(m => referencedItem.Item.GetMetadataValue(m)));
+                }
+            }
+        }
+
+        private MetadataSet(MatchOnMetadataOptions options)
+        {
+            StringComparer comparer = options == MatchOnMetadataOptions.CaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            children = new Dictionary<string, MetadataSet<P, I>>(comparer);
+            this.options = options;
+        }
+
+        // Relies on IEnumerable returning the metadata in a reasonable order. Reasonable?
+        private void Add(IEnumerable<string> metadata)
+        {
+            MetadataSet<P, I> current = this;
+            foreach (string s in metadata)
+            {
+                string normalizedString = options == MatchOnMetadataOptions.PathLike ?
+                    FileUtilities.NormalizeForPathComparison(s) :
+                    s;
+                if (current.children.TryGetValue(normalizedString, out MetadataSet<P, I> child))
+                {
+                    current = child;
+                }
+                else
+                {
+                    current.children.Add(normalizedString, new MetadataSet<P, I>(current.options));
+                    current = current.children[normalizedString];
+                }
+            }
+        }
+
+        internal bool Contains(IEnumerable<string> metadata)
+        {
+            List<string> metadataList = metadata.ToList();
+            return this.Contains(metadataList, 0);
+        }
+
+        private bool Contains(List<string> metadata, int index)
+        {
+            if (index == metadata.Count)
+            {
+                return true;
+            }
+            else if (String.IsNullOrEmpty(metadata[index]))
+            {
+                return children.Any(kvp => !String.IsNullOrEmpty(kvp.Key) && kvp.Value.Contains(metadata, index + 1));
+            }
+            else
+            {
+                return (children.TryGetValue(FileUtilities.NormalizeForPathComparison(metadata[index]), out MetadataSet<P, I> child) && child.Contains(metadata, index + 1)) ||
+                    (children.TryGetValue(string.Empty, out MetadataSet<P, I> emptyChild) && emptyChild.Contains(metadata, index + 1));
+            }
+        }
+    }
+
+    public enum MatchOnMetadataOptions
+    {
+        CaseSensitive,
+        CaseInsensitive,
+        PathLike
+    }
+
+    public static class MatchOnMetadataConstants
+    {
+        public const MatchOnMetadataOptions MatchOnMetadataOptionsDefaultValue = MatchOnMetadataOptions.CaseSensitive;
     }
 }

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -49,9 +49,6 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            // Dictionary of <metadata to match on, values of those metadata>
-            private Dictionary<IEnumerable<string>, HashSet<IEnumerable<string>>> ReferencedItemsByMetadata { get; set; }
-
             protected override IMSBuildGlob MsBuildGlob
             {
                 get
@@ -90,20 +87,8 @@ namespace Microsoft.Build.Evaluation
 
             public override bool IsMatchOnMetadata(IItem item, IEnumerable<string> metadata, MatchOnMetadataOptions options)
             {
-                IEnumerable<string> metadataValues = metadata.Select(m => item.GetMetadataValue(m));
-                if (ReferencedItemsByMetadata == null)
-                {
-                    ReferencedItemsByMetadata = new Dictionary<IEnumerable<string>, HashSet<IEnumerable<string>>>();
-                }
-                if (!ReferencedItemsByMetadata.TryGetValue(metadata, out HashSet<IEnumerable<string>> metadataMatcher))
-                {
-                    ReferencedItemsByMetadata.Add(metadata, new HashSet<IEnumerable<string>>());
-                    foreach (ReferencedItem i in ReferencedItems)
-                    {
-                        ReferencedItemsByMetadata[metadata].Add(metadata.Select(m => i.Item.GetMetadataValue(m)));
-                    }
-                }
-                return metadataMatcher.Contains(metadataValues);
+                return ReferencedItems.Any(referencedItem =>
+                        metadata.All(m => !item.GetMetadataValue(m).Equals(string.Empty) && MetadataComparer(options, item.GetMetadataValue(m), referencedItem.Item.GetMetadataValue(m))));
             }
 
             private bool MetadataComparer(MatchOnMetadataOptions options, string itemMetadata, string referencedItemMetadata)

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -474,34 +474,31 @@ namespace Microsoft.Build.Evaluation
             {
                 foreach (ItemSpec<P, I>.ReferencedItem referencedItem in frag.ReferencedItems)
                 {
-                    this.Add(metadata.Select(m => referencedItem.Item.GetMetadataValue(m)));
+                    this.Add(metadata.Select(m => referencedItem.Item.GetMetadataValue(m)), comparer);
                 }
             }
         }
 
-        private MetadataSet(MatchOnMetadataOptions options)
+        private MetadataSet(StringComparer comparer)
         {
-            StringComparer comparer = options == MatchOnMetadataOptions.CaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
             children = new Dictionary<string, MetadataSet<P, I>>(comparer);
-            this.options = options;
         }
 
         // Relies on IEnumerable returning the metadata in a reasonable order. Reasonable?
-        private void Add(IEnumerable<string> metadata)
+        private void Add(IEnumerable<string> metadata, StringComparer comparer)
         {
+            Func<string, string> normalize = options == MatchOnMetadataOptions.PathLike ? FileUtilities.NormalizeForPathComparison : s => s;
             MetadataSet<P, I> current = this;
             foreach (string s in metadata)
             {
-                string normalizedString = options == MatchOnMetadataOptions.PathLike ?
-                    FileUtilities.NormalizeForPathComparison(s) :
-                    s;
+                string normalizedString = normalize(s);
                 if (current.children.TryGetValue(normalizedString, out MetadataSet<P, I> child))
                 {
                     current = child;
                 }
                 else
                 {
-                    current.children.Add(normalizedString, new MetadataSet<P, I>(current.options));
+                    current.children.Add(normalizedString, new MetadataSet<P, I>(comparer));
                     current = current.children[normalizedString];
                 }
             }

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -505,7 +505,7 @@ namespace Microsoft.Build.Evaluation
                 options == MatchOnMetadataOptions.CaseInsensitive || FileUtilities.PathComparison == StringComparison.OrdinalIgnoreCase ? StringComparer.OrdinalIgnoreCase :
                 StringComparer.Ordinal;
             _children = new Dictionary<string, MetadataTrie<P, I>>(comparer);
-            _normalize = options == MatchOnMetadataOptions.PathLike ? p => FileUtilities.NormalizePathForComparisonNoThrow(p, Environment.CurrentDirectory) : p => p;
+            _normalize = options == MatchOnMetadataOptions.PathLike ? (Func<string, string>) (p => FileUtilities.NormalizePathForComparisonNoThrow(p, Environment.CurrentDirectory)) : p => p;
             foreach (ItemSpec<P, I>.ItemExpressionFragment frag in itemSpec.Fragments)
             {
                 foreach (ItemSpec<P, I>.ReferencedItem referencedItem in frag.ReferencedItems)

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
+            // Dictionary of <metadata to match on, values of those metadata>
+            private Dictionary<IEnumerable<string>, HashSet<IEnumerable<string>>> ReferencedItemsByMetadata { get; set; }
+
             protected override IMSBuildGlob MsBuildGlob
             {
                 get
@@ -87,8 +90,20 @@ namespace Microsoft.Build.Evaluation
 
             public override bool IsMatchOnMetadata(IItem item, IEnumerable<string> metadata, MatchOnMetadataOptions options)
             {
-                return ReferencedItems.Any(referencedItem =>
-                        metadata.All(m => !item.GetMetadataValue(m).Equals(string.Empty) && MetadataComparer(options, item.GetMetadataValue(m), referencedItem.Item.GetMetadataValue(m))));
+                IEnumerable<string> metadataValues = metadata.Select(m => item.GetMetadataValue(m));
+                if (ReferencedItemsByMetadata == null)
+                {
+                    ReferencedItemsByMetadata = new Dictionary<IEnumerable<string>, HashSet<IEnumerable<string>>>();
+                }
+                if (!ReferencedItemsByMetadata.TryGetValue(metadata, out HashSet<IEnumerable<string>> metadataMatcher))
+                {
+                    ReferencedItemsByMetadata.Add(metadata, new HashSet<IEnumerable<string>>());
+                    foreach (ReferencedItem i in ReferencedItems)
+                    {
+                        ReferencedItemsByMetadata[metadata].Add(metadata.Select(m => i.Item.GetMetadataValue(m)));
+                    }
+                }
+                return metadataMatcher.Contains(metadataValues);
             }
 
             private bool MetadataComparer(MatchOnMetadataOptions options, string itemMetadata, string referencedItemMetadata)

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Evaluation
             {
                 if (metadataSet == null)
                 {
-                    metadataSet = new MetadataSet();
+                    metadataSet = new MetadataSet(_matchOnMetadataOptions);
                     foreach (ItemSpec<P, I>.ItemExpressionFragment frag in _itemSpec.Fragments)
                     {
                         foreach (ItemSpec<P, I>.ReferencedItem referencedItem in frag.ReferencedItems)
@@ -124,10 +124,13 @@ namespace Microsoft.Build.Evaluation
     internal class MetadataSet
     {
         private Dictionary<string, MetadataSet> children;
+        MatchOnMetadataOptions options;
 
-        internal MetadataSet()
+        internal MetadataSet(MatchOnMetadataOptions options)
         {
-            children = new Dictionary<string, MetadataSet>();
+            StringComparer comparer = options == MatchOnMetadataOptions.CaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            children = new Dictionary<string, MetadataSet>(comparer);
+            this.options = options;
         }
 
         // Relies on IEnumerable returning the metadata in a reasonable order. Reasonable?
@@ -136,14 +139,17 @@ namespace Microsoft.Build.Evaluation
             MetadataSet current = this;
             foreach (string s in metadata)
             {
-                if (current.children.TryGetValue(s, out MetadataSet child))
+                string normalizedString = options == MatchOnMetadataOptions.PathLike ?
+                    FileUtilities.NormalizeForPathComparison(s) :
+                    s;
+                if (current.children.TryGetValue(normalizedString, out MetadataSet child))
                 {
                     current = child;
                 }
                 else
                 {
-                    current.children.Add(s, new MetadataSet());
-                    current = current.children[s];
+                    current.children.Add(normalizedString, new MetadataSet(current.options));
+                    current = current.children[normalizedString];
                 }
             }
         }
@@ -166,7 +172,7 @@ namespace Microsoft.Build.Evaluation
             }
             else
             {
-                return (children.TryGetValue(metadata[index], out MetadataSet child) && child.Contains(metadata, index + 1)) ||
+                return (children.TryGetValue(FileUtilities.NormalizeForPathComparison(metadata[index]), out MetadataSet child) && child.Contains(metadata, index + 1)) ||
                     (children.TryGetValue(string.Empty, out MetadataSet emptyChild) && emptyChild.Contains(metadata, index + 1));
             }
         }

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Build.Evaluation
                     metadataSet = new MetadataSet<P, I>(_matchOnMetadataOptions, _matchOnMetadata, _itemSpec);
                 }
 
-                return metadataSet.Contains(_matchOnMetadata.Select(m => (item.GetMetadata(m) as ProjectMetadata).EvaluatedValue));
+                return metadataSet.Contains(_matchOnMetadata.Select(m => item.GetMetadataValue(m)));
             }
 
             protected override void SaveItems(ImmutableList<I> items, ImmutableList<ItemData>.Builder listBuilder)

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.Evaluation
                 ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(
                     _matchOnMetadata.IsEmpty || _itemSpec.Fragments.All(f => f is ItemSpec<ProjectProperty, ProjectItem>.ItemExpressionFragment),
                     new BuildEventFileInfo(string.Empty),
-                    "OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem");
+                    "OM_MatchOnMetadataIsRestrictedToReferencedItems");
 
                 if (!_matchOnMetadata.IsEmpty)
                 {

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Shared;
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -14,6 +16,7 @@ namespace Microsoft.Build.Evaluation
         {
             readonly ImmutableList<string> _matchOnMetadata;
             readonly MatchOnMetadataOptions _matchOnMetadataOptions;
+            private MetadataSet metadataSet;
 
             public RemoveOperation(RemoveOperationBuilder builder, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
                 : base(builder, lazyEvaluator)
@@ -55,11 +58,28 @@ namespace Microsoft.Build.Evaluation
                 var items = ImmutableHashSet.CreateBuilder<I>();
                 foreach (ItemData item in listBuilder)
                 {
-                    if (_matchOnMetadata.IsEmpty ? _itemSpec.MatchesItem(item.Item) : _itemSpec.MatchesItemOnMetadata(item.Item, _matchOnMetadata, _matchOnMetadataOptions))
+                    if (_matchOnMetadata.IsEmpty ? _itemSpec.MatchesItem(item.Item) : MatchesItemOnMetadata(item.Item))
                         items.Add(item.Item);
                 }
 
                 return items.ToImmutableList();
+            }
+
+            private bool MatchesItemOnMetadata(I item)
+            {
+                if (metadataSet == null)
+                {
+                    metadataSet = new MetadataSet();
+                    foreach (ItemSpec<P, I>.ItemExpressionFragment frag in _itemSpec.Fragments)
+                    {
+                        foreach (ItemSpec<P, I>.ReferencedItem referencedItem in frag.ReferencedItems)
+                        {
+                            metadataSet.Add(_matchOnMetadata.Select(m => (referencedItem.Item.GetMetadata(m) as ProjectMetadata).EvaluatedValue));
+                        }
+                    }
+                }
+
+                return metadataSet.Contains(_matchOnMetadata.Select(m => (item.GetMetadata(m) as ProjectMetadata).EvaluatedValue));
             }
 
             protected override void SaveItems(ImmutableList<I> items, ImmutableList<ItemData>.Builder listBuilder)
@@ -97,6 +117,57 @@ namespace Microsoft.Build.Evaluation
 
             public RemoveOperationBuilder(ProjectItemElement itemElement, bool conditionResult) : base(itemElement, conditionResult)
             {
+            }
+        }
+    }
+
+    internal class MetadataSet
+    {
+        private Dictionary<string, MetadataSet> children;
+
+        internal MetadataSet()
+        {
+            children = new Dictionary<string, MetadataSet>();
+        }
+
+        // Relies on IEnumerable returning the metadata in a reasonable order. Reasonable?
+        internal void Add(IEnumerable<string> metadata)
+        {
+            MetadataSet current = this;
+            foreach (string s in metadata)
+            {
+                if (current.children.TryGetValue(s, out MetadataSet child))
+                {
+                    current = child;
+                }
+                else
+                {
+                    current.children.Add(s, new MetadataSet());
+                    current = current.children[s];
+                }
+            }
+        }
+
+        internal bool Contains(IEnumerable<string> metadata)
+        {
+            List<string> metadataList = metadata.ToList();
+            return this.Contains(metadataList, 0);
+        }
+
+        private bool Contains(List<string> metadata, int index)
+        {
+            if (index == metadata.Count)
+            {
+                return true;
+            }
+            else if (String.IsNullOrEmpty(metadata[index]))
+            {
+                return children.Any(kvp => !String.IsNullOrEmpty(kvp.Key) && kvp.Value.Contains(metadata, index + 1));
+            }
+            else
+            {
+                return (children.TryGetValue(metadata[index], out MetadataSet child) && child.Contains(metadata, index + 1)) ||
+                    (children.TryGetValue(string.Empty, out MetadataSet emptyChild) && emptyChild.Contains(metadata, index + 1));
             }
         }
     }

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.Evaluation
         class RemoveOperation : LazyItemOperation
         {
             readonly ImmutableList<string> _matchOnMetadata;
-            private MetadataSet<P, I> _metadataSet;
+            private MetadataTrie<P, I> _metadataSet;
 
             public RemoveOperation(RemoveOperationBuilder builder, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
                 : base(builder, lazyEvaluator)
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Evaluation
 
                 if (!_matchOnMetadata.IsEmpty)
                 {
-                    _metadataSet = new MetadataSet<P, I>(builder.MatchOnMetadataOptions, _matchOnMetadata, _itemSpec);
+                    _metadataSet = new MetadataTrie<P, I>(builder.MatchOnMetadataOptions, _matchOnMetadata, _itemSpec);
                 }
             }
 

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Construction;
-using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1548,8 +1548,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="OM_MatchingProjectAlreadyInCollection" xml:space="preserve">
     <value>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</value>
   </data>
-  <data name="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem" xml:space="preserve">
-    <value>Only one item type may be referenced when removing with MatchOnMetadata.</value>
+  <data name="OM_MatchOnMetadataIsRestrictedToReferencedItems" xml:space="preserve">
+    <value>Only item types may be referenced when removing with MatchOnMetadata.</value>
   </data>
   <data name="OM_ProjectWasNotLoaded" xml:space="preserve">
     <value>The project provided was not loaded in the collection.</value>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">Při odebrání pomocí MatchOnMetadata je možné odkazovat jen na jeden typ položky.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">Beim Entfernen mit MatchOnMetadata kann nur ein Elementtyp referenziert werden.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="new">Only one item type may be referenced when removing with MatchOnMetadata.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">Solo se puede hacer referencia a un tipo de elemento al quitarlo con MatchOnMetadata.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">Un seul type d'élément peut être référencé pour la suppression à l'aide de MatchOnMetadata.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">Durante la rimozione con MatchOnMetadata è possibile fare riferimento a un solo tipo di elemento.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">MatchOnMetadata で削除する場合、参照できる項目の種類は 1 つだけです。</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">MatchOnMetadata를 사용하여 제거하는 경우 항목 종류를 하나만 참조할 수 있습니다.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">Tylko jeden typ elementu może być przywoływany podczas usuwania przy użyciu elementu MatchOnMetadata.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">Somente um tipo de item pode ser referenciado na remoção com MatchOnMetadata.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">При удалении с помощью MatchOnMetadata можно ссылаться только на один тип элемента.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">MatchOnMetadata ile kaldırırken yalnızca bir öğe türüne başvurulabilir.</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">使用 MatchOnMetadata 删除时，只能引用一个项类型。</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -167,9 +167,9 @@
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
     </note>
       </trans-unit>
-      <trans-unit id="OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem">
-        <source>Only one item type may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">使用 MatchOnMetadata 移除時，只能參考一個項目類型。</target>
+      <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
+        <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">


### PR DESCRIPTION
Fixes [AB#1261123](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1261123) (feedback ticket)

### Context
Checking metadata for matches was taking (#fragments in item) * (#fragments in item to remove) * (#metadata). For many users, this was extremely slow.

### Changes Made
Put fragments into a custom MetadataSet object before checking for a match. This takes it from O(n * r * m) to O(m * (n + r)). Since m is normally small, this is a substantial improvement.

### Testing
Time on a single operation went from ~180 seconds to ~150 ms for the penultimate version. It also passes @cdmihai's extensive unit tests.*

### Notes
Is there any reason to keep the error for referencing multiple items? As a user, I would expect not-match-on-metadata to ignore metadata and match-on-metadata to ignore the item.
Is it ok to rely on IEnumerable returning element in a consistent order?
Should we keep returning no-match if all the metadata are empty on both items? It makes more sense to me to have that be a match, and it would simplify the code slightly. If it makes more sense to others, now would be the time to do it, since the code isn't that old.

\* Except one on paths. Not sure why that's failing, since it's passing in VS, just not from the command line. Will look into it more.