### PR TITLE
Fix how ClickOnce handles developement dependency package references

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4172,10 +4172,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_SatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
       <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)"
-                                 Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe' Or '%(Extension)' == '.md'">
+                                 Condition="('%(Extension)' == '.dll' Or '%(Extension)' == '.exe' Or '%(Extension)' == '.md') and ('%(ReferenceCopyLocalPaths.CopyToPublishDirectory)' != 'false')">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
-      <_DeploymentReferencePaths Include="@(_DeploymentReferencePaths);@(_CopyLocalFalseRefPathsWithExclusion)" />
+      <_DeploymentReferencePaths Include="@(_CopyLocalFalseRefPathsWithExclusion)" />
     </ItemGroup>
 
     <!-- Include managed references in clickonce manifest only if single file publish is false -->


### PR DESCRIPTION
Fixes #1257168

### Context
Issue: ClickOnce is currently publishing contents of Nuget packages that are marked as developement dependencies. These package references should be excluded by publishing providers.

### Changes Made
Filter out the development dependencies from the _DeploymentReferencePaths item group. The filtering happens by looking at the CopyToPublishDirectory attribute on ReferenceCopyLocalPaths group which is set to false for said packages.

### Testing
CTI has validated specific packages that are affected and also validated the change against top 50 NuGet packages.

### Notes
