### PR TITLE
Tasks `Log.HasLoggedError` now respects `MSBuildWarningsAsErrors`

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -211,6 +211,10 @@ namespace Microsoft.Build.Framework
     {
         bool AllowFailureWithoutError { get; set; }
     }
+    public partial interface IBuildEngine8 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5, Microsoft.Build.Framework.IBuildEngine6, Microsoft.Build.Framework.IBuildEngine7
+    {
+        event Microsoft.Build.Framework.BuildWarningEventHandler WarningLoggedAsError;
+    }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {
         void Cancel();

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Build.Framework
     }
     public partial interface IBuildEngine8 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5, Microsoft.Build.Framework.IBuildEngine6, Microsoft.Build.Framework.IBuildEngine7
     {
-        event Microsoft.Build.Framework.BuildWarningEventHandler WarningLoggedAsError;
+        System.Collections.Generic.HashSet<string> WarningsLoggedAsErrors { get; }
     }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -211,6 +211,10 @@ namespace Microsoft.Build.Framework
     {
         bool AllowFailureWithoutError { get; set; }
     }
+    public partial interface IBuildEngine8 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5, Microsoft.Build.Framework.IBuildEngine6, Microsoft.Build.Framework.IBuildEngine7
+    {
+        event Microsoft.Build.Framework.BuildWarningEventHandler WarningLoggedAsError;
+    }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {
         void Cancel();

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Build.Framework
     }
     public partial interface IBuildEngine8 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5, Microsoft.Build.Framework.IBuildEngine6, Microsoft.Build.Framework.IBuildEngine7
     {
-        event Microsoft.Build.Framework.BuildWarningEventHandler WarningLoggedAsError;
+        System.Collections.Generic.HashSet<string> WarningsLoggedAsErrors { get; }
     }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {

--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -391,6 +391,7 @@ namespace Microsoft.Build.Utilities
         public string HelpKeywordPrefix { get { throw null; } set { } }
         protected string TaskName { get { throw null; } }
         public System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+        public void BuildEngineLoggedWarningAsError(object sender, Microsoft.Build.Framework.BuildWarningEventArgs args) { }
         public string ExtractMessageCode(string message, out string messageWithoutCodePrefix) { messageWithoutCodePrefix = default(string); throw null; }
         public virtual string FormatResourceString(string resourceName, params object[] args) { throw null; }
         public virtual string FormatString(string unformatted, params object[] args) { throw null; }

--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -353,6 +353,7 @@ namespace Microsoft.Build.Utilities
         public Microsoft.Build.Framework.IBuildEngine5 BuildEngine5 { get { throw null; } }
         public Microsoft.Build.Framework.IBuildEngine6 BuildEngine6 { get { throw null; } }
         public Microsoft.Build.Framework.IBuildEngine7 BuildEngine7 { get { throw null; } }
+        public Microsoft.Build.Framework.IBuildEngine8 BuildEngine8 { get { throw null; } }
         protected string HelpKeywordPrefix { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskHost HostObject { get { throw null; } set { } }
         public Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
@@ -391,7 +392,6 @@ namespace Microsoft.Build.Utilities
         public string HelpKeywordPrefix { get { throw null; } set { } }
         protected string TaskName { get { throw null; } }
         public System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
-        public void BuildEngineLoggedWarningAsError(object sender, Microsoft.Build.Framework.BuildWarningEventArgs args) { }
         public string ExtractMessageCode(string message, out string messageWithoutCodePrefix) { messageWithoutCodePrefix = default(string); throw null; }
         public virtual string FormatResourceString(string resourceName, params object[] args) { throw null; }
         public virtual string FormatString(string unformatted, params object[] args) { throw null; }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -198,6 +198,7 @@ namespace Microsoft.Build.Utilities
         public Microsoft.Build.Framework.IBuildEngine5 BuildEngine5 { get { throw null; } }
         public Microsoft.Build.Framework.IBuildEngine6 BuildEngine6 { get { throw null; } }
         public Microsoft.Build.Framework.IBuildEngine7 BuildEngine7 { get { throw null; } }
+        public Microsoft.Build.Framework.IBuildEngine8 BuildEngine8 { get { throw null; } }
         protected string HelpKeywordPrefix { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskHost HostObject { get { throw null; } set { } }
         public Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
@@ -234,7 +235,6 @@ namespace Microsoft.Build.Utilities
         public string HelpKeywordPrefix { get { throw null; } set { } }
         protected string TaskName { get { throw null; } }
         public System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
-        public void BuildEngineLoggedWarningAsError(object sender, Microsoft.Build.Framework.BuildWarningEventArgs args) { }
         public string ExtractMessageCode(string message, out string messageWithoutCodePrefix) { messageWithoutCodePrefix = default(string); throw null; }
         public virtual string FormatResourceString(string resourceName, params object[] args) { throw null; }
         public virtual string FormatString(string unformatted, params object[] args) { throw null; }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -234,6 +234,7 @@ namespace Microsoft.Build.Utilities
         public string HelpKeywordPrefix { get { throw null; } set { } }
         protected string TaskName { get { throw null; } }
         public System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+        public void BuildEngineLoggedWarningAsError(object sender, Microsoft.Build.Framework.BuildWarningEventArgs args) { }
         public string ExtractMessageCode(string message, out string messageWithoutCodePrefix) { messageWithoutCodePrefix = default(string); throw null; }
         public virtual string FormatResourceString(string resourceName, params object[] args) { throw null; }
         public virtual string FormatString(string unformatted, params object[] args) { throw null; }

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -557,6 +557,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             return false;
         }
 
+        public bool ShouldTreatWarningAsError(string code, BuildEventContext context)
+        {
+            throw new NotImplementedException();
+        }
+
         #endregion
     }
 }

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -350,6 +350,14 @@ namespace Microsoft.Build.BackEnd.Logging
 
         #region Log warnings
         /// <summary>
+        /// Determines if the specified warning code should be treated as an error.
+        /// </summary>
+        /// <param name="code">A <see cref="BuildWarningEventArgs"/> that specifies the warning.</param>
+        /// <param name="context">The event context for where the warning occurred</param>
+        /// <returns><code>true</code> if the warning should be treated as an error, otherwise <code>false</code>.</returns>
+        bool ShouldTreatWarningAsError(string code, BuildEventContext context);
+
+        /// <summary>
         /// Log a warning based on an exception
         /// </summary>
         /// <param name="buildEventContext">The event context for where the warning occurred</param>

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -352,8 +352,8 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Determines if the specified warning code should be treated as an error.
         /// </summary>
-        /// <param name="code">A <see cref="BuildWarningEventArgs"/> that specifies the warning.</param>
-        /// <param name="context">The event context for where the warning occurred</param>
+        /// <param name="code">The warning code to check..</param>
+        /// <param name="context">The event context for where the warning occurred.</param>
         /// <returns><code>true</code> if the warning should be treated as an error, otherwise <code>false</code>.</returns>
         bool ShouldTreatWarningAsError(string code, BuildEventContext context);
 

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -212,14 +212,6 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
 
-            string warningCode = null;
-            ResourceUtilities.ExtractMessageCode(true, ResourceUtilities.GetResourceString(messageResourceName), out warningCode);
-
-            if(_loggingService.ShouldTreatWarningAsError(warningCode, _eventContext))
-            {
-                _loggingService.LogError(_eventContext, file, messageResourceName, messageArgs);
-            }
-            
             _loggingService.LogWarning(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
         }
 
@@ -234,11 +226,6 @@ namespace Microsoft.Build.BackEnd.Logging
         internal void LogWarningFromText(string subcategoryResourceName, string warningCode, string helpKeyword, BuildEventFileInfo file, string message)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-
-            if (_loggingService.ShouldTreatWarningAsError(warningCode, _eventContext))
-            {
-                _loggingService.LogErrorFromText(_eventContext, subcategoryResourceName, warningCode, helpKeyword, file, message);
-            }
 
             _loggingService.LogWarningFromText(_eventContext, subcategoryResourceName, warningCode, helpKeyword, file, message);
         }

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -211,6 +211,15 @@ namespace Microsoft.Build.BackEnd.Logging
         internal void LogWarning(string subcategoryResourceName, BuildEventFileInfo file, string messageResourceName, params object[] messageArgs)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+
+            string warningCode = null;
+            ResourceUtilities.ExtractMessageCode(true, ResourceUtilities.GetResourceString(messageResourceName), out warningCode);
+
+            if(_loggingService.ShouldTreatWarningAsError(warningCode, _eventContext))
+            {
+                _loggingService.LogError(_eventContext, file, messageResourceName, messageArgs);
+            }
+            
             _loggingService.LogWarning(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
         }
 
@@ -225,6 +234,12 @@ namespace Microsoft.Build.BackEnd.Logging
         internal void LogWarningFromText(string subcategoryResourceName, string warningCode, string helpKeyword, BuildEventFileInfo file, string message)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+
+            if (_loggingService.ShouldTreatWarningAsError(warningCode, _eventContext))
+            {
+                _loggingService.LogErrorFromText(_eventContext, subcategoryResourceName, warningCode, helpKeyword, file, message);
+            }
+
             _loggingService.LogWarningFromText(_eventContext, subcategoryResourceName, warningCode, helpKeyword, file, message);
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.BackEnd
 #if FEATURE_APPDOMAIN
         MarshalByRefObject,
 #endif
-        IBuildEngine7
+        IBuildEngine8
     {
         /// <summary>
         /// True if the "secret" environment variable MSBUILDNOINPROCNODE is set.
@@ -489,6 +489,8 @@ namespace Microsoft.Build.BackEnd
 
                 if (_taskLoggingContext.LoggingService.ShouldTreatWarningAsError(e.Code, e.BuildEventContext))
                 {
+                    WarningLoggedAsError(null, e);
+
                     BuildErrorEventArgs errorEvent = new BuildErrorEventArgs
                             (
                                 e.Subcategory,
@@ -698,6 +700,9 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public bool AllowFailureWithoutError { get; set; } = false;
         #endregion
+
+
+        public event BuildWarningEventHandler WarningLoggedAsError;
 
         /// <summary>
         /// Called by the internal MSBuild task.

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -487,31 +487,14 @@ namespace Microsoft.Build.BackEnd
 
                 e.BuildEventContext = _taskLoggingContext.BuildEventContext;
 
+                // If the warning we're about to log will be logged as an error, store it so
+                // the TaskLoggingHelper can determine what was actually logged as an error.
                 if (_taskLoggingContext.LoggingService.ShouldTreatWarningAsError(e.Code, e.BuildEventContext))
                 {
-                    WarningLoggedAsError(null, e);
+                    WarningsLoggedAsErrors.Add(e.Code);
+                }
 
-                    BuildErrorEventArgs errorEvent = new BuildErrorEventArgs
-                            (
-                                e.Subcategory,
-                                e.Code,
-                                e.File,
-                                e.LineNumber,
-                                e.ColumnNumber,
-                                e.EndLineNumber,
-                                e.EndColumnNumber,
-                                e.Message,
-                                e.HelpKeyword,
-                                e.SenderName
-                            );
-                    errorEvent.BuildEventContext = e.BuildEventContext;
-                    _taskLoggingContext.HasLoggedErrors = true;
-                    _taskLoggingContext.LoggingService.LogBuildEvent(errorEvent);
-                }
-                else
-                {
-                    _taskLoggingContext.LoggingService.LogBuildEvent(e);
-                }
+                _taskLoggingContext.LoggingService.LogBuildEvent(e);
             }
         }
 
@@ -701,8 +684,12 @@ namespace Microsoft.Build.BackEnd
         public bool AllowFailureWithoutError { get; set; } = false;
         #endregion
 
-
-        public event BuildWarningEventHandler WarningLoggedAsError;
+        #region IBuildEngine8 Members
+        /// <summary>
+        /// Returns a set containing all warnings the build engine converted into errors.
+        /// </summary>
+        public HashSet<string> WarningsLoggedAsErrors { get; } = new HashSet<string>();
+        #endregion
 
         /// <summary>
         /// Called by the internal MSBuild task.

--- a/src/Framework/IBuildEngine8.cs
+++ b/src/Framework/IBuildEngine8.cs
@@ -1,14 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Build.Framework
 {
     /// <summary>
-    /// This interface extends <see cref="IBuildEngine6" /> to allow tasks to know when the
-    /// warnings they log were actually converted to errors.
+    /// This interface extends <see cref="IBuildEngine7" /> to allow tasks to know what
+    /// warnings they logged were converted to errors.
     /// </summary>
     public interface IBuildEngine8 : IBuildEngine7
     {
-        public event BuildWarningEventHandler WarningLoggedAsError;
+        /// <summary>
+        /// A set containing warning codes that the build engine converted into an error.
+        /// </summary>
+        public HashSet<string> WarningsLoggedAsErrors { get; }
     }
 }

--- a/src/Framework/IBuildEngine8.cs
+++ b/src/Framework/IBuildEngine8.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// This interface extends <see cref="IBuildEngine6" /> to allow tasks to know when the
+    /// warnings they log were actually converted to errors.
+    /// </summary>
+    public interface IBuildEngine8 : IBuildEngine7
+    {
+        public event BuildWarningEventHandler WarningLoggedAsError;
+    }
+}

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -164,8 +164,6 @@ namespace Microsoft.Build.CommandLine
         private RegisteredTaskObjectCacheBase _registeredTaskObjectCache;
 #endif
 
-        public event BuildWarningEventHandler WarningLoggedAsError;
-
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -871,10 +869,6 @@ namespace Microsoft.Build.CommandLine
                     if (taskResult == null)
                     {
                         taskResult = new OutOfProcTaskHostTaskResult(TaskCompleteType.Failure);
-                        if(_isTaskExecuting)
-                        {
-                            WarningLoggedAsError(null, null);
-                        }
                     }
 
                     lock (_taskCompleteLock)

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.CommandLine
 #if CLR2COMPATIBILITY
         IBuildEngine3
 #else
-        IBuildEngine7
+        IBuildEngine8
 #endif
     {
         /// <summary>
@@ -162,6 +162,8 @@ namespace Microsoft.Build.CommandLine
         /// The task object cache.
         /// </summary>
         private RegisteredTaskObjectCacheBase _registeredTaskObjectCache;
+
+        public event BuildWarningEventHandler WarningLoggedAsError;
 #endif
 
         /// <summary>
@@ -861,6 +863,10 @@ namespace Microsoft.Build.CommandLine
                     if (taskResult == null)
                     {
                         taskResult = new OutOfProcTaskHostTaskResult(TaskCompleteType.Failure);
+                        if(_isTaskExecuting)
+                        {
+                            WarningLoggedAsError(null, null);
+                        }
                     }
 
                     lock (_taskCompleteLock)

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -162,9 +162,9 @@ namespace Microsoft.Build.CommandLine
         /// The task object cache.
         /// </summary>
         private RegisteredTaskObjectCacheBase _registeredTaskObjectCache;
+#endif
 
         public event BuildWarningEventHandler WarningLoggedAsError;
-#endif
 
         /// <summary>
         /// Constructor.
@@ -457,6 +457,14 @@ namespace Microsoft.Build.CommandLine
 
         #endregion
 #endif
+
+        #region IBuildEngine8 Implementation
+        /// <summary>
+        /// Returns a set containing all warnings the build engine converted into errors.
+        /// </summary>
+        public HashSet<string> WarningsLoggedAsErrors { get; } = new HashSet<string>();
+        #endregion
+
 
         #region INodePacketFactory Members
 

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Build.Utilities
         public string HelpKeywordPrefix { get; set; }
 
         /// <summary>
-        /// 
+        /// A bool that determines whether or not the task has logged an error.
         /// </summary>
         private bool _hasLoggedErrors;
 
@@ -1042,11 +1042,6 @@ namespace Microsoft.Build.Utilities
             // If the task has missed out all location information, add the location of the task invocation;
             // that gives the user something.
             bool fillInLocation = (String.IsNullOrEmpty(file) && (lineNumber == 0) && (columnNumber == 0));
-
-            if(warningCode == null)
-            {
-
-            }
 
             // Keep track of warnings logged and compare to the what the build engine logged as an error.
             _warningCodesLogged.Add(warningCode);

--- a/src/Utilities/Task.cs
+++ b/src/Utilities/Task.cs
@@ -106,6 +106,11 @@ namespace Microsoft.Build.Utilities
         public IBuildEngine7 BuildEngine7 => (IBuildEngine7)BuildEngine;
 
         /// <summary>
+        /// Retrieves the <see cref="IBuildEngine8" /> version of the build engine interface provided by the host.
+        /// </summary>
+        public IBuildEngine8 BuildEngine8 => (IBuildEngine8)BuildEngine;
+
+        /// <summary>
         /// The build engine sets this property if the host IDE has associated a host object with this particular task.
         /// </summary>
         /// <value>The host object instance (can be null).</value>

--- a/src/Utilities/Task.cs
+++ b/src/Utilities/Task.cs
@@ -50,22 +50,11 @@ namespace Microsoft.Build.Utilities
 
         #region Properties
 
-        private IBuildEngine _engine;
         /// <summary>
         /// The build engine automatically sets this property to allow tasks to call back into it.
         /// </summary>
         /// <value>The build engine interface available to tasks.</value>
-        public IBuildEngine BuildEngine
-        {
-            get
-            {
-                return _engine;
-            }
-            set
-            {
-                _engine = value;
-            }
-        }
+        public IBuildEngine BuildEngine { get; set; }
 
         // The casts below are always possible because this class is built against the 
         // Orcas Framework assembly or later, so the version of MSBuild that does not

--- a/src/Utilities/Task.cs
+++ b/src/Utilities/Task.cs
@@ -50,11 +50,22 @@ namespace Microsoft.Build.Utilities
 
         #region Properties
 
+        private IBuildEngine _engine;
         /// <summary>
         /// The build engine automatically sets this property to allow tasks to call back into it.
         /// </summary>
         /// <value>The build engine interface available to tasks.</value>
-        public IBuildEngine BuildEngine { get; set; }
+        public IBuildEngine BuildEngine
+        {
+            get
+            {
+                return _engine;
+            }
+            set
+            {
+                _engine = value;
+            }
+        }
 
         // The casts below are always possible because this class is built against the 
         // Orcas Framework assembly or later, so the version of MSBuild that does not


### PR DESCRIPTION
Fixes #5511

### Context
Tasks have a Log.HasLoggedErrors property that does not respect warnings that were thrown as errors when listed under `MSBuildWarningsAsErrors`.

For an easier code review, commits 1 & 3 are the most relevant. Then check the main diff.

### Changes Made
- `LoggingService` now exposes its `ShouldLogWarningAsError` method through the `ILoggingService` interface.
- IBuildEngine8 exposes a `HashSet<string>` that contains all warning codes that were logged as errors.
- TaskHost adds all warning codes that were logged as errors to a HashSet<string>.
- The TaskLoggingHelper's `HasLoggedErrors` property returns whether it logged an error OR if its build engine has thrown a warning that the task previously logged.

### Testing
- [x] Confirmed this fixes the repro in the linked issue.
- [ ] Need to test batched builds, as a `TaskHost` is generated per 'bucket'

### Notes
Comment from Rainer in previous PR about this: https://github.com/dotnet/msbuild/pull/5957 

> The PR that introduced warning-as-error is #1355--#1928 extended it to allow the project level properties.
> 
> Since that's done in the logging infrastructure rather than at the point of logging, I think that's the problem. Unfortunately I don't know if there's an easy way to move it. Can you investigate that angle? Is the warning-as-errors stuff available in TaskHost and if not how hard would it be to get it there?
> 
> I don't think we should attack the problem for TaskLoggingHelper alone--if you attack it at the IBuildEngine API layer, it'll work for everything, not just tasks that use the helper classes.