### PR TITLE
Fix Nullable Warnings & projectcacheplugin.csproj now targets net5.0

### DIFF
--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -43,7 +43,7 @@
     <ProjectReference Include="..\Samples\ProjectCachePlugin\ProjectCachePlugin.csproj" Private="false" ReferenceOutputAssembly="false">
       <SetTargetFramework Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">TargetFramework=$(FullFrameworkTFM)</SetTargetFramework>
       <SetTargetFramework Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(MonoBuild)' == 'true'">TargetFramework=$(FullFrameworkTFM)</SetTargetFramework>
-      <SetTargetFramework Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">TargetFramework=netcoreapp2.1</SetTargetFramework>
+      <SetTargetFramework Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
 
     <Reference Include="System.Configuration" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheItem.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheItem.cs
@@ -26,25 +26,25 @@ namespace Microsoft.Build.Experimental.ProjectCache
         public string PluginPath { get; }
         public IReadOnlyDictionary<string, string> PluginSettings { get; }
 
-        public bool Equals(ProjectCacheItem other)
+        public bool Equals(ProjectCacheItem? other)
         {
             if (ReferenceEquals(this, other))
             {
                 return true;
             }
 
-            return PluginPath == other.PluginPath &&
+            return PluginPath == other?.PluginPath &&
                    CollectionHelpers.DictionaryEquals(PluginSettings, other.PluginSettings);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(this, obj))
             {
                 return true;
             }
 
-            if (obj.GetType() != GetType())
+            if (obj?.GetType() != GetType())
             {
                 return false;
             }

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
         {
             try
             {
-                return (ProjectCachePluginBase) Activator.CreateInstance(pluginType);
+                return (ProjectCachePluginBase) Activator.CreateInstance(pluginType)!;
             }
             catch (TargetInvocationException e) when (e.InnerException != null)
             {

--- a/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
+++ b/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
@@ -4,8 +4,8 @@
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OsEnvironment)'=='windows'">$(FullFrameworkTFM);netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(FullFrameworkTFM);net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(MonoBuild)'=='true'">$(RuntimeOutputTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes CI

### Context
Arcade PR passed CI -> projectcache was merged -> Arcade PR was merged using the stale CI success from before projectcache being merged.

### Changes Made
`ProjectCachePlugin.csproj` now targets net5.0.
`Microsoft.Build.Engine.UnitTests.csproj` assigns `net5.0` TargetFramework instead of `netcoreapp2.1`.
Relaxed nullable warnings that were turned into errors in pipeline builds. @cdmihai please double check `ProjectCacheItem.cs` for what I did with the nullable warnings.

### Testing
CI testing should be enough. If we want to play it safe, an `exp/` run should be good validation.

### Notes
Fun fact: Apparently, `Microsoft.Build.Engine.UnitTests.csproj` manually assigns a TargetFramework?