### PR TITLE
Fix null reference error on ResolveAssemblyReference

### DIFF
--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1024,8 +1024,8 @@ namespace Microsoft.Build.Tasks
                                 {
                                     { "logMessage", output },
                                     { "logMessageDetails", details },
-                                    { "victorVersionNumber", victor.ReferenceVersion.ToString() },
-                                    { "victimVersionNumber", conflictCandidate.ReferenceVersion.ToString() }
+                                    { "victorVersionNumber", victor.ReferenceVersion?.ToString() },
+                                    { "victimVersionNumber", conflictCandidate.ReferenceVersion?.ToString() }
                                 }));
                             }
                         }


### PR DESCRIPTION
### Context
Null reference error when ReferenceVersions are not set, introduced in https://github.com/dotnet/msbuild/pull/5990

### Testing
Bug repros with https://github.com/dotnet/sdk/pull/15430. These changes were tested with that PR and fix the issue.