### PR TITLE
V3 publishing

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -80,8 +80,8 @@ stages:
     - script: eng/CIBuild.cmd
                 -configuration $(BuildConfiguration)
                 -officialBuildId $(Build.BuildNumber)
-                -officialSkipApplyOptimizationData true
-                /p:RepositoryName=https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-msbuild
+                -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
+                /p:RepositoryName=$(Build.Repository.Name)
                 /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
                 /p:VisualStudioDropAccessToken=$(System.AccessToken)
                 /p:VisualStudioDropName=$(VisualStudio.DropName)
@@ -222,6 +222,7 @@ stages:
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until
       # https://github.com/dotnet/arcade/issues/2871 is resolved.
+      publishingInfraVersion: 3
       enableSymbolValidation: false
       enableSourceLinkValidation: false
       enableNugetValidation: false

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -81,7 +81,7 @@ stages:
                 -configuration $(BuildConfiguration)
                 -officialBuildId $(Build.BuildNumber)
                 -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
-                /p:RepositoryName=$(Build.Repository.Name)
+                /p:RepositoryName=https://dnceng@dev.azure.com/dnceng/internal/_git/msbuild
                 /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
                 /p:VisualStudioDropAccessToken=$(System.AccessToken)
                 /p:VisualStudioDropName=$(VisualStudio.DropName)

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -12,7 +12,7 @@ trigger:
 
 variables:
   - name: SourceBranch
-    value: $(IbcSourceBranchName)
+    value: master
   - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/') }}:
     - name: SourceBranch
       value: master

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -80,8 +80,8 @@ stages:
     - script: eng/CIBuild.cmd
                 -configuration $(BuildConfiguration)
                 -officialBuildId $(Build.BuildNumber)
-                -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
-                /p:RepositoryName=$(Build.Repository.Name)
+                -officialSkipApplyOptimizationData true
+                /p:RepositoryName=https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-msbuild
                 /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
                 /p:VisualStudioDropAccessToken=$(System.AccessToken)
                 /p:VisualStudioDropName=$(VisualStudio.DropName)

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -81,7 +81,7 @@ stages:
                 -configuration $(BuildConfiguration)
                 -officialBuildId $(Build.BuildNumber)
                 -officialSkipApplyOptimizationData true
-                /p:RepositoryName=https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-msbuild
+                /p:RepositoryName=$(Build.Repository.Name)
                 /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
                 /p:VisualStudioDropAccessToken=$(System.AccessToken)
                 /p:VisualStudioDropName=$(VisualStudio.DropName)

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -222,6 +222,7 @@ stages:
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until
       # https://github.com/dotnet/arcade/issues/2871 is resolved.
+      publishingInfraVersion: 3
       enableSymbolValidation: false
       enableSourceLinkValidation: false
       enableNugetValidation: false

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -12,7 +12,7 @@ trigger:
 
 variables:
   - name: SourceBranch
-    value: master
+    value: $(IbcSourceBranchName)
   - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/') }}:
     - name: SourceBranch
       value: master
@@ -80,8 +80,8 @@ stages:
     - script: eng/CIBuild.cmd
                 -configuration $(BuildConfiguration)
                 -officialBuildId $(Build.BuildNumber)
-                -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
-                /p:RepositoryName=https://dnceng@dev.azure.com/dnceng/internal/_git/msbuild
+                -officialSkipApplyOptimizationData true
+                /p:RepositoryName=https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-msbuild
                 /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
                 /p:VisualStudioDropAccessToken=$(System.AccessToken)
                 /p:VisualStudioDropName=$(VisualStudio.DropName)
@@ -222,7 +222,6 @@ stages:
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until
       # https://github.com/dotnet/arcade/issues/2871 is resolved.
-      publishingInfraVersion: 3
       enableSymbolValidation: false
       enableSourceLinkValidation: false
       enableNugetValidation: false

--- a/PublishToBlob.proj
+++ b/PublishToBlob.proj
@@ -25,6 +25,7 @@
                     ItemsToPush="@(ItemsToPush)"
                     Overwrite="$(PublishOverwrite)"
                     ManifestBranch="$(ManifestBranch)"
+                    ManifestRepoUri="https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-msbuild"
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestCommit="$(ManifestCommit)"
                     ManifestName="msbuild"

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+   <PropertyGroup>
+      <PublishingVersion>3</PublishingVersion>
+   </PropertyGroup>
+</Project>

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -30,10 +30,13 @@ Param(
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
+# This is a temporary fix to get msbuild onboarded with v3 publishing. This will be resolved soon ->https://github.com/dotnet/arcade/issues/6827
+[Environment]::SetEnvironmentVariable("BUILD_REPOSITORY_URI", "https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-msbuild")
+
 # Unset 'Platform' environment variable to avoid unwanted collision in InstallDotNetCore.targets file
 # some computer has this env var defined (e.g. Some HP)
 if($env:Platform) {
-  $env:Platform=""  
+  $env:Platform=""
 }
 function Print-Usage() {
   Write-Host "Common settings:"
@@ -98,10 +101,10 @@ function Build {
     # Re-assign properties to a new variable because PowerShell doesn't let us append properties directly for unclear reasons.
     # Explicitly set the type as string[] because otherwise PowerShell would make this char[] if $properties is empty.
     [string[]] $msbuildArgs = $properties
-    
-    # Resolve relative project paths into full paths 
+
+    # Resolve relative project paths into full paths
     $projects = ($projects.Split(';').ForEach({Resolve-Path $_}) -join ';')
-    
+
     $msbuildArgs += "/p:Projects=$projects"
     $properties = $msbuildArgs
   }


### PR DESCRIPTION
Fixes #

### Context
Moving ms build to use V3 publishing 

Link to what is V3 -> https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Publishing.md#what-is-v3-publishing-how-is-it-different-from-v2

### Changes Made


### Testing


### Notes
