### PR TITLE
Onboarding to V3 publishing 

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -77,6 +77,13 @@ stages:
       inputs:
         dropName: $(VisualStudio.DropName)
 
+    - task: PowerShell@2
+      inputs: # This is a temporary fix to get msbuild onboarded with v3 publishing. This will be resolved soon ->https://github.com/dotnet/arcade/issues/6827
+        targetType: 'inline'
+        script: |
+          Write-Host "Overwriting BUILD_REPOSITORY_URI."
+          Write-Host "##vso[task.setvariable variable=BUILD_REPOSITORY_URI;]https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-msbuild"
+
     - script: eng/CIBuild.cmd
                 -configuration $(BuildConfiguration)
                 -officialBuildId $(Build.BuildNumber)
@@ -222,6 +229,7 @@ stages:
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until
       # https://github.com/dotnet/arcade/issues/2871 is resolved.
+      publishingInfraVersion: 3
       enableSymbolValidation: false
       enableSourceLinkValidation: false
       enableNugetValidation: false

--- a/PublishToBlob.proj
+++ b/PublishToBlob.proj
@@ -26,6 +26,7 @@
                     Overwrite="$(PublishOverwrite)"
                     ManifestBranch="$(ManifestBranch)"
                     ManifestBuildId="$(ManifestBuildId)"
+                    ManifestRepoUri="https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-msbuild"
                     ManifestCommit="$(ManifestCommit)"
                     ManifestName="msbuild"
                     SkipCreateManifest="false" />

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+   <PropertyGroup>
+      <PublishingVersion>3</PublishingVersion>
+   </PropertyGroup>
+</Project>

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -53,9 +53,16 @@ jobs:
         downloadPath: '$(Build.StagingDirectory)/Download'
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-    
+
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: NuGetAuthenticate@0
+
+    - task: PowerShell@2
+      inputs: # This is a temporary fix to get msbuild onboarded with v3 publishing. This will be resolved soon ->https://github.com/dotnet/arcade/issues/6827
+        targetType: 'inline'
+        script: |
+          Write-Host "Overwriting BUILD_REPOSITORY_URI."
+          Write-Host "##vso[task.setvariable variable=BUILD_REPOSITORY_URI;]https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-msbuild"
 
     - task: PowerShell@2
       displayName: Publish Build Assets
@@ -70,7 +77,7 @@ jobs:
           /p:OfficialBuildId=$(Build.BuildNumber)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-    
+
     - task: powershell@2
       displayName: Create ReleaseConfigs Artifact
       inputs:
@@ -79,15 +86,15 @@ jobs:
           Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(BARBuildId)
           Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value "$(DefaultChannels)"
           Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(IsStableBuild)
-    
+
     - task: PublishBuildArtifacts@1
       displayName: Publish ReleaseConfigs Artifact
       inputs:
         PathtoPublish: '$(Build.StagingDirectory)/ReleaseConfigs.txt'
         PublishLocation: Container
         ArtifactName: ReleaseConfigs
-    
+
     - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
       - template: /eng/common/templates/steps/publish-logs.yml
         parameters:
-          JobLabel: 'Publish_Artifacts_Logs'     
+          JobLabel: 'Publish_Artifacts_Logs'


### PR DESCRIPTION
Fixes #

### Context

Onboarding to V3 publishing. 
Link to what is V3 -> https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Publishing.md#what-is-v3-publishing-how-is-it-different-from-v2

### Changes Made


### Testing

CI build - https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4391278&view=results
Promotion pipeline - https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4391300&view=results

### Notes

Hardcoding of BUILD_REPOSITORY_URI is temporary fix. This will be reverted once this is fixed https://github.com/dotnet/arcade/issues/6827
