### PR TITLE
Disable Mono CI

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -209,6 +209,8 @@ jobs:
     condition: always()
 
 - job: MonoOnMac
+  # Mono CI disabled until it can parse C# 9 syntax: https://github.com/dotnet/msbuild/issues/6058
+  condition: eq(1,2)
   displayName: "macOS Mono"
   pool:
     vmImage: 'macOS-10.14'


### PR DESCRIPTION
Until it can parse C# 9 syntax. Followed by issue #6058 