### PR TITLE
Update to assembly filtering in ClickOnce task for .NET Core scenario

### DIFF
--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -732,7 +732,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (identity?.IsInFramework(Constants.DotNetCoreIdentifier, null) == true)
                 {
-                    return true;
+                    return !GetItemCopyLocal(item);
                 }
             }
             else if (identity?.IsInFramework(Constants.DotNetFrameworkIdentifier, TargetFrameworkVersion) == true)


### PR DESCRIPTION
**Context**
Issue: 
ClickOnce filters our assemblies that are part of the .NET Framework from publishing. This is done by looking up the assembly reference in C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\<version> folder. This works reliably for .NET FX scenarios. However for .NET Core, this check is not reliable. For a packages like System.ServiceModel.Primitives, the system.servicemodel and system.servicemodel.primitives assemblies get filtered out because they are present under C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore but they are not present in .NET Core's runtime pack.
This will lead to app launch failure due to missing dependency.

**Changes Made**
Fix ClickOnce's assembly filtering code for .net core to not filter copylocal assemblies even if the look up under C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore has succeeded.

**Testing**
CTI has validated specific packages that are affected and also validated the change against top 50 NuGet packages.

**Work Item**
https://developercommunity2.visualstudio.com/t/ClickOnce-no-longer-works/1288425