### PR TITLE
Fix deploy-MSBuild after arcade change

### DIFF
--- a/scripts/Deploy-MSBuild.ps1
+++ b/scripts/Deploy-MSBuild.ps1
@@ -48,7 +48,7 @@ Write-Host "Existing MSBuild assemblies backed up to $BackupFolder"
 if ($runtime -eq "Desktop") {
     $targetFramework = "net472"
 } else {
-    $targetFramework = "netcoreapp2.1"
+    $targetFramework = "net5.0"
 }
 
 $bootstrapBinDirectory = "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework"


### PR DESCRIPTION
Arcade change didn't take into account Deploy-MSBuild, and it failed with a Microsoft.NET.StringTools.dll does not exist error. That was actually very fortunate (thanks ladipro!) since it otherwise would have silently accepted looking into the wrong folder (from a previous bootstrap build) and deploying something that hadn't actually been updated, which would have been extremely confusing.

This only fixes the instance I found, but I would recommend someone look for other similar instances.

Also, assuming this is eventually merged, @BenVillalobos for awareness, since it would have to be reverted also if we revert the arcade change.