### PR TITLE
Revert 16.10 branding changes in app.config to match Microsoft.Build.CPPTasks.Common

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -48,8 +48,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.10.0.0" newVersion="16.10.0.0" />
-          <codeBase version="16.10.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.9.0.0" newVersion="16.9.0.0" />
+          <codeBase version="16.9.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -60,8 +60,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.10.0.0" newVersion="16.10.0.0" />
-          <codeBase version="16.10.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.9.0.0" newVersion="16.9.0.0" />
+          <codeBase version="16.9.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->


### PR DESCRIPTION
### Context

The recent branding changes made us expect 16.10 version of `Microsoft.Build.CPPTasks.Common` but the current VS Main is still building this assembly as 16.9.

### Changes Made

Reverted branding changes made to `app.config`, both flavors.

### Testing

Verified that latest Visual Studio Main with this change can successfully build C++ projects.
