### PR TITLE
Skip reading environment variable when changewave has already been parsed

### DIFF
--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Build.Utilities
                 ConversionState = ChangeWaveConversionState.Valid;
                 _cachedWave = ChangeWaves.EnableAllFeatures;
             }
-            else if (_cachedWave == null && !Version.TryParse(msbuildDisableFeaturesFromVersion, out _cachedWave))
+            else if (!Version.TryParse(msbuildDisableFeaturesFromVersion, out _cachedWave))
             {
                 ConversionState = ChangeWaveConversionState.InvalidFormat;
                 _cachedWave = ChangeWaves.EnableAllFeatures;

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -110,18 +110,20 @@ namespace Microsoft.Build.Utilities
         internal static void ApplyChangeWave()
         {
             // Once set, change wave should not need to be set again.
-            string mSBuildDisableFeaturesFromVersion = Environment.GetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION");
             if (!ShouldApplyChangeWave)
             {
                 return;
             }
+
+            string msbuildDisableFeaturesFromVersion = Environment.GetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION");
+
             // Most common case, `MSBuildDisableFeaturesFromVersion` unset
-            else if (string.IsNullOrEmpty(mSBuildDisableFeaturesFromVersion))
+            if (string.IsNullOrEmpty(msbuildDisableFeaturesFromVersion))
             {
                 ConversionState = ChangeWaveConversionState.Valid;
                 _cachedWave = ChangeWaves.EnableAllFeatures;
             }
-            else if (_cachedWave == null && !Version.TryParse(mSBuildDisableFeaturesFromVersion, out _cachedWave))
+            else if (_cachedWave == null && !Version.TryParse(msbuildDisableFeaturesFromVersion, out _cachedWave))
             {
                 ConversionState = ChangeWaveConversionState.InvalidFormat;
                 _cachedWave = ChangeWaves.EnableAllFeatures;


### PR DESCRIPTION
Fixes #6077

### Context
ChangeWaves.ApplyChangeWave reads the environment variable every single call, regardless of whether or not _cachedWave is set. The parsed change wave is already cached, so let's take advantage of that.

### Changes Made
Place the `ShouldApplyChangeWave` check before we pull the environment variable.

### Testing
Existing tests should suffice.

### Notes
