### PR TITLE
Pass $(Nullable) to csc in XamlPreCompile

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -278,6 +278,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               NoLogo="$(NoLogo)"
               NoStandardLib="$(NoCompilerStandardLib)"
               NoWin32Manifest="$(NoWin32Manifest)"
+              Nullable="$(Nullable)"
               Optimize="$(Optimize)"
               OutputAssembly="@(XamlIntermediateAssembly)"
               PdbFile="$(PdbFile)" 


### PR DESCRIPTION
Fixes #6088

### Context
$(Nullable) not passed into csc invoked in XamlPreCompile, causing nullable waring in project with xaml and nullable enabled

### Changes Made
Passes $(Nullable) as targets in roslyn

### Testing
None

### Notes
I wonder what are involved by this issue. WPF (.NET Core) is not involve.
Technically this is a critical bug to every version after 16.3 because it blocks WarningAsError.