### PR TITLE
Bring XamlPreCompile up to date with roslyn targets

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -237,9 +237,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           <AdditionalFiles Include="@(%(AdditionalFileItems.Identity))" />
         </ItemGroup>
         
-       <!-- Don't run analyzers for Csc task on XamlPrecompile pass, we only want to run them on core compile. -->
-       <!-- Analyzers="@(Analyzer)" -->
-
        <PropertyGroup Condition="'$(UseSharedCompilation)' == ''">
          <UseSharedCompilation>true</UseSharedCompilation>
        </PropertyGroup>
@@ -250,6 +247,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               AddModules="@(AddModules)"
               AdditionalFiles="@(AdditionalFiles)"
               AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
+              Analyzers="@(Analyzer)"
               ApplicationConfiguration="$(AppConfigForCompiler)"
               BaseAddress="$(BaseAddress)"
               CheckForOverflowUnderflow="$(CheckForOverflowUnderflow)"
@@ -288,6 +286,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               ReportAnalyzer="$(ReportAnalyzer)"
               Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
               ResponseFiles="$(CompilerResponseFile)"
+              SkipAnalyzers="$(_SkipAnalyzers)"
               Sources="@(Compile)"
               SubsystemVersion="$(SubsystemVersion)"
               TargetType="$(OutputType)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/46300

### Context

Source generators fail on projects that depend on the `XamlPreCompile` target because it removes analyzers for performance reasons. Because source generators are passed in via the analyzers collection, they are also removed, which causes build failures. Roslyn added the `/skipAnalyzers` flag in https://github.com/dotnet/roslyn/pull/46669 which allows the caller to keep the analyzers item group populated, skipping the analyzers and running the generators.

### Changes Made

Changed the `XamlPreCompile` target to match the roslyn CSC invocation, as it should.

### Testing

Manually tested patching the file on VS preview and confirmed the project can succesfully build, where it didn't without the patch.

### Notes
