### PR TITLE
Support Common output via `BuildDir` and `PublishDir`

### DIFF
--- a/src/Tasks.UnitTests/OutputPathTests.cs
+++ b/src/Tasks.UnitTests/OutputPathTests.cs
@@ -61,7 +61,7 @@ $@"<Project DefaultTargets=`Build` xmlns=`msbuildnamespace` ToolsVersion=`msbuil
             project.Build(new MockLogger(_output)).ShouldBeFalse();
 
             // Assert
-            project.GetPropertyValue("BaseOutputPath").ShouldBe(baseOutputPath + '\\');
+            project.GetPropertyValue("BaseOutputPath").ShouldBe(baseOutputPath.WithTrailingSlash());
             project.GetPropertyValue("BaseOutputPathWasSpecified").ShouldBe(string.Empty);
             project.GetPropertyValue("_OutputPathWasMissing").ShouldBe("true");
         }

--- a/src/Tasks.UnitTests/ProjectExtensionsImportTestBase.cs
+++ b/src/Tasks.UnitTests/ProjectExtensionsImportTestBase.cs
@@ -171,25 +171,25 @@ namespace Microsoft.Build.UnitTests
 
             MockLogger logger = new MockLogger();
 
-            project.Build("_CheckForInvalidConfigurationAndPlatform", new[] {logger}).ShouldBeFalse();
+            project.Build("_CheckForInvalidOutputPaths", new[] {logger}).ShouldBeFalse();
 
             logger.Errors.Select(i => i.Code).FirstOrDefault().ShouldBe("MSB3540");
         }
 
         /// <summary>
-        /// Ensures that an error is logged if BaseIntermediateOutputPath is modified after it was set by Microsoft.Common.props and 
-        /// EnableBaseIntermediateOutputPathMismatchWarning is 'true'.
+        /// Ensures that an error is logged if BuildDir is modified after it was set by Microsoft.Common.props and 
+        /// EnableBuildDirMismatchWarning is 'true'.
         /// </summary>
         [Fact]
-        public void WarningIfBaseIntermediateOutputPathIsChangedInBodyOfProject()
+        public void WarningIfBuildDirIsChangedInBodyOfProject()
         {
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, @"
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
 
                     <PropertyGroup>
-                        <EnableBaseIntermediateOutputPathMismatchWarning>true</EnableBaseIntermediateOutputPathMismatchWarning>
-                        <BaseIntermediateOutputPath>foo</BaseIntermediateOutputPath>
+                        <EnableBuildDirMismatchWarning>true</EnableBuildDirMismatchWarning>
+                        <BuildDir>foo</BuildDir>
                     </PropertyGroup>
 
                     <Import Project=`$(MSBuildBinPath)\Microsoft.CSharp.targets` />
@@ -198,7 +198,7 @@ namespace Microsoft.Build.UnitTests
 
             MockLogger logger = new MockLogger();
 
-            project.Build("_CheckForInvalidConfigurationAndPlatform", new[] { logger }).ShouldBeTrue();
+            project.Build("_CheckForInvalidOutputPaths", new[] { logger }).ShouldBeTrue();
 
             logger.Warnings.Select(i => i.Code).FirstOrDefault().ShouldBe("MSB3539");
         }

--- a/src/Tasks.UnitTests/ProjectExtensionsPropsImportTest.cs
+++ b/src/Tasks.UnitTests/ProjectExtensionsPropsImportTest.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Build.UnitTests
     /// </summary>
     sealed public class ProjectExtensionsPropsImportTest : ProjectExtensionsImportTestBase
     {
-        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.props");
+        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "ext", $"{Path.GetFileName(_projectRelativePath)}.custom.props");
 
-        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.props");
+        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "ext", $"{Path.GetFileName(_projectRelativePath)}.custom.props");
 
         protected override string PropertyNameToEnableImport => "ImportProjectExtensionProps";
 

--- a/src/Tasks.UnitTests/ProjectExtensionsTargetsImportTest.cs
+++ b/src/Tasks.UnitTests/ProjectExtensionsTargetsImportTest.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Build.UnitTests
     /// </summary>
     sealed public class ProjectExtensionsTargetsImportTest : ProjectExtensionsImportTestBase
     {
-        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.targets");
+        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "ext", $"{Path.GetFileName(_projectRelativePath)}.custom.targets");
 
-        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.targets");
+        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "ext", $"{Path.GetFileName(_projectRelativePath)}.custom.targets");
 
         protected override string PropertyNameToEnableImport => "ImportProjectExtensionTargets";
 

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -215,7 +215,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true' and '$(DirectoryBuildTargetsPath)' == ''">
     <_DirectoryBuildTargetsFile Condition="'$(_DirectoryBuildTargetsFile)' == ''">Directory.Build.targets</_DirectoryBuildTargetsFile>
     <_DirectoryBuildTargetsBasePath Condition="'$(_DirectoryBuildTargetsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectoryBuildTargetsFile)'))</_DirectoryBuildTargetsBasePath>
-    <DirectoryBuildTargetsPath Condition="'$(_DirectoryBuildTargetsBasePath)' != '' and '$(_DirectoryBuildTargetsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildTargetsBasePath)', '$(_DirectoryBuildTargetsFile)'))</DirectoryBuildTargetsPath>
+    <DirectoryBuildTargetsPath Condition="'$(_DirectoryBuildTargetsBasePath)' != '' and '$(_DirectoryBuildTargetsFile)' != ''">$([MSBuild]::NormalizePath('$(_DirectoryBuildTargetsBasePath)', '$(_DirectoryBuildTargetsFile)'))</DirectoryBuildTargetsPath>
   </PropertyGroup>
 
   <Import Project="$(DirectoryBuildTargetsPath)" Condition="'$(ImportDirectoryBuildTargets)' == 'true' and exists('$(DirectoryBuildTargetsPath)')"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -481,7 +481,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!-- Output location for publish target. -->
   <PropertyGroup>
-    <PublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(PublishDir)', 'publish'))))</PublishDir>
+    <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
+    <PublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(PublishDir)', '$(PublishDirName)'))))</PublishDir>
     <PublishDir Condition="$([System.IO.Path]::IsPathRooted('$(PublishDir)')) and !$(PublishDir.StartsWith('$(MSBuildProjectDirectory)'))">$([MSBuild]::NormalizeDirectory('$(PublishDir)', '$(MSBuildProjectName)'))</PublishDir>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -822,11 +822,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Message Condition="'$(DesignTimeBuild)' != 'true'" Text="Configuration=$(Configuration)" Importance="Low" />
     <Message Condition="'$(DesignTimeBuild)' != 'true'" Text="Platform=$(Platform)" Importance="Low" />
 
-    <!-- Although we try to ensure a trailing slash, it's possible to circumvent this if the property is set on the command line -->
-    <Error Condition="'$(OutDir)' != '' and !HasTrailingSlash('$(OutDir)')" Text="The 'OutDir' property must end with a trailing slash." />
-    <Error Condition="'$(IntermediateOutputPath)' != '' and !HasTrailingSlash('$(IntermediateOutputPath)')" Text="The 'IntermediateOutputPath' must end with a trailing slash." />
-    <Error Condition="'$(BaseIntermediateOutputPath)' != '' and !HasTrailingSlash('$(BaseIntermediateOutputPath)')" Text="The 'BaseIntermediateOutputPath' must end with a trailing slash." />
-
     <!--
       Also update the value of PlatformTargetAsMSBuildArchitecture per the value of Prefer32Bit.  We are doing
       this here because Prefer32Bit may be set anywhere in the targets, so we can't depend on it having the
@@ -836,15 +831,42 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <PlatformTargetAsMSBuildArchitecture>x86</PlatformTargetAsMSBuildArchitecture>
     </PropertyGroup>
 
+  </Target>
+
+  <!--
+    ============================================================
+                  _CheckForInvalidOutputPaths
+
+    This target checks for errors in statically defined output path properties.
+    By setting BeforeTargets, we try to ensure that the target runs before any build related targets.
+
+    If your target requires this check and is running as a BeforeTargets of one of the first targets
+    of $(BuildDependsOn), $(RebuildDependsOn), or $(CleanDependsOn) you will need to set your DependsOn
+    to this target.
+    ============================================================
+  -->
+  <Target
+      Name="_CheckForInvalidOutputPaths"
+      BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
+
+    <!-- Although we try to ensure a trailing slash, it's possible to circumvent this if the property is set on the command line -->
+    <Error Condition="'$(BaseIntermediateOutputPath)' != '' and !HasTrailingSlash('$(BaseIntermediateOutputPath)')" Text="The 'BaseIntermediateOutputPath' must end with a trailing slash." />
+    <Error Condition="'$(IntermediateOutputPath)' != '' and !HasTrailingSlash('$(IntermediateOutputPath)')" Text="The 'IntermediateOutputPath' must end with a trailing slash." />
+    <Error Condition="'$(OutDir)' != '' and !HasTrailingSlash('$(OutDir)')" Text="The 'OutDir' property must end with a trailing slash." />
+
+    <PropertyGroup>
+      <_SetBuildDirsCommonText>To set this property, you must do so before 'Microsoft.Common.props' is imported, for example by using 'Directory.Build.props'.  For more information, please visit https://go.microsoft.com/fwlink/?linkid=869650</_SetBuildDirsCommonText>
+      <_ProjectExtensionsPathMismatchErrorText>The value of the property 'MSBuildProjectExtensionsPath' was modified after it was used by MSBuild which can lead to unexpected build results.</_ProjectExtensionsPathMismatchErrorText>
+      <_BuildDirMismatchWarningText>The value of the property 'BuildDir' was modified after it was used by MSBuild which can lead to unexpected build results. Tools such as NuGet will write outputs to the path specified by the 'MSBuildProjectExtensionsPath' instead.</_BuildDirMismatchWarningText>
+    </PropertyGroup>
+
     <!--
       Log an error if the user set MSBuildProjectExtensionsPath in the body of a project. In an SDK style project
       if you set a value in the body, the value is not used by the top implicit import but is used by the bottom.
       This can lead to confusing behavior and builds can fail for obscure reasons.
     -->
-    <Error Condition=" '$(_InitialMSBuildProjectExtensionsPath)' != '' And '$(MSBuildProjectExtensionsPath)' != '$(_InitialMSBuildProjectExtensionsPath)' "
-           Code="MSB3540"
-           Text="The value of the property &quot;MSBuildProjectExtensionsPath&quot; was modified after it was used by MSBuild which can lead to unexpected build results.  To set this property, you must do so before Microsoft.Common.props is imported, for example by using Directory.Build.props.  For more information, please visit https://go.microsoft.com/fwlink/?linkid=869650"
-            />
+    <Error Condition="'$(_InitialMSBuildProjectExtensionsPath)' != '' And '$(MSBuildProjectExtensionsPath)' != '$(_InitialMSBuildProjectExtensionsPath)'"
+           Code="MSB3540" Text="$(_ProjectExtensionsPathMismatchErrorText)  $(_SetBuildDirsCommonText)" />
 
     <!--
       Log a warning if:
@@ -855,10 +877,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Similar to the error above, there are cases when users set $(BuildDir) in the body of their project and things build but only by coincidence.
       MSBuild does not know if $(BuildDir) changing would cause problems so tools like NuGet must set $(EnableBuildDirMismatchWarning) to 'true'.
     -->
-    <Warning Condition=" '$(EnableBuildDirMismatchWarning)' == 'true' And '$(_InitialBuildDir)' != '$(BuildDir)' And '$(BuildDir)' != '$(MSBuildProjectExtensionsPath)' "
-             Code="MSB3539"
-             Text="The value of the property &quot;BuildDir&quot; was modified after it was used by MSBuild which can lead to unexpected build results. Tools such as NuGet will write outputs to the path specified by the &quot;MSBuildProjectExtensionsPath&quot; instead. To set this property, you must do so before Microsoft.Common.props is imported, for example by using Directory.Build.props.  For more information, please visit https://go.microsoft.com/fwlink/?linkid=869650"
-             />
+    <Warning Condition="'$(EnableBuildDirMismatchWarning)' == 'true' And '$(_InitialBuildDir)' != '$(BuildDir)' And '$(BuildDir)' != '$(MSBuildProjectExtensionsPath)'"
+             Code="MSB3539" Text="$(_BuildDirMismatchWarningText)  $(_SetBuildDirsCommonText)" />
+
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -482,6 +482,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Output location for publish target. -->
   <PropertyGroup>
     <PublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(PublishDir)', 'publish'))))</PublishDir>
+    <PublishDir Condition="$([System.IO.Path]::IsPathRooted('$(PublishDir)')) and !$(PublishDir.StartsWith('$(MSBuildProjectDirectory)'))">$([MSBuild]::NormalizeDirectory('$(PublishDir)', '$(MSBuildProjectName)'))</PublishDir>
   </PropertyGroup>
 
   <!--
@@ -5658,9 +5659,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target
       Name="CleanPublishFolder">
 
+    <PropertyGroup>
+      <_DefaultPublishDir>$([MSBuild]::EnsureTrailingSlash('publish'))</_DefaultPublishDir>
+    </PropertyGroup>
+
     <RemoveDir
         Directories="$(PublishDir)"
-        Condition="'$(PublishDir)' == '$([MSBuild]::EnsureTrailingSlash(`publish`))' and Exists('$(PublishDir)')"/>
+        Condition="'$(PublishDir)' == '$(_DefaultPublishDir)' and Exists('$(PublishDir)')"/>
 
   </Target>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -260,11 +260,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <_DeploymentTargetApplicationManifestFileName Condition="'$(OutputType)'=='library'">Native.$(AssemblyName).manifest</_DeploymentTargetApplicationManifestFileName>
     <!-- Example, Native.MyAssembly.manifest -->
-    <_DeploymentTargetApplicationManifestFileName Condition="'$(OutputType)'=='winexe'">$(TargetFileName).manifest</_DeploymentTargetApplicationManifestFileName>
-    <!-- Example, MyAssembly.exe.manifest -->
-    <_DeploymentTargetApplicationManifestFileName Condition="'$(OutputType)'=='exe'">$(TargetFileName).manifest</_DeploymentTargetApplicationManifestFileName>
-    <!-- Example, MyAssembly.exe.manifest -->
-    <_DeploymentTargetApplicationManifestFileName Condition="'$(OutputType)'=='appcontainerexe'">$(TargetFileName).manifest</_DeploymentTargetApplicationManifestFileName>
+    <_DeploymentTargetApplicationManifestFileName Condition="'$(OutputType)'=='winexe' or '$(OutputType)'=='exe' or '$(OutputType)'=='appcontainerexe'">$(TargetFileName).manifest</_DeploymentTargetApplicationManifestFileName>
     <!-- Example, MyAssembly.exe.manifest -->
     <TargetDeployManifestFileName Condition="'$(TargetDeployManifestFileName)' == '' and '$(HostInBrowser)' != 'true'">$(AssemblyName).application</TargetDeployManifestFileName>
     <!-- Example, MyAssembly.application -->
@@ -273,9 +269,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <GenerateClickOnceManifests Condition="'$(OutputType)'=='winexe' or '$(OutputType)'=='exe' or '$(OutputType)'=='appcontainerexe'">$(GenerateManifests)</GenerateClickOnceManifests>
 
     <_DeploymentApplicationManifestIdentity Condition="'$(OutputType)'=='library'">Native.$(AssemblyName)</_DeploymentApplicationManifestIdentity>
-    <_DeploymentApplicationManifestIdentity Condition="'$(OutputType)'=='winexe'">$(AssemblyName).exe</_DeploymentApplicationManifestIdentity>
-    <_DeploymentApplicationManifestIdentity Condition="'$(OutputType)'=='exe'">$(AssemblyName).exe</_DeploymentApplicationManifestIdentity>
-    <_DeploymentApplicationManifestIdentity Condition="'$(OutputType)'=='appcontainerexe'">$(AssemblyName).exe</_DeploymentApplicationManifestIdentity>
+    <_DeploymentApplicationManifestIdentity Condition="'$(OutputType)'=='winexe' or '$(OutputType)'=='exe' or '$(OutputType)'=='appcontainerexe'">$(AssemblyName).exe</_DeploymentApplicationManifestIdentity>
     <_DeploymentDeployManifestIdentity Condition="'$(HostInBrowser)' != 'true'">$(AssemblyName).application</_DeploymentDeployManifestIdentity>
     <_DeploymentDeployManifestIdentity Condition="'$(HostInBrowser)' == 'true'">$(AssemblyName).xbap</_DeploymentDeployManifestIdentity>
 
@@ -327,6 +321,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ProjectDir Condition=" '$(ProjectDir)' == '' ">$([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))</ProjectDir>
 
     <!-- Example, C:\MyProjects\MyProject\MyProject.csproj -->
+    <ProjectPath Condition=" '$(ProjectPath)' == '' ">$(MSBuildProjectFullPath)</ProjectPath>
     <ProjectPath Condition=" '$(ProjectPath)' == '' ">$(ProjectDir)$(ProjectFileName)</ProjectPath>
   </PropertyGroup>
 
@@ -809,21 +804,21 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       BeforeTargets="$(BuildDependsOn);Build;$(RebuildDependsOn);Rebuild;$(CleanDependsOn);Clean">
 
     <PropertyGroup>
-      <_InvalidConfigurationMessageText>The BaseOutputPath/OutputPath property is not set for project '$(MSBuildProjectFile)'.  Please check to make sure that you have specified a valid combination of Configuration and Platform for this project.  Configuration='$(_OriginalConfiguration)'  Platform='$(_OriginalPlatform)'.</_InvalidConfigurationMessageText>
+      <_InvalidConfigurationMessageText>The 'BaseOutputPath'/'OutputPath' property is not set for project '$(MSBuildProjectFile)'.  Please check to make sure that you have specified a valid combination of Configuration and Platform for this project.  Configuration='$(_OriginalConfiguration)'  Platform='$(_OriginalPlatform)'.</_InvalidConfigurationMessageText>
       <_InvalidConfigurationMessageText Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(_InvalidConfigurationMessageText)  This error may also appear if some other project is trying to follow a project-to-project reference to this project, this project has been unloaded or is not included in the solution, and the referencing project does not build using the same or an equivalent Configuration or Platform.</_InvalidConfigurationMessageText>
       <_InvalidConfigurationMessageText Condition="'$(BuildingInsideVisualStudio)' != 'true'">$(_InvalidConfigurationMessageText)  You may be seeing this message because you are trying to build a project without a solution file, and have specified a non-default Configuration or Platform that doesn't exist for this project.</_InvalidConfigurationMessageText>
     </PropertyGroup>
 
-    <Error Condition=" '$(_InvalidConfigurationError)' == 'true' " Text="$(_InvalidConfigurationMessageText)"/>
-    <Warning Condition=" '$(_InvalidConfigurationWarning)' == 'true' " Text="$(_InvalidConfigurationMessageText)"/>
+    <Error Condition="'$(_InvalidConfigurationError)' == 'true'" Text="$(_InvalidConfigurationMessageText)"/>
+    <Warning Condition="'$(_InvalidConfigurationWarning)' == 'true'" Text="$(_InvalidConfigurationMessageText)"/>
 
     <Message Condition="'$(DesignTimeBuild)' != 'true'" Text="Configuration=$(Configuration)" Importance="Low" />
     <Message Condition="'$(DesignTimeBuild)' != 'true'" Text="Platform=$(Platform)" Importance="Low" />
 
     <!-- Although we try to ensure a trailing slash, it's possible to circumvent this if the property is set on the command line -->
-    <Error Condition="'$(OutDir)' != '' and !HasTrailingSlash('$(OutDir)')" Text="The OutDir property must end with a trailing slash." />
-    <Error Condition="'$(IntermediateOutputPath)' != '' and !HasTrailingSlash('$(IntermediateOutputPath)')" Text="The IntermediateOutputPath must end with a trailing slash." />
-    <Error Condition="'$(BaseIntermediateOutputPath)' != '' and !HasTrailingSlash('$(BaseIntermediateOutputPath)')" Text="The BaseIntermediateOutputPath must end with a trailing slash." />
+    <Error Condition="'$(OutDir)' != '' and !HasTrailingSlash('$(OutDir)')" Text="The 'OutDir' property must end with a trailing slash." />
+    <Error Condition="'$(IntermediateOutputPath)' != '' and !HasTrailingSlash('$(IntermediateOutputPath)')" Text="The 'IntermediateOutputPath' must end with a trailing slash." />
+    <Error Condition="'$(BaseIntermediateOutputPath)' != '' and !HasTrailingSlash('$(BaseIntermediateOutputPath)')" Text="The 'BaseIntermediateOutputPath' must end with a trailing slash." />
 
     <!--
       Also update the value of PlatformTargetAsMSBuildArchitecture per the value of Prefer32Bit.  We are doing
@@ -2544,8 +2539,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetedSDKConfiguration Condition="'$(TargetedSDKConfiguration)' == '' and '_$(Configuration)' == '_Debug'">Debug</TargetedSDKConfiguration>
-    <TargetedSDKConfiguration Condition="'$(TargetedSDKConfiguration)' == '' and '_$(Configuration)' == '_Release'">Retail</TargetedSDKConfiguration>
+    <TargetedSDKConfiguration Condition="'$(TargetedSDKConfiguration)' == '' and '$(ConfigurationName)' == 'Debug'">Debug</TargetedSDKConfiguration>
+    <TargetedSDKConfiguration Condition="'$(TargetedSDKConfiguration)' == '' and '$(ConfigurationName)' == 'Release'">Retail</TargetedSDKConfiguration>
     <TargetedSDKConfiguration Condition="'$(TargetedSDKConfiguration)' == ''">Retail</TargetedSDKConfiguration>
     <TargetedSDKArchitecture Condition="'$(TargetedSDKArchitecture)' == ''">$(ProcessorArchitecture)</TargetedSDKArchitecture>
     <TargetedSDKArchitecture Condition="'$(TargetedSDKArchitecture)' == ''">Neutral</TargetedSDKArchitecture>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -131,7 +131,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     (eg. obj\Debug). If this property is overridden, then setting BaseIntermediateOutputPath has no effect.
 
     Ensure any and all path property has a trailing slash, so it can be concatenated.
-    -->
+  -->
 
   <PropertyGroup>
     <!-- Example, AnyCPU -->
@@ -781,10 +781,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!--
     ***********************************************************************************************
     ***********************************************************************************************
-                                                                Build Section
+                                            Build Section
     ***********************************************************************************************
     ***********************************************************************************************
-    -->
+  -->
 
   <Target Name="_AddOutputPathToGlobalPropertiesToRemove">
     <PropertyGroup>
@@ -794,15 +794,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ============================================================
-                                        _CheckForInvalidConfigurationAndPlatform
+              _CheckForInvalidConfigurationAndPlatform
 
-    This target checks for errors in statically defined properties.  By setting BeforeTargets, we try
-    to ensure that the target runs before any build related targets.
+    This target checks for errors in statically defined build properties.
+    By setting BeforeTargets, we try to ensure that the target runs before any build related targets.
+
     If your target requires this check and is running as a BeforeTargets of one of the first targets
     of $(BuildDependsOn), $(RebuildDependsOn), or $(CleanDependsOn) you will need to set your DependsOn
     to this target.
     ============================================================
-    -->
+  -->
   <Target
       Name="_CheckForInvalidConfigurationAndPlatform"
       BeforeTargets="$(BuildDependsOn);Build;$(RebuildDependsOn);Rebuild;$(CleanDependsOn);Clean">
@@ -824,9 +825,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Error Condition="'$(IntermediateOutputPath)' != '' and !HasTrailingSlash('$(IntermediateOutputPath)')" Text="The IntermediateOutputPath must end with a trailing slash." />
     <Error Condition="'$(BaseIntermediateOutputPath)' != '' and !HasTrailingSlash('$(BaseIntermediateOutputPath)')" Text="The BaseIntermediateOutputPath must end with a trailing slash." />
 
-    <!-- Also update the value of PlatformTargetAsMSBuildArchitecture per the value of Prefer32Bit.  We are doing
-         this here because Prefer32Bit may be set anywhere in the targets, so we can't depend on it having the
-         correct value when we're trying to figure out PlatformTargetAsMSBuildArchitecture -->
+    <!--
+      Also update the value of PlatformTargetAsMSBuildArchitecture per the value of Prefer32Bit.  We are doing
+      this here because Prefer32Bit may be set anywhere in the targets, so we can't depend on it having the
+      correct value when we're trying to figure out PlatformTargetAsMSBuildArchitecture
+    -->
     <PropertyGroup Condition="'$(Prefer32Bit)' == 'true' and ('$(PlatformTarget)' == 'AnyCPU' or '$(PlatformTarget)' == '') and '$(PlatformTargetAsMSBuildArchitectureExplicitlySet)' != 'true'">
       <PlatformTargetAsMSBuildArchitecture>x86</PlatformTargetAsMSBuildArchitecture>
     </PropertyGroup>
@@ -844,7 +847,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!--
       Log a warning if:
         1. $(EnableBaseIntermediateOutputPathMismatchWarning) is 'true'
-        2. $(BaseIntermediateOutputPath) was set in the body of a project after its default value was set in Microsoft.Common.props
+        2. $(BaseIntermediateOutputPath) was set in the body of a project after its default value was set in 'Microsoft.Common.props'
         3. $(BaseIntermediateOutputPath) is not the same as $(MSBuildProjectExtensionsPath)
 
       Similar to the error above, there are cases when users set $(BaseIntermediateOutputPath) in the body of their project and things build but only by coincidence.
@@ -5649,9 +5652,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ============================================================
-                                        CleanPublishFolder
+                        CleanPublishFolder
     ============================================================
-    -->
+  -->
   <Target
       Name="CleanPublishFolder">
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -150,17 +150,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <ConfigurationName Condition="'$(ConfigurationName)' == ''">$(Configuration)</ConfigurationName>
 
-    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
-    <BaseOutputPath Condition="!HasTrailingSlash('$(BaseOutputPath)')">$(BaseOutputPath)\</BaseOutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
-    <OutputPath Condition="!HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
+    <BaseOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseOutputPath)', 'bin'))))</BaseOutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseOutputPath)', '$(Configuration)'))</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseOutputPath)', '$(PlatformName)', '$(Configuration)'))</OutputPath>
+    <OutputPath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))</OutputPath>
 
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
-    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
+    <BaseIntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseIntermediateOutputPath)', 'obj'))))</BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseIntermediateOutputPath)', '$(Configuration)'))</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseIntermediateOutputPath)', '$(PlatformName)', '$(Configuration)'))</IntermediateOutputPath>
+    <IntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash('$(IntermediateOutputPath)'))</IntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -225,15 +223,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Required for enabling Team Build for packaging app package-generating projects -->
     <OutDirWasSpecified Condition=" '$(OutDir)'!='' and '$(OutDirWasSpecified)'=='' ">true</OutDirWasSpecified>
 
-    <OutDir Condition=" '$(OutDir)' == '' ">$(OutputPath)</OutDir>
     <!-- Example, bin\Debug\ -->
     <!-- Ensure OutDir has a trailing slash, so it can be concatenated -->
-    <OutDir Condition="'$(OutDir)' != '' and !HasTrailingSlash('$(OutDir)')">$(OutDir)\</OutDir>
+    <OutDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(OutDir)', '$(OutputPath)'))))</OutDir>
     <ProjectName Condition=" '$(ProjectName)' == '' ">$(MSBuildProjectName)</ProjectName>
     <!-- Example, MyProject -->
 
     <!-- For projects that generate app packages or ones that want a per-project output directory, update OutDir to include the project name -->
-    <OutDir Condition="'$(OutDir)' != '' and '$(OutDirWasSpecified)' == 'true' and (('$(WindowsAppContainer)' == 'true' and '$(GenerateProjectSpecificOutputFolder)' != 'false') or '$(GenerateProjectSpecificOutputFolder)' == 'true')">$(OutDir)$(ProjectName)\</OutDir>
+    <OutDir Condition="'$(OutDir)' != '' and '$(OutDirWasSpecified)' == 'true' and (('$(WindowsAppContainer)' == 'true' and '$(GenerateProjectSpecificOutputFolder)' != 'false') or '$(GenerateProjectSpecificOutputFolder)' == 'true')">$([MSBuild]::EnsureTrailingSlash('$(OutDir)$(ProjectName)'))</OutDir>
 
     <AssemblyName Condition=" '$(AssemblyName)'=='' ">$(MSBuildProjectName)</AssemblyName>
     <TargetName Condition="'$(TargetName)' == '' and '$(OutputType)' == 'winmdobj' and '$(RootNamespace)' != ''">$(RootNamespace)</TargetName>
@@ -319,7 +316,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Condition intentionally omitted on this one, because it causes problems
         when we pick up the value of an environment variable named TargetDir
         -->
-    <TargetDir Condition="'$(OutDir)' != ''">$([MSBuild]::Escape($([System.IO.Path]::GetFullPath(`$([System.IO.Path]::Combine(`$(MSBuildProjectDirectory)`, `$(OutDir)`))`))))</TargetDir>
+    <TargetDir Condition="'$(OutDir)' != ''">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutDir)'))</TargetDir>
 
     <!-- Example, C:\MyProjects\MyProject\bin\Debug\MyAssembly.dll -->
     <TargetPath Condition=" '$(TargetPath)' == '' ">$(TargetDir)$(TargetFileName)</TargetPath>
@@ -406,12 +403,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <PropertyGroup Condition="'$(_DebugSymbolsProduced)' == 'true' and '$(OutputType)' == 'winmdobj'">
     <WinMDExpOutputPdb Condition="'$(WinMDExpOutputPdb)' == ''">$(IntermediateOutputPath)$(TargetName).pdb</WinMDExpOutputPdb>
-    <_WinMDDebugSymbolsOutputPath>$([System.IO.Path]::Combine('$(OutDir)', $([System.IO.Path]::GetFileName('$(WinMDExpOutputPdb)'))))</_WinMDDebugSymbolsOutputPath>
+    <_WinMDDebugSymbolsOutputPath>$(OutDir)$([System.IO.Path]::GetFileName('$(WinMDExpOutputPdb)'))</_WinMDDebugSymbolsOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OutputType)' == 'winmdobj' and '$(DocumentationFile)'!=''">
     <WinMDOutputDocumentationFile Condition="'$(WinMDOutputDocumentationFile)' == ''">$(IntermediateOutputPath)$(TargetName).xml</WinMDOutputDocumentationFile>
-    <_WinMDDocFileOutputPath>$([System.IO.Path]::Combine('$(OutDir)', $([System.IO.Path]::GetFileName('$(WinMDOutputDocumentationFile)'))))</_WinMDDocFileOutputPath>
+    <_WinMDDocFileOutputPath>$(OutDir)$([System.IO.Path]::GetFileName('$(WinMDOutputDocumentationFile)'))</_WinMDDocFileOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(WinMDExpOutputWindowsMetadataFilename)' != ''">
@@ -483,8 +480,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!-- Output location for publish target. -->
   <PropertyGroup>
-    <PublishDir Condition="'$(PublishDir)' != '' and !HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
-    <PublishDir Condition="'$(PublishDir)'==''">$(OutputPath)app.publish\</PublishDir>
+    <PublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(PublishDir)', '$(OutputPath)app.publish'))))</PublishDir>
   </PropertyGroup>
 
   <!--
@@ -3511,7 +3507,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkMoniker)' != ''">
     <!-- Do not clean if we are going to default the path to the temp directory -->
     <TargetFrameworkMonikerAssemblyAttributesFileClean Condition="'$(TargetFrameworkMonikerAssemblyAttributesFileClean)' == '' and '$(TargetFrameworkMonikerAssemblyAttributesPath)' != ''">true</TargetFrameworkMonikerAssemblyAttributesFileClean>
-    <TargetFrameworkMonikerAssemblyAttributesPath Condition="'$(TargetFrameworkMonikerAssemblyAttributesPath)' == ''">$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+    <TargetFrameworkMonikerAssemblyAttributesPath Condition="'$(TargetFrameworkMonikerAssemblyAttributesPath)' == ''">$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)</TargetFrameworkMonikerAssemblyAttributesPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -4781,7 +4777,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="DestinationFiles" ItemName="FinalWinmdExpArtifacts" />
     </Copy>
 
-    <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $([System.IO.Path]::GetFullPath('$(_WindowsMetadataOutputPath)'))" Condition="'$(SkipCopyWinMDArtifact)' != 'true' and '$(_WindowsMetadataOutputPath)' != ''" />
+    <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $([MSBuild]::NormalizePath('$(_WindowsMetadataOutputPath)'))" Condition="'$(SkipCopyWinMDArtifact)' != 'true' and '$(_WindowsMetadataOutputPath)' != ''" />
 
   </Target>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -105,6 +105,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Several properties must be set in the main project file, before using this .TARGETS file.
     However, if the properties are not set, we pick some defaults.
 
+    BuildDir:
+    Indicates the final output location for the project or solution.
+    All the *OutpuPath properties should derive from this.
+
     OutDir:
     Indicates the final output location for the project or solution. When building a solution,
     OutDir can be used to gather multiple project outputs in one location. In addition,
@@ -130,7 +134,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     This is the full intermediate Output Path, and is derived from BaseIntermediateOutputPath, if none specified
     (eg. obj\Debug). If this property is overridden, then setting BaseIntermediateOutputPath has no effect.
 
-    Ensure any and all path property has a trailing slash, so it can be concatenated.
+    Ensure any and all path properties have a trailing slash which enables concatenation without specifying path separator.
   -->
 
   <PropertyGroup>
@@ -142,6 +146,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_OutputPathWasMissing Condition="'$(_OriginalPlatform)' != '' and '$(_OriginalConfiguration)' != '' and '$(OutputPath)' == ''">true</_OutputPathWasMissing>
     <!-- Check whether BaseOutputPath was specified -->
     <BaseOutputPathWasSpecified Condition="'$(BaseOutputPath)' != ''">true</BaseOutputPathWasSpecified>
+    <!-- Initialize BuildDir when empty, to ensure build doesn't produce inconsistent paths -->
+    <BuildDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BuildDir)', 'build'))))</BuildDir>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -150,12 +156,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <ConfigurationName Condition="'$(ConfigurationName)' == ''">$(Configuration)</ConfigurationName>
 
-    <BaseOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseOutputPath)', 'bin'))))</BaseOutputPath>
+    <BaseOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseOutputPath)', '$(BuildDir)bin'))))</BaseOutputPath>
     <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseOutputPath)', '$(Configuration)'))</OutputPath>
     <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseOutputPath)', '$(PlatformName)', '$(Configuration)'))</OutputPath>
     <OutputPath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))</OutputPath>
 
-    <BaseIntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseIntermediateOutputPath)', 'obj'))))</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseIntermediateOutputPath)', '$(BuildDir)obj'))))</BaseIntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseIntermediateOutputPath)', '$(Configuration)'))</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$([System.IO.Path]::Combine('$(BaseIntermediateOutputPath)', '$(PlatformName)', '$(Configuration)'))</IntermediateOutputPath>
     <IntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash('$(IntermediateOutputPath)'))</IntermediateOutputPath>
@@ -475,7 +481,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!-- Output location for publish target. -->
   <PropertyGroup>
-    <PublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(PublishDir)', '$(OutputPath)app.publish'))))</PublishDir>
+    <PublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(PublishDir)', 'publish'))))</PublishDir>
   </PropertyGroup>
 
   <!--
@@ -841,17 +847,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!--
       Log a warning if:
-        1. $(EnableBaseIntermediateOutputPathMismatchWarning) is 'true'
-        2. $(BaseIntermediateOutputPath) was set in the body of a project after its default value was set in 'Microsoft.Common.props'
-        3. $(BaseIntermediateOutputPath) is not the same as $(MSBuildProjectExtensionsPath)
+        1. $(EnableBuildDirMismatchWarning) is 'true'
+        2. $(BuildDir) was set in the body of a project after its default value was set in 'Microsoft.Common.props'
+        3. $(BuildDir) is not the same as $(MSBuildProjectExtensionsPath)
 
-      Similar to the error above, there are cases when users set $(BaseIntermediateOutputPath) in the body of their project and things build but only by coincidence.
-      MSBuild does not know if $(BaseIntermediateOutputPath) changing would cause problems so tools like NuGet must set $(EnableBaseIntermediateOutputPathMismatchWarning)
-      to 'true'.
+      Similar to the error above, there are cases when users set $(BuildDir) in the body of their project and things build but only by coincidence.
+      MSBuild does not know if $(BuildDir) changing would cause problems so tools like NuGet must set $(EnableBuildDirMismatchWarning) to 'true'.
     -->
-    <Warning Condition=" '$(EnableBaseIntermediateOutputPathMismatchWarning)' == 'true' And '$(_InitialBaseIntermediateOutputPath)' != '$(BaseIntermediateOutputPath)' And '$(BaseIntermediateOutputPath)' != '$(MSBuildProjectExtensionsPath)' "
+    <Warning Condition=" '$(EnableBuildDirMismatchWarning)' == 'true' And '$(_InitialBuildDir)' != '$(BuildDir)' And '$(BuildDir)' != '$(MSBuildProjectExtensionsPath)' "
              Code="MSB3539"
-             Text="The value of the property &quot;BaseIntermediateOutputPath&quot; was modified after it was used by MSBuild which can lead to unexpected build results. Tools such as NuGet will write outputs to the path specified by the &quot;MSBuildProjectExtensionsPath&quot; instead. To set this property, you must do so before Microsoft.Common.props is imported, for example by using Directory.Build.props.  For more information, please visit https://go.microsoft.com/fwlink/?linkid=869650"
+             Text="The value of the property &quot;BuildDir&quot; was modified after it was used by MSBuild which can lead to unexpected build results. Tools such as NuGet will write outputs to the path specified by the &quot;MSBuildProjectExtensionsPath&quot; instead. To set this property, you must do so before Microsoft.Common.props is imported, for example by using Directory.Build.props.  For more information, please visit https://go.microsoft.com/fwlink/?linkid=869650"
              />
   </Target>
 
@@ -5655,7 +5660,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <RemoveDir
         Directories="$(PublishDir)"
-        Condition="'$(PublishDir)'=='$(OutputPath)app.publish\' and Exists('$(PublishDir)')"/>
+        Condition="'$(PublishDir)' == '$([MSBuild]::EnsureTrailingSlash(`publish`))' and Exists('$(PublishDir)')"/>
 
   </Target>
 

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -38,6 +38,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   -->
   <PropertyGroup>
     <BuildDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BuildDir)', 'build'))))</BuildDir>
+    <BuildDir Condition="$([System.IO.Path]::IsPathRooted('$(BuildDir)')) and !$(BuildDir.StartsWith('$(MSBuildProjectDirectory)'))">$([MSBuild]::NormalizeDirectory('$(BuildDir)', '$(MSBuildProjectName)'))</BuildDir>
     <_InitialBuildDir>$(BuildDir)</_InitialBuildDir>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -33,12 +33,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
 
   <!--
-      The declaration of $(BaseIntermediateOutputPath) had to be moved up from Microsoft.Common.CurrentVersion.targets
-      in order for the $(MSBuildProjectExtensionsPath) to use it as a default.
+      The $(BuildDir) replaces $(BaseIntermediateOutputPath) to enable common root output path in a solution
+      and across multiple projects. Also for the $(MSBuildProjectExtensionsPath) to use it as a common root.
   -->
   <PropertyGroup>
-    <BaseIntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseIntermediateOutputPath)', 'obj'))))</BaseIntermediateOutputPath>
-    <_InitialBaseIntermediateOutputPath>$(BaseIntermediateOutputPath)</_InitialBaseIntermediateOutputPath>
+    <BuildDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BuildDir)', 'build'))))</BuildDir>
+    <_InitialBuildDir>$(BuildDir)</_InitialBuildDir>
   </PropertyGroup>
 
   <!--
@@ -49,10 +49,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
   -->
   <PropertyGroup>
-    <MSBuildProjectExtensionsPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(MSBuildProjectExtensionsPath)', '$(BaseIntermediateOutputPath)'))))</MSBuildProjectExtensionsPath>
+    <MSBuildProjectExtensionsPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(MSBuildProjectExtensionsPath)', '$(BuildDir)ext'))))</MSBuildProjectExtensionsPath>
     <!--
         Import paths that are relative default to be relative to the importing file.  However, since MSBuildExtensionsPath
-        defaults to BaseIntermediateOutputPath we expect it to be relative to the project directory.  So if the path is relative
+        defaults to BuildDir we expect it to be relative to the project directory.  So if the path is relative
         it needs to be made absolute based on the project directory.
     -->
     <MSBuildProjectExtensionsPath Condition="!$([System.IO.Path]::IsPathRooted('$(MSBuildProjectExtensionsPath)'))">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(MSBuildProjectExtensionsPath)'))</MSBuildProjectExtensionsPath>

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -37,7 +37,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       and across multiple projects. Also for the $(MSBuildProjectExtensionsPath) to use it as a common root.
   -->
   <PropertyGroup>
-    <BuildDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BuildDir)', 'build'))))</BuildDir>
+    <BuildDirName Condition="'$(BuildDirName)' == ''">build</BuildDirName>
+    <BuildDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BuildDir)', '$(BuildDirName)'))))</BuildDir>
     <BuildDir Condition="$([System.IO.Path]::IsPathRooted('$(BuildDir)')) and !$(BuildDir.StartsWith('$(MSBuildProjectDirectory)'))">$([MSBuild]::NormalizeDirectory('$(BuildDir)', '$(MSBuildProjectName)'))</BuildDir>
     <_InitialBuildDir>$(BuildDir)</_InitialBuildDir>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -27,7 +27,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup Condition="'$(ImportDirectoryBuildProps)' == 'true' and '$(DirectoryBuildPropsPath)' == ''">
     <_DirectoryBuildPropsFile Condition="'$(_DirectoryBuildPropsFile)' == ''">Directory.Build.props</_DirectoryBuildPropsFile>
     <_DirectoryBuildPropsBasePath Condition="'$(_DirectoryBuildPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectoryBuildPropsFile)'))</_DirectoryBuildPropsBasePath>
-    <DirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsBasePath)' != '' and '$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildPropsBasePath)', '$(_DirectoryBuildPropsFile)'))</DirectoryBuildPropsPath>
+    <DirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsBasePath)' != '' and '$(_DirectoryBuildPropsFile)' != ''">$([MSBuild]::NormalizePath('$(_DirectoryBuildPropsBasePath)', '$(_DirectoryBuildPropsFile)'))</DirectoryBuildPropsPath>
   </PropertyGroup>
 
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
@@ -44,18 +44,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             The declaration of $(BaseIntermediateOutputPath) had to be moved up from Microsoft.Common.CurrentVersion.targets
             in order for the $(MSBuildProjectExtensionsPath) to use it as a default.
         -->
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">obj\</BaseIntermediateOutputPath>
-    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseIntermediateOutputPath)', 'obj'))))</BaseIntermediateOutputPath>
     <_InitialBaseIntermediateOutputPath>$(BaseIntermediateOutputPath)</_InitialBaseIntermediateOutputPath>
 
-    <MSBuildProjectExtensionsPath Condition="'$(MSBuildProjectExtensionsPath)' == '' ">$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
+    <MSBuildProjectExtensionsPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(MSBuildProjectExtensionsPath)', '$(BaseIntermediateOutputPath)'))))</MSBuildProjectExtensionsPath>
     <!--
         Import paths that are relative default to be relative to the importing file.  However, since MSBuildExtensionsPath
         defaults to BaseIntermediateOutputPath we expect it to be relative to the project directory.  So if the path is relative
         it needs to be made absolute based on the project directory.
       -->
-    <MSBuildProjectExtensionsPath Condition="'$([System.IO.Path]::IsPathRooted($(MSBuildProjectExtensionsPath)))' == 'false'">$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(MSBuildProjectExtensionsPath)'))</MSBuildProjectExtensionsPath>
-    <MSBuildProjectExtensionsPath Condition="!HasTrailingSlash('$(MSBuildProjectExtensionsPath)')">$(MSBuildProjectExtensionsPath)\</MSBuildProjectExtensionsPath>
+    <MSBuildProjectExtensionsPath Condition="!$([System.IO.Path]::IsPathRooted('$(MSBuildProjectExtensionsPath)'))">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(MSBuildProjectExtensionsPath)'))</MSBuildProjectExtensionsPath>
     <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == ''">true</ImportProjectExtensionProps>
     <_InitialMSBuildProjectExtensionsPath Condition=" '$(ImportProjectExtensionProps)' == 'true' ">$(MSBuildProjectExtensionsPath)</_InitialMSBuildProjectExtensionsPath>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -33,6 +33,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
 
   <!--
+      The declaration of $(BaseIntermediateOutputPath) had to be moved up from Microsoft.Common.CurrentVersion.targets
+      in order for the $(MSBuildProjectExtensionsPath) to use it as a default.
+  -->
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseIntermediateOutputPath)', 'obj'))))</BaseIntermediateOutputPath>
+    <_InitialBaseIntermediateOutputPath>$(BaseIntermediateOutputPath)</_InitialBaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <!--
       Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
         $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.props
 
@@ -40,13 +49,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
   -->
   <PropertyGroup>
-    <!--
-        The declaration of $(BaseIntermediateOutputPath) had to be moved up from Microsoft.Common.CurrentVersion.targets
-        in order for the $(MSBuildProjectExtensionsPath) to use it as a default.
-    -->
-    <BaseIntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseIntermediateOutputPath)', 'obj'))))</BaseIntermediateOutputPath>
-    <_InitialBaseIntermediateOutputPath>$(BaseIntermediateOutputPath)</_InitialBaseIntermediateOutputPath>
-
     <MSBuildProjectExtensionsPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(MSBuildProjectExtensionsPath)', '$(BaseIntermediateOutputPath)'))))</MSBuildProjectExtensionsPath>
     <!--
         Import paths that are relative default to be relative to the importing file.  However, since MSBuildExtensionsPath
@@ -55,7 +57,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
     <MSBuildProjectExtensionsPath Condition="!$([System.IO.Path]::IsPathRooted('$(MSBuildProjectExtensionsPath)'))">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(MSBuildProjectExtensionsPath)'))</MSBuildProjectExtensionsPath>
     <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == ''">true</ImportProjectExtensionProps>
-    <_InitialMSBuildProjectExtensionsPath Condition=" '$(ImportProjectExtensionProps)' == 'true' ">$(MSBuildProjectExtensionsPath)</_InitialMSBuildProjectExtensionsPath>
+    <_InitialMSBuildProjectExtensionsPath Condition="'$(ImportProjectExtensionProps)' == 'true'">$(MSBuildProjectExtensionsPath)</_InitialMSBuildProjectExtensionsPath>
   </PropertyGroup>
 
   <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.props" Condition="'$(ImportProjectExtensionProps)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -21,9 +21,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <!--
-        Determine the path to the directory build props file if the user did not disable $(ImportDirectoryBuildProps) and
-        they did not already specify an absolute path to use via $(DirectoryBuildPropsPath)
-    -->
+      Determine the path to the directory build props file if the user did not disable $(ImportDirectoryBuildProps) and
+      they did not already specify an absolute path to use via $(DirectoryBuildPropsPath)
+  -->
   <PropertyGroup Condition="'$(ImportDirectoryBuildProps)' == 'true' and '$(DirectoryBuildPropsPath)' == ''">
     <_DirectoryBuildPropsFile Condition="'$(_DirectoryBuildPropsFile)' == ''">Directory.Build.props</_DirectoryBuildPropsFile>
     <_DirectoryBuildPropsBasePath Condition="'$(_DirectoryBuildPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectoryBuildPropsFile)'))</_DirectoryBuildPropsBasePath>
@@ -33,17 +33,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
 
   <!--
-        Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
-          $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.props
+      Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
+        $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.props
 
-        Each package management system should use a unique moniker to avoid collisions.  It is a wild-card import so the package
-        management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
-    -->
+      Each package management system should use a unique moniker to avoid collisions.  It is a wild-card import so the package
+      management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
+  -->
   <PropertyGroup>
     <!--
-            The declaration of $(BaseIntermediateOutputPath) had to be moved up from Microsoft.Common.CurrentVersion.targets
-            in order for the $(MSBuildProjectExtensionsPath) to use it as a default.
-        -->
+        The declaration of $(BaseIntermediateOutputPath) had to be moved up from Microsoft.Common.CurrentVersion.targets
+        in order for the $(MSBuildProjectExtensionsPath) to use it as a default.
+    -->
     <BaseIntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::ValueOrDefault('$(BaseIntermediateOutputPath)', 'obj'))))</BaseIntermediateOutputPath>
     <_InitialBaseIntermediateOutputPath>$(BaseIntermediateOutputPath)</_InitialBaseIntermediateOutputPath>
 
@@ -52,7 +52,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Import paths that are relative default to be relative to the importing file.  However, since MSBuildExtensionsPath
         defaults to BaseIntermediateOutputPath we expect it to be relative to the project directory.  So if the path is relative
         it needs to be made absolute based on the project directory.
-      -->
+    -->
     <MSBuildProjectExtensionsPath Condition="!$([System.IO.Path]::IsPathRooted('$(MSBuildProjectExtensionsPath)'))">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(MSBuildProjectExtensionsPath)'))</MSBuildProjectExtensionsPath>
     <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == ''">true</ImportProjectExtensionProps>
     <_InitialMSBuildProjectExtensionsPath Condition=" '$(ImportProjectExtensionProps)' == 'true' ">$(MSBuildProjectExtensionsPath)</_InitialMSBuildProjectExtensionsPath>
@@ -61,58 +61,62 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.props" Condition="'$(ImportProjectExtensionProps)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
 
   <!--
-        Import wildcard "ImportBefore" props files if we're actually in a 12.0+ project (rather than a project being
-        treated as 4.0)
-    -->
+      Import wildcard "ImportBefore" props files if we're actually in a 12.0+ project (rather than a project being
+      treated as 4.0)
+  -->
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' != ''">
     <!--
-            Wildcard imports come from $(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props.d folder.
-            This is very similar to the same extension point used in Microsoft.Common.targets, which is located in
-            the $(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ directory. Unfortunately, there
-            is already a file named "Microsoft.Common.props" in this directory so we have to have a slightly different
-            directory name to hold extensions.
-        -->
+        Wildcard imports come from $(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props.d folder.
+        This is very similar to the same extension point used in Microsoft.Common.targets, which is located in
+        the $(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ directory. Unfortunately, there
+        is already a file named "Microsoft.Common.props" in this directory so we have to have a slightly different
+        directory name to hold extensions.
+    -->
     <Import Project="$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBeforeMicrosoftCommonProps)' == 'true' and exists('$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportBefore')"/>
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportBefore\*" Condition="'$(ImportByWildcardBeforeMicrosoftCommonProps)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportBefore')"/>
   </ImportGroup>
 
   <!--
-        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
-        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
-        just used whatever ToolsVersion was in the project file if it existed on the machine, and
-        only forced 4.0 if that ToolsVersion did not exist.
+      In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
+      as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
+      just used whatever ToolsVersion was in the project file if it existed on the machine, and
+      only forced 4.0 if that ToolsVersion did not exist.
 
-        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio,
-        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected
-        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved
-        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist
-        as part of the .NET Framework.  Only if we're using the new MSBuild will we point to the current
-        targets.
-   -->
+      Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio,
+      but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected
+      the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved
+      property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist
+      as part of the .NET Framework.  Only if we're using the new MSBuild will we point to the current
+      targets.
+  -->
   <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == '' and ('$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' &gt;= '12.0')">
     <!--
-           Reset VisualStudioVersion if it's 12.0+: Should be 10.0 if VS 2010 is installed or 11.0 otherwise,
-           but since we don't have a good way of telling whether VS 2010 is installed, make it 11.0 if
-           VS 2012 is installed or 10.0 otherwise.  The reset should be safe because if it was already
-           set to something (e.g. 11.0 in a VS 2012 command prompt) then MSBuild's internal
-           VisualStudioVersion-defaulting code should never come into the picture, so the only way it could
-           be 12.0+ when building a TV 12.0 project (because we're in this file) using MSBuild 4.5 (because
-           MSBuildAssemblyVersion hasn't been set) is if it's a TV 12.0 project on an empty command prompt.
-      -->
+        Reset VisualStudioVersion if it's 12.0+: Should be 10.0 if VS 2010 is installed or 11.0 otherwise,
+        but since we don't have a good way of telling whether VS 2010 is installed, make it 11.0 if
+        VS 2012 is installed or 10.0 otherwise.  The reset should be safe because if it was already
+        set to something (e.g. 11.0 in a VS 2012 command prompt) then MSBuild's internal
+        VisualStudioVersion-defaulting code should never come into the picture, so the only way it could
+        be 12.0+ when building a TV 12.0 project (because we're in this file) using MSBuild 4.5 (because
+        MSBuildAssemblyVersion hasn't been set) is if it's a TV 12.0 project on an empty command prompt.
+    -->
     <VisualStudioVersion Condition="Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props')">11.0</VisualStudioVersion>
     <VisualStudioVersion Condition="!Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props')">10.0</VisualStudioVersion>
   </PropertyGroup>
 
-  <!-- If building using 4.X MSBuild, we want to act like this project is TV 4.0, so override
-         the custom extensibility target locations with the hard-coded 4.0 equivalent. -->
+  <!--
+      If building using 4.X MSBuild, we want to act like this project is TV 4.0, so override
+      the custom extensibility target locations with the hard-coded 4.0 equivalent.
+  -->
   <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <CustomBeforeMicrosoftCommonProps Condition="'$(CustomBeforeMicrosoftCommonProps)'==''">$(MSBuildExtensionsPath)\v4.0\Custom.Before.$(MSBuildThisFile)</CustomBeforeMicrosoftCommonProps>
     <CustomAfterMicrosoftCommonProps Condition="'$(CustomAfterMicrosoftCommonProps)'==''">$(MSBuildExtensionsPath)\v4.0\Custom.After.$(MSBuildThisFile)</CustomAfterMicrosoftCommonProps>
   </PropertyGroup>
 
-  <!-- If building using 4.X MSBuild, we want to act like this project is TV 4.0, so import
-         Microsoft.Common.props from the 4.0 location, and make sure everything else in here is
-         set up such that if it's defaulted to something there, it won't be overridden here. -->
+  <!--
+      If building using 4.X MSBuild, we want to act like this project is TV 4.0, so import
+      Microsoft.Common.props from the 4.0 location, and make sure everything else in here is
+      set up such that if it's defaulted to something there, it won't be overridden here.
+  -->
   <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props" Condition="'$(MSBuildAssemblyVersion)' == '' and Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props')" />
 
   <PropertyGroup>
@@ -121,16 +125,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <!--
-         Only import the extension targets if we're actually in a 12.0 project here (rather than one we're attempting
-         to treat as 4.0) OR if the Dev11 Microsoft.Common.props don't exist.  If it's a 12.0 project we're redirecting
-         to 4.0 and the Dev11 Microsoft.Common.props do exist, the extension targets will have been imported already
-         so there's no need to import them twice.
-     -->
+      Only import the extension targets if we're actually in a 12.0 project here (rather than one we're attempting
+      to treat as 4.0) OR if the Dev11 Microsoft.Common.props don't exist.  If it's a 12.0 project we're redirecting
+      to 4.0 and the Dev11 Microsoft.Common.props do exist, the extension targets will have been imported already
+      so there's no need to import them twice.
+  -->
   <Import Project="$(CustomBeforeMicrosoftCommonProps)" Condition="'$(CustomBeforeMicrosoftCommonProps)' != '' and Exists('$(CustomBeforeMicrosoftCommonProps)') and ('$(MSBuildAssemblyVersion)' != '' or !Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props'))" />
 
-  <!-- This is used to determine whether Microsoft.Common.targets needs to import
-         Microsoft.Common.props itself, or whether it has been imported previously,
-         e.g. by the project itself. -->
+  <!--
+      This is used to determine whether Microsoft.Common.targets needs to import
+      Microsoft.Common.props itself, or whether it has been imported previously,
+      e.g. by the project itself.
+  -->
   <PropertyGroup>
     <MicrosoftCommonPropsHasBeenImported>true</MicrosoftCommonPropsHasBeenImported>
   </PropertyGroup>
@@ -148,25 +154,25 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.VisualStudioVersion.v*.Common.props" Condition="'$(VisualStudioVersion)' == ''" />
 
   <!--
-         Only import the extension targets if we're actually in a 12.0 project here (rather than one we're attempting
-         to treat as 4.0) OR if the Dev11 Microsoft.Common.props don't exist.  If it's a 12.0 project we're redirecting
-         to 4.0 and the Dev11 Microsoft.Common.props do exist, the extension targets will have been imported already
-         so there's no need to import them twice.
-     -->
+      Only import the extension targets if we're actually in a 12.0 project here (rather than one we're attempting
+      to treat as 4.0) OR if the Dev11 Microsoft.Common.props don't exist.  If it's a 12.0 project we're redirecting
+      to 4.0 and the Dev11 Microsoft.Common.props do exist, the extension targets will have been imported already
+      so there's no need to import them twice.
+  -->
   <Import Project="$(CustomAfterMicrosoftCommonProps)" Condition="'$(CustomAfterMicrosoftCommonProps)' != '' and Exists('$(CustomAfterMicrosoftCommonProps)') and ('$(MSBuildAssemblyVersion)' != '' or !Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props'))" />
 
   <!--
-        Import wildcard "ImportAfter" props files if we're actually in a 12.0+ project (rather than a project being
-        treated as 4.0)
-    -->
+      Import wildcard "ImportAfter" props files if we're actually in a 12.0+ project (rather than a project being
+      treated as 4.0)
+  -->
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' != ''">
     <Import Project="$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfterMicrosoftCommonProps)' == 'true' and exists('$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportAfter')"/>
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportAfter\*" Condition="'$(ImportByWildcardAfterMicrosoftCommonProps)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportAfter')"/>
   </ImportGroup>
 
   <!--
-        Import NuGet.props file.
-    -->
+      Import NuGet.props file.
+  -->
   <PropertyGroup>
     <MSBuildUseVisualStudioDirectoryLayout Condition="'$(MSBuildUseVisualStudioDirectoryLayout)'==''">$([MSBuild]::IsRunningFromVisualStudio())</MSBuildUseVisualStudioDirectoryLayout>
     <NuGetPropsFile Condition="'$(NuGetPropsFile)'=='' and '$(MSBuildUseVisualStudioDirectoryLayout)'=='true'">$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.props</NuGetPropsFile>

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -138,7 +138,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true' and '$(DirectoryBuildTargetsPath)' == ''">
     <_DirectoryBuildTargetsFile Condition="'$(_DirectoryBuildTargetsFile)' == ''">Directory.Build.targets</_DirectoryBuildTargetsFile>
     <_DirectoryBuildTargetsBasePath Condition="'$(_DirectoryBuildTargetsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectoryBuildTargetsFile)'))</_DirectoryBuildTargetsBasePath>
-    <DirectoryBuildTargetsPath Condition="'$(_DirectoryBuildTargetsBasePath)' != '' and '$(_DirectoryBuildTargetsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildTargetsBasePath)', '$(_DirectoryBuildTargetsFile)'))</DirectoryBuildTargetsPath>
+    <DirectoryBuildTargetsPath Condition="'$(_DirectoryBuildTargetsBasePath)' != '' and '$(_DirectoryBuildTargetsFile)' != ''">$([MSBuild]::NormalizePath('$(_DirectoryBuildTargetsBasePath)', '$(_DirectoryBuildTargetsFile)'))</DirectoryBuildTargetsPath>
   </PropertyGroup>
 
   <Import Project="$(DirectoryBuildTargetsPath)" Condition="'$(ImportDirectoryBuildTargets)' == 'true' and exists('$(DirectoryBuildTargetsPath)')"/>


### PR DESCRIPTION
Fixes #3497

### Context
We as devs want simplified singular root output path across build and publish. 

### Changes Made
Promote `PublishDir` to `BuildDir` status
Use `BuildDir` to initialize `MSBuildProjectExtensionsPath`
Use `BuildDir` for mismatch warning instead of `BaseIntermediateOutputPath`

### Testing
TBD

### Notes
This is just a concept of the new output paths behaviour using a new common directory to hold all the temporary build outputs. This is not the final implementation as this break previous behaviour. I'm still experimenting, whether to introduce a new property to split the behaviour, either within the targets or to a new targets file with an import switch. If we do favour the spilt, we can do it with #1686. The Sdk way easier since it also reduces duplicating the logic between .NET SDK and the Common targets.

**Please hold up your reviews until it's out of draft.**