### PR TITLE
Update Optprof Tests 

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -14,13 +14,13 @@
           "container": "MSBuild",
           "testCases": [
             "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild",
-            "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild_4proc",
+            "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild_4proc"
           ]
         },
         {
           "container": "ManagedLangs",
           "testCases": [
-            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
+            "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug"
           ]
         }  
       ]


### PR DESCRIPTION
### Context
[Gen Lu suggested](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1269588) that our previous optprof test "ManagedLangs" may not be what we need anymore. I agree, considering our original test included building & typing and we only care about builds.

### Changes Made
Use "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" test rather than "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs" for optprof runs.

### Testing
Will launch an exp/ branch.

### Notes
This won't solve our optprof issues, but is a small fix while I'm here.