### PR TITLE
Fix cache exception handling

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1945,8 +1945,14 @@ namespace Microsoft.Build.Execution
 
                 lock (_buildManager._syncLock)
                 {
-                    _buildManager._projectCacheService?.Result.ShutDown().GetAwaiter().GetResult();
-                    _buildManager._projectCacheService = null;
+                    try
+                    {
+                        _buildManager._projectCacheService?.Result.ShutDown().GetAwaiter().GetResult();
+                    }
+                    finally
+                    {
+                        _buildManager._projectCacheService = null;
+                    }
                 }
             }
         }

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1944,10 +1944,15 @@ namespace Microsoft.Build.UnitTests
 
                 return buildResult;
             }
-			
-			public GraphBuildResult BuildGraphSubmission(GraphBuildRequestData requestData)
+
+            public GraphBuildResult BuildGraphSubmission(GraphBuildRequestData requestData)
             {
                 return _buildManager.BuildRequest(requestData);
+            }
+
+            public GraphBuildResult BuildGraph(ProjectGraph graph, string[] entryTargets = null)
+            {
+                return _buildManager.BuildRequest(new GraphBuildRequestData(graph, entryTargets ?? new string[0]));
             }
 
             public void Dispose()
@@ -1961,11 +1966,6 @@ namespace Microsoft.Build.UnitTests
 
                 _buildManager.EndBuild();
                 _buildManager.Dispose();
-            }
-
-            public GraphBuildResult BuildGraph(ProjectGraph graph, string[] entryTargets = null)
-            {
-                return _buildManager.BuildRequest(new GraphBuildRequestData(graph, entryTargets ?? new string[0]));
             }
         }
 


### PR DESCRIPTION
Fixes two issues when the plugin throws an exception in Plugin.EndBuildAsync during graph builds:
- Plugin.EndBuildAsync got called twice because of a missing finally clause: https://github.com/dotnet/msbuild/compare/master...cdmihai:fixCacheExceptionHandling?expand=1#diff-2b0716a511d8f4ee690ebd5c3a59dec1e3f9a5eab4ab2a80a1018820a658accbR1946
- Plugin.EndBuildAsync got called after the graph build returned, instead of before (which allows the GraphBuildResult to be properly set as failed with the exception from Plugin.EndBuildAsync): https://github.com/dotnet/msbuild/compare/master...cdmihai:fixCacheExceptionHandling?expand=1#diff-2b0716a511d8f4ee690ebd5c3a59dec1e3f9a5eab4ab2a80a1018820a658accbR1730