### PR TITLE
Remove Version Requirement On M.VS.PG.NuGet

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -8,7 +8,6 @@ package name=Microsoft.Build
 vs.dependencies
   vs.dependency id=Microsoft.Build.UnGAC
   vs.dependency id=Microsoft.VisualStudio.PackageGroup.NuGet
-                version=[15.0,17.0]
 
 vs.relatedProcessFiles
   vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\Microsoft.Build.dll"

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -8,7 +8,7 @@ package name=Microsoft.Build
 vs.dependencies
   vs.dependency id=Microsoft.Build.UnGAC
   vs.dependency id=Microsoft.VisualStudio.PackageGroup.NuGet
-                version=[15.0,17.0)
+                version=[15.0,17.0]
 
 vs.relatedProcessFiles
   vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\Microsoft.Build.dll"


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6116

### Changes Made
Include the next version of Microsoft.VisualStudio.PackageGroup.NuGet to unblock an internal team.

### Testing
We should run this through an experimental branch. (not prefixed with exp/ so we can use the optprof workaround)

### Notes
See teams channel