### PR TITLE
Change Load Behavior for NuGet Components

### DIFF
--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Evaluation
                 BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
             try
             {
-                var NuGetAssembly = Assembly.LoadFile(Path.Combine(assemblyDirectory, "NuGet.Frameworks.dll"));
+                var NuGetAssembly = Assembly.LoadFrom(Path.Combine(assemblyDirectory, "NuGet.Frameworks.dll"));
                 var NuGetFramework = NuGetAssembly.GetType("NuGet.Frameworks.NuGetFramework");
                 var NuGetFrameworkCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.CompatibilityProvider");
                 var NuGetFrameworkDefaultCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.DefaultCompatibilityProvider");

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -25,8 +25,20 @@ namespace Microsoft.Build.Shared
                 "MSBuild",
                 "Microsoft.Build",
                 "Microsoft.Build.Framework",
+                "Microsoft.Build.NuGetSdkResolver",
                 "Microsoft.Build.Tasks.Core",
                 "Microsoft.Build.Utilities.Core",
+                "NuGet.Build.Tasks",
+                "NuGet.Common",
+                "NuGet.Configuration",
+                "NuGet.Credentials",
+                "NuGet.DependencyResolver.Core",
+                "NuGet.Frameworks",
+                "NuGet.LibraryModel",
+                "NuGet.Packaging",
+                "NuGet.Protocol",
+                "NuGet.ProjectModel",
+                "NuGet.Versioning",
             }.ToImmutableHashSet();
 
         internal static readonly string[] Extensions = new[] { "ni.dll", "ni.exe", "dll", "exe" };


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/issues/15558.

### Context
In a single MSBuild process, most of the NuGet binaries are being loaded into more than one `AssemblyLoadContext`.  The ready to run code associated with these binaries can only be used in a single `AssemblyLoadContext`, which means that usage of the assembly in all other contexts must be jitted.  This shows up as an extra 736 methods that get jitted (measured as 147.6ms).

### Changes Made
1. Change `NuGetFrameworkWrapper` to use `Assembly.LoadFrom` instead of `Assembly.LoadFile` when using reflection to load NuGet.Frameworks.dll.  This ensures that the assembly is not loaded into the NULL loader context, and unifies the load with later loads of the same assembly.
2. Add all of the NuGet assemblies to the list of well-known assemblies in `MSBuildLoadContext`, forcing them to all be loaded in the default `AssemblyLoadContext`.  This is an important part of the fix because these loads occur after the load that occurs in `NuGetFrameworkWrapper`, and so by MSBuild taking a dependency on these NuGet assemblies, they should be treated as part of MSBuild itself, and not as part of a task using the task loader behavior.

### Testing
 - Verified that basic build scenarios work.
 - Used COMPlus_ReadyToRunLogFile to confirm that R2R code is not rejected due to multiple loads in different `AssemblyLoadContexts`.
 - Captured before/after profiles to confirm wins.

### Notes
This PR contains the following performance wins:
 - -736 drop in method jitting overall.
 - 147.6ms improvement in JIT time (15.5%)
 - 5.1% wall-clock latency improvement overall

cc: @stephentoub, @DamianEdwards, @marcpopMSFT 