### PR TITLE
Optimize property expansion

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1106,7 +1106,7 @@ namespace Microsoft.Build.Evaluation
                 // so that we can either maintain the object's type in the event
                 // that we have a single component, or convert to a string
                 // if concatenation is required.
-                List<object> results = new List<object>();
+                using Expander<P, I>.SpanBasedConcatenator results = new Expander<P, I>.SpanBasedConcatenator();
 
                 // The sourceIndex is the zero-based index into the expression,
                 // where we've essentially read up to and copied into the target string.
@@ -1120,7 +1120,7 @@ namespace Microsoft.Build.Evaluation
                     // (but not including) the "$(", and advance the sourceIndex pointer.
                     if (propertyStartIndex - sourceIndex > 0)
                     {
-                        results.Add(expression.Substring(sourceIndex, propertyStartIndex - sourceIndex));
+                        results.Add(expression.AsMemory(sourceIndex, propertyStartIndex - sourceIndex));
                     }
 
                     // Following the "$(" we need to locate the matching ')'
@@ -1135,7 +1135,7 @@ namespace Microsoft.Build.Evaluation
                         // isn't really a well-formed property tag.  Just literally
                         // copy the remainder of the expression (starting with the "$("
                         // that we found) into the result, and quit.
-                        results.Add(expression.Substring(propertyStartIndex, expression.Length - propertyStartIndex));
+                        results.Add(expression.AsMemory(propertyStartIndex, expression.Length - propertyStartIndex));
                         sourceIndex = expression.Length;
                     }
                     else
@@ -1219,43 +1219,13 @@ namespace Microsoft.Build.Evaluation
                     propertyStartIndex = s_invariantCompareInfo.IndexOf(expression, "$(", sourceIndex, CompareOptions.Ordinal);
                 }
 
-                // If we have only a single result, then just return it
-                if (results.Count == 1 && expression.Length == sourceIndex)
+                // If we couldn't find any more property tags in the expression just copy the remainder into the result.
+                if (expression.Length - sourceIndex > 0)
                 {
-                    var resultString = results[0] as string;
-                    return resultString != null ? FileUtilities.MaybeAdjustFilePath(resultString) : results[0];
+                    results.Add(expression.AsMemory(sourceIndex, expression.Length - sourceIndex));
                 }
-                else
-                {
-                    // The expression is constant, return it as is
-                    if (sourceIndex == 0)
-                    {
-                        return expression;
-                    }
 
-                    // We have more than one result collected, therefore we need to concatenate
-                    // into the final result string. This does mean that we will lose type information.
-                    // However since the user wanted contatenation, then they clearly wanted that to happen.
-
-                    // Initialize our output string to empty string.
-                    // This method is called very often - of the order of 3,000 times per project.
-                    using SpanBasedStringBuilder result = Strings.GetSpanBasedStringBuilder();
-
-                    // Create a combined result string from the result components that we've gathered
-                    foreach (object component in results)
-                    {
-                        result.Append(FileUtilities.MaybeAdjustFilePath(component.ToString()));
-                    }
-
-                    // And if we couldn't find anymore property tags in the expression,
-                    // so just literally copy the remainder into the result.
-                    if (expression.Length - sourceIndex > 0)
-                    {
-                        result.Append(expression, sourceIndex, expression.Length - sourceIndex);
-                    }
-
-                    return result.ToString();
-                }
+                return results.GetResult();
             }
 
             /// <summary>

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1280,76 +1280,72 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             internal static string ConvertToString(object valueToConvert)
             {
-                if (valueToConvert != null)
+                if (valueToConvert == null)
                 {
-                    Type valueType = valueToConvert.GetType();
-                    string convertedString;
+                    return String.Empty;
+                }
+                // If the value is a string, then there is nothing to do
+                if (valueToConvert is string stringValue)
+                {
+                    return stringValue;
+                }
 
-                    // If the type is a string, then there is nothing to do
-                    if (valueType == typeof(string))
+                string convertedString;
+                if (valueToConvert is IDictionary dictionary)
+                {
+                    // If the return type is an IDictionary, then we convert this to
+                    // a semi-colon delimited set of A=B pairs.
+                    // Key and Value are converted to string and escaped
+                    if (dictionary.Count > 0)
                     {
-                        convertedString = (string)valueToConvert;
-                    }
-                    else if (valueToConvert is IDictionary dictionary)
-                    {
-                        // If the return type is an IDictionary, then we convert this to
-                        // a semi-colon delimited set of A=B pairs.
-                        // Key and Value are converted to string and escaped
-                        if (dictionary.Count > 0)
-                        {
-                            using SpanBasedStringBuilder builder = Strings.GetSpanBasedStringBuilder();
-
-                            foreach (DictionaryEntry entry in dictionary)
-                            {
-                                if (builder.Length > 0)
-                                {
-                                    builder.Append(";");
-                                }
-
-                                // convert and escape each key and value in the dictionary entry
-                                builder.Append(EscapingUtilities.Escape(ConvertToString(entry.Key)));
-                                builder.Append("=");
-                                builder.Append(EscapingUtilities.Escape(ConvertToString(entry.Value)));
-                            }
-
-                            convertedString = builder.ToString();
-                        }
-                        else
-                        {
-                            convertedString = string.Empty;
-                        }
-                    }
-                    else if (valueToConvert is IEnumerable enumerable)
-                    {
-                        // If the return is enumerable, then we'll convert to semi-colon delimited elements
-                        // each of which must be converted, so we'll recurse for each element
                         using SpanBasedStringBuilder builder = Strings.GetSpanBasedStringBuilder();
 
-                        foreach (object element in enumerable)
+                        foreach (DictionaryEntry entry in dictionary)
                         {
                             if (builder.Length > 0)
                             {
                                 builder.Append(";");
                             }
 
-                            // we need to convert and escape each element of the array
-                            builder.Append(EscapingUtilities.Escape(ConvertToString(element)));
+                            // convert and escape each key and value in the dictionary entry
+                            builder.Append(EscapingUtilities.Escape(ConvertToString(entry.Key)));
+                            builder.Append("=");
+                            builder.Append(EscapingUtilities.Escape(ConvertToString(entry.Value)));
                         }
 
                         convertedString = builder.ToString();
                     }
                     else
                     {
-                        // The fall back is always to just convert to a string directly.
-                        convertedString = valueToConvert.ToString();
+                        convertedString = string.Empty;
+                    }
+                }
+                else if (valueToConvert is IEnumerable enumerable)
+                {
+                    // If the return is enumerable, then we'll convert to semi-colon delimited elements
+                    // each of which must be converted, so we'll recurse for each element
+                    using SpanBasedStringBuilder builder = Strings.GetSpanBasedStringBuilder();
+
+                    foreach (object element in enumerable)
+                    {
+                        if (builder.Length > 0)
+                        {
+                            builder.Append(";");
+                        }
+
+                        // we need to convert and escape each element of the array
+                        builder.Append(EscapingUtilities.Escape(ConvertToString(element)));
                     }
 
-                    return convertedString;
+                    convertedString = builder.ToString();
                 }
                 else
                 {
-                    return String.Empty;
+                    // The fall back is always to just convert to a string directly.
+                    convertedString = valueToConvert.ToString();
                 }
+
+                return convertedString;
             }
 
             /// <summary>

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -488,19 +488,6 @@ namespace Microsoft.Build.Evaluation
         /// essentially, pushes and pops on a stack of parentheses to do this.
         /// Takes the expression and the index to start at.
         /// Returns the index of the matching parenthesis, or -1 if it was not found.
-        /// </summary>
-        private static int ScanForClosingParenthesis(string expression, int index)
-        {
-            bool potentialPropertyFunction;
-            bool potentialRegistryFunction;
-            return ScanForClosingParenthesis(expression, index, out potentialPropertyFunction, out potentialRegistryFunction);
-        }
-
-        /// <summary>
-        /// Scan for the closing bracket that matches the one we've already skipped;
-        /// essentially, pushes and pops on a stack of parentheses to do this.
-        /// Takes the expression and the index to start at.
-        /// Returns the index of the matching parenthesis, or -1 if it was not found.
         /// Also returns flags to indicate if a propertyfunction or registry property is likely
         /// to be found in the expression.
         /// </summary>
@@ -512,16 +499,15 @@ namespace Microsoft.Build.Evaluation
             potentialPropertyFunction = false;
             potentialRegistryFunction = false;
 
-            unsafe
+            // Scan for our closing ')'
+            while (index < length && nestLevel > 0)
             {
-                fixed (char* pchar = expression)
+                char character = expression[index];
+                switch (character)
                 {
-                    // Scan for our closing ')'
-                    while (index < length && nestLevel > 0)
-                    {
-                        char character = pchar[index];
-
-                        if (character == '\'' || character == '`' || character == '"')
+                    case '\'':
+                    case '`':
+                    case '"':
                         {
                             index++;
                             index = ScanForClosingQuote(character, expression, index);
@@ -530,27 +516,33 @@ namespace Microsoft.Build.Evaluation
                             {
                                 return -1;
                             }
+                            break;
                         }
-                        else if (character == '(')
+                    case '(':
                         {
                             nestLevel++;
+                            break;
                         }
-                        else if (character == ')')
+                    case ')':
                         {
                             nestLevel--;
+                            break;
                         }
-                        else if (character == '.' || character == '[' || character == '$')
+                    case '.':
+                    case '[':
+                    case '$':
                         {
                             potentialPropertyFunction = true;
+                            break;
                         }
-                        else if (character == ':')
+                    case ':':
                         {
                             potentialRegistryFunction = true;
+                            break;
                         }
-
-                        index++;
-                    }
                 }
+
+                index++;
             }
 
             // We will have parsed past the ')', so step back one character
@@ -666,7 +658,7 @@ namespace Microsoft.Build.Evaluation
                     n += 2; // skip over the opening '$('
 
                     // Scan for the matching closing bracket, skipping any nested ones
-                    n = ScanForClosingParenthesis(argumentsString, n);
+                    n = ScanForClosingParenthesis(argumentsString, n, out _, out _);
 
                     if (n == -1)
                     {
@@ -1034,13 +1026,11 @@ namespace Microsoft.Build.Evaluation
                         results.Add(expression.Substring(sourceIndex, propertyStartIndex - sourceIndex));
                     }
 
-                    bool tryExtractPropertyFunction;
-                    bool tryExtractRegistryFunction;
                     // Following the "$(" we need to locate the matching ')'
                     // Scan for the matching closing bracket, skipping any nested ones
                     // This is a very complete, fast validation of parenthesis matching including for nested
                     // function calls.
-                    propertyEndIndex = ScanForClosingParenthesis(expression, propertyStartIndex + 2, out tryExtractPropertyFunction, out tryExtractRegistryFunction);
+                    propertyEndIndex = ScanForClosingParenthesis(expression, propertyStartIndex + 2, out bool tryExtractPropertyFunction, out bool tryExtractRegistryFunction);
 
                     if (propertyEndIndex == -1)
                     {
@@ -4736,7 +4726,7 @@ namespace Microsoft.Build.Evaluation
                     argumentStartIndex++;
 
                     // Scan for the matching closing bracket, skipping any nested ones
-                    int argumentsEndIndex = ScanForClosingParenthesis(expressionFunction, argumentStartIndex);
+                    int argumentsEndIndex = ScanForClosingParenthesis(expressionFunction, argumentStartIndex, out _, out _);
 
                     if (argumentsEndIndex == -1)
                     {

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -556,24 +556,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private static int ScanForClosingQuote(char quoteChar, string expression, int index)
         {
-            unsafe
-            {
-                fixed (char* pchar = expression)
-                {
-                    // Scan for our closing quoteChar
-                    while (index < expression.Length)
-                    {
-                        if (pchar[index] == quoteChar)
-                        {
-                            return index;
-                        }
-
-                        index++;
-                    }
-                }
-            }
-
-            return -1;
+            // Scan for our closing quoteChar
+            return expression.IndexOf(quoteChar, index);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -124,6 +124,136 @@ namespace Microsoft.Build.Evaluation
         where I : class, IItem
     {
         /// <summary>
+        /// A helper struct wrapping a <see cref="SpanBasedStringBuilder"/> and providing file path conversion
+        /// as used in e.g. property expansion.
+        /// </summary>
+        /// <remarks>
+        /// If exactly one value is added and no concatenation takes places, this value is returned without
+        /// conversion. In other cases values are stringified and attempted to be interpreted as file paths
+        /// before concatenation.
+        /// </remarks>
+        private struct SpanBasedConcatenator : IDisposable
+        {
+            /// <summary>
+            /// The backing <see cref="SpanBasedStringBuilder"/>, null until the second value is added.
+            /// </summary>
+            private SpanBasedStringBuilder _builder;
+
+            /// <summary>
+            /// The first value added to the concatenator. Tracked in its own field so it can be returned
+            /// without conversion if no concatenation takes place.
+            /// </summary>
+            private object _firstObject;
+
+            /// <summary>
+            /// The first value added to the concatenator if it is a span. Tracked in its own field so the
+            /// <see cref="SpanBasedStringBuilder"/> functionality doesn't have to be invoked if no concatenation
+            /// takes place.
+            /// </summary>
+            private ReadOnlyMemory<char> _firstSpan;
+
+            /// <summary>
+            /// True if this instance is already disposed.
+            /// </summary>
+            private bool _disposed;
+
+            /// <summary>
+            /// Adds an object to be concatenated.
+            /// </summary>
+            public void Add(object obj)
+            {
+                CheckDisposed();
+                FlushFirstValueIfNeeded();
+                if (_builder != null)
+                {
+                    _builder.Append(FileUtilities.MaybeAdjustFilePath(obj.ToString()));
+                }
+                else
+                {
+                    _firstObject = obj;
+                }
+            }
+
+            /// <summary>
+            /// Adds a span to be concatenated.
+            /// </summary>
+            public void Add(ReadOnlyMemory<char> span)
+            {
+                CheckDisposed();
+                FlushFirstValueIfNeeded();
+                if (_builder != null)
+                {
+                    _builder.Append(FileUtilities.MaybeAdjustFilePath(span));
+                }
+                else
+                {
+                    _firstSpan = span;
+                }
+            }
+
+            /// <summary>
+            /// Returns the result of the concatenation.
+            /// </summary>
+            /// <returns>
+            /// If only one value has been added and it is not a string, it is returned unchanged.
+            /// In all other cases (no value, one string value, multiple values) the result is a
+            /// concatenation of the string representation of the values, each additionally subjected
+            /// to file path adjustment.
+            /// </returns>
+            public object GetResult()
+            {
+                CheckDisposed();
+                if (_firstObject != null)
+                {
+                    return (_firstObject is string stringValue) ? FileUtilities.MaybeAdjustFilePath(stringValue) : _firstObject;
+                }
+                return _firstSpan.IsEmpty
+                    ? _builder?.ToString() ?? string.Empty
+                    : FileUtilities.MaybeAdjustFilePath(_firstSpan).ToString();
+            }
+
+            /// <summary>
+            /// Disposes of the struct by delegating the call to the underlying <see cref="SpanBasedStringBuilder"/>.
+            /// </summary>
+            public void Dispose()
+            {
+                CheckDisposed();
+                _builder?.Dispose();
+                _disposed = true;
+            }
+
+            /// <summary>
+            /// Throws <see cref="ObjectDisposedException"/> if this concatenator is already disposed.
+            /// </summary>
+            private void CheckDisposed() =>
+                ErrorUtilities.VerifyThrowObjectDisposed(!_disposed, nameof(SpanBasedConcatenator));
+
+            /// <summary>
+            /// Lazily initializes <see cref="_builder"/> and populates it with the first value
+            /// when the second value is being added.
+            /// </summary>
+            private void FlushFirstValueIfNeeded()
+            {
+                if (_firstObject != null)
+                {
+                    _builder = Strings.GetSpanBasedStringBuilder();
+                    _builder.Append(FileUtilities.MaybeAdjustFilePath(_firstObject.ToString()));
+                    _firstObject = null;
+                }
+                else if (!_firstSpan.IsEmpty)
+                {
+                    _builder = Strings.GetSpanBasedStringBuilder();
+#if FEATURE_SPAN
+                    _builder.Append(FileUtilities.MaybeAdjustFilePath(_firstSpan));
+#else
+                    _builder.Append(FileUtilities.MaybeAdjustFilePath(_firstSpan.ToString()));
+#endif
+                    _firstSpan = new ReadOnlyMemory<char>();
+                }
+            }
+        }
+
+        /// <summary>
         /// A limit for truncating string expansions within an evaluated Condition. Properties, item metadata, or item groups will be truncated to N characters such as 'N...'.
         /// Enabled by ExpanderOptions.Truncate.
         /// </summary>

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -976,8 +976,7 @@ namespace Microsoft.Build.Evaluation
                 // so that we can either maintain the object's type in the event
                 // that we have a single component, or convert to a string
                 // if concatenation is required.
-                List<object> results = null;
-                object lastResult = null;
+                List<object> results = new List<object>();
 
                 // The sourceIndex is the zero-based index into the expression,
                 // where we've essentially read up to and copied into the target string.
@@ -987,26 +986,10 @@ namespace Microsoft.Build.Evaluation
                 // any more.
                 while (propertyStartIndex != -1)
                 {
-                    if (lastResult != null)
-                    {
-                        if (results == null)
-                        {
-                            results = new List<object>(4);
-                        }
-
-                        results.Add(lastResult);
-                    }
-
-
                     // Append the result with the portion of the expression up to
                     // (but not including) the "$(", and advance the sourceIndex pointer.
                     if (propertyStartIndex - sourceIndex > 0)
                     {
-                        if (results == null)
-                        {
-                            results = new List<object>(4);
-                        }
-
                         results.Add(expression.Substring(sourceIndex, propertyStartIndex - sourceIndex));
                     }
 
@@ -1022,7 +1005,7 @@ namespace Microsoft.Build.Evaluation
                         // isn't really a well-formed property tag.  Just literally
                         // copy the remainder of the expression (starting with the "$("
                         // that we found) into the result, and quit.
-                        lastResult = expression.Substring(propertyStartIndex, expression.Length - propertyStartIndex);
+                        results.Add(expression.Substring(propertyStartIndex, expression.Length - propertyStartIndex));
                         sourceIndex = expression.Length;
                     }
                     else
@@ -1099,7 +1082,7 @@ namespace Microsoft.Build.Evaluation
                         // Record our result, and advance
                         // our sourceIndex pointer to the character just after the closing
                         // parenthesis.
-                        lastResult = propertyValue;
+                        results.Add(propertyValue);
                         sourceIndex = propertyEndIndex + 1;
                     }
 
@@ -1107,10 +1090,10 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 // If we have only a single result, then just return it
-                if (results == null && expression.Length == sourceIndex)
+                if (results.Count == 1 && expression.Length == sourceIndex)
                 {
-                    var resultString = lastResult as string;
-                    return resultString != null ? FileUtilities.MaybeAdjustFilePath(resultString) : lastResult;
+                    var resultString = results[0] as string;
+                    return resultString != null ? FileUtilities.MaybeAdjustFilePath(resultString) : results[0];
                 }
                 else
                 {
@@ -1128,20 +1111,10 @@ namespace Microsoft.Build.Evaluation
                     // This method is called very often - of the order of 3,000 times per project.
                     using SpanBasedStringBuilder result = Strings.GetSpanBasedStringBuilder();
 
-                    // Append our collected results
-                    if (results != null)
+                    // Create a combined result string from the result components that we've gathered
+                    foreach (object component in results)
                     {
-                        // Create a combined result string from the result components that we've gathered
-                        foreach (object component in results)
-                        {
-                            result.Append(FileUtilities.MaybeAdjustFilePath(component.ToString()));
-                        }
-                    }
-
-                    // Append the last result we collected (it wasn't added to the list)
-                    if (lastResult != null)
-                    {
-                        result.Append(FileUtilities.MaybeAdjustFilePath(lastResult.ToString()));
+                        result.Append(FileUtilities.MaybeAdjustFilePath(component.ToString()));
                     }
 
                     // And if we couldn't find anymore property tags in the expression,

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -850,6 +850,20 @@ namespace Microsoft.Build.Shared
         }
 
         #endregion
+
+        #region VerifyThrowObjectDisposed
+
+        internal static void VerifyThrowObjectDisposed(bool condition, string objectName)
+        {
+            {
+                if (s_throwExceptions && !condition)
+                {
+                    throw new ObjectDisposedException(objectName);
+                }
+            }
+        }
+
+        #endregion
 #endif
     }
 }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -481,6 +481,38 @@ namespace Microsoft.Build.Shared
             return shouldAdjust ? newValue.ToString() : value;
         }
 
+        /// <summary>
+        /// If on Unix, convert backslashes to slashes for strings that resemble paths.
+        /// This overload takes and returns ReadOnlyMemory of characters.
+        /// </summary>
+        internal static ReadOnlyMemory<char> MaybeAdjustFilePath(ReadOnlyMemory<char> value, string baseDirectory = "")
+        {
+            if (NativeMethodsShared.IsWindows || value.IsEmpty)
+            {
+                return value;
+            }
+
+            // Don't bother with arrays or properties or network paths.
+            if (value.Length >= 2)
+            {
+                var span = value.Span;
+
+                // The condition is equivalent to span.StartsWith("$(") || span.StartsWith("@(") || span.StartsWith("\\\\")
+                if ((span[1] == '(' && (span[0] == '$' || span[0] == '@')) ||
+                    (span[1] == '\\' && span[0] == '\\'))
+                {
+                    return value;
+                }
+            }
+
+            // For Unix-like systems, we may want to convert backslashes to slashes
+            Span<char> newValue = ConvertToUnixSlashes(value.ToArray());
+
+            // Find the part of the name we want to check, that is remove quotes, if present
+            bool shouldAdjust = newValue.IndexOf('/') != -1 && LooksLikeUnixFilePath(RemoveQuotes(newValue), baseDirectory);
+            return shouldAdjust ? newValue.ToString().AsMemory() : value;
+        }
+
         private static Span<char> ConvertToUnixSlashes(Span<char> path)
         {
             return path.IndexOf('\\') == -1 ? path : CollapseSlashes(path);

--- a/src/StringTools/SpanBasedStringBuilder.cs
+++ b/src/StringTools/SpanBasedStringBuilder.cs
@@ -189,6 +189,19 @@ namespace Microsoft.NET.StringTools
         }
 
         /// <summary>
+        /// Appends a character span represented by <see cref="ReadOnlyMemory{T}" />.
+        /// </summary>
+        /// <param name="span">The character span to append.</param>
+        public void Append(ReadOnlyMemory<char> span)
+        {
+            if (!span.IsEmpty)
+            {
+                _spans.Add(span);
+                Length += span.Length;
+            }
+        }
+
+        /// <summary>
         /// Removes leading white-space characters from the string.
         /// </summary>
         public void TrimStart()


### PR DESCRIPTION
Fixes #6063

### Context
Property expansion has been identified as one of the hot spots in project evaluation and `ExpandPropertiesLeaveEscaped` alone
accounts for almost 20% of overall evaluation time of simple projects.

### Changes Made
Several optimizations have been made to the calltree under `ExpandPropertiesLeaveEscaped`. Notably:
- Unnecessary and counter-productive string pinning has been removed.
- A slow `strchr`-like function has been replaced with a simple call to `String.IndexOf`.
- Series of `if`s have been replaced with a `switch`.
- Allocation of `List<object> results` has been eliminated.
- Allocation of temporary substrings extracted from the expression has been eliminated.

The combined performance win is 10% in `ExpandPropertiesLeaveEscaped`, so close to 2% for evaluation overall.

### Testing
Expander is well covered by existing unit tests.

### Notes
Please review commit by commit for easier to read diffs.