### PR TITLE
Enable building StringTools without 3.5 SP1 targeting pack installed

### DIFF
--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -15,7 +15,12 @@
     <SemanticVersioningV1>true</SemanticVersioningV1>
 
     <AssemblyName>Microsoft.NET.StringTools</AssemblyName>
-    <AssemblyName Condition="'$(TargetFramework)' == 'net35'">Microsoft.NET.StringTools.net35</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
+    <AssemblyName>Microsoft.NET.StringTools.net35</AssemblyName>
+    <!-- Disable Fx install checks as we're building against jnm2's 3.5 reference assemblies -->
+    <BypassFrameworkInstallChecks>true</BypassFrameworkInstallChecks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net35'">


### PR DESCRIPTION
Fixes #6084

### Context
As a dependency of MSBuildTaskHost, StringTools is built for .NET 3.5, in addition to modern .NET Framework and .NET Core.

### Changes Made
Made the project built on machines without the 3.5 targeting pack installed by setting `BypassFrameworkInstallChecks`, same as #5621.

### Testing
Successfully built MSBuild on a clean VM without any 3.5 bits installed.

### Notes
Thank you @KirillOsenkov for spotting this and suggesting the fix.