### PR TITLE
Use Span<T> on all platforms that support it

### DIFF
--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -127,7 +127,6 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'net5.0'">
     <DefineConstants>$(DefineConstants);FEATURE_PIPEOPTIONS_CURRENTUSERONLY</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GenerateReferenceAssemblySources)' != 'true'">

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -451,6 +451,7 @@ namespace Microsoft.Build.Shared
             return string.IsNullOrEmpty(path) || Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');//.Replace("//", "/");
         }
 
+#if !CLR2COMPATIBILITY
         /// <summary>
         /// If on Unix, convert backslashes to slashes for strings that resemble paths.
         /// The heuristic is if something resembles paths (contains slashes) check if the
@@ -474,60 +475,13 @@ namespace Microsoft.Build.Shared
             }
 
             // For Unix-like systems, we may want to convert backslashes to slashes
-#if FEATURE_SPAN
             Span<char> newValue = ConvertToUnixSlashes(value.ToCharArray());
-#else
-            string newValue = ConvertToUnixSlashes(value);
-#endif
 
             // Find the part of the name we want to check, that is remove quotes, if present
             bool shouldAdjust = newValue.IndexOf('/') != -1 && LooksLikeUnixFilePath(RemoveQuotes(newValue), baseDirectory);
             return shouldAdjust ? newValue.ToString() : value;
         }
 
-#if !FEATURE_SPAN
-        private static string ConvertToUnixSlashes(string path)
-        {
-            if (path.IndexOf('\\') == -1)
-            {
-                return path;
-            }
-            StringBuilder unixPath = StringBuilderCache.Acquire(path.Length);
-            CopyAndCollapseSlashes(path, unixPath);
-            return StringBuilderCache.GetStringAndRelease(unixPath);
-        }
-
-#if !CLR2COMPATIBILITY && !FEATURE_SPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-        private static void CopyAndCollapseSlashes(string str, StringBuilder copy)
-        {
-            // Performs Regex.Replace(str, @"[\\/]+", "/")
-            for (int i = 0; i < str.Length; i++)
-            {
-                bool isCurSlash = IsAnySlash(str[i]);
-                bool isPrevSlash = i > 0 && IsAnySlash(str[i - 1]);
-
-                if (!isCurSlash || !isPrevSlash)
-                {
-                    copy.Append(str[i] == '\\' ? '/' : str[i]);
-                }
-            }
-        }
-
-        private static string RemoveQuotes(string path)
-        {
-            int endId = path.Length - 1;
-            char singleQuote = '\'';
-            char doubleQuote = '\"';
-
-            bool hasQuotes = path.Length > 2
-                && ((path[0] == singleQuote && path[endId] == singleQuote)
-                || (path[0] == doubleQuote && path[endId] == doubleQuote));
-
-            return hasQuotes ? path.Substring(1, endId - 1) : path;
-        }
-#else
         private static Span<char> ConvertToUnixSlashes(Span<char> path)
         {
             return path.IndexOf('\\') == -1 ? path : CollapseSlashes(path);
@@ -573,6 +527,7 @@ namespace Microsoft.Build.Shared
 #endif
         internal static bool IsAnySlash(char c) => c == '/' || c == '\\';
 
+#if !CLR2COMPATIBILITY
         /// <summary>
         /// If on Unix, check if the string looks like a file path.
         /// The heuristic is if something resembles paths (contains slashes) check if the
@@ -582,24 +537,8 @@ namespace Microsoft.Build.Shared
         /// that
         /// </summary>
         internal static bool LooksLikeUnixFilePath(string value, string baseDirectory = "")
-        {
-            if (NativeMethodsShared.IsWindows)
-            {
-                return false;
-            }
+            => LooksLikeUnixFilePath(value.AsSpan(), baseDirectory);
 
-            // The first slash will either be at the beginning of the string or after the first directory name
-            int directoryLength = value.IndexOf('/', 1) + 1;
-            bool shouldCheckDirectory = directoryLength != 0;
-
-            // Check for actual files or directories under / that get missed by the above logic
-            bool shouldCheckFileOrDirectory = !shouldCheckDirectory && value.Length > 0 && value[0] == '/';
-
-            return (shouldCheckDirectory && DefaultFileSystem.DirectoryExists(Path.Combine(baseDirectory, value.Substring(0, directoryLength))))
-                || (shouldCheckFileOrDirectory && DefaultFileSystem.DirectoryEntryExists(value));
-        }
-
-#if FEATURE_SPAN
         internal static bool LooksLikeUnixFilePath(ReadOnlySpan<char> value, string baseDirectory = "")
         {
             if (NativeMethodsShared.IsWindows)


### PR DESCRIPTION
### Context
`FEATURE_SPAN` is defined only when building the .NET Core flavor of MSBuild but the feature has been supported everywhere but downlevel .NET Framework for some time.

### Changes Made
Removed `FEATURE_SPAN` together with all code conditionally compiled when the flag was **not** defined. Wrapped the code in `#if !CLR2COMPATIBILITY` instead as it's not used when building MSBuildTaskHost.

### Testing
Existing unit tests. There might be some very minor perf win on non-Windows OSes where we were previously using strings (i.e. Mono).

### Notes
This is code cleanup.