### PR TITLE
Remove dotnet-core feed & Update GenAPI Assembly Name

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="arcade" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -5,7 +5,7 @@
     <PackageReference Update="LargeAddressAware" Version="1.0.3" />
     <PackageReference Update="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetBuildTasksVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="$(MicrosoftNetCompilersToolsetVersion)" />
-    <PackageReference Update="Microsoft.DotNet.BuildTools.GenAPI" Version="2.1.0-prerelease-02404-02" />
+    <PackageReference Update="Microsoft.DotNet.GenAPI" Version="2.1.0-prerelease-02404-02" />
     <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" />
     <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -86,7 +86,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(GenerateReferenceAssemblySources)' == 'true' and $([MSBuild]::IsOSPlatform('windows'))">
-    <PackageReference Include="Microsoft.DotNet.BuildTools.GenAPI" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.DotNet.GenAPI" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsUnitTestProject)' == 'true' And '$(TargetFrameworkIdentifier)' != '.NETFramework' ">


### PR DESCRIPTION
Fixes CI

### Context
The new NuGet security analysis will fail builds that don't meet certain criteria.

`Microsoft.DotNet.BuildTools.GenAPI` binaries were generated by the dotnet/buildtools repo. Looking at the repo it looks like its been replaced with arcade. The arcade feed we have (dotnet-eng) contains the `GenAPI` binaries under a slightly different name (buildtools removed from the name).

### Changes Made
Remove the dotnet-core feed because it doesn't point to an internal site.
Look for `Microsoft.DotNet.GenAPI` instead of `Microsoft.DotNet.BuildTools.GenAPI`. It exists on the `dotnet-eng` feed. 

### Testing
CI will tell us if this doesn't work.

### Notes
https://docs.opensource.microsoft.com/tools/nuget_security_analysis.html