### PR TITLE
Optimize glob evaluation

### DIFF
--- a/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
+++ b/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
@@ -471,6 +471,14 @@ namespace Microsoft.Build.UnitTests.Definition
         [MemberData(nameof(ContextDisambiguatesRelativeGlobsData))]
         public void ContextDisambiguatesAFullyQualifiedGlobPointingInAnotherRelativeGlobsCone(EvaluationContext.SharingPolicy policy, string[][] expectedGlobExpansions)
         {
+            if (policy == EvaluationContext.SharingPolicy.Shared)
+            {
+                // This test case has a dependency on our glob expansion caching policy. If the evaluation context is reused
+                // between evaluations and files are added to the filesystem between evaluations, the cache may be returning
+                // stale results. Run only the Isolated variant.
+                return;
+            }
+
             var project1Directory = _env.DefaultTestDirectory.CreateDirectory("Project1");
             var project1GlobDirectory = project1Directory.CreateDirectory("Glob").CreateDirectory("1").Path;
 

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.FileSystem;
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Evaluation.Context
         /// <summary>
         /// Key to file entry list. Example usages: cache glob expansion and intermediary directory expansions during glob expansion.
         /// </summary>
-        private ConcurrentDictionary<string, ImmutableArray<string>> FileEntryExpansionCache { get; }
+        private ConcurrentDictionary<string, IReadOnlyList<string>> FileEntryExpansionCache { get; }
 
         private EvaluationContext(SharingPolicy policy, IFileSystem fileSystem)
         {
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Evaluation.Context
             Policy = policy;
 
             SdkResolverService = new CachingSdkResolverService();
-            FileEntryExpansionCache = new ConcurrentDictionary<string, ImmutableArray<string>>();
+            FileEntryExpansionCache = new ConcurrentDictionary<string, IReadOnlyList<string>>();
             FileSystem = fileSystem ?? new CachingFileSystemWrapper(FileSystems.Default);
             EngineFileUtilities = new EngineFileUtilities(new FileMatcher(FileSystem, FileEntryExpansionCache));
         }

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -117,23 +117,20 @@ namespace Microsoft.Build.Globbing
         {
             ErrorUtilities.VerifyThrowArgumentNull(stringToMatch, nameof(stringToMatch));
 
-            if (FileUtilities.PathIsInvalid(stringToMatch) ||
-                !IsLegal)
+            if (FileUtilities.PathIsInvalid(stringToMatch) || !IsLegal)
             {
                 return MatchInfoResult.Empty;
             }
 
-            var normalizedInput = NormalizeMatchInput(stringToMatch);
+            string normalizedInput = NormalizeMatchInput(stringToMatch);
 
-            bool isMatch;
-            string fixedDirectoryPart, wildcardDirectoryPart, filenamePart;
             FileMatcher.GetRegexMatchInfo(
                 normalizedInput,
                 _state.Value.Regex,
-                out isMatch,
-                out fixedDirectoryPart,
-                out wildcardDirectoryPart,
-                out filenamePart);
+                out bool isMatch,
+                out string fixedDirectoryPart,
+                out string wildcardDirectoryPart,
+                out string filenamePart);
 
             return new MatchInfoResult(isMatch, fixedDirectoryPart, wildcardDirectoryPart, filenamePart);
         }
@@ -145,7 +142,7 @@ namespace Microsoft.Build.Globbing
 
             // Degenerate case when the string to match is empty.
             // Ensure trailing slash because the fixed directory part has a trailing slash.
-            if (stringToMatch == string.Empty)
+            if (string.IsNullOrEmpty(stringToMatch))
             {
                 normalizedInput += Path.DirectorySeparatorChar;
             }
@@ -172,7 +169,7 @@ namespace Microsoft.Build.Globbing
             ErrorUtilities.VerifyThrowArgumentNull(fileSpec, nameof(fileSpec));
             ErrorUtilities.VerifyThrowArgumentInvalidPath(globRoot, nameof(globRoot));
 
-            if (globRoot == string.Empty)
+            if (string.IsNullOrEmpty(globRoot))
             {
                 globRoot = Directory.GetCurrentDirectory();
             }
@@ -181,22 +178,14 @@ namespace Microsoft.Build.Globbing
 
             var lazyState = new Lazy<GlobState>(() =>
             {
-                string fixedDirectoryPart = null;
-                string wildcardDirectoryPart = null;
-                string filenamePart = null;
-
-                string matchFileExpression;
-                bool needsRecursion;
-                bool isLegalFileSpec;
-
                 FileMatcher.Default.GetFileSpecInfo(
                     fileSpec,
-                    out fixedDirectoryPart,
-                    out wildcardDirectoryPart,
-                    out filenamePart,
-                    out matchFileExpression,
-                    out needsRecursion,
-                    out isLegalFileSpec,
+                    out string fixedDirectoryPart,
+                    out string wildcardDirectoryPart,
+                    out string filenamePart,
+                    out string matchFileExpression,
+                    out bool needsRecursion,
+                    out bool isLegalFileSpec,
                     (fixedDirPart, wildcardDirPart, filePart) =>
                     {
                         var normalizedFixedPart = NormalizeTheFixedDirectoryPartAgainstTheGlobRoot(fixedDirPart, globRoot);

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -28,11 +28,10 @@ namespace Microsoft.Build.Globbing
             public string FixedDirectoryPart { get; }
             public string WildcardDirectoryPart { get; }
             public string FilenamePart { get; }
-            public string MatchFileExpression { get; }
             public bool NeedsRecursion { get; }
             public Regex Regex { get; }
 
-            public GlobState(string globRoot, string fileSpec, bool isLegal, string fixedDirectoryPart, string wildcardDirectoryPart, string filenamePart, string matchFileExpression, bool needsRecursion, Regex regex)
+            public GlobState(string globRoot, string fileSpec, bool isLegal, string fixedDirectoryPart, string wildcardDirectoryPart, string filenamePart, bool needsRecursion, Regex regex)
             {
                 GlobRoot = globRoot;
                 FileSpec = fileSpec;
@@ -40,7 +39,6 @@ namespace Microsoft.Build.Globbing
                 FixedDirectoryPart = fixedDirectoryPart;
                 WildcardDirectoryPart = wildcardDirectoryPart;
                 FilenamePart = filenamePart;
-                MatchFileExpression = matchFileExpression;
                 NeedsRecursion = needsRecursion;
                 Regex = regex;
             }
@@ -183,7 +181,6 @@ namespace Microsoft.Build.Globbing
                     out string fixedDirectoryPart,
                     out string wildcardDirectoryPart,
                     out string filenamePart,
-                    out string matchFileExpression,
                     out bool needsRecursion,
                     out bool isLegalFileSpec,
                     (fixedDirPart, wildcardDirPart, filePart) =>
@@ -196,6 +193,8 @@ namespace Microsoft.Build.Globbing
                 Regex regex = null;
                 if (isLegalFileSpec)
                 {
+                    string matchFileExpression = FileMatcher.RegularExpressionFromFileSpec(fixedDirectoryPart, wildcardDirectoryPart, filenamePart);
+
                     lock (s_regexCache)
                     {
                         s_regexCache.TryGetValue(matchFileExpression, out regex);
@@ -215,7 +214,7 @@ namespace Microsoft.Build.Globbing
                         regex ??= newRegex;
                     }
                 }
-                return new GlobState(globRoot, fileSpec, isLegalFileSpec, fixedDirectoryPart, wildcardDirectoryPart, filenamePart, matchFileExpression, needsRecursion, regex);
+                return new GlobState(globRoot, fileSpec, isLegalFileSpec, fixedDirectoryPart, wildcardDirectoryPart, filenamePart, needsRecursion, regex);
             },
             true);
 

--- a/src/Build/Utilities/FileSpecMatchTester.cs
+++ b/src/Build/Utilities/FileSpecMatchTester.cs
@@ -13,34 +13,56 @@ namespace Microsoft.Build.Internal
     {
         private readonly string _currentDirectory;
         private readonly string _unescapedFileSpec;
+        private readonly string _filenamePattern;
         private readonly Regex _regex;
         
-        private FileSpecMatcherTester(string currentDirectory, string unescapedFileSpec, Regex regex)
+        private FileSpecMatcherTester(string currentDirectory, string unescapedFileSpec, string filenamePattern, Regex regex)
         {
             Debug.Assert(!string.IsNullOrEmpty(unescapedFileSpec));
+            Debug.Assert(currentDirectory != null);
 
             _currentDirectory = currentDirectory;
             _unescapedFileSpec = unescapedFileSpec;
+            _filenamePattern = filenamePattern;
             _regex = regex;
         }
 
         public static FileSpecMatcherTester Parse(string currentDirectory, string fileSpec)
         {
             string unescapedFileSpec = EscapingUtilities.UnescapeAll(fileSpec);
-            Regex regex = EngineFileUtilities.FilespecHasWildcards(fileSpec) ? CreateRegex(unescapedFileSpec, currentDirectory) : null;
+            string filenamePattern = null;
+            Regex regex = null;
 
-            return new FileSpecMatcherTester(currentDirectory, unescapedFileSpec, regex);
+            if (EngineFileUtilities.FilespecHasWildcards(fileSpec))
+            {
+                CreateRegexOrFilenamePattern(unescapedFileSpec, currentDirectory, out filenamePattern, out regex);
+            }
+
+            return new FileSpecMatcherTester(currentDirectory, unescapedFileSpec, filenamePattern, regex);
         }
 
         public bool IsMatch(string fileToMatch)
         {
             Debug.Assert(!string.IsNullOrEmpty(fileToMatch));
 
-            // check if there is a regex matching the file
+            // We do the matching using one of three code paths, depending on the value of _filenamePattern and _regex.
             if (_regex != null)
             {
                 string normalizedFileToMatch = FileUtilities.GetFullPathNoThrow(Path.Combine(_currentDirectory, fileToMatch));
                 return _regex.IsMatch(normalizedFileToMatch);
+            }
+
+            if (_filenamePattern != null)
+            {
+                // Check file name first as it's more likely to not match.
+                string filename = Path.GetFileName(fileToMatch);
+                if (!FileMatcher.IsMatch(filename, _filenamePattern))
+                {
+                    return false;
+                }
+
+                var normalizedFileToMatch = FileUtilities.GetFullPathNoThrow(Path.Combine(_currentDirectory, fileToMatch));
+                return normalizedFileToMatch.StartsWith(_currentDirectory, StringComparison.OrdinalIgnoreCase);
             }
 
             return FileUtilities.ComparePathsNoThrow(_unescapedFileSpec, fileToMatch, _currentDirectory, alwaysIgnoreCase: true);
@@ -50,17 +72,27 @@ namespace Microsoft.Build.Internal
         // without this normalization step, strings pointing outside the globbing cone would still match when they shouldn't
         // for example, we dont want "**/*.cs" to match "../Shared/Foo.cs"
         // todo: glob rooting knowledge partially duplicated with MSBuildGlob.Parse and FileMatcher.ComputeFileEnumerationCacheKey
-        private static Regex CreateRegex(string unescapedFileSpec, string currentDirectory)
+        private static void CreateRegexOrFilenamePattern(string unescapedFileSpec, string currentDirectory, out string filenamePattern, out Regex regex)
         {
             FileMatcher.Default.SplitFileSpec(
-            unescapedFileSpec,
-            out string fixedDirPart,
-            out string wildcardDirectoryPart,
-            out string filenamePart);
+                unescapedFileSpec,
+                out string fixedDirPart,
+                out string wildcardDirectoryPart,
+                out string filenamePart);
 
             if (FileUtilities.PathIsInvalid(fixedDirPart))
             {
-                return null;
+                filenamePattern = null;
+                regex = null;
+                return;
+            }
+
+            // Most file specs have "**" as their directory specification so we special case these and make matching faster.
+            if (string.IsNullOrEmpty(fixedDirPart) && FileMatcher.IsRecursiveDirectoryMatch(wildcardDirectoryPart))
+            {
+                filenamePattern = filenamePart;
+                regex = null;
+                return;
             }
 
             var absoluteFixedDirPart = Path.Combine(currentDirectory, fixedDirPart);
@@ -75,11 +107,12 @@ namespace Microsoft.Build.Internal
 
             FileMatcher.Default.GetFileSpecInfoWithRegexObject(
                 recombinedFileSpec,
-                out Regex regex,
+                out Regex regexObject,
                 out bool _,
                 out bool isLegal);
 
-            return isLegal ? regex : null;
+            filenamePattern = null;
+            regex = isLegal ? regexObject : null;
         }
     }
 }

--- a/src/Build/Utilities/FileSpecMatchTester.cs
+++ b/src/Build/Utilities/FileSpecMatchTester.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Shared;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -38,7 +39,7 @@ namespace Microsoft.Build.Internal
             // check if there is a regex matching the file
             if (_regex != null)
             {
-                var normalizedFileToMatch = FileUtilities.GetFullPathNoThrow(Path.Combine(_currentDirectory, fileToMatch));
+                string normalizedFileToMatch = FileUtilities.GetFullPathNoThrow(Path.Combine(_currentDirectory, fileToMatch));
                 return _regex.IsMatch(normalizedFileToMatch);
             }
 

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -179,14 +179,6 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
-        /// Determines whether the given path has any wild card characters or semicolons.
-        /// </summary>
-        internal static bool HasWildcardsOrSemicolon(string filespec)
-        {
-            return -1 != filespec.LastIndexOfAny(s_wildcardAndSemicolonCharacters);
-        }
-
-        /// <summary>
         /// Determines whether the given path has any wild card characters, any semicolons or any property references.
         /// </summary>
         internal static bool HasWildcardsSemicolonItemOrPropertyReferences(string filespec)

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -750,11 +750,13 @@ namespace Microsoft.Build.Shared
         {
             public FilesSearchData(
                 string filespec,                // can be null
+                string directoryPattern,        // can be null
                 Regex regexFileMatch,           // can be null
                 bool needsRecursion
                 )
             {
                 Filespec = filespec;
+                DirectoryPattern = directoryPattern;
                 RegexFileMatch = regexFileMatch;
                 NeedsRecursion = needsRecursion;
             }
@@ -763,6 +765,13 @@ namespace Microsoft.Build.Shared
             /// The filespec.
             /// </summary>
             public string Filespec { get; }
+            /// <summary>
+            /// Holds the directory pattern for globs like **/{pattern}/**, i.e. when we're looking for a matching directory name
+            /// regardless of where on the path it is. This field is used only if the wildcard directory part has this shape. In
+            /// other cases such as **/{pattern1}/**/{pattern2}/**, we don't use this optimization and instead rely on
+            /// <see cref="RegexFileMatch"/> to test if a file path matches the glob or not.
+            /// </summary>
+            public string DirectoryPattern { get; }
             /// <summary>
             /// Wild-card matching.
             /// </summary>
@@ -784,9 +793,18 @@ namespace Microsoft.Build.Shared
             /// </summary>
             public string RemainingWildcardDirectory;
             /// <summary>
+            /// True if SearchData.DirectoryPattern is non-null and we have descended into a directory that matches the pattern.
+            /// </summary>
+            public bool IsInsideMatchingDirectory;
+            /// <summary>
             /// Data about a search that does not change as the search recursively traverses directories
             /// </summary>
             public FilesSearchData SearchData;
+
+            /// <summary>
+            /// True if a SearchData.DirectoryPattern is specified but we have not descended into a matching directory.
+            /// </summary>
+            public bool IsLookingForMatchingDirectory => (SearchData.DirectoryPattern != null && !IsInsideMatchingDirectory);
         }
 
         /// <summary>
@@ -832,6 +850,8 @@ namespace Microsoft.Build.Shared
 
                     //  We can exclude all results in this folder if:
                     if (
+                        //  We are not looking for a directory matching the pattern given in SearchData.DirectoryPattern
+                        !searchToExclude.IsLookingForMatchingDirectory &&
                         //  We are matching files based on a filespec and not a regular expression
                         searchToExclude.SearchData.Filespec != null &&
                         //  The wildcard path portion of the excluded search matches the include search
@@ -892,6 +912,12 @@ namespace Microsoft.Build.Shared
                 newRecursionState.BaseDirectory = subdir;
                 newRecursionState.RemainingWildcardDirectory = nextStep.RemainingWildcardDirectory;
 
+                if (newRecursionState.IsLookingForMatchingDirectory &&
+                    DirectoryEndsWithPattern(subdir, recursionState.SearchData.DirectoryPattern))
+                {
+                    newRecursionState.IsInsideMatchingDirectory = true;
+                }
+
                 List<RecursionState> newSearchesToExclude = null;
 
                 if (excludeNextSteps != null)
@@ -906,6 +932,11 @@ namespace Microsoft.Build.Shared
                             RecursionState thisExcludeStep = searchesToExclude[i];
                             thisExcludeStep.BaseDirectory = subdir;
                             thisExcludeStep.RemainingWildcardDirectory = excludeNextSteps[i].RemainingWildcardDirectory;
+                            if (thisExcludeStep.IsLookingForMatchingDirectory &&
+                                DirectoryEndsWithPattern(subdir, thisExcludeStep.SearchData.DirectoryPattern))
+                            {
+                                thisExcludeStep.IsInsideMatchingDirectory = true;
+                            }
                             newSearchesToExclude.Add(thisExcludeStep);
                         }
                     }
@@ -1038,9 +1069,14 @@ namespace Microsoft.Build.Shared
             bool considerFiles = false;
 
             // Only consider files if...
-            if (recursionState.RemainingWildcardDirectory.Length == 0)
+            if (recursionState.SearchData.DirectoryPattern != null)
             {
-                // We've reached the end of the wildcard directory elements.
+                // We are looking for a directory pattern and have descended into a matching directory,
+                considerFiles = recursionState.IsInsideMatchingDirectory;
+            }
+            else if (recursionState.RemainingWildcardDirectory.Length == 0)
+            {
+                // or we've reached the end of the wildcard directory elements,
                 considerFiles = true;
             }
             else if (recursionState.RemainingWildcardDirectory.IndexOf(recursiveDirectoryMatch, StringComparison.Ordinal) == 0)
@@ -2042,11 +2078,37 @@ namespace Microsoft.Build.Shared
                 return SearchAction.ReturnEmptyList;
             }
 
+            string directoryPattern = null;
+            if (wildcardDirectoryPart.Length > 0)
+            {
+                // If the wildcard directory part looks like "**/{pattern}/**", we are essentially looking for files that have
+                // a matching directory anywhere on their path. This is commonly used when excluding hidden directories using
+                // "**/.*/**" for example, and is worth special-casing so it doesn't fall into the slow regex logic.
+                string wildcard = wildcardDirectoryPart.TrimTrailingSlashes();
+                int wildcardLength = wildcard.Length;
+                if (wildcardLength > 6 &&
+                    wildcard[0] == '*' &&
+                    wildcard[1] == '*' &&
+                    FileUtilities.IsAnySlash(wildcard[2]) &&
+                    FileUtilities.IsAnySlash(wildcard[wildcardLength - 3]) &&
+                    wildcard[wildcardLength - 2] == '*' &&
+                    wildcard[wildcardLength - 1] == '*')
+                {
+                    // Check that there are no other slashes in the wildcard.
+                    if (wildcard.IndexOfAny(FileUtilities.Slashes, 3, wildcardLength - 6) == -1)
+                    {
+                        directoryPattern = wildcard.Substring(3, wildcardLength - 6);
+                    }
+                }
+            }
+
             // determine if we need to use the regular expression to match the files
             // PERF NOTE: Constructing a Regex object is expensive, so we avoid it whenever possible
             bool matchWithRegex =
                 // if we have a directory specification that uses wildcards, and
                 (wildcardDirectoryPart.Length > 0) &&
+                // the directory pattern is not a simple "**/{pattern}/**", and
+                directoryPattern == null &&
                 // the specification is not a simple "**"
                 !IsRecursiveDirectoryMatch(wildcardDirectoryPart);
             // then we need to use the regular expression
@@ -2054,6 +2116,7 @@ namespace Microsoft.Build.Shared
             var searchData = new FilesSearchData(
                 // if using the regular expression, ignore the file pattern
                 matchWithRegex ? null : filenamePart,
+                directoryPattern,
                 // if using the file pattern, ignore the regular expression
                 matchWithRegex ? new Regex(matchFileExpression, RegexOptions.IgnoreCase) : null,
                 needsRecursion);
@@ -2338,7 +2401,8 @@ namespace Microsoft.Build.Shared
                                 //  BaseDirectory to be the same as the exclude BaseDirectory, and change the wildcard part to be "**\"
                                 //  because we don't know where the different parts of the exclude wildcard part would be matched.
                                 //  Example: include="c:\git\msbuild\src\Framework\**\*.*" exclude="c:\git\msbuild\**\bin\**\*.*"
-                                Debug.Assert(excludeState.SearchData.RegexFileMatch != null, "Expected Regex to be used for exclude file matching");
+                                Debug.Assert(excludeState.SearchData.RegexFileMatch != null || excludeState.SearchData.DirectoryPattern != null,
+                                    "Expected Regex or directory pattern to be used for exclude file matching");
                                 excludeState.BaseDirectory = state.BaseDirectory;
                                 excludeState.RemainingWildcardDirectory = recursiveDirectoryMatch + s_directorySeparator;
                                 searchesToExclude.Add(excludeState);
@@ -2456,6 +2520,19 @@ namespace Microsoft.Build.Shared
             {
                 return directorySeparatorCharacters.Contains(possibleChild[possibleParent.Length]);
             }
+        }
+
+        /// <summary>
+        /// Returns true if the last component of the given directory path (assumed to not have any trailing slashes)
+        /// matches the given pattern.
+        /// </summary>
+        /// <param name="directoryPath">The path to test.</param>
+        /// <param name="pattern">The pattern to test against.</param>
+        /// <returns>True in case of a match (e.g. directoryPath = "dir/subdir" and pattern = "s*"), false otherwise.</returns>
+        private static bool DirectoryEndsWithPattern(string directoryPath, string pattern)
+        {
+            int index = directoryPath.LastIndexOfAny(FileUtilities.Slashes);
+            return (index != -1 && IsMatch(directoryPath.Substring(index + 1), pattern));
         }
 
         private static bool IsRecursiveDirectoryMatch(string path) => path.TrimTrailingSlashes() == recursiveDirectoryMatch;

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -130,13 +130,13 @@ namespace Microsoft.Build.Shared
                                     path,
                                     "*",
                                     directory,
-                                    false).ToArray());
+                                    false));
                         IEnumerable<string> filteredEntriesForPath = (pattern != null && pattern != "*")
                             ? allEntriesForPath.Where(o => IsMatch(Path.GetFileName(o), pattern))
                             : allEntriesForPath;
                         return stripProjectDirectory
-                            ? RemoveProjectDirectory(filteredEntriesForPath, directory)
-                            : filteredEntriesForPath;
+                            ? RemoveProjectDirectory(filteredEntriesForPath, directory).ToArray()
+                            : filteredEntriesForPath.ToArray();
                     }
                     else
                     {
@@ -178,7 +178,7 @@ namespace Microsoft.Build.Shared
         /// <param name="projectDirectory"></param>
         /// <param name="stripProjectDirectory"></param>
         /// <returns>An enumerable of filesystem entries.</returns>
-        internal delegate IEnumerable<string> GetFileSystemEntries(FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory);
+        internal delegate IReadOnlyList<string> GetFileSystemEntries(FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory);
 
         internal static void ClearFileEnumerationsCache()
         {
@@ -237,7 +237,7 @@ namespace Microsoft.Build.Shared
         /// <param name="stripProjectDirectory">If true the project directory should be stripped</param>
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns></returns>
-        private static IEnumerable<string> GetAccessibleFileSystemEntries(IFileSystem fileSystem, FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
+        private static IReadOnlyList<string> GetAccessibleFileSystemEntries(IFileSystem fileSystem, FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
         {
             path = FileUtilities.FixFilePath(path);
             switch (entityType)
@@ -260,7 +260,7 @@ namespace Microsoft.Build.Shared
         /// <param name="pattern"></param>
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns>An enumerable of matching file system entries (can be empty).</returns>
-        private static IEnumerable<string> GetAccessibleFilesAndDirectories(IFileSystem fileSystem, string path, string pattern)
+        private static IReadOnlyList<string> GetAccessibleFilesAndDirectories(IFileSystem fileSystem, string path, string pattern)
         {
             if (fileSystem.DirectoryExists(path))
             {
@@ -270,7 +270,7 @@ namespace Microsoft.Build.Shared
                         ? fileSystem.EnumerateFileSystemEntries(path, pattern)
                             .Where(o => IsMatch(Path.GetFileName(o), pattern))
                         : fileSystem.EnumerateFileSystemEntries(path, pattern)
-                        );
+                        ).ToArray();
                 }
                 // for OS security
                 catch (UnauthorizedAccessException)
@@ -326,7 +326,7 @@ namespace Microsoft.Build.Shared
         /// <param name="stripProjectDirectory"></param>
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns>Files that can be accessed.</returns>
-        private static IEnumerable<string> GetAccessibleFiles
+        private static IReadOnlyList<string> GetAccessibleFiles
         (
             IFileSystem fileSystem,
             string path,
@@ -370,7 +370,7 @@ namespace Microsoft.Build.Shared
                     files = RemoveInitialDotSlash(files);
                 }
 
-                return files;
+                return files.ToArray();
             }
             catch (System.Security.SecurityException)
             {
@@ -394,7 +394,7 @@ namespace Microsoft.Build.Shared
         /// <param name="pattern">Pattern to match</param>
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns>Accessible directories.</returns>
-        private static IEnumerable<string> GetAccessibleDirectories
+        private static IReadOnlyList<string> GetAccessibleDirectories
         (
             IFileSystem fileSystem,
             string path,
@@ -428,7 +428,7 @@ namespace Microsoft.Build.Shared
                     directories = RemoveInitialDotSlash(directories);
                 }
 
-                return directories;
+                return directories.ToArray();
             }
             catch (System.Security.SecurityException)
             {
@@ -528,11 +528,10 @@ namespace Microsoft.Build.Shared
                     }
                     else
                     {
-                        // getFileSystemEntries(...) returns an empty array if longPath doesn't exist.
-                        IEnumerable<string> entries = getFileSystemEntries(FileSystemEntity.FilesAndDirectories, longPath, parts[i], null, false);
+                        // getFileSystemEntries(...) returns an empty enumerable if longPath doesn't exist.
+                        IReadOnlyList<string> entries = getFileSystemEntries(FileSystemEntity.FilesAndDirectories, longPath, parts[i], null, false);
 
-                        int entriesCount = entries.Count();
-                        if (0 == entriesCount)
+                        if (0 == entries.Count)
                         {
                             // The next part doesn't exist. Therefore, no more of the path will exist.
                             // Just return the rest.
@@ -543,13 +542,13 @@ namespace Microsoft.Build.Shared
                             break;
                         }
 
-                        // Since we know there are no wild cards, this should be length one.
-                        ErrorUtilities.VerifyThrow(entriesCount == 1,
+                        // Since we know there are no wild cards, this should be length one, i.e. MoveNext should return false.
+                        ErrorUtilities.VerifyThrow(entries.Count == 1,
                             "Unexpected number of entries ({3}) found when enumerating '{0}' under '{1}'. Original path was '{2}'",
-                            parts[i], longPath, path, entriesCount);
+                            parts[i], longPath, path, entries.Count);
 
                         // Entries[0] contains the full path.
-                        longPath = entries.First();
+                        longPath = entries[0];
 
                         // We just want the trailing node.
                         longParts[i - startingElement] = Path.GetFileName(longPath);

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
@@ -37,10 +36,10 @@ namespace Microsoft.Build.Shared
         internal static readonly char[] directorySeparatorCharacters = FileUtilities.Slashes;
 
         // until Cloudbuild switches to EvaluationContext, we need to keep their dependence on global glob caching via an environment variable
-        private static readonly Lazy<ConcurrentDictionary<string, ImmutableArray<string>>> s_cachedGlobExpansions = new Lazy<ConcurrentDictionary<string, ImmutableArray<string>>>(() => new ConcurrentDictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase));
+        private static readonly Lazy<ConcurrentDictionary<string, IReadOnlyList<string>>> s_cachedGlobExpansions = new Lazy<ConcurrentDictionary<string, IReadOnlyList<string>>>(() => new ConcurrentDictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
         private static readonly Lazy<ConcurrentDictionary<string, object>> s_cachedGlobExpansionsLock = new Lazy<ConcurrentDictionary<string, object>>(() => new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase));
 
-        private readonly ConcurrentDictionary<string, ImmutableArray<string>> _cachedGlobExpansions;
+        private readonly ConcurrentDictionary<string, IReadOnlyList<string>> _cachedGlobExpansions;
         private readonly Lazy<ConcurrentDictionary<string, object>> _cachedGlobExpansionsLock = new Lazy<ConcurrentDictionary<string, object>>(() => new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase));
 
         /// <summary>
@@ -82,7 +81,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         public static FileMatcher Default = new FileMatcher(FileSystems.Default, null);
 
-        public FileMatcher(IFileSystem fileSystem, ConcurrentDictionary<string, ImmutableArray<string>> fileEntryExpansionCache = null) : this(
+        public FileMatcher(IFileSystem fileSystem, ConcurrentDictionary<string, IReadOnlyList<string>> fileEntryExpansionCache = null) : this(
             fileSystem,
             (entityType, path, pattern, projectDirectory, stripProjectDirectory) => GetAccessibleFileSystemEntries(
                 fileSystem,
@@ -90,12 +89,12 @@ namespace Microsoft.Build.Shared
                 path,
                 pattern,
                 projectDirectory,
-                stripProjectDirectory),
+                stripProjectDirectory).ToArray(),
             fileEntryExpansionCache)
         {
         }
 
-        public FileMatcher(IFileSystem fileSystem, GetFileSystemEntries getFileSystemEntries, ConcurrentDictionary<string, ImmutableArray<string>> getFileSystemDirectoryEntriesCache = null)
+        internal FileMatcher(IFileSystem fileSystem, GetFileSystemEntries getFileSystemEntries, ConcurrentDictionary<string, IReadOnlyList<string>> getFileSystemDirectoryEntriesCache = null)
         {
             if (Traits.Instance.MSBuildCacheFileEnumerations)
             {
@@ -123,7 +122,7 @@ namespace Microsoft.Build.Shared
                                 path,
                                 pattern,
                                 directory,
-                                projectDirectory));
+                                projectDirectory).ToArray());
                     }
                     return getFileSystemEntries(type, path, pattern, directory, projectDirectory);
                 };
@@ -148,8 +147,8 @@ namespace Microsoft.Build.Shared
         /// <param name="pattern">The file pattern.</param>
         /// <param name="projectDirectory"></param>
         /// <param name="stripProjectDirectory"></param>
-        /// <returns>An immutable array of filesystem entries.</returns>
-        internal delegate ImmutableArray<string> GetFileSystemEntries(FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory);
+        /// <returns>An enumerable of filesystem entries.</returns>
+        internal delegate IEnumerable<string> GetFileSystemEntries(FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory);
 
         internal static void ClearFileEnumerationsCache()
         {
@@ -208,7 +207,7 @@ namespace Microsoft.Build.Shared
         /// <param name="stripProjectDirectory">If true the project directory should be stripped</param>
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns></returns>
-        private static ImmutableArray<string> GetAccessibleFileSystemEntries(IFileSystem fileSystem, FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
+        private static IEnumerable<string> GetAccessibleFileSystemEntries(IFileSystem fileSystem, FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
         {
             path = FileUtilities.FixFilePath(path);
             switch (entityType)
@@ -220,18 +219,18 @@ namespace Microsoft.Build.Shared
                     ErrorUtilities.VerifyThrow(false, "Unexpected filesystem entity type.");
                     break;
             }
-            return ImmutableArray<string>.Empty;
+            return Array.Empty<string>();
         }
 
         /// <summary>
-        /// Returns an immutable array of file system entries matching the specified search criteria. Inaccessible or non-existent file
+        /// Returns an enumerable of file system entries matching the specified search criteria. Inaccessible or non-existent file
         /// system entries are skipped.
         /// </summary>
         /// <param name="path"></param>
         /// <param name="pattern"></param>
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
-        /// <returns>An immutable array of matching file system entries (can be empty).</returns>
-        private static ImmutableArray<string> GetAccessibleFilesAndDirectories(IFileSystem fileSystem, string path, string pattern)
+        /// <returns>An enumerable of matching file system entries (can be empty).</returns>
+        private static IEnumerable<string> GetAccessibleFilesAndDirectories(IFileSystem fileSystem, string path, string pattern)
         {
             if (fileSystem.DirectoryExists(path))
             {
@@ -241,7 +240,7 @@ namespace Microsoft.Build.Shared
                         ? fileSystem.EnumerateFileSystemEntries(path, pattern)
                             .Where(o => IsMatch(Path.GetFileName(o), pattern))
                         : fileSystem.EnumerateFileSystemEntries(path, pattern)
-                        ).ToImmutableArray();
+                        );
                 }
                 // for OS security
                 catch (UnauthorizedAccessException)
@@ -255,7 +254,7 @@ namespace Microsoft.Build.Shared
                 }
             }
 
-            return ImmutableArray<string>.Empty;
+            return Array.Empty<string>();
         }
 
         /// <summary>
@@ -297,7 +296,7 @@ namespace Microsoft.Build.Shared
         /// <param name="stripProjectDirectory"></param>
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns>Files that can be accessed.</returns>
-        private static ImmutableArray<string> GetAccessibleFiles
+        private static IEnumerable<string> GetAccessibleFiles
         (
             IFileSystem fileSystem,
             string path,
@@ -341,17 +340,17 @@ namespace Microsoft.Build.Shared
                     files = RemoveInitialDotSlash(files);
                 }
 
-                return files.ToImmutableArray();
+                return files;
             }
             catch (System.Security.SecurityException)
             {
                 // For code access security.
-                return ImmutableArray<string>.Empty;
+                return Array.Empty<string>();
             }
             catch (System.UnauthorizedAccessException)
             {
                 // For OS security.
-                return ImmutableArray<string>.Empty;
+                return Array.Empty<string>();
             }
         }
 
@@ -365,7 +364,7 @@ namespace Microsoft.Build.Shared
         /// <param name="pattern">Pattern to match</param>
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns>Accessible directories.</returns>
-        private static ImmutableArray<string> GetAccessibleDirectories
+        private static IEnumerable<string> GetAccessibleDirectories
         (
             IFileSystem fileSystem,
             string path,
@@ -399,17 +398,17 @@ namespace Microsoft.Build.Shared
                     directories = RemoveInitialDotSlash(directories);
                 }
 
-                return directories.ToImmutableArray();
+                return directories;
             }
             catch (System.Security.SecurityException)
             {
                 // For code access security.
-                return ImmutableArray<string>.Empty;
+                return Array.Empty<string>();
             }
             catch (System.UnauthorizedAccessException)
             {
                 // For OS security.
-                return ImmutableArray<string>.Empty;
+                return Array.Empty<string>();
             }
         }
 
@@ -500,9 +499,10 @@ namespace Microsoft.Build.Shared
                     else
                     {
                         // getFileSystemEntries(...) returns an empty array if longPath doesn't exist.
-                        ImmutableArray<string> entries = getFileSystemEntries(FileSystemEntity.FilesAndDirectories, longPath, parts[i], null, false);
+                        IEnumerable<string> entries = getFileSystemEntries(FileSystemEntity.FilesAndDirectories, longPath, parts[i], null, false);
 
-                        if (0 == entries.Length)
+                        int entriesCount = entries.Count();
+                        if (0 == entriesCount)
                         {
                             // The next part doesn't exist. Therefore, no more of the path will exist.
                             // Just return the rest.
@@ -514,12 +514,12 @@ namespace Microsoft.Build.Shared
                         }
 
                         // Since we know there are no wild cards, this should be length one.
-                        ErrorUtilities.VerifyThrow(entries.Length == 1,
+                        ErrorUtilities.VerifyThrow(entriesCount == 1,
                             "Unexpected number of entries ({3}) found when enumerating '{0}' under '{1}'. Original path was '{2}'",
-                            parts[i], longPath, path, entries.Length);
+                            parts[i], longPath, path, entriesCount);
 
                         // Entries[0] contains the full path.
-                        longPath = entries[0];
+                        longPath = entries.First();
 
                         // We just want the trailing node.
                         longParts[i - startingElement] = Path.GetFileName(longPath);
@@ -1892,7 +1892,7 @@ namespace Microsoft.Build.Shared
 
             var enumerationKey = ComputeFileEnumerationCacheKey(projectDirectoryUnescaped, filespecUnescaped, excludeSpecsUnescaped);
 
-            ImmutableArray<string> files;
+            IReadOnlyList<string> files;
             if (!_cachedGlobExpansions.TryGetValue(enumerationKey, out files))
             {
                 // avoid parallel evaluations of the same wildcard by using a unique lock for each wildcard
@@ -1908,8 +1908,7 @@ namespace Microsoft.Build.Shared
                                     GetFilesImplementation(
                                         projectDirectoryUnescaped,
                                         filespecUnescaped,
-                                        excludeSpecsUnescaped)
-                                        .ToImmutableArray());
+                                        excludeSpecsUnescaped));
                     }
                 }
             }

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1063,8 +1063,24 @@ namespace Microsoft.Build.Shared
             {
                 return Enumerable.Empty<string>();
             }
+
+            // Back-compat hack: We don't use case-insensitive file enumeration I/O on Linux so the behavior is different depending
+            // on the NeedsToProcessEachFile flag. If the flag is false and matching is done within the _getFileSystemEntries call,
+            // it is case sensitive. If the flag is true and matching is handled with MatchFileRecursionStep, it is case-insensitive.
+            // TODO: Can we fix this by using case-insensitive file I/O on Linux?
+            string filespec;
+            if (NativeMethodsShared.IsLinux && recursionState.SearchData.DirectoryPattern != null)
+            {
+                filespec = "*.*";
+                stepResult.NeedsToProcessEachFile = true;
+            }
+            else
+            {
+                filespec = recursionState.SearchData.Filespec;
+            }
+
             IEnumerable<string> files = _getFileSystemEntries(FileSystemEntity.Files, recursionState.BaseDirectory,
-                recursionState.SearchData.Filespec, projectDirectory, stripProjectDirectory);
+                filespec, projectDirectory, stripProjectDirectory);
 
             if (!stepResult.NeedsToProcessEachFile)
             {

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1671,26 +1671,20 @@ namespace Microsoft.Build.Shared
             bool CompareIgnoreCase(char inputChar, char patternChar, int iIndex, int pIndex)
 #endif
             {
-                // We will mostly be comparing ASCII characters, check this first
-                if (inputChar < 128 && patternChar < 128)
+                // We will mostly be comparing ASCII characters, check English letters first.
+                char inputCharLower = (char)(inputChar | 0x20);
+                if (inputCharLower >= 'a' && inputCharLower <= 'z')
                 {
-                    if (inputChar >= 'A' && inputChar <= 'Z' && patternChar >= 'a' && patternChar <= 'z')
-                    {
-                        return inputChar + 32 == patternChar;
-                    }
-                    if (inputChar >= 'a' && inputChar <= 'z' && patternChar >= 'A' && patternChar <= 'Z')
-                    {
-                        return inputChar == patternChar + 32;
-                    }
+                    // This test covers all combinations of lower/upper as both sides are converted to lower case.
+                    return inputCharLower == (patternChar | 0x20);
+                }
+                if (inputChar < 128 || patternChar < 128)
+                {
+                    // We don't need to compare, an ASCII character cannot have its lowercase/uppercase outside the ASCII table
+                    // and a non ASCII character cannot have its lowercase/uppercase inside the ASCII table
                     return inputChar == patternChar;
                 }
-                if (inputChar > 128 && patternChar > 128)
-                {
-                    return string.Compare(input, iIndex, pattern, pIndex, 1, StringComparison.OrdinalIgnoreCase) == 0;
-                }
-                // We don't need to compare, an ASCII character cannot have its lowercase/uppercase outside the ASCII table
-                // and a non ASCII character cannot have its lowercase/uppercase inside the ASCII table
-                return false;
+                return string.Compare(input, iIndex, pattern, pIndex, 1, StringComparison.OrdinalIgnoreCase) == 0;
             }
 #if MONO
             ; // The end of the CompareIgnoreCase anonymous function

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -2102,7 +2102,7 @@ namespace Microsoft.Build.Shared
                 sb.Append(aString[0]);
                 sb.Append(aString[1]);
 
-                var i = SkipCharacters(aString, 2, c => FileUtilities.IsAnySlash(c));
+                var i = SkipSlashes(aString, 2);
 
                 if (index != i)
                 {
@@ -2114,22 +2114,22 @@ namespace Microsoft.Build.Shared
             else if (aString.StartsWith("/", StringComparison.Ordinal))
             {
                 sb.Append('/');
-                index = SkipCharacters(aString, 1, c => FileUtilities.IsAnySlash(c));
+                index = SkipSlashes(aString, 1);
             }
             else if (aString.StartsWith(@"\\", StringComparison.Ordinal))
             {
                 sb.Append(@"\\");
-                index = SkipCharacters(aString, 2, c => FileUtilities.IsAnySlash(c));
+                index = SkipSlashes(aString, 2);
             }
             else if (aString.StartsWith(@"\", StringComparison.Ordinal))
             {
                 sb.Append(@"\");
-                index = SkipCharacters(aString, 1, c => FileUtilities.IsAnySlash(c));
+                index = SkipSlashes(aString, 1);
             }
 
             while (index < aString.Length)
             {
-                var afterSlashesIndex = SkipCharacters(aString, index, c => FileUtilities.IsAnySlash(c));
+                var afterSlashesIndex = SkipSlashes(aString, index);
 
                 // do not append separator at the end of the string
                 if (afterSlashesIndex >= aString.Length)
@@ -2142,7 +2142,9 @@ namespace Microsoft.Build.Shared
                     sb.Append(s_directorySeparator);
                 }
 
-                var afterNonSlashIndex = SkipCharacters(aString, afterSlashesIndex, c => !FileUtilities.IsAnySlash(c));
+                // skip non-slashes
+                var indexOfAnySlash = aString.IndexOfAny(directorySeparatorCharacters, afterSlashesIndex);
+                var afterNonSlashIndex = indexOfAnySlash == -1 ? aString.Length : indexOfAnySlash;
 
                 sb.Append(aString, afterSlashesIndex, afterNonSlashIndex - afterSlashesIndex);
 
@@ -2153,16 +2155,16 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
-        /// Skips characters that satisfy the condition <param name="jumpOverCharacter"></param>
+        /// Skips slash characters in a string.
         /// </summary>
         /// <param name="aString">The working string</param>
         /// <param name="startingIndex">Offset in string to start the search in</param>
-        /// <returns>First index that does not satisfy the condition. Returns the string's length if end of string is reached</returns>
-        private static int SkipCharacters(string aString, int startingIndex, Func<char, bool> jumpOverCharacter)
+        /// <returns>First index that is not a slash. Returns the string's length if end of string is reached</returns>
+        private static int SkipSlashes(string aString, int startingIndex)
         {
             var index = startingIndex;
 
-            while (index < aString.Length && jumpOverCharacter(aString[index]))
+            while (index < aString.Length && FileUtilities.IsAnySlash(aString[index]))
             {
                 index++;
             }

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -2529,6 +2529,6 @@ namespace Microsoft.Build.Shared
             return (index != -1 && IsMatch(directoryPath.Substring(index + 1), pattern));
         }
 
-        private static bool IsRecursiveDirectoryMatch(string path) => path.TrimTrailingSlashes() == recursiveDirectoryMatch;
+        internal static bool IsRecursiveDirectoryMatch(string path) => path.TrimTrailingSlashes() == recursiveDirectoryMatch;
     }
 }

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Build.Shared
                 {
                     return (ShouldEnforceMatching(pattern)
                         ? fileSystem.EnumerateFileSystemEntries(path, pattern)
-                            .Where(o => IsMatch(Path.GetFileName(o), pattern, true))
+                            .Where(o => IsMatch(Path.GetFileName(o), pattern))
                         : fileSystem.EnumerateFileSystemEntries(path, pattern)
                         ).ToImmutableArray();
                 }
@@ -322,7 +322,7 @@ namespace Microsoft.Build.Shared
                     files = fileSystem.EnumerateFiles(dir, filespec);
                     if (ShouldEnforceMatching(filespec))
                     {
-                        files = files.Where(o => IsMatch(Path.GetFileName(o), filespec, true));
+                        files = files.Where(o => IsMatch(Path.GetFileName(o), filespec));
                     }
                 }
                 // If the Item is based on a relative path we need to strip
@@ -385,7 +385,7 @@ namespace Microsoft.Build.Shared
                     directories = fileSystem.EnumerateDirectories((path.Length == 0) ? s_thisDirectory : path, pattern);
                     if (ShouldEnforceMatching(pattern))
                     {
-                        directories = directories.Where(o => IsMatch(Path.GetFileName(o), pattern, true));
+                        directories = directories.Where(o => IsMatch(Path.GetFileName(o), pattern));
                     }
                 }
 
@@ -901,7 +901,7 @@ namespace Microsoft.Build.Shared
                     for (int i = 0; i < excludeNextSteps.Length; i++)
                     {
                         if (excludeNextSteps[i].NeedsDirectoryRecursion &&
-                            (excludeNextSteps[i].DirectoryPattern == null || IsMatch(Path.GetFileName(subdir), excludeNextSteps[i].DirectoryPattern, true)))
+                            (excludeNextSteps[i].DirectoryPattern == null || IsMatch(Path.GetFileName(subdir), excludeNextSteps[i].DirectoryPattern)))
                         {
                             RecursionState thisExcludeStep = searchesToExclude[i];
                             thisExcludeStep.BaseDirectory = subdir;
@@ -1017,7 +1017,7 @@ namespace Microsoft.Build.Shared
         {
             if (recursionState.SearchData.Filespec != null)
             {
-                return IsMatch(Path.GetFileName(file), recursionState.SearchData.Filespec, true);
+                return IsMatch(Path.GetFileName(file), recursionState.SearchData.Filespec);
             }
 
             // if no file-spec provided, match the file to the regular expression
@@ -1596,8 +1596,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="input">String which is matched against the pattern.</param>
         /// <param name="pattern">Pattern against which string is matched.</param>
-        /// <param name="ignoreCase">Determines whether ignoring case when comparing two characters</param>
-        internal static bool IsMatch(string input, string pattern, bool ignoreCase)
+        internal static bool IsMatch(string input, string pattern)
         {
             if (input == null)
             {
@@ -1695,10 +1694,7 @@ namespace Microsoft.Build.Shared
                                     break;
                                 }
                                 // If the tail doesn't match, we can safely return e.g. ("aaa", "*b")
-                                if ((
-                                        (!ignoreCase && input[inputTailIndex] != pattern[patternTailIndex]) ||
-                                        (ignoreCase && !CompareIgnoreCase(input[inputTailIndex], pattern[patternTailIndex], patternTailIndex, inputTailIndex))
-                                    ) &&
+                                if (!CompareIgnoreCase(input[inputTailIndex], pattern[patternTailIndex], patternTailIndex, inputTailIndex) &&
                                     pattern[patternTailIndex] != '?')
                                 {
                                     return false;
@@ -1718,9 +1714,7 @@ namespace Microsoft.Build.Shared
                         // The ? wildcard cannot be skipped as we will have a wrong result for e.g. ("aab" "*?b")
                         if (pattern[patternIndex] != '?')
                         {
-                            while (
-                                (!ignoreCase && input[inputIndex] != pattern[patternIndex]) ||
-                                (ignoreCase && !CompareIgnoreCase(input[inputIndex], pattern[patternIndex], inputIndex, patternIndex)))
+                            while (!CompareIgnoreCase(input[inputIndex], pattern[patternIndex], inputIndex, patternIndex))
                             {
                                 // Return if there is no character that match e.g. ("aa", "*b")
                                 if (++inputIndex >= inputLength)
@@ -1735,9 +1729,7 @@ namespace Microsoft.Build.Shared
                     }
 
                     // If we have a match, step to the next character
-                    if (
-                        (!ignoreCase && input[inputIndex] == pattern[patternIndex]) ||
-                        (ignoreCase && CompareIgnoreCase(input[inputIndex], pattern[patternIndex], inputIndex, patternIndex)) ||
+                    if (CompareIgnoreCase(input[inputIndex], pattern[patternIndex], inputIndex, patternIndex) ||
                         pattern[patternIndex] == '?')
                     {
                         patternIndex++;

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -34,8 +34,7 @@ namespace Microsoft.Build.Shared
         private static readonly string[] s_propertyAndItemReferences = { "$(", "@(" };
 
         // on OSX both System.IO.Path separators are '/', so we have to use the literals
-        internal static readonly char[] directorySeparatorCharacters = { '/', '\\' };
-        internal static readonly string[] directorySeparatorStrings = directorySeparatorCharacters.Select(c => c.ToString()).ToArray();
+        internal static readonly char[] directorySeparatorCharacters = FileUtilities.Slashes;
 
         // until Cloudbuild switches to EvaluationContext, we need to keep their dependence on global glob caching via an environment variable
         private static readonly Lazy<ConcurrentDictionary<string, ImmutableArray<string>>> s_cachedGlobExpansions = new Lazy<ConcurrentDictionary<string, ImmutableArray<string>>>(() => new ConcurrentDictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase));
@@ -1460,15 +1459,9 @@ namespace Microsoft.Build.Shared
             out bool needsRecursion,
             out bool isLegalFileSpec)
         {
-            string fixedDirectoryPart;
-            string wildcardDirectoryPart;
-            string filenamePart;
-            string matchFileExpression;
-
             GetFileSpecInfo(filespec,
-                out fixedDirectoryPart, out wildcardDirectoryPart, out filenamePart,
-                out matchFileExpression, out needsRecursion, out isLegalFileSpec);
-
+                out _, out _, out _,
+                out string matchFileExpression, out needsRecursion, out isLegalFileSpec);
             
             regexFileMatch = isLegalFileSpec
                 ? new Regex(matchFileExpression, DefaultRegexOptions)
@@ -2012,21 +2005,15 @@ namespace Microsoft.Build.Shared
             stripProjectDirectory = false;
             result = new RecursionState();
 
-            string fixedDirectoryPart;
-            string wildcardDirectoryPart;
-            string filenamePart;
-            string matchFileExpression;
-            bool needsRecursion;
-            bool isLegalFileSpec;
             GetFileSpecInfo
             (
                 filespecUnescaped,
-                out fixedDirectoryPart,
-                out wildcardDirectoryPart,
-                out filenamePart,
-                out matchFileExpression,
-                out needsRecursion,
-                out isLegalFileSpec
+                out string fixedDirectoryPart,
+                out string wildcardDirectoryPart,
+                out string filenamePart,
+                out string matchFileExpression,
+                out bool needsRecursion,
+                out bool isLegalFileSpec
             );
 
             /*
@@ -2110,7 +2097,7 @@ namespace Microsoft.Build.Shared
             var index = 0;
 
             // preserve meaningful roots and their slashes
-            if (aString.Length >= 2 && IsValidDriveChar(aString[0]) && aString[1] == ':')
+            if (aString.Length >= 2 && aString[1] == ':' && IsValidDriveChar(aString[0]))
             {
                 sb.Append(aString[0]);
                 sb.Append(aString[1]);
@@ -2187,12 +2174,12 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Returns true if the given character is a valid drive letter
         /// </summary>
-        internal static bool IsValidDriveChar(char value)
+        private static bool IsValidDriveChar(char value)
         {
             return (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z');
         }
 
-        static string[] CreateArrayWithSingleItemIfNotExcluded(string filespecUnescaped, List<string> excludeSpecsUnescaped)
+        private static string[] CreateArrayWithSingleItemIfNotExcluded(string filespecUnescaped, List<string> excludeSpecsUnescaped)
         {
             if (excludeSpecsUnescaped != null)
             {
@@ -2235,10 +2222,8 @@ namespace Microsoft.Build.Shared
             /*
              * Analyze the file spec and get the information we need to do the matching.
              */
-            bool stripProjectDirectory;
-            RecursionState state;
             var action = GetFileSearchData(projectDirectoryUnescaped, filespecUnescaped,
-                out stripProjectDirectory, out state);
+                out bool stripProjectDirectory, out RecursionState state);
 
             if (action == SearchAction.ReturnEmptyList)
             {
@@ -2267,11 +2252,8 @@ namespace Microsoft.Build.Shared
                 foreach (string excludeSpec in excludeSpecsUnescaped)
                 {
                     //  This is ignored, we always use the include pattern's value for stripProjectDirectory
-                    bool excludeStripProjectDirectory;
-
-                    RecursionState excludeState;
                     var excludeAction = GetFileSearchData(projectDirectoryUnescaped, excludeSpec,
-                        out excludeStripProjectDirectory, out excludeState);
+                        out _, out RecursionState excludeState);
 
                     if (excludeAction == SearchAction.ReturnFileSpec)
                     {
@@ -2455,7 +2437,6 @@ namespace Microsoft.Build.Shared
             }
 
             bool prefixMatch = possibleChild.StartsWith(possibleParent, StringComparison.OrdinalIgnoreCase);
-
             if (!prefixMatch)
             {
                 return false;

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -524,10 +524,9 @@ namespace Microsoft.Build.UnitTests
             {
                 try
                 {
-                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1, input.Item2, false));
-                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1, input.Item2, true));
-                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1.ToUpperInvariant(), input.Item2, true));
-                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1, input.Item2.ToUpperInvariant(), true));
+                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1, input.Item2));
+                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1.ToUpperInvariant(), input.Item2));
+                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1, input.Item2.ToUpperInvariant()));
                 }
                 catch (Exception)
                 {

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -5,7 +5,6 @@ using Microsoft.Build.Shared;
 using Shouldly;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -542,7 +541,7 @@ namespace Microsoft.Build.UnitTests
          * Simulate Directories.GetFileSystemEntries where file names are short.
          *
          */
-        private static ImmutableArray<string> GetFileSystemEntries(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
+        private static IReadOnlyList<string> GetFileSystemEntries(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
         {
             if
             (
@@ -550,7 +549,7 @@ namespace Microsoft.Build.UnitTests
                 && (@"D:\" == path || @"\\server\share\" == path || path.Length == 0)
             )
             {
-                return ImmutableArray.Create(Path.Combine(path, "LongDirectoryName"));
+                return new string[] { Path.Combine(path, "LongDirectoryName") };
             }
             else if
             (
@@ -558,7 +557,7 @@ namespace Microsoft.Build.UnitTests
                 && (@"D:\LongDirectoryName" == path || @"\\server\share\LongDirectoryName" == path || @"LongDirectoryName" == path)
             )
             {
-                return ImmutableArray.Create(Path.Combine(path, "LongSubDirectory"));
+                return new string[] { Path.Combine(path, "LongSubDirectory") };
             }
             else if
             (
@@ -566,7 +565,7 @@ namespace Microsoft.Build.UnitTests
                 && (@"D:\LongDirectoryName\LongSubDirectory" == path || @"\\server\share\LongDirectoryName\LongSubDirectory" == path || @"LongDirectoryName\LongSubDirectory" == path)
             )
             {
-                return ImmutableArray.Create(Path.Combine(path, "LongFileName.txt"));
+                return new string[] { Path.Combine(path, "LongFileName.txt") };
             }
             else if
             (
@@ -574,7 +573,7 @@ namespace Microsoft.Build.UnitTests
                 && @"c:\apple\banana\tomato" == path
             )
             {
-                return ImmutableArray.Create(Path.Combine(path, "pomegranate"));
+                return new string[] { Path.Combine(path, "pomegranate") };
             }
             else if
             (
@@ -582,14 +581,14 @@ namespace Microsoft.Build.UnitTests
             )
             {
                 // No files exist here. This is an empty directory.
-                return ImmutableArray<string>.Empty;
+                return Array.Empty<string>();
             }
             else
             {
                 Console.WriteLine("GetFileSystemEntries('{0}', '{1}')", path, pattern);
                 Assert.True(false, "Unexpected input into GetFileSystemEntries");
             }
-            return ImmutableArray.Create("<undefined>");
+            return new string[] { "<undefined>" };
         }
 
         private static readonly char S = Path.DirectorySeparatorChar;
@@ -2121,7 +2120,7 @@ namespace Microsoft.Build.UnitTests
             /// <param name="path">The path to search.</param>
             /// <param name="pattern">The pattern to search (may be null)</param>
             /// <returns>The matched files or folders.</returns>
-            internal ImmutableArray<string> GetAccessibleFileSystemEntries(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
+            internal IReadOnlyList<string> GetAccessibleFileSystemEntries(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
             {
                 string normalizedPath = Normalize(path);
 
@@ -2140,7 +2139,7 @@ namespace Microsoft.Build.UnitTests
                     GetMatchingDirectories(_fileSet3, normalizedPath, pattern, files);
                 }
 
-                return files.ToImmutableArray();
+                return files.ToList();
             }
 
             /// <summary>
@@ -2393,9 +2392,9 @@ namespace Microsoft.Build.UnitTests
         /// <param name="path"></param>
         /// <param name="pattern"></param>
         /// <returns>Array of matching file system entries (can be empty).</returns>
-        private static ImmutableArray<string> GetFileSystemEntriesLoopBack(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
+        private static IReadOnlyList<string> GetFileSystemEntriesLoopBack(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
         {
-            return ImmutableArray.Create(Path.Combine(path, pattern));
+            return new string[] { Path.Combine(path, pattern) };
         }
 
         /*************************************************************************************

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -1625,7 +1625,7 @@ namespace Microsoft.Build.UnitTests
             "",
             "",
             "",
-            null,
+            "",
             false,
             false
         )]
@@ -1635,7 +1635,7 @@ namespace Microsoft.Build.UnitTests
             "",
             "",
             "",
-            null,
+            "",
             false,
             false
         )]
@@ -1876,10 +1876,13 @@ namespace Microsoft.Build.UnitTests
                 out string fixedDirectoryPart,
                 out string wildcardDirectoryPart,
                 out string filenamePart,
-                out string matchFileExpression,
                 out bool needsRecursion,
                 out bool isLegalFileSpec
             );
+            string matchFileExpression = isLegalFileSpec
+                ? FileMatcher.RegularExpressionFromFileSpec(fixedDirectoryPart, wildcardDirectoryPart, filenamePart)
+                : string.Empty;
+
             fixedDirectoryPart.ShouldBe(expectedFixedDirectoryPart);
             wildcardDirectoryPart.ShouldBe(expectedWildcardDirectoryPart);
             filenamePart.ShouldBe(expectedFilenamePart);

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -409,6 +409,44 @@ namespace Microsoft.Build.UnitTests
                         ExpectNoMatches = NativeMethodsShared.IsLinux,
                     }
                 };
+
+                // Hits the early elimination of exclude file patterns that do not intersect with the include.
+                // The exclude is redundant and can be eliminated before starting the file system walk.
+                yield return new object[]
+                {
+                    new GetFilesComplexGlobbingMatchingInfo
+                    {
+                        Include = @"src\foo\**\*.cs",
+                        Excludes = new[]
+                        {
+                            @"src\foo\**\foo\**",
+                            @"src\foo\**\*.vb" // redundant exclude
+                        },
+                        ExpectedMatches = new[]
+                        {
+                            @"src\foo\foo.cs",
+                            @"src\foo\inner\foo.cs",
+                            @"src\foo\inner\bar\bar.cs"
+                        },
+                        ExpectNoMatches = NativeMethodsShared.IsLinux,
+                    }
+                };
+
+                // Hits the early elimination of exclude file patterns that do not intersect with the include.
+                // The exclude is not redundant and must not be eliminated.
+                yield return new object[]
+                {
+                    new GetFilesComplexGlobbingMatchingInfo
+                    {
+                        Include = @"src\foo\**\*.cs",
+                        Excludes = new[]
+                        {
+                            @"src\foo\**\*.*" // effective exclude
+                        },
+                        ExpectedMatches = Array.Empty<string>(),
+                        ExpectNoMatches = NativeMethodsShared.IsLinux,
+                    }
+                };
             }
         }
 

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -243,12 +243,12 @@ namespace Microsoft.Build.Tasks
 
             if (_includePatterns.Length > 0)
             {
-                result = _includePatterns.All(pattern => !FileMatcher.IsMatch(FileMatcher.Normalize(zipArchiveEntry.FullName), pattern, true));
+                result = _includePatterns.All(pattern => !FileMatcher.IsMatch(FileMatcher.Normalize(zipArchiveEntry.FullName), pattern));
             }
 
             if (_excludePatterns.Length > 0)
             {
-                result |= _excludePatterns.Any(pattern => FileMatcher.IsMatch(FileMatcher.Normalize(zipArchiveEntry.FullName), pattern, true));
+                result |= _excludePatterns.Any(pattern => FileMatcher.IsMatch(FileMatcher.Normalize(zipArchiveEntry.FullName), pattern));
             }
 
             return result;


### PR DESCRIPTION
Fixes #6069 

### Context
Glob expansion has been identified as one of the performance bottlenecks when building .NET Core projects. The cost is not negligible with a simple Hello World project and gets progressively worse when the project directory (transitively) contains more files, be it source files or completely unrelated files. Since glob expansion is part of project evaluation, it directly impacts Visual Studio performance as well, especially solution load performance.

### Changes Made
This PR is a collection of several changes to the globbing logic aiming to make .NET Core project evaluation faster.

- Refactor, simplify, and micro-optimize hot code paths,
- Eliminate exclude patterns early if it's clear that they don't intersect with the include,
- Optimize most common glob patterns to match without regex (building a typical .NET Core app now does not instantiate a single regex for glob matching),
- Cache the results of all filesystem enumeration calls, not just directories.

### Testing
Existing unit tests for correctness, ETL traces for performance.

Performance:

The wins in terms of the Microsoft-Build/ExpandGlob event duration range from 16% (Hello World project built with `MSBuild.exe`) to 48% (Hello World project with ~4000 files in ~600 folders, all non-.cs and non-.resx, built with `dotnet build`). These numbers were measured with incremental build on the command line, the project was a .NET Core project in all cases, just with a different build engine. Here's a table with all numbers:

Project | MSBuild.exe | dotnet build
--- | --- | ---
Hello World (no extra files) | 16% | 29%
Hello World (4000 extra files) | 35% | 48%

In terms of the overall build time, we're looking at a 1-2% improvement for a Hello World project and 8-10% for a project with thousands of extra files in the source tree.

### Notes
This PR is recommended to be reviewed commit by commit. `FileMatcher` is a complex class and there is non-trivial breaking potential as projects may depend on all kinds of corner case behavior. Which is the primary reason for not rewriting the entire thing. The most impactful change in this PR - caching files to avoid repeated filesystem API calls - is behind a change wave condition, just in case.