### PR TITLE
Introduce TaskParameterEventArgs

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Build.Framework
         public Microsoft.Build.Framework.BuildEventContext BuildEventContext { get { throw null; } set { } }
         public string HelpKeyword { get { throw null; } }
         public virtual string Message { get { throw null; } protected set { } }
+        protected System.DateTime RawTimestamp { get { throw null; } set { } }
         public string SenderName { get { throw null; } }
         public int ThreadId { get { throw null; } }
         public System.DateTime Timestamp { get { throw null; } }
@@ -589,6 +590,22 @@ namespace Microsoft.Build.Framework
         public string TaskName { get { throw null; } }
     }
     public delegate void TaskFinishedEventHandler(object sender, Microsoft.Build.Framework.TaskFinishedEventArgs e);
+    public partial class TaskParameterEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public TaskParameterEventArgs(Microsoft.Build.Framework.TaskParameterMessageKind kind, string itemName, System.Collections.IList items, bool logItemMetadata, System.DateTime eventTimestamp) { }
+        public string ItemName { get { throw null; } }
+        public System.Collections.IList Items { get { throw null; } }
+        public Microsoft.Build.Framework.TaskParameterMessageKind Kind { get { throw null; } }
+        public bool LogItemMetadata { get { throw null; } }
+        public override string Message { get { throw null; } }
+    }
+    public enum TaskParameterMessageKind
+    {
+        TaskInput = 0,
+        TaskOutput = 1,
+        AddItem = 2,
+        RemoveItem = 3,
+    }
     public partial class TaskPropertyInfo
     {
         public TaskPropertyInfo(string name, System.Type typeOfParameter, bool output, bool required) { }

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -592,9 +592,9 @@ namespace Microsoft.Build.Framework
     public delegate void TaskFinishedEventHandler(object sender, Microsoft.Build.Framework.TaskFinishedEventArgs e);
     public partial class TaskParameterEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
-        public TaskParameterEventArgs(Microsoft.Build.Framework.TaskParameterMessageKind kind, string itemName, System.Collections.IList items, bool logItemMetadata, System.DateTime eventTimestamp) { }
-        public string ItemName { get { throw null; } }
+        public TaskParameterEventArgs(Microsoft.Build.Framework.TaskParameterMessageKind kind, string itemType, System.Collections.IList items, bool logItemMetadata, System.DateTime eventTimestamp) { }
         public System.Collections.IList Items { get { throw null; } }
+        public string ItemType { get { throw null; } }
         public Microsoft.Build.Framework.TaskParameterMessageKind Kind { get { throw null; } }
         public bool LogItemMetadata { get { throw null; } }
         public override string Message { get { throw null; } }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Build.Framework
         public Microsoft.Build.Framework.BuildEventContext BuildEventContext { get { throw null; } set { } }
         public string HelpKeyword { get { throw null; } }
         public virtual string Message { get { throw null; } protected set { } }
+        protected System.DateTime RawTimestamp { get { throw null; } set { } }
         public string SenderName { get { throw null; } }
         public int ThreadId { get { throw null; } }
         public System.DateTime Timestamp { get { throw null; } }
@@ -588,6 +589,22 @@ namespace Microsoft.Build.Framework
         public string TaskName { get { throw null; } }
     }
     public delegate void TaskFinishedEventHandler(object sender, Microsoft.Build.Framework.TaskFinishedEventArgs e);
+    public partial class TaskParameterEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public TaskParameterEventArgs(Microsoft.Build.Framework.TaskParameterMessageKind kind, string itemName, System.Collections.IList items, bool logItemMetadata, System.DateTime eventTimestamp) { }
+        public string ItemName { get { throw null; } }
+        public System.Collections.IList Items { get { throw null; } }
+        public Microsoft.Build.Framework.TaskParameterMessageKind Kind { get { throw null; } }
+        public bool LogItemMetadata { get { throw null; } }
+        public override string Message { get { throw null; } }
+    }
+    public enum TaskParameterMessageKind
+    {
+        TaskInput = 0,
+        TaskOutput = 1,
+        AddItem = 2,
+        RemoveItem = 3,
+    }
     public partial class TaskPropertyInfo
     {
         public TaskPropertyInfo(string name, System.Type typeOfParameter, bool output, bool required) { }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -591,9 +591,9 @@ namespace Microsoft.Build.Framework
     public delegate void TaskFinishedEventHandler(object sender, Microsoft.Build.Framework.TaskFinishedEventArgs e);
     public partial class TaskParameterEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
-        public TaskParameterEventArgs(Microsoft.Build.Framework.TaskParameterMessageKind kind, string itemName, System.Collections.IList items, bool logItemMetadata, System.DateTime eventTimestamp) { }
-        public string ItemName { get { throw null; } }
+        public TaskParameterEventArgs(Microsoft.Build.Framework.TaskParameterMessageKind kind, string itemType, System.Collections.IList items, bool logItemMetadata, System.DateTime eventTimestamp) { }
         public System.Collections.IList Items { get { throw null; } }
+        public string ItemType { get { throw null; } }
         public Microsoft.Build.Framework.TaskParameterMessageKind Kind { get { throw null; } }
         public bool LogItemMetadata { get { throw null; } }
         public override string Message { get { throw null; } }

--- a/src/Build.UnitTests/BackEnd/EventSourceSink_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/EventSourceSink_Tests.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Build.UnitTests.Logging
             eventHelper.RaiseBuildEvent(RaiseEventHelper.NormalMessage);
             eventHelper.RaiseBuildEvent(RaiseEventHelper.TaskFinished);
             eventHelper.RaiseBuildEvent(RaiseEventHelper.CommandLine);
+            eventHelper.RaiseBuildEvent(RaiseEventHelper.TaskParameter);
             eventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
             eventHelper.RaiseBuildEvent(RaiseEventHelper.Error);
             eventHelper.RaiseBuildEvent(RaiseEventHelper.TargetStarted);
@@ -99,6 +100,7 @@ namespace Microsoft.Build.UnitTests.Logging
                 RaiseExceptionInEventHandler(RaiseEventHelper.NormalMessage, exception);
                 RaiseExceptionInEventHandler(RaiseEventHelper.TaskFinished, exception);
                 RaiseExceptionInEventHandler(RaiseEventHelper.CommandLine, exception);
+                RaiseExceptionInEventHandler(RaiseEventHelper.TaskParameter, exception);
                 RaiseExceptionInEventHandler(RaiseEventHelper.Warning, exception);
                 RaiseExceptionInEventHandler(RaiseEventHelper.Error, exception);
                 RaiseExceptionInEventHandler(RaiseEventHelper.TargetStarted, exception);
@@ -734,6 +736,11 @@ namespace Microsoft.Build.UnitTests.Logging
             private static TaskCommandLineEventArgs s_taskCommandLine = new TaskCommandLineEventArgs("commandLine", "taskName", MessageImportance.Low);
 
             /// <summary>
+            /// Task Parameter Event
+            /// </summary>
+            private static TaskParameterEventArgs s_taskParameter = new TaskParameterEventArgs(TaskParameterMessageKind.TaskInput, "ItemName", null, true, DateTime.MinValue);
+
+            /// <summary>
             /// Build Warning Event
             /// </summary>
             private static BuildWarningEventArgs s_buildWarning = new BuildWarningEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender")
@@ -882,6 +889,11 @@ namespace Microsoft.Build.UnitTests.Logging
                     return s_taskCommandLine;
                 }
             }
+
+            /// <summary>
+            /// Event which can be raised in multiple tests.
+            /// </summary>
+            internal static TaskParameterEventArgs TaskParameter => s_taskParameter;
 
             /// <summary>
             /// Event which can be raised in multiple tests.

--- a/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Shared;
@@ -44,6 +45,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             TaskStartedEventArgs taskStarted = new TaskStartedEventArgs("message", "help", "projectFile", "taskFile", "taskName");
             TaskFinishedEventArgs taskFinished = new TaskFinishedEventArgs("message", "help", "projectFile", "taskFile", "taskName", true);
             TaskCommandLineEventArgs commandLine = new TaskCommandLineEventArgs("commandLine", "taskName", MessageImportance.Low);
+            TaskParameterEventArgs taskParameter = CreateTaskParameter();
             BuildWarningEventArgs warning = new BuildWarningEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender");
             BuildErrorEventArgs error = new BuildErrorEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender");
             TargetStartedEventArgs targetStarted = new TargetStartedEventArgs("message", "help", "targetName", "ProjectFile", "targetFile");
@@ -58,6 +60,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             VerifyLoggingPacket(taskStarted, LoggingEventType.TaskStartedEvent);
             VerifyLoggingPacket(taskFinished, LoggingEventType.TaskFinishedEvent);
             VerifyLoggingPacket(commandLine, LoggingEventType.TaskCommandLineEvent);
+            VerifyLoggingPacket(taskParameter, LoggingEventType.TaskParameterEvent);
             VerifyLoggingPacket(warning, LoggingEventType.BuildWarningEvent);
             VerifyLoggingPacket(error, LoggingEventType.BuildErrorEvent);
             VerifyLoggingPacket(targetStarted, LoggingEventType.TargetStartedEvent);
@@ -67,12 +70,41 @@ namespace Microsoft.Build.UnitTests.BackEnd
             VerifyLoggingPacket(externalStartedEvent, LoggingEventType.CustomEvent);
         }
 
+        private static TaskParameterEventArgs CreateTaskParameter()
+        {
+            var items = new TaskItemData[]
+            {
+                new TaskItemData("ItemSpec1", null),
+                new TaskItemData("ItemSpec2", Enumerable.Range(1,3).ToDictionary(i => i.ToString(), i => i.ToString() + "value"))
+            };
+            var result = new TaskParameterEventArgs(
+                TaskParameterMessageKind.TaskInput,
+                "ItemName",
+                items,
+                logItemMetadata: true,
+                DateTime.MinValue);
+
+            // normalize line endings as we can't rely on the line endings of NodePackets_Tests.cs
+            Assert.Equal(@"Task Parameter:
+    ItemName=
+        ItemSpec1
+        ItemSpec2
+                1=1value
+                2=2value
+                3=3value".Replace("\r\n", "\n"), result.Message);
+
+            return result;
+        }
+
         /// <summary>
         /// Tests serialization of LogMessagePacket with each kind of event type.
         /// </summary>
         [Fact]
         public void TestTranslation()
         {
+            // need to touch the type so that the static constructor runs
+            _ = ItemGroupLoggingHelper.OutputItemParameterMessagePrefix;
+
             TaskItem item = new TaskItem("Hello", "my.proj");
             List<TaskItem> targetOutputs = new List<TaskItem>();
             targetOutputs.Add(item);
@@ -88,6 +120,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     new TaskStartedEventArgs("message", "help", "projectFile", "taskFile", "taskName"),
                     new TaskFinishedEventArgs("message", "help", "projectFile", "taskFile", "taskName", true),
                     new TaskCommandLineEventArgs("commandLine", "taskName", MessageImportance.Low),
+                    CreateTaskParameter(),
                     new BuildWarningEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender"),
                     new BuildErrorEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender"),
                     new TargetStartedEventArgs("message", "help", "targetName", "ProjectFile", "targetFile"),
@@ -279,6 +312,19 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     Assert.Equal(leftCommand.CommandLine, rightCommand.CommandLine);
                     Assert.Equal(leftCommand.Importance, rightCommand.Importance);
                     Assert.Equal(leftCommand.TaskName, rightCommand.TaskName);
+                    break;
+
+                case LoggingEventType.TaskParameterEvent:
+                    var leftTaskParameter = left.NodeBuildEvent.Value.Value as TaskParameterEventArgs;
+                    var rightTaskParameter = right.NodeBuildEvent.Value.Value as TaskParameterEventArgs;
+                    Assert.NotNull(leftTaskParameter);
+                    Assert.NotNull(rightTaskParameter);
+                    Assert.Equal(leftTaskParameter.Kind, rightTaskParameter.Kind);
+                    Assert.Equal(leftTaskParameter.ItemName, rightTaskParameter.ItemName);
+                    Assert.Equal(leftTaskParameter.Items.Count, rightTaskParameter.Items.Count);
+                    Assert.Equal(leftTaskParameter.Message, rightTaskParameter.Message);
+                    Assert.Equal(leftTaskParameter.BuildEventContext, rightTaskParameter.BuildEventContext);
+                    Assert.Equal(leftTaskParameter.Timestamp, rightTaskParameter.Timestamp);
                     break;
 
                 case LoggingEventType.TaskFinishedEvent:

--- a/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     Assert.NotNull(leftTaskParameter);
                     Assert.NotNull(rightTaskParameter);
                     Assert.Equal(leftTaskParameter.Kind, rightTaskParameter.Kind);
-                    Assert.Equal(leftTaskParameter.ItemName, rightTaskParameter.ItemName);
+                    Assert.Equal(leftTaskParameter.ItemType, rightTaskParameter.ItemType);
                     Assert.Equal(leftTaskParameter.Items.Count, rightTaskParameter.Items.Count);
                     Assert.Equal(leftTaskParameter.Message, rightTaskParameter.Message);
                     Assert.Equal(leftTaskParameter.BuildEventContext, rightTaskParameter.BuildEventContext);

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -340,7 +340,7 @@ namespace Microsoft.Build.UnitTests
 
             Roundtrip(args,
                 e => e.Kind.ToString(),
-                e => e.ItemName,
+                e => e.ItemType,
                 e => e.LogItemMetadata.ToString(),
                 e => GetItemsString(e.Items));
         }

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.Logging;
@@ -70,19 +71,37 @@ namespace Microsoft.Build.UnitTests
                 toolsVersion: "Current");
             args.BuildEventContext = new BuildEventContext(1, 2, 3, 4, 5, 6);
 
-            Roundtrip(args,
+            Roundtrip<ProjectStartedEventArgs>(args,
                 e => ToString(e.BuildEventContext),
                 e => ToString(e.GlobalProperties),
-                e => ToString(e.Items.OfType<DictionaryEntry>().ToDictionary(d => d.Key.ToString(), d => ((ITaskItem)d.Value).ItemSpec)),
+                e => GetItemsString(e.Items),
                 e => e.Message,
                 e => ToString(e.ParentProjectBuildEventContext),
                 e => e.ProjectFile,
                 e => e.ProjectId.ToString(),
-                e => ToString(e.Properties.OfType<DictionaryEntry>().ToDictionary(d => d.Key.ToString(), d => d.Value.ToString())),
+                e => ToString(e.Properties.OfType<DictionaryEntry>().ToDictionary((Func<DictionaryEntry, string>)(d => d.Key.ToString()), (Func<DictionaryEntry, string>)(d => d.Value.ToString()))),
                 e => e.TargetNames,
                 e => e.ThreadId.ToString(),
                 e => e.Timestamp.ToString(),
                 e => e.ToolsVersion);
+        }
+
+        private string GetItemsString(IEnumerable items)
+        {
+            return ToString(items.OfType<DictionaryEntry>().ToDictionary(d => d.Key.ToString(), d => GetTaskItemString((ITaskItem)d.Value)));
+        }
+
+        private string GetTaskItemString(ITaskItem taskItem)
+        {
+            var sb = new StringBuilder();
+            sb.Append(taskItem.ItemSpec);
+            foreach (string name in taskItem.MetadataNames)
+            {
+                var value = taskItem.GetMetadata(name);
+                sb.Append($";{name}={value}");
+            }
+
+            return sb.ToString();
         }
 
         [Fact]
@@ -307,6 +326,23 @@ namespace Microsoft.Build.UnitTests
                 e => e.Message,
                 e => e.ProjectFile,
                 e => e.Subcategory);
+        }
+
+        [Fact]
+        public void RoundtripTaskParameterEventArgs()
+        {
+            var items = new TaskItemData[]
+            {
+                new TaskItemData("ItemSpec1", null),
+                new TaskItemData("ItemSpec2", Enumerable.Range(1,3).ToDictionary(i => i.ToString(), i => i.ToString() + "value"))
+            };
+            var args = new TaskParameterEventArgs(TaskParameterMessageKind.TaskOutput, "ItemName", items, true, DateTime.MinValue);
+
+            Roundtrip(args,
+                e => e.Kind.ToString(),
+                e => e.ItemName,
+                e => e.LogItemMetadata.ToString(),
+                e => GetItemsString(e.Items));
         }
 
         [Fact]

--- a/src/Build.UnitTests/ConfigureableForwardingLogger_Tests.cs
+++ b/src/Build.UnitTests/ConfigureableForwardingLogger_Tests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
@@ -20,6 +21,7 @@ namespace Microsoft.Build.UnitTests
         private readonly TaskStartedEventArgs _taskStarted = new TaskStartedEventArgs("message", "help", "projectFile", "taskFile", "taskName");
         private readonly TaskFinishedEventArgs _taskFinished = new TaskFinishedEventArgs("message", "help", "projectFile", "taskFile", "taskName", true);
         private readonly TaskCommandLineEventArgs _commandLine = new TaskCommandLineEventArgs("commandLine", "taskName", MessageImportance.Low);
+        private readonly TaskParameterEventArgs _taskParameter = new TaskParameterEventArgs(TaskParameterMessageKind.TaskInput, "ItemName", null, true, DateTime.MinValue);
         private readonly BuildWarningEventArgs _warning = new BuildWarningEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender");
         private readonly BuildErrorEventArgs _error = new BuildErrorEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender");
         private readonly TargetStartedEventArgs _targetStarted = new TargetStartedEventArgs("message", "help", "targetName", "ProjectFile", "targetFile");
@@ -131,6 +133,7 @@ namespace Microsoft.Build.UnitTests
                         _normalMessage,
                         _highMessage,
                         _commandLine,
+                        _taskParameter,
                         _warning,
                         _error,
                         _taskFinished,
@@ -150,6 +153,7 @@ namespace Microsoft.Build.UnitTests
                         _normalMessage,
                         _highMessage,
                         _commandLine,
+                        _taskParameter,
                         _externalStartedEvent,
                         _warning,
                         _error,
@@ -266,6 +270,7 @@ namespace Microsoft.Build.UnitTests
             source.Consume(_normalMessage);
             source.Consume(_highMessage);
             source.Consume(_commandLine);
+            source.Consume(_taskParameter);
             source.Consume(_externalStartedEvent);
             source.Consume(_warning);
             source.Consume(_error);

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -285,6 +285,10 @@ namespace Microsoft.Build.BackEnd.Logging
                 CreateLoggingEventQueue();
             }
 
+            // Ensure the static constructor of ItemGroupLoggingHelper runs.
+            // It is important to ensure the Message delegate on TaskParameterEventArgs is set.
+            _ = ItemGroupLoggingHelper.ItemGroupIncludeLogMessagePrefix;
+
             _serviceState = LoggingServiceState.Instantiated;
         }
 

--- a/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
@@ -138,6 +138,11 @@ namespace Microsoft.Build.BackEnd.Logging
                 _backingItems = backingItems;
             }
 
+            // For performance reasons we need to expose the raw items to BinaryLogger
+            // as we know we're not going to mutate anything. This allows us to bypass DeepClone
+            // for each item
+            internal IEnumerable<TaskItem> BackingItems => _backingItems;
+
             /// <summary>
             /// Returns an enumerator that provides copies of the items
             /// in the backing store.

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -213,12 +213,12 @@ namespace Microsoft.Build.BackEnd
 
             if (LogTaskInputs && !LoggingContext.LoggingService.OnlyLogCriticalEvents && itemsToAdd?.Count > 0)
             {
-                var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
-                    ItemGroupLoggingHelper.ItemGroupIncludeLogMessagePrefix,
+                ItemGroupLoggingHelper.LogTaskParameter(
+                    LoggingContext,
+                    TaskParameterMessageKind.AddItem,
                     child.ItemType,
                     itemsToAdd,
                     logItemMetadata: true);
-                LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
             }
 
             // Now add the items we created to the lookup.
@@ -256,12 +256,12 @@ namespace Microsoft.Build.BackEnd
             {
                 if (LogTaskInputs && !LoggingContext.LoggingService.OnlyLogCriticalEvents && itemsToRemove.Count > 0)
                 {
-                    var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
-                        ItemGroupLoggingHelper.ItemGroupRemoveLogMessage,
+                    ItemGroupLoggingHelper.LogTaskParameter(
+                        LoggingContext,
+                        TaskParameterMessageKind.RemoveItem,
                         child.ItemType,
                         itemsToRemove,
                         logItemMetadata: true);
-                    LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
                 }
 
                 bucket.Lookup.RemoveItems(itemsToRemove);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
@@ -30,6 +32,17 @@ namespace Microsoft.Build.BackEnd
         internal static string ItemGroupRemoveLogMessage = ResourceUtilities.GetResourceString("ItemGroupRemoveLogMessage");
         internal static string OutputItemParameterMessagePrefix = ResourceUtilities.GetResourceString("OutputItemParameterMessagePrefix");
         internal static string TaskParameterPrefix = ResourceUtilities.GetResourceString("TaskParameterPrefix");
+
+        /// <summary>
+        /// <see cref="TaskParameterEventArgs"/> by itself doesn't have the implementation
+        /// to materialize the Message as that's a declaration assembly. We inject the logic
+        /// here.
+        /// </summary>
+        static ItemGroupLoggingHelper()
+        {
+            TaskParameterEventArgs.MessageGetter = GetTaskParameterText;
+            TaskParameterEventArgs.DictionaryFactory = SmallDictionary<string, string>.Create;
+        }
 
         /// <summary>
         /// Gets a text serialized value of a parameter for logging.
@@ -202,6 +215,57 @@ namespace Microsoft.Build.BackEnd
             {
                 ErrorUtilities.ThrowInternalErrorUnreachable();
             }
+        }
+
+        internal static void LogTaskParameter(
+            LoggingContext loggingContext,
+            TaskParameterMessageKind messageKind,
+            string itemName,
+            IList items,
+            bool logItemMetadata)
+        {
+            var args = CreateTaskParameterEventArgs(loggingContext.BuildEventContext, messageKind, itemName, items, logItemMetadata, DateTime.UtcNow);
+            loggingContext.LogBuildEvent(args);
+        }
+
+        internal static TaskParameterEventArgs CreateTaskParameterEventArgs(
+            BuildEventContext buildEventContext,
+            TaskParameterMessageKind messageKind,
+            string itemName,
+            IList items,
+            bool logItemMetadata,
+            DateTime timestamp)
+        {
+            var args = new TaskParameterEventArgs(
+                messageKind,
+                itemName,
+                items,
+                logItemMetadata,
+                timestamp);
+            args.BuildEventContext = buildEventContext;
+            return args;
+        }
+
+        internal static string GetTaskParameterText(TaskParameterEventArgs args)
+            => GetTaskParameterText(args.Kind, args.ItemName, args.Items, args.LogItemMetadata);
+
+        internal static string GetTaskParameterText(TaskParameterMessageKind messageKind, string itemName, IList items, bool logItemMetadata)
+        {
+            var resourceText = messageKind switch
+            {
+                TaskParameterMessageKind.AddItem => ItemGroupIncludeLogMessagePrefix,
+                TaskParameterMessageKind.RemoveItem => ItemGroupRemoveLogMessage,
+                TaskParameterMessageKind.TaskInput => TaskParameterPrefix,
+                TaskParameterMessageKind.TaskOutput => OutputItemParameterMessagePrefix,
+                _ => throw new NotImplementedException($"Unsupported {nameof(TaskParameterMessageKind)} value: {messageKind}")
+            };
+
+            var itemGroupText = GetParameterText(
+                resourceText,
+                itemName,
+                items,
+                logItemMetadata);
+            return itemGroupText;
         }
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.BackEnd
         static ItemGroupLoggingHelper()
         {
             TaskParameterEventArgs.MessageGetter = GetTaskParameterText;
-            TaskParameterEventArgs.DictionaryFactory = SmallDictionary<string, string>.Create;
+            TaskParameterEventArgs.DictionaryFactory = ArrayDictionary<string, string>.Create;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -220,25 +220,31 @@ namespace Microsoft.Build.BackEnd
         internal static void LogTaskParameter(
             LoggingContext loggingContext,
             TaskParameterMessageKind messageKind,
-            string itemName,
+            string itemType,
             IList items,
             bool logItemMetadata)
         {
-            var args = CreateTaskParameterEventArgs(loggingContext.BuildEventContext, messageKind, itemName, items, logItemMetadata, DateTime.UtcNow);
+            var args = CreateTaskParameterEventArgs(
+                loggingContext.BuildEventContext,
+                messageKind,
+                itemType,
+                items,
+                logItemMetadata,
+                DateTime.UtcNow);
             loggingContext.LogBuildEvent(args);
         }
 
         internal static TaskParameterEventArgs CreateTaskParameterEventArgs(
             BuildEventContext buildEventContext,
             TaskParameterMessageKind messageKind,
-            string itemName,
+            string itemType,
             IList items,
             bool logItemMetadata,
             DateTime timestamp)
         {
             var args = new TaskParameterEventArgs(
                 messageKind,
-                itemName,
+                itemType,
                 items,
                 logItemMetadata,
                 timestamp);
@@ -247,9 +253,9 @@ namespace Microsoft.Build.BackEnd
         }
 
         internal static string GetTaskParameterText(TaskParameterEventArgs args)
-            => GetTaskParameterText(args.Kind, args.ItemName, args.Items, args.LogItemMetadata);
+            => GetTaskParameterText(args.Kind, args.ItemType, args.Items, args.LogItemMetadata);
 
-        internal static string GetTaskParameterText(TaskParameterMessageKind messageKind, string itemName, IList items, bool logItemMetadata)
+        internal static string GetTaskParameterText(TaskParameterMessageKind messageKind, string itemType, IList items, bool logItemMetadata)
         {
             var resourceText = messageKind switch
             {
@@ -262,7 +268,7 @@ namespace Microsoft.Build.BackEnd
 
             var itemGroupText = GetParameterText(
                 resourceText,
-                itemName,
+                itemType,
                 items,
                 logItemMetadata);
             return itemGroupText;

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1333,12 +1333,12 @@ namespace Microsoft.Build.BackEnd
                 parameterValue.Count > 0 &&
                 parameter.Log)
             {
-                string parameterText = ItemGroupLoggingHelper.GetParameterText(
-                    ItemGroupLoggingHelper.TaskParameterPrefix,
+                ItemGroupLoggingHelper.LogTaskParameter(
+                    _taskLoggingContext,
+                    TaskParameterMessageKind.TaskInput,
                     parameter.Name,
                     parameterValue,
                     parameter.LogItemMetadata);
-                _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
             }
 
             return InternalSetTaskParameter(parameter, (object)parameterValue);
@@ -1426,11 +1426,16 @@ namespace Microsoft.Build.BackEnd
             {
                 if (outputTargetIsItem)
                 {
+                    // Only count non-null elements. We sometimes have a single-element array where the element is null
+                    bool hasElements = false;
+
                     foreach (ITaskItem output in outputs)
                     {
                         // if individual items in the array are null, ignore them
                         if (output != null)
                         {
+                            hasElements = true;
+
                             ProjectItemInstance newItem;
 
                             TaskItem outputAsProjectItem = output as TaskItem;
@@ -1474,15 +1479,14 @@ namespace Microsoft.Build.BackEnd
                         }
                     }
 
-                    if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0 && parameter.Log)
+                    if (hasElements && LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && parameter.Log)
                     {
-                        string parameterText = ItemGroupLoggingHelper.GetParameterText(
-                            ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
+                        ItemGroupLoggingHelper.LogTaskParameter(
+                            _taskLoggingContext,
+                            TaskParameterMessageKind.TaskOutput,
                             outputTargetName,
                             outputs,
                             parameter.LogItemMetadata);
-
-                        _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
                 }
                 else
@@ -1553,12 +1557,12 @@ namespace Microsoft.Build.BackEnd
 
                     if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0 && parameter.Log)
                     {
-                        string parameterText = ItemGroupLoggingHelper.GetParameterText(
-                            ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
+                        ItemGroupLoggingHelper.LogTaskParameter(
+                            _taskLoggingContext,
+                            TaskParameterMessageKind.TaskOutput,
                             outputTargetName,
                             outputs,
                             parameter.LogItemMetadata);
-                        _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
                 }
                 else

--- a/src/Build/Collections/ArrayDictionary.cs
+++ b/src/Build/Collections/ArrayDictionary.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -5,20 +8,21 @@ using System.Collections.Generic;
 namespace Microsoft.Build.Collections
 {
     /// <summary>
-    /// Small, lightweight, read-only IDictionary implementation using two arrays
-    /// and O(n) lookup. Requires specifying capacity at construction and does not
+    /// Lightweight, read-only IDictionary implementation using two arrays
+    /// and O(n) lookup.
+    /// Requires specifying capacity at construction and does not
     /// support reallocation to increase capacity.
     /// </summary>
     /// <typeparam name="TKey">Type of keys</typeparam>
     /// <typeparam name="TValue">Type of values</typeparam>
-    internal class SmallDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary
+    internal class ArrayDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary
     {
         private TKey[] keys;
         private TValue[] values;
 
         private int count;
 
-        public SmallDictionary(int capacity)
+        public ArrayDictionary(int capacity)
         {
             keys = new TKey[capacity];
             values = new TValue[capacity];
@@ -26,7 +30,7 @@ namespace Microsoft.Build.Collections
 
         public static IDictionary<TKey, TValue> Create(int capacity)
         {
-            return new SmallDictionary<TKey, TValue>(capacity);
+            return new ArrayDictionary<TKey, TValue>(capacity);
         }
 
         public TValue this[TKey key]
@@ -91,7 +95,7 @@ namespace Microsoft.Build.Collections
             }
             else
             {
-                throw new InvalidOperationException($"SmallDictionary is at capacity {keys.Length}");
+                throw new InvalidOperationException($"ArrayDictionary is at capacity {keys.Length}");
             }
         }
 
@@ -212,11 +216,11 @@ namespace Microsoft.Build.Collections
 
         private struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator
         {
-            private readonly SmallDictionary<TKey, TValue> _dictionary;
+            private readonly ArrayDictionary<TKey, TValue> _dictionary;
             private readonly bool _emitDictionaryEntries;
             private int _position;
 
-            public Enumerator(SmallDictionary<TKey, TValue> dictionary, bool emitDictionaryEntries = false)
+            public Enumerator(ArrayDictionary<TKey, TValue> dictionary, bool emitDictionaryEntries = false)
             {
                 this._dictionary = dictionary;
                 this._position = -1;

--- a/src/Build/Collections/SmallDictionary.cs
+++ b/src/Build/Collections/SmallDictionary.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Collections
+{
+    /// <summary>
+    /// Small, lightweight, read-only IDictionary implementation using two arrays
+    /// and O(n) lookup. Requires specifying capacity at construction and does not
+    /// support reallocation to increase capacity.
+    /// </summary>
+    /// <typeparam name="TKey">Type of keys</typeparam>
+    /// <typeparam name="TValue">Type of values</typeparam>
+    internal class SmallDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary
+    {
+        private TKey[] keys;
+        private TValue[] values;
+
+        private int count;
+
+        public SmallDictionary(int capacity)
+        {
+            keys = new TKey[capacity];
+            values = new TValue[capacity];
+        }
+
+        public static IDictionary<TKey, TValue> Create(int capacity)
+        {
+            return new SmallDictionary<TKey, TValue>(capacity);
+        }
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                TryGetValue(key, out var value);
+                return value;
+            }
+
+            set
+            {
+                var comparer = KeyComparer;
+                for (int i = 0; i < count; i++)
+                {
+                    if (comparer.Equals(key, keys[i]))
+                    {
+                        values[i] = value;
+                        return;
+                    }
+                }
+
+                Add(key, value);
+            }
+        }
+
+        object IDictionary.this[object key]
+        {
+            get => this[(TKey)key];
+            set => this[(TKey)key] = (TValue)value;
+        }
+
+        public ICollection<TKey> Keys => keys;
+
+        ICollection IDictionary.Keys => keys;
+
+        public ICollection<TValue> Values => values;
+
+        ICollection IDictionary.Values => values;
+
+        private IEqualityComparer<TKey> KeyComparer => EqualityComparer<TKey>.Default;
+
+        private IEqualityComparer<TValue> ValueComparer => EqualityComparer<TValue>.Default;
+
+        public int Count => count;
+
+        public bool IsReadOnly => true;
+
+        bool IDictionary.IsFixedSize => true;
+
+        object ICollection.SyncRoot => this;
+
+        bool ICollection.IsSynchronized => false;
+
+        public void Add(TKey key, TValue value)
+        {
+            if (count < keys.Length)
+            {
+                keys[count] = key;
+                values[count] = value;
+                count += 1;
+            }
+            else
+            {
+                throw new InvalidOperationException($"SmallDictionary is at capacity {keys.Length}");
+            }
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        public void Clear()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            var keyComparer = KeyComparer;
+            var valueComparer = ValueComparer;
+            for (int i = 0; i < count; i++)
+            {
+                if (keyComparer.Equals(item.Key, keys[i]) && valueComparer.Equals(item.Value, values[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            var comparer = KeyComparer;
+            for (int i = 0; i < count; i++)
+            {
+                if (comparer.Equals(key, keys[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                array[arrayIndex + i] = new KeyValuePair<TKey, TValue>(keys[i], values[i]);
+            }
+        }
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+        {
+            return new Enumerator(this, emitDictionaryEntries: true);
+        }
+
+        public bool Remove(TKey key)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            var comparer = KeyComparer;
+            for (int i = 0; i < count; i++)
+            {
+                if (comparer.Equals(key, keys[i]))
+                {
+                    value = values[i];
+                    return true;
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        bool IDictionary.Contains(object key)
+        {
+            if (key is not TKey typedKey)
+            {
+                return false;
+            }
+
+            return ContainsKey(typedKey);
+        }
+
+        void IDictionary.Add(object key, object value)
+        {
+            if (key is TKey typedKey && value is TValue typedValue)
+            {
+                Add(typedKey, typedValue);
+            }
+
+            throw new NotSupportedException();
+        }
+
+        void IDictionary.Remove(object key)
+        {
+            throw new NotImplementedException();
+        }
+
+        private struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator
+        {
+            private readonly SmallDictionary<TKey, TValue> _dictionary;
+            private readonly bool _emitDictionaryEntries;
+            private int _position;
+
+            public Enumerator(SmallDictionary<TKey, TValue> dictionary, bool emitDictionaryEntries = false)
+            {
+                this._dictionary = dictionary;
+                this._position = -1;
+                this._emitDictionaryEntries = emitDictionaryEntries;
+            }
+
+            public KeyValuePair<TKey, TValue> Current =>
+                new KeyValuePair<TKey, TValue>(
+                    _dictionary.keys[_position],
+                    _dictionary.values[_position]);
+
+            private DictionaryEntry CurrentDictionaryEntry => new DictionaryEntry(_dictionary.keys[_position], _dictionary.values[_position]);
+
+            object IEnumerator.Current => _emitDictionaryEntries ? CurrentDictionaryEntry : Current;
+
+            object IDictionaryEnumerator.Key => _dictionary.keys[_position];
+
+            object IDictionaryEnumerator.Value => _dictionary.values[_position];
+
+            DictionaryEntry IDictionaryEnumerator.Entry => CurrentDictionaryEntry;
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                _position += 1;
+                return _position < _dictionary.Count;
+            }
+
+            public void Reset()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -28,7 +28,13 @@ namespace Microsoft.Build.Execution
     /// and evaluation has already been performed, so it is unnecessary bulk.
     /// </remarks>
     [DebuggerDisplay("{ItemType}={EvaluatedInclude} #DirectMetadata={DirectMetadataCount})")]
-    public class ProjectItemInstance : IItem<ProjectMetadataInstance>, ITaskItem2, IMetadataTable, ITranslatable, IDeepCloneable<ProjectItemInstance>
+    public class ProjectItemInstance :
+        IItem<ProjectMetadataInstance>,
+        ITaskItem2,
+        IMetadataTable,
+        ITranslatable,
+        IDeepCloneable<ProjectItemInstance>,
+        IMetadataContainer
     {
         /// <summary>
         /// The project instance to which this item belongs.
@@ -515,6 +521,8 @@ namespace Microsoft.Build.Execution
             return ((ITaskItem2)_taskItem).CloneCustomMetadataEscaped();
         }
 
+        IEnumerable<KeyValuePair<string, string>> IMetadataContainer.Metadata => _taskItem.Metadata;
+
         #region IMetadataTable Members
 
         /// <summary>
@@ -723,7 +731,11 @@ namespace Microsoft.Build.Execution
 #if FEATURE_APPDOMAIN
             MarshalByRefObject,
 #endif
-            ITaskItem2, IItem<ProjectMetadataInstance>, ITranslatable, IEquatable<TaskItem>
+            ITaskItem2,
+            IItem<ProjectMetadataInstance>,
+            ITranslatable,
+            IEquatable<TaskItem>,
+            IMetadataContainer
         {
             /// <summary>
             /// The source file that defined this item.
@@ -1043,6 +1055,39 @@ namespace Microsoft.Build.Execution
             internal int DirectMetadataCount
             {
                 get { return (_directMetadata == null) ? 0 : _directMetadata.Count; }
+            }
+
+            /// <summary>
+            /// Efficient way to retrieve metadata used by packet serialization
+            /// and binary logger.
+            /// </summary>
+            public IEnumerable<KeyValuePair<string, string>> Metadata
+            {
+                get
+                {
+                    // If we have item definitions, call the expensive property that does the right thing.
+                    // Otherwise use _directMetadata to avoid allocations caused by DeepClone().
+                    var list = _itemDefinitions != null ? MetadataCollection : _directMetadata;
+                    if (list != null)
+                    {
+                        return EnumerateMetadata(list);
+                    }
+                    else
+                    {
+                        return Array.Empty<KeyValuePair<string, string>>();
+                    }
+                }
+            }
+
+            private IEnumerable<KeyValuePair<string, string>> EnumerateMetadata(CopyOnWritePropertyDictionary<ProjectMetadataInstance> list)
+            {
+                foreach (var projectMetadataInstance in list)
+                {
+                    if (projectMetadataInstance != null)
+                    {
+                        yield return new KeyValuePair<string, string>(projectMetadataInstance.Name, projectMetadataInstance.EvaluatedValue);
+                    }
+                }
             }
 
             /// <summary>

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -521,7 +521,7 @@ namespace Microsoft.Build.Execution
             return ((ITaskItem2)_taskItem).CloneCustomMetadataEscaped();
         }
 
-        IEnumerable<KeyValuePair<string, string>> IMetadataContainer.Metadata => _taskItem.Metadata;
+        IEnumerable<KeyValuePair<string, string>> IMetadataContainer.EnumerateMetadata() => _taskItem.EnumerateMetadata();
 
         #region IMetadataTable Members
 
@@ -1061,21 +1061,18 @@ namespace Microsoft.Build.Execution
             /// Efficient way to retrieve metadata used by packet serialization
             /// and binary logger.
             /// </summary>
-            public IEnumerable<KeyValuePair<string, string>> Metadata
+            public IEnumerable<KeyValuePair<string, string>> EnumerateMetadata()
             {
-                get
+                // If we have item definitions, call the expensive property that does the right thing.
+                // Otherwise use _directMetadata to avoid allocations caused by DeepClone().
+                var list = _itemDefinitions != null ? MetadataCollection : _directMetadata;
+                if (list != null)
                 {
-                    // If we have item definitions, call the expensive property that does the right thing.
-                    // Otherwise use _directMetadata to avoid allocations caused by DeepClone().
-                    var list = _itemDefinitions != null ? MetadataCollection : _directMetadata;
-                    if (list != null)
-                    {
-                        return EnumerateMetadata(list);
-                    }
-                    else
-                    {
-                        return Array.Empty<KeyValuePair<string, string>>();
-                    }
+                    return EnumerateMetadata(list);
+                }
+                else
+                {
+                    return Array.Empty<KeyValuePair<string, string>>();
                 }
             }
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -27,5 +27,6 @@
         PropertyInitialValueSet,
         NameValueList,
         String,
+        TaskParameter
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Compression;
 using System.Threading;
+using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -14,6 +15,14 @@ namespace Microsoft.Build.Logging
     /// <remarks>The class is public so that we can call it from MSBuild.exe when replaying a log file.</remarks>
     public sealed class BinaryLogReplayEventSource : EventArgsDispatcher
     {
+        /// Touches the <see cref="ItemGroupLoggingHelper"/> static constructor
+        /// to ensure it initializes <see cref="TaskParameterEventArgs.MessageGetter"/>
+        /// and <see cref="TaskParameterEventArgs.DictionaryFactory"/>
+        static BinaryLogReplayEventSource()
+        {
+            _ = ItemGroupLoggingHelper.ItemGroupIncludeLogMessagePrefix;
+        }
+
         /// <summary>
         /// Read the provided binary log file and raise corresponding events for each BuildEventArgs
         /// </summary>

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -41,7 +41,9 @@ namespace Microsoft.Build.Logging
         //      * NameValueList - deduplicate arrays of name-value pairs such as properties, items and metadata
         //                        in a separate record and refer to those records from regular records
         //                        where a list used to be written in-place
-        internal const int FileFormatVersion = 10;
+        // version 11:
+        //   - new record kind: TaskParameterEventArgs
+        internal const int FileFormatVersion = 11;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -4,8 +4,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Logging
 {
@@ -29,6 +32,8 @@ namespace Microsoft.Build.Logging
         /// <summary>
         /// A list of dictionaries we've encountered so far. Dictionaries are referred to by their order in this list.
         /// </summary>
+        /// <remarks>This is designed to not hold on to strings. We just store the string indices and
+        /// hydrate the dictionary on demand before returning.</remarks>
         private readonly List<(int keyIndex, int valueIndex)[]> nameValueListRecords = new List<(int, int)[]>();
 
         /// <summary>
@@ -146,6 +151,9 @@ namespace Microsoft.Build.Logging
                 case BinaryLogRecordKind.TaskCommandLine:
                     result = ReadTaskCommandLineEventArgs();
                     break;
+                case BinaryLogRecordKind.TaskParameter:
+                    result = ReadTaskParameterEventArgs();
+                    break;
                 case BinaryLogRecordKind.ProjectEvaluationStarted:
                     result = ReadProjectEvaluationStartedEventArgs();
                     break;
@@ -215,14 +223,17 @@ namespace Microsoft.Build.Logging
             {
                 var list = nameValueListRecords[id];
 
-                var dictionary = new Dictionary<string, string>(list.Length);
+                // We can't cache these as they would hold on to strings.
+                // This reader is designed to not hold onto strings,
+                // so that we can fit in a 32-bit process when reading huge binlogs
+                var dictionary = SmallDictionary<string, string>.Create(list.Length);
                 for (int i = 0; i < list.Length; i++)
                 {
                     string key = GetStringFromRecord(list[i].keyIndex);
                     string value = GetStringFromRecord(list[i].valueIndex);
                     if (key != null)
                     {
-                        dictionary[key] = value;
+                        dictionary.Add(key, value);
                     }
                 }
 
@@ -596,6 +607,27 @@ namespace Microsoft.Build.Logging
             return e;
         }
 
+        private BuildEventArgs ReadTaskParameterEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            // Read unused Importance, it defaults to Low
+            ReadInt32();
+
+            var kind = (TaskParameterMessageKind)ReadInt32();
+            var itemName = ReadDeduplicatedString();
+            var items = ReadTaskItemList() as IList;
+
+            var e = ItemGroupLoggingHelper.CreateTaskParameterEventArgs(
+                fields.BuildEventContext,
+                kind,
+                itemName,
+                items,
+                true,
+                fields.Timestamp);
+            e.ProjectFile = fields.ProjectFile;
+            return e;
+        }
+
         private BuildEventArgs ReadCriticalBuildMessageEventArgs()
         {
             var fields = ReadBuildEventArgsFields();
@@ -896,65 +928,12 @@ namespace Microsoft.Build.Logging
             return result;
         }
 
-        private class TaskItem : ITaskItem
-        {
-            private static readonly Dictionary<string, string> emptyMetadata = new Dictionary<string, string>();
-
-            public string ItemSpec { get; set; }
-            public IDictionary<string, string> Metadata { get; }
-
-            public TaskItem()
-            {
-                Metadata = new Dictionary<string, string>();
-            }
-
-            public TaskItem(string itemSpec, IDictionary<string, string> metadata)
-            {
-                ItemSpec = itemSpec;
-                Metadata = metadata ?? emptyMetadata;
-            }
-
-            public int MetadataCount => Metadata.Count;
-
-            public ICollection MetadataNames => (ICollection)Metadata.Keys;
-
-            public IDictionary CloneCustomMetadata()
-            {
-                return (IDictionary)Metadata;
-            }
-
-            public void CopyMetadataTo(ITaskItem destinationItem)
-            {
-                throw new NotImplementedException();
-            }
-
-            public string GetMetadata(string metadataName)
-            {
-                return Metadata[metadataName];
-            }
-
-            public void RemoveMetadata(string metadataName)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void SetMetadata(string metadataName, string metadataValue)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override string ToString()
-            {
-                return $"{ItemSpec} Metadata: {MetadataCount}";
-            }
-        }
-
         private ITaskItem ReadTaskItem()
         {
             string itemSpec = ReadDeduplicatedString();
             var metadata = ReadStringDictionary();
 
-            var taskItem = new TaskItem(itemSpec, metadata);
+            var taskItem = new TaskItemData(itemSpec, metadata);
             return taskItem;
         }
 
@@ -1079,7 +1058,10 @@ namespace Microsoft.Build.Logging
 
         private int ReadInt32()
         {
-            return Read7BitEncodedInt(binaryReader);
+            // on some platforms (net5) this method was added to BinaryReader
+            // but it's not available on others. Call our own extension method
+            // explicitly to avoid ambiguity.
+            return BinaryReaderExtensions.Read7BitEncodedInt(binaryReader);
         }
 
         private long ReadInt64()
@@ -1100,30 +1082,6 @@ namespace Microsoft.Build.Logging
         private TimeSpan ReadTimeSpan()
         {
             return new TimeSpan(binaryReader.ReadInt64());
-        }
-
-        private int Read7BitEncodedInt(BinaryReader reader)
-        {
-            // Read out an Int32 7 bits at a time.  The high bit
-            // of the byte when on means to continue reading more bytes.
-            int count = 0;
-            int shift = 0;
-            byte b;
-            do
-            {
-                // Check for a corrupted stream.  Read a max of 5 bytes.
-                // In a future version, add a DataFormatException.
-                if (shift == 5 * 7)  // 5 bytes max per Int32, shift += 7
-                {
-                    throw new FormatException();
-                }
-
-                // ReadByte handles end of stream cases for us.
-                b = reader.ReadByte();
-                count |= (b & 0x7F) << shift;
-                shift += 7;
-            } while ((b & 0x80) != 0);
-            return count;
         }
 
         private ProfiledLocation ReadProfiledLocation()

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -226,7 +229,7 @@ namespace Microsoft.Build.Logging
                 // We can't cache these as they would hold on to strings.
                 // This reader is designed to not hold onto strings,
                 // so that we can fit in a 32-bit process when reading huge binlogs
-                var dictionary = SmallDictionary<string, string>.Create(list.Length);
+                var dictionary = ArrayDictionary<string, string>.Create(list.Length);
                 for (int i = 0; i < list.Length; i++)
                 {
                     string key = GetStringFromRecord(list[i].keyIndex);

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -521,7 +521,7 @@ namespace Microsoft.Build.Logging
             Write(BinaryLogRecordKind.TaskParameter);
             WriteMessageFields(e, writeMessage: false);
             Write((int)e.Kind);
-            WriteDeduplicatedString(e.ItemName);
+            WriteDeduplicatedString(e.ItemType);
             WriteTaskItemList(e.Items, e.LogItemMetadata);
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -134,71 +134,33 @@ namespace Microsoft.Build.Logging
 
         private void WriteCore(BuildEventArgs e)
         {
-            // the cases are ordered by most used first for performance
-            if (e is BuildMessageEventArgs buildMessage)
+            switch (e)
             {
-                Write(buildMessage);
-            }
-            else if (e is TaskStartedEventArgs taskStarted)
-            {
-                Write(taskStarted);
-            }
-            else if (e is TaskFinishedEventArgs taskFinished)
-            {
-                Write(taskFinished);
-            }
-            else if (e is TargetStartedEventArgs targetStarted)
-            {
-                Write(targetStarted);
-            }
-            else if (e is TargetFinishedEventArgs targetFinished)
-            {
-                Write(targetFinished);
-            }
-            else if (e is BuildErrorEventArgs buildError)
-            {
-                Write(buildError);
-            }
-            else if (e is BuildWarningEventArgs buildWarning)
-            {
-                Write(buildWarning);
-            }
-            else if (e is ProjectStartedEventArgs projectStarted)
-            {
-                Write(projectStarted);
-            }
-            else if (e is ProjectFinishedEventArgs projectFinished)
-            {
-                Write(projectFinished);
-            }
-            else if (e is BuildStartedEventArgs buildStarted)
-            {
-                Write(buildStarted);
-            }
-            else if (e is BuildFinishedEventArgs buildFinished)
-            {
-                Write(buildFinished);
-            }
-            else if (e is ProjectEvaluationStartedEventArgs projectEvaluationStarted)
-            {
-                Write(projectEvaluationStarted);
-            }
-            else if (e is ProjectEvaluationFinishedEventArgs projectEvaluationFinished)
-            {
-                Write(projectEvaluationFinished);
-            }
-            else
-            {
-                // convert all unrecognized objects to message
-                // and just preserve the message
-                var buildMessageEventArgs = new BuildMessageEventArgs(
-                    e.Message,
-                    e.HelpKeyword,
-                    e.SenderName,
-                    MessageImportance.Normal,
-                    e.Timestamp);
-                buildMessageEventArgs.BuildEventContext = e.BuildEventContext ?? BuildEventContext.Invalid;
-                Write(buildMessageEventArgs);
+                case BuildMessageEventArgs buildMessage: Write(buildMessage); break;
+                case TaskStartedEventArgs taskStarted: Write(taskStarted); break;
+                case TaskFinishedEventArgs taskFinished: Write(taskFinished); break;
+                case TargetStartedEventArgs targetStarted: Write(targetStarted); break;
+                case TargetFinishedEventArgs targetFinished: Write(targetFinished); break;
+                case BuildErrorEventArgs buildError: Write(buildError); break;
+                case BuildWarningEventArgs buildWarning: Write(buildWarning); break;
+                case ProjectStartedEventArgs projectStarted: Write(projectStarted); break;
+                case ProjectFinishedEventArgs projectFinished: Write(projectFinished); break;
+                case BuildStartedEventArgs buildStarted: Write(buildStarted); break;
+                case BuildFinishedEventArgs buildFinished: Write(buildFinished); break;
+                case ProjectEvaluationStartedEventArgs projectEvaluationStarted: Write(projectEvaluationStarted); break;
+                case ProjectEvaluationFinishedEventArgs projectEvaluationFinished: Write(projectEvaluationFinished); break;
+                default:
+                    // convert all unrecognized objects to message
+                    // and just preserve the message
+                    var buildMessageEventArgs = new BuildMessageEventArgs(
+                        e.Message,
+                        e.HelpKeyword,
+                        e.SenderName,
+                        MessageImportance.Normal,
+                        e.Timestamp);
+                    buildMessageEventArgs.BuildEventContext = e.BuildEventContext ?? BuildEventContext.Invalid;
+                    Write(buildMessageEventArgs);
+                    break;
             }
         }
 

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -375,6 +375,7 @@
     <Compile Include="Collections\ReadOnlyConvertingDictionary.cs" />
     <!-- ######################## -->
     <Compile Include="Collections\WeakValueDictionary.cs" />
+    <Compile Include="Collections\SmallDictionary.cs" />
     <!-- #### CONSTRUCTION MODEL ### -->
     <Compile Include="Construction\ProjectElement.cs" />
     <Compile Include="Construction\ProjectElementContainer.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -375,7 +375,7 @@
     <Compile Include="Collections\ReadOnlyConvertingDictionary.cs" />
     <!-- ######################## -->
     <Compile Include="Collections\WeakValueDictionary.cs" />
-    <Compile Include="Collections\SmallDictionary.cs" />
+    <Compile Include="Collections\ArrayDictionary.cs" />
     <!-- #### CONSTRUCTION MODEL ### -->
     <Compile Include="Construction\ProjectElement.cs" />
     <Compile Include="Construction\ProjectElementContainer.cs" />

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -112,6 +112,17 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
+        /// Exposes the private <see cref="timestamp"/> field to derived types.
+        /// Used for serialization. Avoids the side effects of calling the
+        /// <see cref="Timestamp"/> getter.
+        /// </summary>
+        protected DateTime RawTimestamp
+        {
+            get => timestamp;
+            set => timestamp = value;
+        }
+
+        /// <summary>
         /// The thread that raised event.  
         /// </summary>
         public int ThreadId => threadId;
@@ -155,24 +166,8 @@ namespace Microsoft.Build.Framework
             writer.WriteOptionalString(helpKeyword);
             writer.WriteOptionalString(senderName);
             writer.WriteTimestamp(timestamp);
-
-            writer.Write((Int32)threadId);
-
-            if (buildEventContext == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write((Int32)buildEventContext.NodeId);
-                writer.Write((Int32)buildEventContext.ProjectContextId);
-                writer.Write((Int32)buildEventContext.TargetId);
-                writer.Write((Int32)buildEventContext.TaskId);
-                writer.Write((Int32)buildEventContext.SubmissionId);
-                writer.Write((Int32)buildEventContext.ProjectInstanceId);
-                writer.Write((Int32)buildEventContext.EvaluationId);
-            }
+            writer.Write(threadId);
+            writer.WriteOptionalBuildEventContext(buildEventContext);
         }
 
         /// <summary>
@@ -182,9 +177,9 @@ namespace Microsoft.Build.Framework
         /// <param name="version">The version of the runtime the message packet was created from</param>
         internal virtual void CreateFromStream(BinaryReader reader, int version)
         {
-            message = reader.ReadByte() == 0 ? null : reader.ReadString();
-            helpKeyword = reader.ReadByte() == 0 ? null : reader.ReadString();
-            senderName = reader.ReadByte() == 0 ? null : reader.ReadString();
+            message = reader.ReadOptionalString();
+            helpKeyword = reader.ReadOptionalString();
+            senderName = reader.ReadOptionalString();
 
             long timestampTicks = reader.ReadInt64();
 

--- a/src/Framework/IMetadataContainer.cs
+++ b/src/Framework/IMetadataContainer.cs
@@ -17,6 +17,6 @@ namespace Microsoft.Build.Framework
         /// is used for serialization (in node packet translator) as well as
         /// in the binary logger.
         /// </summary>
-        IEnumerable<KeyValuePair<string, string>> Metadata { get; }
+        IEnumerable<KeyValuePair<string, string>> EnumerateMetadata();
     }
 }

--- a/src/Framework/IMetadataContainer.cs
+++ b/src/Framework/IMetadataContainer.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Provides a way to efficiently enumerate item metadata
+    /// </summary>
+    internal interface IMetadataContainer
+    {
+        /// <summary>
+        /// Returns a list of metadata names and unescaped values, including
+        /// metadata from item definition groups, but not including built-in
+        /// metadata. Implementations should be low-overhead as the method
+        /// is used for serialization (in node packet translator) as well as
+        /// in the binary logger.
+        /// </summary>
+        IEnumerable<KeyValuePair<string, string>> Metadata { get; }
+    }
+}

--- a/src/Framework/ITaskItemExtensions.cs
+++ b/src/Framework/ITaskItemExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Framework
             if (taskItem is IMetadataContainer container)
             {
                 // This is the common case: most implementations should implement this for quick access
-                return container.Metadata;
+                return container.EnumerateMetadata();
             }
 
             // This runs if ITaskItem is Microsoft.Build.Utilities.TaskItem from Microsoft.Build.Utilities.v4.0.dll

--- a/src/Framework/ITaskItemExtensions.cs
+++ b/src/Framework/ITaskItemExtensions.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Build.Framework
+{
+    internal static class ITaskItemExtensions
+    {
+        /// <summary>
+        /// Provides a way to efficiently enumerate custom metadata of an item, without built-in metadata.
+        /// </summary>
+        /// <param name="taskItem">TaskItem implementation to return metadata from</param>
+        /// <remarks>WARNING: do NOT use List`1.AddRange to iterate over this collection.
+        /// CopyOnWriteDictionary from Microsoft.Build.Utilities.v4.0.dll is broken.</remarks>
+        /// <returns>A non-null (but possibly empty) enumerable of item metadata.</returns>
+        public static IEnumerable<KeyValuePair<string, string>> EnumerateMetadata(this ITaskItem taskItem)
+        {
+            if (taskItem is IMetadataContainer container)
+            {
+                // This is the common case: most implementations should implement this for quick access
+                return container.Metadata;
+            }
+
+            // This runs if ITaskItem is Microsoft.Build.Utilities.TaskItem from Microsoft.Build.Utilities.v4.0.dll
+            // that is loaded from the GAC.
+            IDictionary customMetadata = taskItem.CloneCustomMetadata();
+            if (customMetadata is IEnumerable<KeyValuePair<string, string>> enumerableMetadata)
+            {
+                return enumerableMetadata;
+            }
+
+            // In theory this should never be reachable.
+            var list = new KeyValuePair<string, string>[customMetadata.Count];
+            int i = 0;
+
+            foreach (string metadataName in customMetadata.Keys)
+            {
+                string valueOrError;
+
+                try
+                {
+                    valueOrError = taskItem.GetMetadata(metadataName);
+                }
+                // Temporarily try catch all to mitigate frequent NullReferenceExceptions in
+                // the logging code until CopyOnWritePropertyDictionary is replaced with
+                // ImmutableDictionary. Calling into Debug.Fail to crash the process in case
+                // the exception occurres in Debug builds.
+                catch (Exception e)
+                {
+                    valueOrError = e.Message;
+                    Debug.Fail(e.ToString());
+                }
+
+                list[i] = new KeyValuePair<string, string>(metadataName, valueOrError);
+                i += 1;
+            }
+
+            return list;
+        }
+    }
+}

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -8,9 +8,6 @@
     <IncludeSatelliteOutputInPack>false</IncludeSatelliteOutputInPack>
     <ApplyNgenOptimization Condition="'$(TargetFramework)' == '$(FullFrameworkTFM)'">partial</ApplyNgenOptimization>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="BinaryWriterExtensions.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Security.Permissions" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
@@ -20,6 +17,9 @@
   <ItemGroup>
     <Compile Include="..\Shared\Constants.cs">
       <Link>Shared\Constants.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\BinaryReaderExtensions.cs">
+      <Link>Shared\BinaryReaderExtensions.cs</Link>
     </Compile>
     <Compile Include="..\Shared\BinaryWriterExtensions.cs">
       <Link>Shared\BinaryWriterExtensions.cs</Link>

--- a/src/Framework/TaskItemData.cs
+++ b/src/Framework/TaskItemData.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.Build.Framework
 {
     /// <summary>
-    /// Lightweight specialized implementation of ITaskItem only used for deserializing items.
+    /// Lightweight specialized implementation of <see cref="ITaskItem"/> only used for deserializing items.
     /// The goal is to minimize overhead when representing deserialized items.
     /// Used by node packet translator and binary logger.
     /// </summary>

--- a/src/Framework/TaskItemData.cs
+++ b/src/Framework/TaskItemData.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Lightweight specialized implementation of ITaskItem only used for deserializing items.
+    /// The goal is to minimize overhead when representing deserialized items.
+    /// Used by node packet translator and binary logger.
+    /// </summary>
+    internal class TaskItemData : ITaskItem, IMetadataContainer
+    {
+        private static readonly Dictionary<string, string> _emptyMetadata = new Dictionary<string, string>();
+
+        public string ItemSpec { get; set; }
+        public IDictionary<string, string> Metadata { get; }
+
+        public TaskItemData(string itemSpec, IDictionary<string, string> metadata)
+        {
+            ItemSpec = itemSpec;
+            Metadata = metadata ?? _emptyMetadata;
+        }
+
+        IEnumerable<KeyValuePair<string, string>> IMetadataContainer.Metadata => Metadata;
+
+        public int MetadataCount => Metadata.Count;
+
+        public ICollection MetadataNames => (ICollection)Metadata.Keys;
+
+        public IDictionary CloneCustomMetadata()
+        {
+            // against the guidance for CloneCustomMetadata this returns the original collection.
+            // Since this is only to be used for serialization and logging, consumers should not
+            // modify the collection. We need to minimize allocations so avoid cloning here.
+            return (IDictionary)Metadata;
+        }
+
+        public void CopyMetadataTo(ITaskItem destinationItem)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetMetadata(string metadataName)
+        {
+            Metadata.TryGetValue(metadataName, out var result);
+            return result;
+        }
+
+        public void RemoveMetadata(string metadataName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetMetadata(string metadataName, string metadataValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ToString()
+        {
+            return $"{ItemSpec} Metadata: {MetadataCount}";
+        }
+    }
+}

--- a/src/Framework/TaskItemData.cs
+++ b/src/Framework/TaskItemData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -25,7 +25,7 @@ namespace Microsoft.Build.Framework
             Metadata = metadata ?? _emptyMetadata;
         }
 
-        IEnumerable<KeyValuePair<string, string>> IMetadataContainer.Metadata => Metadata;
+        IEnumerable<KeyValuePair<string, string>> IMetadataContainer.EnumerateMetadata() => Metadata;
 
         public int MetadataCount => Metadata.Count;
 

--- a/src/Framework/TaskParameterEventArgs.cs
+++ b/src/Framework/TaskParameterEventArgs.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Framework
+{
+    public enum TaskParameterMessageKind
+    {
+        TaskInput,
+        TaskOutput,
+        AddItem,
+        RemoveItem,
+    }
+
+    /// <summary>
+    /// This class is used by tasks to log their parameters (input, output).
+    /// The intrinsic ItemGroupIntrinsicTask to add or remove items also
+    /// uses this class.
+    /// </summary>
+    public class TaskParameterEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Creates an instance of this class for the given task parameter.
+        /// </summary>
+        public TaskParameterEventArgs
+        (
+            TaskParameterMessageKind kind,
+            string itemName,
+            IList items,
+            bool logItemMetadata,
+            DateTime eventTimestamp
+        )
+            : base(null, null, null, MessageImportance.Low, eventTimestamp)
+        {
+            Kind = kind;
+            ItemName = itemName;
+            Items = items;
+            LogItemMetadata = logItemMetadata;
+        }
+
+        public TaskParameterMessageKind Kind { get; private set; }
+        public string ItemName { get; private set; }
+        public IList Items { get; private set; }
+        public bool LogItemMetadata { get; private set; }
+
+        /// <summary>
+        /// The <see cref="TaskParameterEventArgs"/> type is declared in Microsoft.Build.Framework.dll
+        /// which is a declarations assembly. The logic to realize the Message is in Microsoft.Build.dll
+        /// which is an implementations assembly. This seems like the easiest way to inject the
+        /// implementation for realizing the Message.
+        /// </summary>
+        /// <remarks>Note that the current implementation never runs and is provided merely
+        /// as a safeguard in case MessageGetter isn't set for some reason.</remarks>
+        internal static Func<TaskParameterEventArgs, string> MessageGetter = args =>
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{args.Kind}: {args.ItemName}");
+            foreach (var item in args.Items)
+            {
+                sb.AppendLine(item.ToString());
+            }
+
+            return sb.ToString();
+        };
+
+        /// <summary>
+        /// Provides a way for Microsoft.Build.dll to provide a more efficient dictionary factory
+        /// (using SmallDictionary`2). Since that is an implementation detail, it is not included
+        /// in Microsoft.Build.Framework.dll so we need this extensibility point here.
+        /// </summary>
+        internal static Func<int, IDictionary<string, string>> DictionaryFactory = capacity => new Dictionary<string, string>(capacity);
+
+        internal override void CreateFromStream(BinaryReader reader, int version)
+        {
+            RawTimestamp = reader.ReadTimestamp();
+            BuildEventContext = reader.ReadOptionalBuildEventContext();
+            Kind = (TaskParameterMessageKind)reader.Read7BitEncodedInt();
+            ItemName = reader.ReadString();
+            Items = ReadItems(reader);
+        }
+
+        private IList ReadItems(BinaryReader reader)
+        {
+            var list = new ArrayList();
+
+            int count = reader.Read7BitEncodedInt();
+            for (int i = 0; i < count; i++)
+            {
+                var item = ReadItem(reader);
+                list.Add(item);
+            }
+
+            return list;
+        }
+
+        private object ReadItem(BinaryReader reader)
+        {
+            string itemSpec = reader.ReadString();
+            int metadataCount = reader.Read7BitEncodedInt();
+            if (metadataCount == 0)
+            {
+                return new TaskItemData(itemSpec, metadata: null);
+            }
+
+            var metadata = DictionaryFactory(metadataCount);
+            for (int i = 0; i < metadataCount; i++)
+            {
+                string key = reader.ReadString();
+                string value = reader.ReadString();
+                if (key != null)
+                {
+                    metadata.Add(key, value);
+                }
+            }
+
+            var taskItem = new TaskItemData(itemSpec, metadata);
+            return taskItem;
+        }
+
+        internal override void WriteToStream(BinaryWriter writer)
+        {
+            writer.WriteTimestamp(RawTimestamp);
+            writer.WriteOptionalBuildEventContext(BuildEventContext);
+            writer.Write7BitEncodedInt((int)Kind);
+            writer.Write(ItemName);
+            WriteItems(writer, Items);
+        }
+
+        private void WriteItems(BinaryWriter writer, IList items)
+        {
+            if (items == null)
+            {
+                writer.Write7BitEncodedInt(0);
+                return;
+            }
+
+            int count = items.Count;
+            writer.Write7BitEncodedInt(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                var item = items[i];
+                WriteItem(writer, item);
+            }
+        }
+
+        private void WriteItem(BinaryWriter writer, object item)
+        {
+            if (item is ITaskItem taskItem)
+            {
+                writer.Write(taskItem.ItemSpec);
+                if (LogItemMetadata)
+                {
+                    WriteMetadata(writer, taskItem);
+                }
+                else
+                {
+                    writer.Write7BitEncodedInt(0);
+                }
+            }
+            else // string or ValueType
+            {
+                writer.Write(item?.ToString() ?? "");
+                writer.Write7BitEncodedInt(0);
+            }
+        }
+
+        [ThreadStatic]
+        private static List<KeyValuePair<string, string>> reusableMetadataList;
+
+        private void WriteMetadata(BinaryWriter writer, ITaskItem taskItem)
+        {
+            if (reusableMetadataList == null)
+            {
+                reusableMetadataList = new List<KeyValuePair<string, string>>();
+            }
+
+            // WARNING: Can't use AddRange here because CopyOnWriteDictionary in Microsoft.Build.Utilities.v4.0.dll
+            // is broken. Microsoft.Build.Utilities.v4.0.dll loads from the GAC by XAML markup tooling and it's
+            // implementation doesn't work with AddRange because AddRange special-cases ICollection<T> and
+            // CopyOnWriteDictionary doesn't implement it properly.
+            foreach (var kvp in taskItem.EnumerateMetadata())
+            {
+                reusableMetadataList.Add(kvp);
+            }
+
+            writer.Write7BitEncodedInt(reusableMetadataList.Count);
+            if (reusableMetadataList.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var kvp in reusableMetadataList)
+            {
+                writer.Write(kvp.Key);
+                writer.Write(kvp.Value);
+            }
+
+            reusableMetadataList.Clear();
+        }
+
+        public override string Message
+        {
+            get
+            {
+                lock (this)
+                {
+                    if (base.Message == null)
+                    {
+                        base.Message = MessageGetter(this);
+                    }
+
+                    return base.Message;
+                }
+            }
+        }
+    }
+}

--- a/src/Framework/TaskParameterEventArgs.cs
+++ b/src/Framework/TaskParameterEventArgs.cs
@@ -56,8 +56,10 @@ namespace Microsoft.Build.Framework
         /// which is an implementations assembly. This seems like the easiest way to inject the
         /// implementation for realizing the Message.
         /// </summary>
-        /// <remarks>Note that the current implementation never runs and is provided merely
-        /// as a safeguard in case MessageGetter isn't set for some reason.</remarks>
+        /// <remarks>
+        /// Note that the current implementation never runs and is provided merely
+        /// as a safeguard in case MessageGetter isn't set for some reason.
+        /// </remarks>
         internal static Func<TaskParameterEventArgs, string> MessageGetter = args =>
         {
             var sb = new StringBuilder();

--- a/src/Framework/TaskParameterEventArgs.cs
+++ b/src/Framework/TaskParameterEventArgs.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Framework
         public TaskParameterEventArgs
         (
             TaskParameterMessageKind kind,
-            string itemName,
+            string itemType,
             IList items,
             bool logItemMetadata,
             DateTime eventTimestamp
@@ -40,13 +40,13 @@ namespace Microsoft.Build.Framework
             : base(null, null, null, MessageImportance.Low, eventTimestamp)
         {
             Kind = kind;
-            ItemName = itemName;
+            ItemType = itemType;
             Items = items;
             LogItemMetadata = logItemMetadata;
         }
 
         public TaskParameterMessageKind Kind { get; private set; }
-        public string ItemName { get; private set; }
+        public string ItemType { get; private set; }
         public IList Items { get; private set; }
         public bool LogItemMetadata { get; private set; }
 
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Framework
         internal static Func<TaskParameterEventArgs, string> MessageGetter = args =>
         {
             var sb = new StringBuilder();
-            sb.AppendLine($"{args.Kind}: {args.ItemName}");
+            sb.AppendLine($"{args.Kind}: {args.ItemType}");
             foreach (var item in args.Items)
             {
                 sb.AppendLine(item.ToString());
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Framework
             RawTimestamp = reader.ReadTimestamp();
             BuildEventContext = reader.ReadOptionalBuildEventContext();
             Kind = (TaskParameterMessageKind)reader.Read7BitEncodedInt();
-            ItemName = reader.ReadString();
+            ItemType = reader.ReadString();
             Items = ReadItems(reader);
         }
 
@@ -129,7 +129,7 @@ namespace Microsoft.Build.Framework
             writer.WriteTimestamp(RawTimestamp);
             writer.WriteOptionalBuildEventContext(BuildEventContext);
             writer.Write7BitEncodedInt((int)Kind);
-            writer.Write(ItemName);
+            writer.Write(ItemType);
             WriteItems(writer, Items);
         }
 

--- a/src/Framework/TaskParameterEventArgs.cs
+++ b/src/Framework/TaskParameterEventArgs.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Build.Framework
 
         /// <summary>
         /// Provides a way for Microsoft.Build.dll to provide a more efficient dictionary factory
-        /// (using SmallDictionary`2). Since that is an implementation detail, it is not included
+        /// (using ArrayDictionary`2). Since that is an implementation detail, it is not included
         /// in Microsoft.Build.Framework.dll so we need this extensibility point here.
         /// </summary>
         internal static Func<int, IDictionary<string, string>> DictionaryFactory = capacity => new Dictionary<string, string>(capacity);

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -16,7 +16,7 @@
     <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
     
     <EnableDefaultItems>false</EnableDefaultItems>
-    <DefineConstants>$(DefineConstants);CLR2COMPATIBILITY</DefineConstants>
+    <DefineConstants>$(DefineConstants);CLR2COMPATIBILITY;TASKHOST</DefineConstants>
     <!-- Need pointers for getting environment block -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- It is vital that msbuildtaskhost.exe is allowed to use the full 4GB on 64 bit machines in order to help avoid 

--- a/src/Shared/BinaryReaderExtensions.cs
+++ b/src/Shared/BinaryReaderExtensions.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Shared
+{
+    internal static class BinaryReaderExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string ReadOptionalString(this BinaryReader reader)
+        {
+            return reader.ReadByte() == 0 ? null : reader.ReadString();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Read7BitEncodedInt(this BinaryReader reader)
+        {
+            // Read out an Int32 7 bits at a time.  The high bit
+            // of the byte when on means to continue reading more bytes.
+            int count = 0;
+            int shift = 0;
+            byte b;
+            do
+            {
+                // Check for a corrupted stream.  Read a max of 5 bytes.
+                // In a future version, add a DataFormatException.
+                if (shift == 5 * 7)  // 5 bytes max per Int32, shift += 7
+                {
+                    throw new FormatException();
+                }
+
+                // ReadByte handles end of stream cases for us.
+                b = reader.ReadByte();
+                count |= (b & 0x7F) << shift;
+                shift += 7;
+            } while ((b & 0x80) != 0);
+            return count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DateTime ReadTimestamp(this BinaryReader reader)
+        {
+            long timestampTicks = reader.ReadInt64();
+            DateTimeKind kind = (DateTimeKind)reader.ReadInt32();
+            var timestamp = new DateTime(timestampTicks, kind);
+            return timestamp;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static BuildEventContext ReadOptionalBuildEventContext(this BinaryReader reader)
+        {
+            if (reader.ReadByte() == 0)
+            {
+                return null;
+            }
+
+            return reader.ReadBuildEventContext();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static BuildEventContext ReadBuildEventContext(this BinaryReader reader)
+        {
+            int nodeId = reader.ReadInt32();
+            int projectContextId = reader.ReadInt32();
+            int targetId = reader.ReadInt32();
+            int taskId = reader.ReadInt32();
+            int submissionId = reader.ReadInt32();
+            int projectInstanceId = reader.ReadInt32();
+            int evaluationId = reader.ReadInt32();
+
+            var buildEventContext = new BuildEventContext(submissionId, nodeId, evaluationId, projectInstanceId, projectContextId, targetId, taskId);
+            return buildEventContext;
+        }
+    }
+}

--- a/src/Shared/BinaryWriterExtensions.cs
+++ b/src/Shared/BinaryWriterExtensions.cs
@@ -1,6 +1,10 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Shared
 {
@@ -23,8 +27,49 @@ namespace Microsoft.Build.Shared
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteTimestamp(this BinaryWriter writer, DateTime timestamp)
         {
-            writer.Write((Int64)timestamp.Ticks);
+            writer.Write(timestamp.Ticks);
             writer.Write((Int32)timestamp.Kind);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Write7BitEncodedInt(this BinaryWriter writer, int value)
+        {
+            // Write out an int 7 bits at a time.  The high bit of the byte,
+            // when on, tells reader to continue reading more bytes.
+            uint v = (uint)value;   // support negative numbers
+            while (v >= 0x80)
+            {
+                writer.Write((byte)(v | 0x80));
+                v >>= 7;
+            }
+
+            writer.Write((byte)v);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteOptionalBuildEventContext(this BinaryWriter writer, BuildEventContext context)
+        {
+            if (context == null)
+            {
+                writer.Write((byte)0);
+            }
+            else
+            {
+                writer.Write((byte)1);
+                writer.WriteBuildEventContext(context);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteBuildEventContext(this BinaryWriter writer, BuildEventContext context)
+        {
+            writer.Write(context.NodeId);
+            writer.Write(context.ProjectContextId);
+            writer.Write(context.TargetId);
+            writer.Write(context.TaskId);
+            writer.Write(context.SubmissionId);
+            writer.Write(context.ProjectInstanceId);
+            writer.Write(context.EvaluationId);
         }
     }
 }

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -89,7 +89,12 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Event is a TaskCommandLineEventArgs
         /// </summary>
-        TaskCommandLineEvent = 12
+        TaskCommandLineEvent = 12,
+
+        /// <summary>
+        /// Event is a TaskParameterEventArgs
+        /// </summary>
+        TaskParameterEvent = 13,
     }
     #endregion
 
@@ -485,6 +490,10 @@ namespace Microsoft.Build.Shared
                     return new TaskFinishedEventArgs(null, null, null, null, null, false);
                 case LoggingEventType.TaskCommandLineEvent:
                     return new TaskCommandLineEventArgs(null, null, MessageImportance.Normal);
+#if !TASKHOST // MSBuildTaskHost is targeting Microsoft.Build.Framework.dll 3.5
+                case LoggingEventType.TaskParameterEvent:
+                    return new TaskParameterEventArgs(0, null, null, true, default);
+#endif
                 default:
                     ErrorUtilities.VerifyThrow(false, "Should not get to the default of GetBuildEventArgFromId ID: " + _eventType);
                     return null;
@@ -509,6 +518,12 @@ namespace Microsoft.Build.Shared
             {
                 return LoggingEventType.TaskCommandLineEvent;
             }
+#if !TASKHOST
+            else if (eventType == typeof(TaskParameterEventArgs))
+            {
+                return LoggingEventType.TaskParameterEvent;
+            }
+#endif
             else if (eventType == typeof(ProjectFinishedEventArgs))
             {
                 return LoggingEventType.ProjectFinishedEvent;

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -757,20 +757,17 @@ namespace Microsoft.Build.BackEnd
                 return clonedDictionary;
             }
 
-            public IEnumerable<KeyValuePair<string, string>> Metadata
+            public IEnumerable<KeyValuePair<string, string>> EnumerateMetadata()
             {
-                get
+                if (_customEscapedMetadata == null)
                 {
-                    if (_customEscapedMetadata == null)
-                    {
-                        yield break;
-                    }
+                    yield break;
+                }
 
-                    foreach (var kvp in _customEscapedMetadata)
-                    {
-                        var unescaped = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
-                        yield return unescaped;
-                    }
+                foreach (var kvp in _customEscapedMetadata)
+                {
+                    var unescaped = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
+                    yield return unescaped;
                 }
             }
         }

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -5,10 +5,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
 using System.Security;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-using System.Reflection;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -492,7 +493,11 @@ namespace Microsoft.Build.BackEnd
 #if FEATURE_APPDOMAIN
             MarshalByRefObject,
 #endif
-            ITaskItem, ITaskItem2
+            ITaskItem,
+            ITaskItem2
+#if !TASKHOST
+            ,IMetadataContainer
+#endif
         {
             /// <summary>
             /// The item spec 
@@ -750,6 +755,23 @@ namespace Microsoft.Build.BackEnd
             {
                 IDictionary clonedDictionary = new Dictionary<string, string>(_customEscapedMetadata);
                 return clonedDictionary;
+            }
+
+            public IEnumerable<KeyValuePair<string, string>> Metadata
+            {
+                get
+                {
+                    if (_customEscapedMetadata == null)
+                    {
+                        yield break;
+                    }
+
+                    foreach (var kvp in _customEscapedMetadata)
+                    {
+                        var unescaped = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
+                        yield return unescaped;
+                    }
+                }
             }
         }
     }

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -463,20 +463,17 @@ namespace Microsoft.Build.Utilities
 
         #endregion
 
-        IEnumerable<KeyValuePair<string, string>> IMetadataContainer.Metadata
+        IEnumerable<KeyValuePair<string, string>> IMetadataContainer.EnumerateMetadata()
         {
-            get
+            if (_metadata == null)
             {
-                if (_metadata == null)
-                {
-                    yield break;
-                }
+                yield break;
+            }
 
-                foreach (var kvp in _metadata)
-                {
-                    var unescaped = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
-                    yield return unescaped;
-                }
+            foreach (var kvp in _metadata)
+            {
+                var unescaped = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
+                yield return unescaped;
             }
         }
     }

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security;
 #if FEATURE_SECURITY_PERMISSIONS
 using System.Security.Permissions;
@@ -30,7 +31,8 @@ namespace Microsoft.Build.Utilities
 #if FEATURE_APPDOMAIN
         MarshalByRefObject,
 #endif
-        ITaskItem2
+        ITaskItem2,
+        IMetadataContainer // expose direct underlying metadata for fast access in binary logger
     {
         #region Member Data
 
@@ -460,5 +462,22 @@ namespace Microsoft.Build.Utilities
             : _metadata.Clone();
 
         #endregion
+
+        IEnumerable<KeyValuePair<string, string>> IMetadataContainer.Metadata
+        {
+            get
+            {
+                if (_metadata == null)
+                {
+                    yield break;
+                }
+
+                foreach (var kvp in _metadata)
+                {
+                    var unescaped = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
+                    yield return unescaped;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Instead of just logging a BuildMessageEventArgs with a list of all items and metadata concatenated into a large string (often 5 MB in size or more) it keeps a structured representation of items and metadata. TaskParameterEventArgs inherits from BuildMessageEventArgs and the Message implementation materializes the large string on demand. However when only the BinaryLogger is present the Message is never accessed, thus saving on allocations. The Message is also never sent across the nodes nor written into the binlog.

TaskParameterEventArgs is instantiated in 5 locations: ItemGroup Include and Remove inside targets, task inputs, and two cases for task outputs.

Storing smaller strings in the binlog results in very significant savings from string deduplication. A 22 MB binlog goes down to 3.5 MB in size. We're also seeing build speed improvements from 33 seconds to 30 seconds. Significant reduction in memory allocations since we no longer need to allocate the large strings and send them across the nodes.

This also shares some extension methods for reading and writing things between the node packet serialization and binary logger. It also shares a new internal type, TaskItemData, used as a holder for deserialized items. The actual ProjectItemInstance.TaskItem is too heavyweight for this.

Binary logger format version goes all the way to 11. The viewer already supports the new format. An additional benefit is that the viewer no longer has to parse the large text messages to recover structure, it will now be more reliable when reading multi-line properties, items and metadata values.

I've replayed the binlog produced by this version and diffed with the old binlog and all information appears to be preserved.