### PR TITLE
Fixup whitespace and new lines in Common props, targets and tasks

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.CSharp.CrossTargeting.targets
@@ -17,6 +17,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
      <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
   </PropertyGroup>
+
   <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
 
   <Import Project="Microsoft.Common.CrossTargeting.targets" />

--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -83,15 +83,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     For other project systems, this transformation may be different.
     -->
+
     <PropertyGroup>
         <CreateManifestResourceNamesDependsOn></CreateManifestResourceNamesDependsOn>
     </PropertyGroup>
+
     <Target
         Name="CreateManifestResourceNames"
         Condition="'@(EmbeddedResource)' != ''"
         DependsOnTargets="$(CreateManifestResourceNamesDependsOn)"
         >
-
         <ItemGroup>
             <_Temporary Remove="@(_Temporary)" />
         </ItemGroup>
@@ -102,9 +103,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               RootNamespace="$(RootNamespace)"
               UseDependentUponConvention="$(EmbeddedResourceUseDependentUponConvention)"
               Condition="'%(EmbeddedResource.ManifestResourceName)' == '' and ('%(EmbeddedResource.WithCulture)' == 'false' or '%(EmbeddedResource.Type)' == 'Resx')">
-
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />
-
         </CreateCSharpManifestResourceName>
 
         <!-- Create manifest names for all culture non-resx resources -->
@@ -114,9 +113,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               PrependCultureAsDirectory="false"
               UseDependentUponConvention="$(EmbeddedResourceUseDependentUponConvention)"
               Condition="'%(EmbeddedResource.ManifestResourceName)' == '' and '%(EmbeddedResource.WithCulture)' == 'true' and '%(EmbeddedResource.Type)' == 'Non-Resx'">
-
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />
-
         </CreateCSharpManifestResourceName>
 
         <ItemGroup>
@@ -124,23 +121,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <EmbeddedResource Include="@(_Temporary)" />
             <_Temporary Remove="@(_Temporary)" />
         </ItemGroup>
-
     </Target>
 
     <Target
         Name="ResolveCodeAnalysisRuleSet"
         Condition="'$(CodeAnalysisRuleSet)' != ''"
         >
-
         <ResolveCodeAnalysisRuleSet
             CodeAnalysisRuleSet="$(CodeAnalysisRuleSet)"
             CodeAnalysisRuleSetDirectories="$(CodeAnalysisRuleSetDirectories)"
             MSBuildProjectDirectory="$(MSBuildProjectDirectory)">
-
             <Output TaskParameter="ResolvedCodeAnalysisRuleSet" PropertyName="ResolvedCodeAnalysisRuleSet" />
-
         </ResolveCodeAnalysisRuleSet>
-
     </Target>
 
     <ItemGroup>
@@ -328,9 +320,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PropertyGroup>
        <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
     </PropertyGroup>
+
     <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
 
     <Import Project="Microsoft.Common.targets" />
+
     <Import Project="$(MSBuildToolsPath)\Microsoft.ServiceModel.targets" Condition="('$(TargetFrameworkVersion)' != 'v2.0' and '$(TargetFrameworkVersion)' != 'v3.0' and '$(TargetFrameworkVersion)' != 'v3.5') and Exists('$(MSBuildToolsPath)\Microsoft.ServiceModel.targets')"/>
 
     <Target Name="_SetTargetFrameworkMonikerAttribute" BeforeTargets="GenerateTargetFrameworkMonikerAttribute">
@@ -346,7 +340,6 @@ using System.Reflection%3b
 
     <PropertyGroup>
        <Utf8Output Condition="'$(Utf8Output)' == ''">true</Utf8Output>
-
       <!-- NoCompilerStandardLib maps to the compiler's /nostdlib option. By default we always
            want that switch to be passed to the compiler so that either we or the user
            provides the references
@@ -354,9 +347,7 @@ using System.Reflection%3b
            so only if NoStdLib isn't set to true, will we provide the standard references
       -->
       <NoCompilerStandardLib Condition=" '$(NoCompilerStandardLib)' == '' ">true</NoCompilerStandardLib>
-
       <ErrorEndLocation Condition="'$(BuildingInsideVisualStudio)' == 'true' and '$(ErrorEndLocation)' == ''">true</ErrorEndLocation>
-
        <!-- When building inside VS, by default use the same language for compiler messages as VS itself does. -->
        <PreferredUILang Condition="'$(BuildingInsideVisualStudio)' == 'true' and '$(PreferredUILang)' == ''">$([System.Globalization.CultureInfo]::CurrentUICulture.Name)</PreferredUILang>
     </PropertyGroup>

--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -8,7 +8,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 This file defines the steps in the standard build process specific for C# .NET projects.
 For example, it contains the step that actually calls the C# compiler.  The remainder
-of the build process is defined in Microsoft.Common.targets, which is imported by 
+of the build process is defined in Microsoft.Common.targets, which is imported by
 this file.
 
 Copyright (C) Microsoft Corporation. All rights reserved.
@@ -66,14 +66,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!--
     The CreateManifestResourceNames target create the manifest resource names from the .RESX
     files.
-    
+
         [IN]
         @(EmbeddedResource) - The list of EmbeddedResource items that have been pre-processed to add metadata about resource type
                               Expected Metadata "Type" can either be "Resx" or "Non-Resx"
 
         [OUT]
-        @(EmbeddedResource) - EmbeddedResource items with metadata         
-        
+        @(EmbeddedResource) - EmbeddedResource items with metadata
+
     For C# applications the transformation is like:
 
         Resources1.resx => RootNamespace.Resources1 => Build into main assembly
@@ -95,7 +95,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <ItemGroup>
             <_Temporary Remove="@(_Temporary)" />
         </ItemGroup>
-        
+
         <!-- Create manifest names for culture and non-culture Resx files, and for non-culture Non-Resx resources -->
         <CreateCSharpManifestResourceName
               ResourceFiles="@(EmbeddedResource)"
@@ -106,7 +106,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />
 
         </CreateCSharpManifestResourceName>
-        
+
         <!-- Create manifest names for all culture non-resx resources -->
         <CreateCSharpManifestResourceName
               ResourceFiles="@(EmbeddedResource)"
@@ -124,7 +124,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <EmbeddedResource Include="@(_Temporary)" />
             <_Temporary Remove="@(_Temporary)" />
         </ItemGroup>
-              
+
     </Target>
 
     <Target
@@ -167,7 +167,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CoreCompileDependsOn>$(CoreCompileDependsOn);_ComputeNonExistentFileProperty;ResolveCodeAnalysisRuleSet</CoreCompileDependsOn>
         <ExportWinMDFile Condition="'$(ExportWinMDFile)' == '' and '$(OutputType)' == 'WinMDObj'">true</ExportWinMDFile>
     </PropertyGroup>
- 
+
 <!--
       The XamlPreCompile target must remain identical to
       the CoreCompile target in Microsoft.CSharp.Core.targets.
@@ -183,14 +183,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 @(ReferencePath);
                 @(CompiledLicenseFile);
                 @(LinkResource);
-                @(EmbeddedDocumentation); 
+                @(EmbeddedDocumentation);
                 $(Win32Resource);
                 $(Win32Manifest);
                 @(CustomAdditionalCompileInputs);
                 @(Page);
                 @(ApplicationDefinition);
                 $(ResolvedCodeAnalysisRuleSet)"
-                  
+
         Outputs="@(DocFileItem);
                  @(XamlIntermediateAssembly);
                  @(_DebugSymbolsIntermediatePath);
@@ -217,13 +217,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 <EmbedInteropTypes/>
             </ReferencePath>
         </ItemGroup>
-        
+
         <PropertyGroup>
             <!-- If the user has specified AppConfigForCompiler, we'll use it. If they have not, but they set UseAppConfigForCompiler,
                  then we'll use AppConfig -->
             <AppConfigForCompiler Condition="'$(AppConfigForCompiler)' == '' and '$(UseAppConfigForCompiler)' == 'true'">$(AppConfig)</AppConfigForCompiler>
-            
-            <!-- If we are targeting winmdobj we want to specifically the pdbFile property since we do not want it to collide with the output of winmdexp--> 
+
+            <!-- If we are targeting winmdobj we want to specifically the pdbFile property since we do not want it to collide with the output of winmdexp-->
             <PdbFile Condition="'$(PdbFile)' == '' and '$(OutputType)' == 'winmdobj' and '$(_DebugSymbolsProduced)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
         </PropertyGroup>
 
@@ -231,12 +231,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <PropertyGroup Condition="('$(TargetFrameworkVersion)' == 'v4.0')">
             <Prefer32Bit>false</Prefer32Bit>
         </PropertyGroup>
-       
+
         <ItemGroup Condition="('$(AdditionalFileItemNames)' != '')">
           <AdditionalFileItems Include="$(AdditionalFileItemNames)" />
           <AdditionalFiles Include="@(%(AdditionalFileItems.Identity))" />
         </ItemGroup>
-        
+
        <PropertyGroup Condition="'$(UseSharedCompilation)' == ''">
          <UseSharedCompilation>true</UseSharedCompilation>
        </PropertyGroup>
@@ -259,7 +259,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               DisabledWarnings="$(NoWarn)"
               DocumentationFile="@(DocFileItem)"
               EmitDebugInformation="$(DebugSymbols)"
-              EnvironmentVariables="$(CscEnvironment)"              
+              EnvironmentVariables="$(CscEnvironment)"
               ErrorEndLocation="$(ErrorEndLocation)"
               ErrorLog="$(ErrorLog)"
               ErrorReport="$(ErrorReport)"
@@ -279,7 +279,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               Nullable="$(Nullable)"
               Optimize="$(Optimize)"
               OutputAssembly="@(XamlIntermediateAssembly)"
-              PdbFile="$(PdbFile)" 
+              PdbFile="$(PdbFile)"
               Platform="$(PlatformTarget)"
               Prefer32Bit="$(Prefer32Bit)"
               PreferredUILang="$(PreferredUILang)"
@@ -322,7 +322,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
 
     <Import Project="$(CSharpCoreTargetsPath)" />
-    
+
     <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
     <!-- Import design time targets before the common targets, which import targets from Nuget. -->
     <PropertyGroup>
@@ -360,12 +360,12 @@ using System.Reflection%3b
        <!-- When building inside VS, by default use the same language for compiler messages as VS itself does. -->
        <PreferredUILang Condition="'$(BuildingInsideVisualStudio)' == 'true' and '$(PreferredUILang)' == ''">$([System.Globalization.CultureInfo]::CurrentUICulture.Name)</PreferredUILang>
     </PropertyGroup>
-    
+
     <!-- Add any "automatic" compiler references that need to be resolved when NoCompilerStandardLib is set
          but the user hasn't told us to not include standard references -->
     <ItemGroup Condition=" '$(NoCompilerStandardLib)' == 'true' and '$(NoStdLib)' != 'true' ">
       <!-- Note that unlike VB, C# does not automatically locate System.dll as a "standard library"
-           instead the reference is always passed from the project. Also, for mscorlib.dll 
+           instead the reference is always passed from the project. Also, for mscorlib.dll
            we need to provide the explicit location in order to avoid resolving from, e.g.,
            {CandidateAssemblyFiles}.
       -->

--- a/src/Tasks/Microsoft.CSharp.targets
+++ b/src/Tasks/Microsoft.CSharp.targets
@@ -16,6 +16,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
         as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
@@ -34,7 +35,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <When Condition="'$(MSBuildAssemblyVersion)' == ''">
          <PropertyGroup>
             <CSharpTargetsPath>$(MSBuildFrameworkToolsPath)\Microsoft.CSharp.targets</CSharpTargetsPath>
-
             <!-- Same condition as in .NET 4.5 C# targets so that we can override the behavior where it defaults to
                  MSBuildToolsPath, which would be incorrect in this case -->
             <CscToolPath Condition="'$(CscToolPath)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">$(MsBuildFrameworkToolsPath)</CscToolPath>
@@ -191,4 +191,5 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>
    </PropertyGroup>
+
 </Project>

--- a/src/Tasks/Microsoft.CSharp.targets
+++ b/src/Tasks/Microsoft.CSharp.targets
@@ -8,7 +8,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 This file defines the steps in the standard build process specific for C# .NET projects.
 For example, it contains the step that actually calls the C# compiler.  The remainder
-of the build process is defined in Microsoft.Common.targets, which is imported by 
+of the build process is defined in Microsoft.Common.targets, which is imported by
 this file.
 
 Copyright (C) Microsoft Corporation. All rights reserved.
@@ -17,17 +17,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <!--
-        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed 
-        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead 
-        just used whatever ToolsVersion was in the project file if it existed on the machine, and 
-        only forced 4.0 if that ToolsVersion did not exist.  
+        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
+        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
+        just used whatever ToolsVersion was in the project file if it existed on the machine, and
+        only forced 4.0 if that ToolsVersion did not exist.
 
-        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio, 
-        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected 
-        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved 
-        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist 
+        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio,
+        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected
+        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved
+        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist
         as part of the .NET Framework.  Only if we're using the new MSBuild will we point to the current
-        targets. 
+        targets.
    -->
 
    <Choose>
@@ -35,7 +35,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          <PropertyGroup>
             <CSharpTargetsPath>$(MSBuildFrameworkToolsPath)\Microsoft.CSharp.targets</CSharpTargetsPath>
 
-            <!-- Same condition as in .NET 4.5 C# targets so that we can override the behavior where it defaults to 
+            <!-- Same condition as in .NET 4.5 C# targets so that we can override the behavior where it defaults to
                  MSBuildToolsPath, which would be incorrect in this case -->
             <CscToolPath Condition="'$(CscToolPath)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">$(MsBuildFrameworkToolsPath)</CscToolPath>
          </PropertyGroup>
@@ -54,14 +54,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 
    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
-      <!-- 
-           Overrides for the Microsoft.Common.targets extension targets. Used to make sure that only the imports we specify 
-           (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Defined here because 
-           Microsoft.CSharp.targets imports Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath, 
+      <!--
+           Overrides for the Microsoft.Common.targets extension targets. Used to make sure that only the imports we specify
+           (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Defined here because
+           Microsoft.CSharp.targets imports Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath,
            so defining these in Microsoft.Common.targets alone would not suffice for C# projects.
 
            NOTE: This logic is duplicated in Microsoft.VisualBasic.targets (VB has the same problem) and in Microsoft.Common.targets
-           (for anyone who DOES import it directly), so for any changes to this logic in this file, please also edit the other two. 
+           (for anyone who DOES import it directly), so for any changes to this logic in this file, please also edit the other two.
        -->
       <ImportByWildcardBefore40MicrosoftCommonTargets Condition="'$(ImportByWildcardBefore40MicrosoftCommonTargets)' == ''">$(ImportByWildcardBeforeMicrosoftCommonTargets)</ImportByWildcardBefore40MicrosoftCommonTargets>
       <ImportByWildcardBefore40MicrosoftCommonTargets Condition="'$(ImportByWildcardBefore40MicrosoftCommonTargets)' == ''">true</ImportByWildcardBefore40MicrosoftCommonTargets>
@@ -106,15 +106,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    </PropertyGroup>
 
    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == '' and ('$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == 'Silverlight' or ('$(TargetFrameworkIdentifier)' == '' and ('$(TargetRuntime)' == 'Managed' or '$(TargetRuntime)' == '')))">
-       <!-- 
-            Overrides for the Microsoft.NETFramework.props extension targets. Used to make sure that only the imports we specify 
-            (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Required because 
-            Microsoft.Common.targets imports it from the current directory, so we don't get a chance to redirect these in its 
+       <!--
+            Overrides for the Microsoft.NETFramework.props extension targets. Used to make sure that only the imports we specify
+            (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Required because
+            Microsoft.Common.targets imports it from the current directory, so we don't get a chance to redirect these in its
             own redirection targets.
 
             NOTE: This logic is duplicated in Microsoft.VisualBasic.targets and in Microsoft.Common.targets because VB and C#
-            import Microsoft.Common.targets from the current directory and thus don't get the benefit of these redirections either, 
-            so for any changes to this logic in this file, please also edit the other two. 
+            import Microsoft.Common.targets from the current directory and thus don't get the benefit of these redirections either,
+            so for any changes to this logic in this file, please also edit the other two.
         -->
       <ImportByWildcardBefore40MicrosoftNetFrameworkProps Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == ''">$(ImportByWildcardBeforeMicrosoftNetFrameworkProps)</ImportByWildcardBefore40MicrosoftNetFrameworkProps>
       <ImportByWildcardBefore40MicrosoftNetFrameworkProps Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == ''">true</ImportByWildcardBefore40MicrosoftNetFrameworkProps>
@@ -137,24 +137,24 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.CSharp.targets\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBefore40MicrosoftCSharpTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.CSharp.targets\ImportBefore')"/>
       <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.CSharp.targets\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftCSharpTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.CSharp.targets\ImportBefore')"/>
-   </ImportGroup> 
+   </ImportGroup>
 
-   <!-- Really should be imported right before Microsoft.Common.targets, but because Microsoft.CSharp.targets imports 
+   <!-- Really should be imported right before Microsoft.Common.targets, but because Microsoft.CSharp.targets imports
         Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
-        targets), we're stuck doing it this way instead. --> 
+        targets), we're stuck doing it this way instead. -->
    <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBefore40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore')"/>
       <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore')"/>
-   </ImportGroup> 
+   </ImportGroup>
 
-   <!-- Really should be imported right before Microsoft.NETFramework.props, but because Microsoft.CSharp.targets imports 
+   <!-- Really should be imported right before Microsoft.NETFramework.props, but because Microsoft.CSharp.targets imports
         Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
-        targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this 
-        way instead. --> 
+        targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this
+        way instead. -->
    <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBefore40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore')"/>
       <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore')"/>
-   </ImportGroup> 
+   </ImportGroup>
 
    <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.Before.targets" />
 
@@ -164,29 +164,29 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
    <!-- Really should be imported right after Microsoft.NETFramework.props, but because Microsoft.CSharp.targets imports
         Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
-        targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this 
-        way instead. --> 
+        targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this
+        way instead. -->
    <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter\*" Condition="'$(ImportByWildcardAfter40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter')"/>
       <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfter40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter')"/>
-   </ImportGroup> 
+   </ImportGroup>
 
-   <!-- Really should be imported right after Microsoft.Common.targets, but because Microsoft.CSharp.targets imports 
+   <!-- Really should be imported right after Microsoft.Common.targets, but because Microsoft.CSharp.targets imports
         Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
-        targets), we're stuck doing it this way instead. --> 
+        targets), we're stuck doing it this way instead. -->
    <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfter40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter')"/>
       <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfter40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter')"/>
-    </ImportGroup> 
+    </ImportGroup>
 
    <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.CSharp.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfter40MicrosoftCSharpTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.CSharp.targets\ImportAfter')"/>
       <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.CSharp.targets\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfter40MicrosoftCSharpTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.CSharp.targets\ImportAfter')"/>
-   </ImportGroup> 
+   </ImportGroup>
 
-   <!-- Fix up FrameworkPathOverride, which is primarily used to determine the location of mscorlib.dll in the 
-        (relatively uncommon) situation where the reference assemblies, in which it's usually found, are not 
-        installed.  Defined here rather than in Microsoft.Common.targets because the .NET Microsoft.CSharp.targets 
+   <!-- Fix up FrameworkPathOverride, which is primarily used to determine the location of mscorlib.dll in the
+        (relatively uncommon) situation where the reference assemblies, in which it's usually found, are not
+        installed.  Defined here rather than in Microsoft.Common.targets because the .NET Microsoft.CSharp.targets
         imports Microsoft.Common.targets from the current directory. -->
    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -11,10 +11,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
     <ImportByWildcardBeforeMicrosoftCommonCrossTargetingTargets Condition="'$(ImportByWildcardBeforeMicrosoftCommonCrossTargetingTargets)' == ''">true</ImportByWildcardBeforeMicrosoftCommonCrossTargetingTargets>
   </PropertyGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.CrossTargeting.targets\ImportBefore\*.targets"
           Condition="'$(ImportByWildcardBeforeMicrosoftCommonCrossTargetingTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.CrossTargeting.targets\ImportBefore')"/>
 
@@ -40,14 +42,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetFrameworkMonikers>@(_TargetFrameworkInfo->'%(TargetFrameworkMonikers)')</TargetFrameworkMonikers>
         <TargetPlatformMonikers>@(_TargetFrameworkInfo->'%(TargetPlatformMonikers)')</TargetPlatformMonikers>
         <AdditionalPropertiesFromProject>$(_AdditionalPropertiesFromProject)</AdditionalPropertiesFromProject>
-
         <HasSingleTargetFramework>false</HasSingleTargetFramework>
-
         <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
         <IsRidAgnostic>false</IsRidAgnostic>
         <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
       </_ThisProjectBuildMetadata>
     </ItemGroup>
+
   </Target>
 
   <Target Name="_ComputeTargetFrameworkItems" Returns="@(InnerOutput)">
@@ -178,6 +179,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <ImportByWildcardAfterMicrosoftCommonCrossTargetingTargets Condition="'$(ImportByWildcardAfterMicrosoftCommonCrossTargetingTargets)' == ''">true</ImportByWildcardAfterMicrosoftCommonCrossTargetingTargets>
   </PropertyGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.CrossTargeting.targets\ImportAfter\*.targets"
           Condition="'$(ImportByWildcardAfterMicrosoftCommonCrossTargetingTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.CrossTargeting.targets\ImportAfter')"/>
 
@@ -217,4 +219,5 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- TODO: https://github.com/Microsoft/msbuild/issues/1062: Remove this temporary hook when possible. -->
   <Import Project="$(CoreCrossTargetingTargetsPath)"
           Condition="'$(CoreCrossTargetingTargetsPath)' != '' and Exists('$(CoreCrossTargetingTargetsPath)')" />
+
 </Project>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -33,7 +33,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="Result"
         PropertyName="_AdditionalPropertiesFromProject"/>
     </CombineXmlElements>
-    
+
     <ItemGroup>
       <_ThisProjectBuildMetadata Include="$(MSBuildProjectFullPath)">
         <TargetFrameworks>@(_TargetFrameworkInfo)</TargetFrameworks>
@@ -178,7 +178,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <ImportByWildcardAfterMicrosoftCommonCrossTargetingTargets Condition="'$(ImportByWildcardAfterMicrosoftCommonCrossTargetingTargets)' == ''">true</ImportByWildcardAfterMicrosoftCommonCrossTargetingTargets>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.CrossTargeting.targets\ImportAfter\*.targets" 
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.CrossTargeting.targets\ImportAfter\*.targets"
           Condition="'$(ImportByWildcardAfterMicrosoftCommonCrossTargetingTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.CrossTargeting.targets\ImportAfter')"/>
 
   <!--
@@ -188,8 +188,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Each package management system should use a unique moniker to avoid collisions.  It is a wild-card iport so the package
     management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
 
-    This is the same import that would happen in an inner (non-cross targeting) build. Package management systems are responsible for generating 
-    appropriate conditions based on $(IsCrossTargetingBuild) to pull in only those package targets that are meant to participate in a cross-targeting 
+    This is the same import that would happen in an inner (non-cross targeting) build. Package management systems are responsible for generating
+    appropriate conditions based on $(IsCrossTargetingBuild) to pull in only those package targets that are meant to participate in a cross-targeting
     build.
   -->
   <PropertyGroup>
@@ -202,7 +202,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ImportDirectoryBuildTargets Condition="'$(ImportDirectoryBuildTargets)' == ''">true</ImportDirectoryBuildTargets>
   </PropertyGroup>
 
-  <!-- 
+  <!--
         Determine the path to the directory build targets file if the user did not disable $(ImportDirectoryBuildTargets) and
         they did not already specify an absolute path to use via $(DirectoryBuildTargetsPath)
     -->
@@ -215,6 +215,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(DirectoryBuildTargetsPath)" Condition="'$(ImportDirectoryBuildTargets)' == 'true' and exists('$(DirectoryBuildTargetsPath)')"/>
 
   <!-- TODO: https://github.com/Microsoft/msbuild/issues/1062: Remove this temporary hook when possible. -->
-  <Import Project="$(CoreCrossTargetingTargetsPath)" 
+  <Import Project="$(CoreCrossTargetingTargetsPath)"
           Condition="'$(CoreCrossTargetingTargetsPath)' != '' and Exists('$(CoreCrossTargetingTargetsPath)')" />
 </Project>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -30,7 +30,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')"/>
 
-
   <!-- VS10 without SP1 and without VS11 will not have VisualStudioVersion set, so do that here -->
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -163,7 +162,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-
     <!-- Determine OutputType property from the legacy TargetType property -->
     <OutputType Condition=" '$(TargetType)' != ''">$(TargetType)</OutputType>
     <OutputType Condition=" '$(TargetType)' == 'Container' or '$(TargetType)' == 'DocumentContainer' ">library</OutputType>
@@ -221,7 +219,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-
     <!-- Required for enabling Team Build for packaging app package-generating projects -->
     <OutDirWasSpecified Condition=" '$(OutDir)'!='' and '$(OutDirWasSpecified)'=='' ">true</OutDirWasSpecified>
 
@@ -362,10 +359,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- It would be a breaking change to automatically turn on binding redirects for existing projects, so turn them on only when opting into a new framework. -->
     <AutoGenerateBindingRedirects Condition="'$(AutoGenerateBindingRedirects)' == '' and '$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(TargetFrameworkVersion.TrimStart(vV))' >= '4.7.2'">true</AutoGenerateBindingRedirects>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(AutoUnifyAssemblyReferences)' == ''">
     <AutoUnifyAssemblyReferences>true</AutoUnifyAssemblyReferences>
     <AutoUnifyAssemblyReferences Condition="'$(GenerateBindingRedirectsOutputType)' == 'true' and '$(AutoGenerateBindingRedirects)' != 'true'">false</AutoUnifyAssemblyReferences>
   </PropertyGroup>
+
   <PropertyGroup>
     <CleanFile Condition="'$(CleanFile)'==''">$(MSBuildProjectFile).FileListAbsolute.txt</CleanFile>
     <!-- During DesignTime Builds, skip project reference build as Design time is only queueing information.-->
@@ -382,6 +381,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <_GenerateBindingRedirectsIntermediateAppConfig>$(IntermediateOutputPath)$(TargetFileName).config</_GenerateBindingRedirectsIntermediateAppConfig>
   </PropertyGroup>
+
   <ItemGroup>
     <IntermediateAssembly Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)"/>
     <FinalDocFile Include="@(DocFileItem->'$(OutDir)%(Filename)%(Extension)')"/>
@@ -521,7 +521,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch Condition="'$(ProcessorArchitecture)'==''">None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <ProcessorArchitecture Condition="'$(ProcessorArchitecture)'==''">$(PROCESSOR_ARCHITECTURE)</ProcessorArchitecture>
   </PropertyGroup>
-
 
   <!-- Sensible defaults for the most-commonly-desired MSBuildRuntime and MSBuildArchitecture values. The Core and Mono runtimes do not currently support specifying task architecture or runtime.
        If support for out-of-proc task execution is added on other runtimes, make sure each task's logic is checked against the current state of support. -->
@@ -924,6 +923,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       PostBuildEvent
     </CoreBuildDependsOn>
   </PropertyGroup>
+
   <Target
       Name="CoreBuild"
       DependsOnTargets="$(CoreBuildDependsOn)">
@@ -941,7 +941,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
     -->
   <PropertyGroup>
-
     <_ProjectDefaultTargets Condition="'$(MSBuildProjectDefaultTargets)' != ''">$(MSBuildProjectDefaultTargets)</_ProjectDefaultTargets>
     <_ProjectDefaultTargets Condition="'$(MSBuildProjectDefaultTargets)' == ''">Build</_ProjectDefaultTargets>
 
@@ -1086,6 +1085,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <RunDependsOn></RunDependsOn>
   </PropertyGroup>
+
   <Target
       Name="Run"
       DependsOnTargets="$(RunDependsOn)">
@@ -1095,9 +1095,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Exec Command="$(TargetPath) $(StartArguments)" WorkingDirectory="$(StartWorkingDirectory)" Condition=" '$(StartWorkingDirectory)' != '' "/>
 
   </Target>
-
-
-
 
   <!--
     ***********************************************************************************************
@@ -1117,15 +1114,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <BuildingProject>false</BuildingProject>
   </PropertyGroup>
+
   <Target
       Name="BuildOnlySettings">
     <PropertyGroup>
       <BuildingProject>true</BuildingProject>
     </PropertyGroup>
   </Target>
-
-
-
 
   <!--
     ***********************************************************************************************
@@ -1145,6 +1140,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <PrepareForBuildDependsOn>$(PrepareForBuildDependsOn);GetFrameworkPaths;GetReferenceAssemblyPaths;AssignLinkMetadata</PrepareForBuildDependsOn>
   </PropertyGroup>
+
   <Target
       Name="PrepareForBuild"
       DependsOnTargets="$(PrepareForBuildDependsOn)">
@@ -1253,6 +1249,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PropertyGroup Condition="'$(_TargetFrameworkDirectories)' == ''">
       <TargetFrameworkProfile/>
     </PropertyGroup>
+
   </Target>
 
    <!-- Returns target framework moniker. E.g. ".NETFramework,Version=v4.0.1" -->
@@ -1280,6 +1277,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
     -->
   <Target Name="AssignLinkMetadata" Condition=" '$(SynthesizeLinkMetadata)' == 'true' ">
+
     <!-- NONE ITEMS -->
     <AssignLinkMetadata Items="@(None)"
                         Condition="'@(None)' != '' and '%(None.DefiningProjectFullPath)' != '$(MSBuildProjectFullPath)'">
@@ -1304,7 +1302,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_Temp Remove="@(_Temp)" />
     </ItemGroup>
 
-
     <!-- PAGE ITEMS -->
     <AssignLinkMetadata Items="@(Page)"
                         Condition="'@(Page)' != '' and '%(Page.DefiningProjectFullPath)' != '$(MSBuildProjectFullPath)'">
@@ -1316,7 +1313,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Page Include="@(_Temp)" />
       <_Temp Remove="@(_Temp)" />
     </ItemGroup>
-
 
     <!-- APPLICATIONDEFINITION ITEMS -->
     <AssignLinkMetadata Items="@(ApplicationDefinition)"
@@ -1341,6 +1337,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <EmbeddedResource Include="@(_Temp)" />
       <_Temp Remove="@(_Temp)" />
     </ItemGroup>
+
   </Target>
 
   <!--
@@ -1361,6 +1358,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <PreBuildEventDependsOn></PreBuildEventDependsOn>
   </PropertyGroup>
+
   <Target
       Name="PreBuildEvent"
       Condition="'$(PreBuildEvent)'!=''"
@@ -1369,9 +1367,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Exec WorkingDirectory="$(OutDir)" Command="$(PreBuildEvent)" />
 
   </Target>
-
-
-
 
   <!--
     ***********************************************************************************************
@@ -1392,6 +1387,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <UnmanagedUnregistrationDependsOn></UnmanagedUnregistrationDependsOn>
   </PropertyGroup>
+
   <Target
       Name="UnmanagedUnregistration"
       Condition="(('$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' or '$(RegisterForComInterop)' != 'true' or '$(OutputType)' != 'library') or
@@ -1416,15 +1412,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <UnregisterAssemblyMSBuildRuntime Condition="'$(UnregisterAssemblyMSBuildRuntime)' == ''">CurrentRuntime</UnregisterAssemblyMSBuildRuntime>
     </PropertyGroup>
 
-
     <UnregisterAssembly AssemblyListFile="@(_UnmanagedRegistrationCache)"
                         MSBuildArchitecture="$(UnregisterAssemblyMSBuildArchitecture)"
                         MSBuildRuntime="$(UnregisterAssemblyMSBuildRuntime)" />
 
   </Target>
-
-
-
 
   <!--
     ***********************************************************************************************
@@ -1557,6 +1549,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <ReferenceOutputAssembly Condition="'%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == ''">true</ReferenceOutputAssembly>
       </ProjectReferenceWithConfiguration>
     </ItemGroup>
+
   </Target>
 
   <!--
@@ -1784,21 +1777,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="Result"
         PropertyName="_AdditionalPropertiesFromProject"/>
     </CombineXmlElements>
-    
+
     <ItemGroup>
       <_ThisProjectBuildMetadata Include="$(MSBuildProjectFullPath)">
         <TargetFrameworks>@(_TargetFrameworkInfo)</TargetFrameworks>
         <TargetFrameworkMonikers>@(_TargetFrameworkInfo->'%(TargetFrameworkMonikers)')</TargetFrameworkMonikers>
         <TargetPlatformMonikers>@(_TargetFrameworkInfo->'%(TargetPlatformMonikers)')</TargetPlatformMonikers>
         <AdditionalPropertiesFromProject>$(_AdditionalPropertiesFromProject)</AdditionalPropertiesFromProject>
-
         <HasSingleTargetFramework>true</HasSingleTargetFramework>
-
         <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
         <IsRidAgnostic>false</IsRidAgnostic>
         <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
       </_ThisProjectBuildMetadata>
     </ItemGroup>
+
   </Target>
 
   <Target Name="GetTargetFrameworksWithPlatformForSingleTargetFramework"
@@ -1866,6 +1858,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       _GetProjectReferenceTargetFrameworkProperties
     </PrepareProjectReferencesDependsOn>
   </PropertyGroup>
+
   <Target Name="PrepareProjectReferences" DependsOnTargets="$(PrepareProjectReferencesDependsOn)" />
 
   <!--
@@ -2146,6 +2139,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       ExpandSDKReferences;
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
+
   <Target
       Name="ResolveAssemblyReferences"
       Returns="@(ReferencePath)"
@@ -2259,6 +2253,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="DependsOnNETStandard" PropertyName="_DependsOnNETStandard"/>
       <Output TaskParameter="UnresolvedAssemblyConflicts" ItemName="ResolveAssemblyReferenceUnresolvedAssemblyConflicts"/>
     </ResolveAssemblyReference>
+
   </Target>
 
   <!--
@@ -2323,9 +2318,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       OutputAppConfigFile="$(_GenerateBindingRedirectsIntermediateAppConfig)"
       SuggestedRedirects="@(SuggestedBindingRedirects)"
       >
-
       <Output TaskParameter="OutputAppConfigFile" ItemName="FileWrites" />
-
     </GenerateBindingRedirects>
 
   </Target>
@@ -2345,6 +2338,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PropertyGroup>
       <AppConfig>$(_GenerateBindingRedirectsIntermediateAppConfig)</AppConfig>
     </PropertyGroup>
+
     <ItemGroup>
       <AppConfigWithTargetPath Remove="@(AppConfigWithTargetPath)" />
       <AppConfigWithTargetPath Include="$(AppConfig)">
@@ -2469,7 +2463,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Name="ResolveSDKReferences"
       Returns="@(ResolvedSDKReference)"
       DependsOnTargets="$(ResolveSDKReferencesDependsOn)">
-
     <ResolveSDKReference
            SDKReferences="@(SDKReference)"
            RuntimeReferenceOnlySDKDependencies="@(RuntimeReferenceOnlySDKDependencies)"
@@ -2544,7 +2537,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       BuildInParallel="$(BuildInParallel)"
       ContinueOnError="!$(BuildingProject)"
       RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)">
-
       <Output TaskParameter="TargetOutputs" ItemName="TargetPathWithTargetPlatformMoniker" />
     </MSBuild>
   </Target>
@@ -2617,7 +2609,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           Inputs="@(IntermediateAssembly);@(DocFileItem);@(_DebugSymbolsIntermediatePath);@(ReferencePathWithRefAssemblies);$(MSBuildAllProjects)"
           Outputs="$(_IntermediateWindowsMetadataPath);$(WinMDExpOutputPdb);$(WinMDOutputDocumentationFile)"
   >
-
       <PropertyGroup>
         <!-- Will be copied by the "copy WinMD artifacts" step instead -->
         <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
@@ -2650,6 +2641,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          <WinMDExpArtifacts Include="$(WinMDExpOutputPdb)"/>
          <FileWrites Include="$(WinMDOutputDocumentationFile);$(WinMDExpOutputPdb)"/>
     </ItemGroup>
+
   </Target>
 
   <Target
@@ -2661,6 +2653,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_ReferencesFromRAR Include="@(ReferencePath->WithMetadataValue('ReferenceSourceTarget', 'ResolveAssemblyReference'))"/>
     </ItemGroup>
+
   </Target>
 
   <PropertyGroup>
@@ -2686,7 +2679,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
         [IN]
         @(DesignTimeReference) - List of assembly references as simple/fusion names.
-
 
         [OUT]
         @(ReferencePath) - Paths to resolved primary files.
@@ -2778,6 +2770,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="ResolvedFiles" ItemName="DesignTimeReferencePath"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
     </ResolveAssemblyReference>
+
   </Target>
 
   <!--
@@ -2897,6 +2890,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       CompileLicxFiles
     </PrepareResourcesDependsOn>
   </PropertyGroup>
+
   <Target
       Name="PrepareResources"
       DependsOnTargets="$(PrepareResourcesDependsOn)"/>
@@ -2916,6 +2910,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       CreateCustomManifestResourceNames
     </PrepareResourceNamesDependsOn>
   </PropertyGroup>
+
   <Target
       Name="PrepareResourceNames"
       DependsOnTargets="$(PrepareResourceNamesDependsOn)"/>
@@ -2931,6 +2926,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <AssignTargetPathsDependsOn></AssignTargetPathsDependsOn>
   </PropertyGroup>
+
   <Target
       Name="AssignTargetPaths"
       DependsOnTargets="$(AssignTargetPathsDependsOn)">
@@ -2943,7 +2939,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <AssignTargetPath Files="@(EmbeddedResource)" RootFolder="$(MSBuildProjectDirectory)">
       <Output TaskParameter="AssignedFiles" ItemName="_Temporary" />
     </AssignTargetPath>
-
 
     <ItemGroup>
       <!-- Replace items in EmbeddedResource with the items emitted by the AssignTargetPath task that have the TargetPath metadata -->
@@ -3075,6 +3070,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <CreateCustomManifestResourceNamesDependsOn></CreateCustomManifestResourceNamesDependsOn>
   </PropertyGroup>
+
   <Target
       Name="CreateCustomManifestResourceNames"
       DependsOnTargets="$(CreateCustomManifestResourceNamesDependsOn)"/>
@@ -3093,6 +3089,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <UseSourcePath Condition="'$(UseSourcePath)'==''">true</UseSourcePath>
     <ResGenExecuteAsTool Condition="'$(ResGenExecuteAsTool)'==''">false</ResGenExecuteAsTool>
   </PropertyGroup>
+
   <Target
       Name="ResGen"
       DependsOnTargets="$(ResGenDependsOn)"/>
@@ -3255,6 +3252,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <CompileLicxFilesDependsOn></CompileLicxFilesDependsOn>
   </PropertyGroup>
+
   <Target
       Name="CompileLicxFiles"
       Condition="'@(_LicxFile)'!=''"
@@ -3286,9 +3284,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </LC>
 
   </Target>
-
-
-
 
   <!--
     ***********************************************************************************************
@@ -3366,6 +3361,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       AfterCompile;
     </CompileDependsOn>
   </PropertyGroup>
+
   <Target
       Name="Compile"
       DependsOnTargets="$(CompileDependsOn)"/>
@@ -3444,8 +3440,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Compile Include="$(TargetFrameworkMonikerAssemblyAttributesPath)"/>
       <!-- Do not put in FileWrites: this is a file shared between projects in %temp%, and cleaning it would create a race between projects during rebuild -->
     </ItemGroup>
-  </Target>
 
+  </Target>
 
   <!--
     ============================================================
@@ -3473,7 +3469,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           AssemblyAttributes="@(AssemblyAttributes)"
           OutputFile="$(AssemblyAttributesPath)"
           Language="$(Language)">
-
       <Output TaskParameter="OutputFile" ItemName="Compile"/>
       <Output TaskParameter="OutputFile" ItemName="FileWrites"/>
     </WriteCodeFragment>
@@ -3595,9 +3590,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
-
-
-
   <!--
     ***********************************************************************************************
     ***********************************************************************************************
@@ -3689,6 +3681,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       GenerateSatelliteAssemblies
     </CreateSatelliteAssembliesDependsOn>
   </PropertyGroup>
+
   <Target
       Name="CreateSatelliteAssemblies"
       DependsOnTargets="$(CreateSatelliteAssembliesDependsOn)" />
@@ -3721,6 +3714,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </_SatelliteAssemblyResourceInputs>
 
     </ItemGroup>
+
   </Target>
 
   <!--
@@ -3791,6 +3785,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       CreateManifestResourceNames
     </ComputeIntermediateSatelliteAssembliesDependsOn>
   </PropertyGroup>
+
   <Target
       Name="ComputeIntermediateSatelliteAssemblies"
       Condition="@(EmbeddedResource->'%(WithCulture)') != ''"
@@ -3803,6 +3798,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPath>%(EmbeddedResource.Culture)\$(TargetName).resources.dll</TargetPath>
       </IntermediateSatelliteAssembliesWithTargetPath>
     </ItemGroup>
+
   </Target>
 
   <!--
@@ -3869,9 +3865,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
-
-
-
   <!--
     ***********************************************************************************************
     ***********************************************************************************************
@@ -3905,6 +3898,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target
       Name="_GenerateResolvedDeploymentManifestEntryPoint">
+
     <ItemGroup>
       <_DeploymentPublishFileOfTypeManifestEntryPoint Include="@(PublishFile)" Condition="'%(FileType)'=='ManifestEntryPoint'"/>
     </ItemGroup>
@@ -3915,10 +3909,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SigningManifests="$(SignManifests)"
         DeploymentManifestEntryPoint="@(ApplicationManifest)"
         PublishFiles="@(_DeploymentPublishFileOfTypeManifestEntryPoint)">
-
       <Output TaskParameter="OutputDeploymentManifestEntryPoint" ItemName="_DeploymentResolvedDeploymentManifestEntryPoint"/>
-
     </ResolveManifestFiles>
+
   </Target>
 
   <Target
@@ -4124,6 +4117,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_DeploymentManifestEntryPoint Remove="@(_DeploymentManifestEntryPoint)"/>
       <_DeploymentManifestEntryPoint Include="@(_DeploymentManifestLauncherEntryPoint)"/>
     </ItemGroup>
+
   </Target>
 
   <!--
@@ -4404,9 +4398,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
-
-
-
   <!--
     ***********************************************************************************************
     ***********************************************************************************************
@@ -4432,6 +4423,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       CopyFilesToOutputDirectory
     </PrepareForRunDependsOn>
   </PropertyGroup>
+
   <Target
       Name="PrepareForRun"
       DependsOnTargets="$(PrepareForRunDependsOn)"/>
@@ -4691,8 +4683,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             GetCopyToOutputDirectoryItems;
             _CopyOutOfDateSourceItemsToOutputDirectory;
             _CopyOutOfDateSourceItemsToOutputDirectoryAlways"/>
-
-
   <!--
     ============================================================
                                         GetCopyToOutputDirectoryItems
@@ -4919,6 +4909,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CopyToPublishDirectory>%(CopyToOutputDirectory)</CopyToPublishDirectory>
       </AllPublishItemsFullPathWithTargetPath>
     </ItemGroup>
+
   </Target>
 
   <!--
@@ -5103,6 +5094,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <FileWrites Include="@(_DebugSymbolsIntermediatePath)" Condition="'$(_DebugSymbolsProduced)'=='true'"/>
     </ItemGroup>
+
   </Target>
 
   <!--
@@ -5129,9 +5121,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
-
-
-
   <!--
     ***********************************************************************************************
     ***********************************************************************************************
@@ -5150,6 +5139,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <UnmanagedRegistrationDependsOn></UnmanagedRegistrationDependsOn>
   </PropertyGroup>
+
   <Target
       Name="UnmanagedRegistration"
       Condition="'$(RegisterForComInterop)'=='true' and '$(OutputType)'=='library'"
@@ -5185,11 +5175,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <FileWrites Include="@(_OutputPathItem->'%(FullPath)$(TargetName).tlb')"/>
     </ItemGroup>
+
   </Target>
-
-
-
-
 
   <!--
     ***********************************************************************************************
@@ -5417,6 +5404,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <CoreCleanDependsOn></CoreCleanDependsOn>
   </PropertyGroup>
+
   <Target
       Name="CoreClean"
       DependsOnTargets="$(CoreCleanDependsOn)">
@@ -5515,9 +5503,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
-
-
-
   <!--
     ***********************************************************************************************
     ***********************************************************************************************
@@ -5548,6 +5533,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <PostBuildEventDependsOn></PostBuildEventDependsOn>
   </PropertyGroup>
+
   <Target
       Name="PostBuildEvent"
       Condition="'$(PostBuildEvent)' != '' and ('$(RunPostBuildEvent)' != 'OnOutputUpdated' or '$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)')"
@@ -5556,9 +5542,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Exec WorkingDirectory="$(OutDir)" Command="$(PostBuildEvent)" />
 
   </Target>
-
-
-
 
   <!--
     ***********************************************************************************************
@@ -5585,6 +5568,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       _DeploymentUnpublishable
     </PublishDependsOn>
   </PropertyGroup>
+
   <Target
       Name="Publish"
       DependsOnTargets="$(PublishDependsOn)"/>
@@ -5644,6 +5628,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       AfterPublish
     </PublishOnlyDependsOn>
   </PropertyGroup>
+
   <Target
       Name="PublishOnly"
       DependsOnTargets="$(PublishOnlyDependsOn)"/>
@@ -5684,6 +5669,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       CreateSatelliteAssemblies;
     </PublishBuildDependsOn>
   </PropertyGroup>
+
   <Target
       Name="PublishBuild"
       DependsOnTargets="$(PublishBuildDependsOn)"/>
@@ -5861,8 +5847,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         TimestampUrl="$(ManifestTimestampUrl)"
         SigningTarget="$(PublishDir)\setup.exe"
         Condition="'$(BootstrapperEnabled)'=='true' and '$(_DeploymentSignClickOnceManifests)'=='true'" />
-  </Target>
 
+  </Target>
 
   <!--
     ***********************************************************************************************
@@ -5931,6 +5917,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <BuiltProjectOutputGroupDependsOn>PrepareForBuild</BuiltProjectOutputGroupDependsOn>
     <AddAppConfigToBuildOutputs Condition="('$(AddAppConfigToBuildOutputs)'=='') and ('$(OutputType)'!='library' and '$(OutputType)'!='winmdobj')">true</AddAppConfigToBuildOutputs>
   </PropertyGroup>
+
   <Target
       Name="BuiltProjectOutputGroup"
       Returns="@(BuiltProjectOutputGroupOutput)"
@@ -5984,12 +5971,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <DebugSymbolsProjectOutputGroupDependsOn></DebugSymbolsProjectOutputGroupDependsOn>
   </PropertyGroup>
+
   <ItemGroup Condition="'$(_DebugSymbolsProduced)' != 'false' and '$(OutputType)' != 'winmdobj'">
     <DebugSymbolsProjectOutputGroupOutput Include="@(_DebugSymbolsIntermediatePath->'%(FullPath)')">
       <FinalOutputPath>@(_DebugSymbolsOutputPath->'%(FullPath)')</FinalOutputPath>
       <TargetPath>@(_DebugSymbolsIntermediatePath->'%(Filename)%(Extension)')</TargetPath>
     </DebugSymbolsProjectOutputGroupOutput>
   </ItemGroup>
+
   <ItemGroup Condition="'$(_DebugSymbolsProduced)' != 'false' and '$(OutputType)' == 'winmdobj'">
     <WinMDExpOutputPdbItem Include="$(WinMDExpOutputPdb)" Condition="'$(WinMDExpOutputPdb)' != ''" />
     <WinMDExpFinalOutputPdbItem Include="$(_WinMDDebugSymbolsOutputPath)" Condition="'$(_WinMDDebugSymbolsOutputPath)' != ''" />
@@ -5998,6 +5987,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <TargetPath>@(WinMDExpOutputPdbItem->'%(Filename)%(Extension)')</TargetPath>
     </DebugSymbolsProjectOutputGroupOutput>
   </ItemGroup>
+
   <Target
       Name="DebugSymbolsProjectOutputGroup"
       Returns="@(DebugSymbolsProjectOutputGroupOutput)"
@@ -6013,6 +6003,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <DocumentationProjectOutputGroupDependsOn></DocumentationProjectOutputGroupDependsOn>
   </PropertyGroup>
+
   <ItemGroup Condition="'$(DocumentationFile)'!='' and '$(OutputType)' != 'winmdobj'">
     <DocumentationProjectOutputGroupOutput Include="@(DocFileItem->'%(FullPath)')">
       <FinalOutputPath>@(FinalDocFile->'%(FullPath)')</FinalOutputPath>
@@ -6020,6 +6011,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <TargetPath>@(DocFileItem->'%(Filename)%(Extension)')</TargetPath>
     </DocumentationProjectOutputGroupOutput>
   </ItemGroup>
+
   <ItemGroup Condition="'$(DocumentationFile)' != '' and '$(OutputType)' == 'winmdobj'">
     <WinMDOutputDocumentationFileItem Include="$(WinMDOutputDocumentationFile)" Condition="'$(WinMDOutputDocumentationFile)' != ''" />
     <WinMDExpFinalOutputDocItem Include="$(_WinMDDocFileOutputPath)" Condition="'$(_WinMDDocFileOutputPath)' != ''" />
@@ -6028,6 +6020,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <TargetPath>@(WinMDOutputDocumentationFileItem->'%(Filename)%(Extension)')</TargetPath>
     </DocumentationProjectOutputGroupOutput>
   </ItemGroup>
+
   <Target
       Name="DocumentationProjectOutputGroup"
       Returns="@(DocumentationProjectOutputGroupOutput)"
@@ -6043,6 +6036,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <SatelliteDllsProjectOutputGroupDependsOn>PrepareForBuild;PrepareResourceNames</SatelliteDllsProjectOutputGroupDependsOn>
   </PropertyGroup>
+
   <Target
       Name="SatelliteDllsProjectOutputGroup"
       Returns="@(SatelliteDllsProjectOutputGroupOutput)"
@@ -6078,6 +6072,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <SourceFilesProjectOutputGroupDependsOn>PrepareForBuild;AssignTargetPaths</SourceFilesProjectOutputGroupDependsOn>
   </PropertyGroup>
+
   <Target
       Name="SourceFilesProjectOutputGroup"
       Returns="@(SourceFilesProjectOutputGroupOutput)"
@@ -6115,6 +6110,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <ContentFilesProjectOutputGroupDependsOn>PrepareForBuild;AssignTargetPaths</ContentFilesProjectOutputGroupDependsOn>
   </PropertyGroup>
+
   <Target
       Name="ContentFilesProjectOutputGroup"
       Returns="@(ContentFilesProjectOutputGroupOutput)"
@@ -6138,6 +6134,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <SGenFilesOutputGroupDependsOn></SGenFilesOutputGroupDependsOn>
   </PropertyGroup>
+
   <ItemGroup
       Condition="'$(_SGenGenerateSerializationAssembliesConfig)' == 'On' or ('@(WebReferenceUrl)'!='' and '$(_SGenGenerateSerializationAssembliesConfig)' == 'Auto')">
     <SGenFilesOutputGroupOutput Include="@(_OutputPathItem->'%(FullPath)$(_SGenDllName)')">
@@ -6145,6 +6142,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <TargetPath>$(_SGenDllName)</TargetPath>
     </SGenFilesOutputGroupOutput>
   </ItemGroup>
+
   <Target
       Name="SGenFilesOutputGroup"
       Returns="@(SGenFilesOutputGroupOutput)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4208,16 +4208,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Include the following files in clickonce manifest only if single file publish is false -->
     <ItemGroup Condition="'$(PublishSingleFile)' != 'true'">
-      <!-- 
-      _ClickOnceRuntimeCopyLocalItems group contains any runtimes folder assets of Nuget packages that are not included in 
-      _DeploymentReferencePaths (e.g. pdbs). They are populated from the RuntimeTargetsCopyLocalItems and NativeCopyLocalItems 
-      group that contain the RID-specific assets that go in runtimes folder on publish. They are output groups of the 
+      <!--
+      _ClickOnceRuntimeCopyLocalItems group contains any runtimes folder assets of Nuget packages that are not included in
+      _DeploymentReferencePaths (e.g. pdbs). They are populated from the RuntimeTargetsCopyLocalItems and NativeCopyLocalItems
+      group that contain the RID-specific assets that go in runtimes folder on publish. They are output groups of the
       ResolvePackageAssets target in dotnet/sdk
       -->
       <_ClickOnceRuntimeCopyLocalItems Include="@(RuntimeTargetsCopyLocalItems)"
                                       Condition="'%(RuntimeTargetsCopyLocalItems.CopyLocal)' == 'true'" />
 
-      <_ClickOnceRuntimeCopyLocalItems Include="@(NativeCopyLocalItems)" 
+      <_ClickOnceRuntimeCopyLocalItems Include="@(NativeCopyLocalItems)"
                                       Condition="'%(NativeCopyLocalItems.CopyLocal)' == 'true'" />
       <_ClickOnceRuntimeCopyLocalItems Remove="@(_DeploymentReferencePaths)" />
       <_ClickOnceFiles Include="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce);@(_ClickOnceRuntimeCopyLocalItems)"/>

--- a/src/Tasks/Microsoft.Common.overridetasks
+++ b/src/Tasks/Microsoft.Common.overridetasks
@@ -9,22 +9,31 @@
     <!-- NOTE: Using the fully qualified class name in a <UsingTask> tag is faster than using a partially qualified name. -->
 
     <UsingTask TaskName="Microsoft.Build.Tasks.ResolveComReference"  AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5'" />
+
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateResource"     AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' and ('$(DisableOutOfProcTaskHost)' != '' or !$([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`)))" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateResource"     AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' and '$(DisableOutOfProcTaskHost)' == '' and $([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`))" Runtime="CLR2" />
+
     <UsingTask TaskName="Microsoft.Build.Tasks.RegisterAssembly"     AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' and ('$(DisableOutOfProcTaskHost)' != '' or !$([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`)))" />
     <UsingTask TaskName="Microsoft.Build.Tasks.RegisterAssembly"     AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' and '$(DisableOutOfProcTaskHost)' == '' and $([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`))" Runtime="CLR2" />
+
     <UsingTask TaskName="Microsoft.Build.Tasks.UnregisterAssembly"   AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' and ('$(DisableOutOfProcTaskHost)' != '' or !$([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`)))" />
     <UsingTask TaskName="Microsoft.Build.Tasks.UnregisterAssembly"   AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' and '$(DisableOutOfProcTaskHost)' == '' and $([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`))" Runtime="CLR2" />
+
     <UsingTask TaskName="ResolveComReference"                        AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '2.0'" />
+
     <UsingTask TaskName="GenerateResource"                           AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '2.0' and ('$(DisableOutOfProcTaskHost)' != '' or !$([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`)))" />
     <UsingTask TaskName="GenerateResource"                           AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '2.0' and '$(DisableOutOfProcTaskHost)' == '' and $([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`))" Runtime="CLR2" />
+
     <UsingTask TaskName="RegisterAssembly"                           AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '2.0' and ('$(DisableOutOfProcTaskHost)' != '' or !$([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`)))" />
     <UsingTask TaskName="RegisterAssembly"                           AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '2.0' and '$(DisableOutOfProcTaskHost)' == '' and $([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`))" Runtime="CLR2" />
+
     <UsingTask TaskName="UnregisterAssembly"                         AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '2.0' and ('$(DisableOutOfProcTaskHost)' != '' or !$([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`)))" />
     <UsingTask TaskName="UnregisterAssembly"                         AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '2.0' and '$(DisableOutOfProcTaskHost)' == '' and $([MSBuild]::DoesTaskHostExist(`CLR2`,`CurrentArchitecture`))" Runtime="CLR2" />
+
     <UsingTask TaskName="ReadLinesFromFile"                          AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' or '$(MSBuildToolsVersion)' == '2.0'" />
     <UsingTask TaskName="FindUnderPath"                              AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' or '$(MSBuildToolsVersion)' == '2.0'" />
     <UsingTask TaskName="ConvertToAbsolutePath"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' or '$(MSBuildToolsVersion)' == '2.0'" />
     <UsingTask TaskName="MSBuild"                                    AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '3.5' or '$(MSBuildToolsVersion)' == '2.0'" />
     <UsingTask TaskName="ResolveAssemblyReference"                   AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildToolsVersion)' == '4.0'" />
+
 </Project>

--- a/src/Tasks/Microsoft.Common.overridetasks
+++ b/src/Tasks/Microsoft.Common.overridetasks
@@ -1,8 +1,8 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- This file lists UsingTask elements that we wish to override 
+    <!-- This file lists UsingTask elements that we wish to override
          any other UsingTask elements -->
-    
+
     <!-- NOTE: Listing a <UsingTask> tag in a *.tasks file like this one rather than in a project or targets file
                can give a significant performance advantage in a large build, because every time a <UsingTask> tag
                is encountered, it will cause the task to be rediscovered next time the task is used. -->

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -11,6 +11,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
     <ImportByWildcardBeforeMicrosoftCommonProps Condition="'$(ImportByWildcardBeforeMicrosoftCommonProps)' == ''">true</ImportByWildcardBeforeMicrosoftCommonProps>
     <ImportByWildcardAfterMicrosoftCommonProps Condition="'$(ImportByWildcardAfterMicrosoftCommonProps)' == ''">true</ImportByWildcardAfterMicrosoftCommonProps>
@@ -171,6 +172,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <NuGetPropsFile Condition="'$(NuGetPropsFile)'=='' and '$(MSBuildUseVisualStudioDirectoryLayout)'=='true'">$(MSBuildToolsPath32)\..\..\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.props</NuGetPropsFile>
     <NuGetPropsFile Condition="'$(NuGetPropsFile)'==''">$(MSBuildToolsPath)\NuGet.props</NuGetPropsFile>
   </PropertyGroup>
+
   <Import Condition="Exists('$(NuGetPropsFile)')" Project="$(NuGetPropsFile)" />
 
   <PropertyGroup Condition=" '$(MSBuildLogVerboseTaskParameters)' != 'true' ">
@@ -188,4 +190,5 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <DisableLogTaskParameterItemMetadata_RemoveDuplicates_Filtered>true</DisableLogTaskParameterItemMetadata_RemoveDuplicates_Filtered>
     <DisableLogTaskParameterItemMetadata_WriteLinesToFile_Lines>true</DisableLogTaskParameterItemMetadata_WriteLinesToFile_Lines>
   </PropertyGroup>
+
 </Project>

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -19,7 +19,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ImportDirectoryBuildProps Condition="'$(ImportDirectoryBuildProps)' == ''">true</ImportDirectoryBuildProps>
   </PropertyGroup>
 
-  <!-- 
+  <!--
         Determine the path to the directory build props file if the user did not disable $(ImportDirectoryBuildProps) and
         they did not already specify an absolute path to use via $(DirectoryBuildPropsPath)
     -->
@@ -31,10 +31,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
 
-  <!-- 
+  <!--
         Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
           $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.props
-          
+
         Each package management system should use a unique moniker to avoid collisions.  It is a wild-card import so the package
         management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
     -->
@@ -59,12 +59,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.props" Condition="'$(ImportProjectExtensionProps)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
 
-  <!-- 
+  <!--
         Import wildcard "ImportBefore" props files if we're actually in a 12.0+ project (rather than a project being
         treated as 4.0)
     -->
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' != ''">
-    <!-- 
+    <!--
             Wildcard imports come from $(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props.d folder.
             This is very similar to the same extension point used in Microsoft.Common.targets, which is located in
             the $(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ directory. Unfortunately, there
@@ -75,34 +75,34 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportBefore\*" Condition="'$(ImportByWildcardBeforeMicrosoftCommonProps)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportBefore')"/>
   </ImportGroup>
 
-  <!-- 
-        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed 
-        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead 
-        just used whatever ToolsVersion was in the project file if it existed on the machine, and 
-        only forced 4.0 if that ToolsVersion did not exist.  
+  <!--
+        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
+        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
+        just used whatever ToolsVersion was in the project file if it existed on the machine, and
+        only forced 4.0 if that ToolsVersion did not exist.
 
-        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio, 
-        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected 
-        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved 
-        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist 
+        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio,
+        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected
+        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved
+        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist
         as part of the .NET Framework.  Only if we're using the new MSBuild will we point to the current
-        targets. 
+        targets.
    -->
   <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == '' and ('$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' &gt;= '12.0')">
     <!--
-           Reset VisualStudioVersion if it's 12.0+: Should be 10.0 if VS 2010 is installed or 11.0 otherwise, 
-           but since we don't have a good way of telling whether VS 2010 is installed, make it 11.0 if 
-           VS 2012 is installed or 10.0 otherwise.  The reset should be safe because if it was already 
-           set to something (e.g. 11.0 in a VS 2012 command prompt) then MSBuild's internal 
-           VisualStudioVersion-defaulting code should never come into the picture, so the only way it could 
-           be 12.0+ when building a TV 12.0 project (because we're in this file) using MSBuild 4.5 (because 
-           MSBuildAssemblyVersion hasn't been set) is if it's a TV 12.0 project on an empty command prompt. 
+           Reset VisualStudioVersion if it's 12.0+: Should be 10.0 if VS 2010 is installed or 11.0 otherwise,
+           but since we don't have a good way of telling whether VS 2010 is installed, make it 11.0 if
+           VS 2012 is installed or 10.0 otherwise.  The reset should be safe because if it was already
+           set to something (e.g. 11.0 in a VS 2012 command prompt) then MSBuild's internal
+           VisualStudioVersion-defaulting code should never come into the picture, so the only way it could
+           be 12.0+ when building a TV 12.0 project (because we're in this file) using MSBuild 4.5 (because
+           MSBuildAssemblyVersion hasn't been set) is if it's a TV 12.0 project on an empty command prompt.
       -->
     <VisualStudioVersion Condition="Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props')">11.0</VisualStudioVersion>
     <VisualStudioVersion Condition="!Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props')">10.0</VisualStudioVersion>
   </PropertyGroup>
 
-  <!-- If building using 4.X MSBuild, we want to act like this project is TV 4.0, so override 
+  <!-- If building using 4.X MSBuild, we want to act like this project is TV 4.0, so override
          the custom extensibility target locations with the hard-coded 4.0 equivalent. -->
   <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <CustomBeforeMicrosoftCommonProps Condition="'$(CustomBeforeMicrosoftCommonProps)'==''">$(MSBuildExtensionsPath)\v4.0\Custom.Before.$(MSBuildThisFile)</CustomBeforeMicrosoftCommonProps>
@@ -110,7 +110,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <!-- If building using 4.X MSBuild, we want to act like this project is TV 4.0, so import
-         Microsoft.Common.props from the 4.0 location, and make sure everything else in here is 
+         Microsoft.Common.props from the 4.0 location, and make sure everything else in here is
          set up such that if it's defaulted to something there, it won't be overridden here. -->
   <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props" Condition="'$(MSBuildAssemblyVersion)' == '' and Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props')" />
 
@@ -119,15 +119,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CustomAfterMicrosoftCommonProps Condition="'$(CustomAfterMicrosoftCommonProps)'==''">$(MSBuildExtensionsPath)\v$(MSBuildToolsVersion)\Custom.After.$(MSBuildThisFile)</CustomAfterMicrosoftCommonProps>
   </PropertyGroup>
 
-  <!-- 
-         Only import the extension targets if we're actually in a 12.0 project here (rather than one we're attempting 
-         to treat as 4.0) OR if the Dev11 Microsoft.Common.props don't exist.  If it's a 12.0 project we're redirecting 
-         to 4.0 and the Dev11 Microsoft.Common.props do exist, the extension targets will have been imported already 
+  <!--
+         Only import the extension targets if we're actually in a 12.0 project here (rather than one we're attempting
+         to treat as 4.0) OR if the Dev11 Microsoft.Common.props don't exist.  If it's a 12.0 project we're redirecting
+         to 4.0 and the Dev11 Microsoft.Common.props do exist, the extension targets will have been imported already
          so there's no need to import them twice.
      -->
   <Import Project="$(CustomBeforeMicrosoftCommonProps)" Condition="'$(CustomBeforeMicrosoftCommonProps)' != '' and Exists('$(CustomBeforeMicrosoftCommonProps)') and ('$(MSBuildAssemblyVersion)' != '' or !Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props'))" />
 
-  <!-- This is used to determine whether Microsoft.Common.targets needs to import 
+  <!-- This is used to determine whether Microsoft.Common.targets needs to import
          Microsoft.Common.props itself, or whether it has been imported previously,
          e.g. by the project itself. -->
   <PropertyGroup>
@@ -146,15 +146,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.VisualStudioVersion.v*.Common.props" Condition="'$(VisualStudioVersion)' == ''" />
 
-  <!-- 
-         Only import the extension targets if we're actually in a 12.0 project here (rather than one we're attempting 
-         to treat as 4.0) OR if the Dev11 Microsoft.Common.props don't exist.  If it's a 12.0 project we're redirecting 
-         to 4.0 and the Dev11 Microsoft.Common.props do exist, the extension targets will have been imported already 
+  <!--
+         Only import the extension targets if we're actually in a 12.0 project here (rather than one we're attempting
+         to treat as 4.0) OR if the Dev11 Microsoft.Common.props don't exist.  If it's a 12.0 project we're redirecting
+         to 4.0 and the Dev11 Microsoft.Common.props do exist, the extension targets will have been imported already
          so there's no need to import them twice.
      -->
   <Import Project="$(CustomAfterMicrosoftCommonProps)" Condition="'$(CustomAfterMicrosoftCommonProps)' != '' and Exists('$(CustomAfterMicrosoftCommonProps)') and ('$(MSBuildAssemblyVersion)' != '' or !Exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.props'))" />
 
-  <!-- 
+  <!--
         Import wildcard "ImportAfter" props files if we're actually in a 12.0+ project (rather than a project being
         treated as 4.0)
     -->
@@ -163,7 +163,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportAfter\*" Condition="'$(ImportByWildcardAfterMicrosoftCommonProps)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Imports\Microsoft.Common.props\ImportAfter')"/>
   </ImportGroup>
 
-  <!-- 
+  <!--
         Import NuGet.props file.
     -->
   <PropertyGroup>

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -15,6 +15,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <!--
        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
@@ -158,4 +159,5 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>
    </PropertyGroup>
+
 </Project>

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -15,18 +15,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- 
-       In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed 
-       as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead 
-       just used whatever ToolsVersion was in the project file if it existed on the machine, and 
-       only forced 4.0 if that ToolsVersion did not exist.  
+  <!--
+       In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
+       as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
+       just used whatever ToolsVersion was in the project file if it existed on the machine, and
+       only forced 4.0 if that ToolsVersion did not exist.
 
-       Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio, 
-       but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected 
-       the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved 
-       property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist 
+       Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio,
+       but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected
+       the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved
+       property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist
        as part of the .NET Framework.  Only if we're using the new MSBuild will we point to the current
-       targets. 
+       targets.
    -->
 
   <Choose>
@@ -43,13 +43,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Choose>
 
   <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
-     <!-- 
-          Overrides for the Microsoft.Common.targets extension targets. Used to make sure that only the imports we specify 
-          (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. 
+     <!--
+          Overrides for the Microsoft.Common.targets extension targets. Used to make sure that only the imports we specify
+          (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default.
 
-          NOTE: This logic is duplicated in Microsoft.VisualBasic.targets and in Microsoft.CSharp.targets because those two files 
-          import Microsoft.Common.targets from the current directory and thus don't get the benefit of the redirections, so for 
-          any changes to this logic in this file, please also edit the other two. 
+          NOTE: This logic is duplicated in Microsoft.VisualBasic.targets and in Microsoft.CSharp.targets because those two files
+          import Microsoft.Common.targets from the current directory and thus don't get the benefit of the redirections, so for
+          any changes to this logic in this file, please also edit the other two.
       -->
     <ImportByWildcardBefore40MicrosoftCommonTargets Condition="'$(ImportByWildcardBefore40MicrosoftCommonTargets)' == ''">$(ImportByWildcardBeforeMicrosoftCommonTargets)</ImportByWildcardBefore40MicrosoftCommonTargets>
     <ImportByWildcardBefore40MicrosoftCommonTargets Condition="'$(ImportByWildcardBefore40MicrosoftCommonTargets)' == ''">true</ImportByWildcardBefore40MicrosoftCommonTargets>
@@ -73,15 +73,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == '' and ('$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == 'Silverlight' or ('$(TargetFrameworkIdentifier)' == '' and ('$(TargetRuntime)' == 'Managed' or '$(TargetRuntime)' == '')))">
-     <!-- 
-          Overrides for the Microsoft.NETFramework.props extension targets. Used to make sure that only the imports we specify 
-          (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Required because 
-          Microsoft.Common.targets imports it from the current directory, so we don't get a chance to redirect these in its 
-          own redirection targets. 
+     <!--
+          Overrides for the Microsoft.NETFramework.props extension targets. Used to make sure that only the imports we specify
+          (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Required because
+          Microsoft.Common.targets imports it from the current directory, so we don't get a chance to redirect these in its
+          own redirection targets.
 
-          NOTE: This logic is duplicated in Microsoft.VisualBasic.targets and in Microsoft.CSharp.targets because those two files 
-          import Microsoft.Common.targets from the current directory and thus don't get the benefit of these redirections either, 
-          so for any changes to this logic in this file, please also edit the other two. 
+          NOTE: This logic is duplicated in Microsoft.VisualBasic.targets and in Microsoft.CSharp.targets because those two files
+          import Microsoft.Common.targets from the current directory and thus don't get the benefit of these redirections either,
+          so for any changes to this logic in this file, please also edit the other two.
       -->
     <ImportByWildcardBefore40MicrosoftNetFrameworkProps Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == ''">$(ImportByWildcardBeforeMicrosoftNetFrameworkProps)</ImportByWildcardBefore40MicrosoftNetFrameworkProps>
     <ImportByWildcardBefore40MicrosoftNetFrameworkProps Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == ''">true</ImportByWildcardBefore40MicrosoftNetFrameworkProps>
@@ -104,7 +104,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBefore40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore')"/>
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore')"/>
-  </ImportGroup> 
+  </ImportGroup>
 
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBefore40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore')"/>
@@ -116,7 +116,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!--
       Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
           $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.targets
-          
+
         Each package management system should use a unique moniker to avoid collisions.  It is a wild-card import so the package
         management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
     -->
@@ -130,7 +130,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ImportDirectoryBuildTargets Condition="'$(ImportDirectoryBuildTargets)' == ''">true</ImportDirectoryBuildTargets>
   </PropertyGroup>
 
-  <!-- 
+  <!--
         Determine the path to the directory build targets file if the user did not disable $(ImportDirectoryBuildTargets) and
         they did not already specify an absolute path to use via $(DirectoryBuildTargetsPath)
     -->
@@ -145,15 +145,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter\*" Condition="'$(ImportByWildcardAfter40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter')"/>
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfter40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter')"/>
-  </ImportGroup> 
+  </ImportGroup>
 
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfter40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter')"/>
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfter40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter')"/>
   </ImportGroup>
 
-   <!-- Fix up FrameworkPathOverride, which is primarily used to determine the location of mscorlib.dll in the 
-        (relatively uncommon) situation where the reference assemblies, in which it's usually found, are not 
+   <!-- Fix up FrameworkPathOverride, which is primarily used to determine the location of mscorlib.dll in the
+        (relatively uncommon) situation where the reference assemblies, in which it's usually found, are not
         installed.  -->
    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <!-- This file lists all the tasks that ship by default with MSBuild -->
-    
+
     <!-- NOTE: Listing a <UsingTask> tag in a *.tasks file like this one rather than in a project or targets file
                can give a significant performance advantage in a large build, because every time a <UsingTask> tag
                is encountered, it will cause the task to be rediscovered next time the task is used. -->
@@ -110,7 +110,7 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.FindAppConfigFile"                     AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.FindInList"                            AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.FindInvalidProjectReferences"          AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
-    
+
     <UsingTask TaskName="Microsoft.Build.Tasks.FindUnderPath"                         AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.FormatUrl"                             AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.FormatVersion"                         AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
@@ -182,4 +182,3 @@
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"                       AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly"           AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
 </Project>
-

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -1,4 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
     <!-- This file lists all the tasks that ship by default with MSBuild -->
 
     <!-- NOTE: Listing a <UsingTask> tag in a *.tasks file like this one rather than in a project or targets file
@@ -181,4 +182,5 @@
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"                       AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"                       AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly"           AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+
 </Project>

--- a/src/Tasks/Microsoft.Data.Entity.targets
+++ b/src/Tasks/Microsoft.Data.Entity.targets
@@ -1,4 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
         outside of the .NET Framework.  As a result of this, there were several targets files, of which

--- a/src/Tasks/Microsoft.Data.Entity.targets
+++ b/src/Tasks/Microsoft.Data.Entity.targets
@@ -1,12 +1,12 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <!-- 
+   <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
-        outside of the .NET Framework.  As a result of this, there were several targets files, of which 
-        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.  
+        outside of the .NET Framework.  As a result of this, there were several targets files, of which
+        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.
 
-        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that 
-        consumers of them are not broken, but since the targets files themselves are still part of .NET, 
-        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
+        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that
+        consumers of them are not broken, but since the targets files themselves are still part of .NET,
+        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework.
    -->
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.Data.Entity.targets" Condition="Exists('$(MSBuildFrameworkToolsPath)\Microsoft.Data.Entity.targets')" />

--- a/src/Tasks/Microsoft.Managed.Before.targets
+++ b/src/Tasks/Microsoft.Managed.Before.targets
@@ -12,6 +12,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project>
+
    <!--
         We are doing a cross-targeting build if there is a non-empty list of target frameworks specified
         and there is no current target framework being built individually. In that case, a multitargeting

--- a/src/Tasks/Microsoft.NET.props
+++ b/src/Tasks/Microsoft.NET.props
@@ -29,7 +29,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!--
     ============================================================
                                         SetHighEntropyVA
-    Set HighEntropyVA according to the TargetFramework 
+    Set HighEntropyVA according to the TargetFramework
     ============================================================
     -->
 

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
@@ -28,9 +28,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <!-- By default we want to replace subsets with profiles, but we do need a way to turning off this "upgrade" in case a user needs to target a subset-->
     <UpgradeSubsetToProfile Condition="'$(UpgradeSubsetToProfile)' == '' ">true</UpgradeSubsetToProfile>
-
     <TargetFrameworkProfile Condition="'$(UpgradeSubsetToProfile)' == 'true' and '$(TargetFrameworkSubset)' != '' and '$(TargetFrameworkProfile)' == ''">$(TargetFrameworkSubset)</TargetFrameworkProfile>
-
     <!-- If we are not upgrading the Subset to a profile this means we want to target a subset, do not wipe out the subset name-->
     <TargetFrameworkSubset Condition="'$(UpgradeTargetFrameworkSubsetToProfile)' == 'true'"></TargetFrameworkSubset>
   </PropertyGroup>
@@ -41,7 +39,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(TargetFrameworkVersion)' == 'v4.0' and '$(FrameworkPathOverride)' == ''">
-
     <!-- The FrameworkPathOverride property is required for the IDE Visual Basic compiler to initialize.
              This location contains reference assemblies for mscorlib.dll and other key VB assemblies.
              This property is required during project evaluation, since the IDE compilers need to initialize before
@@ -62,7 +59,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <MSBuildFrameworkToolsRoot Condition="'$(MSBuildFrameworkToolsRoot)' == '' and '$(MSBuildRuntimeType)' != 'Core'">$(Registry:HKEY_LOCAL_MACHINE\Software\Microsoft\.NETFramework@InstallRoot)</MSBuildFrameworkToolsRoot>
     <_DeploymentSignClickOnceManifests Condition="'$(TargetFrameworkVersion)' == 'v2.0' or '$(TargetFrameworkVersion)' == 'v3.0' or '$(SignManifests)' == 'true'">true</_DeploymentSignClickOnceManifests>
-
     <!-- Assembly names added to the AdditionalExplicitAssemblyReferences property will be added as references to the resolve assembly reference call by default this is done because when upgrading from
          a project targeting 2.0 to 3.5 the system.core reference is not added, therefore we need to add it automatically -->
     <AddAdditionalExplicitAssemblyReferences Condition="'$(AddAdditionalExplicitAssemblyReferences)' == ''">true</AddAdditionalExplicitAssemblyReferences>
@@ -79,17 +75,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <PropertyGroup>
     <TargetingClr2Framework Condition="'$(TargetFrameworkVersion)' == 'v2.0' or '$(TargetFrameworkVersion)' == 'v3.0' or '$(TargetFrameworkVersion)' == 'v3.5'">true</TargetingClr2Framework>
-
     <MSBuildManagedCompilerPath Condition="'$(TargetingClr2Framework)' == 'true'">$(MSBuildFrameworkToolsRoot)\v3.5</MSBuildManagedCompilerPath >
-
     <TargetFrameworkSDKToolsDirectory Condition="'$(TargetingClr2Framework)' == 'true'">$(SDK35ToolsPath)</TargetFrameworkSDKToolsDirectory>
     <!-- If the sdk path is not 3.5 or lower set it to the 40 sdk tools path. This will allow future target framework versions to use the 4.0 sdk tool set
              When a new windows SDK revs they will inplace update the location pointed to by this property. When a new sdk is release this target will have to be
              revised along with another toolsversion. -->
-
     <TargetedRuntimeVersion Condition="'$(TargetedRuntimeVersion)' == '' and ('$(TargetingClr2Framework)' == 'true')">v2.0.50727</TargetedRuntimeVersion>
     <TargetedRuntimeVersion Condition="'$(TargetedRuntimeVersion)' == ''">v$(MSBuildRuntimeVersion)</TargetedRuntimeVersion>
-
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(TargetingClr2Framework)' != 'true' and '$(TargetFrameworkVersion)' != 'v4.0' and ('$(OutputType)' == 'exe' or '$(OutputType)' == 'winexe' or '$(OutputType)' == 'appcontainerexe' or '$(OutputType)' == '')">

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
@@ -24,12 +24,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBeforeMicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportBefore')"/>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportBefore\*" Condition="'$(ImportByWildcardBeforeMicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportBefore')"/>
-  
+
   <Target
       Name="GetFrameworkPaths"
       DependsOnTargets="$(GetFrameworkPathsDependsOn)">
 
-    <!-- For backwards compatibility of targets who replaced this target we cannot move these values outside the target even though they 
+    <!-- For backwards compatibility of targets who replaced this target we cannot move these values outside the target even though they
              now only depend on statically availiable values-->
 
     <ItemGroup>
@@ -82,7 +82,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       GetReferenceAssemblyPaths
     </ImplicitlyExpandDesignTimeFacadesDependsOn>
   </PropertyGroup>
-  
+
   <!-- Implicitly references all portable design-time facades if the user is referencing a System.Runtime-based portable library -->
   <Target Name="ImplicitlyExpandDesignTimeFacades" Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
 
@@ -128,7 +128,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.WinFX.targets" Condition="'$(TargetFrameworkVersion)' != 'v2.0' and '$(TargetCompactFramework)' != 'true' and Exists('$(MSBuildToolsPath)\Microsoft.WinFX.targets')"/>
   <Import Project="$(MSBuildToolsPath)\Microsoft.Data.Entity.targets" Condition="'$(TargetFrameworkVersion)' != 'v2.0' and '$(TargetFrameworkVersion)' !=  'v3.0' and Exists('$(MSBuildToolsPath)\Microsoft.Data.Entity.targets')"/>
-  
+
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfterMicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportAfter')"/>
   <Import Project="$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfterMicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportAfter')"/>
 

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
@@ -58,7 +58,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <_CombinedTargetFrameworkDirectoriesItem Condition=" '@(_CombinedTargetFrameworkDirectoriesItem)' == ''"
                                                  Include="@(_TargetedFrameworkDirectoryItem)" />
-
     </ItemGroup>
 
     <PropertyGroup>
@@ -69,6 +68,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_TargetFrameworkSDKDirectoryItem Include="$(TargetFrameworkSDKDirectory)"/>
     </ItemGroup>
+
   </Target>
 
   <PropertyGroup>
@@ -89,7 +89,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PropertyGroup>
       <!-- Does one of our dependencies reference a System.Runtime-based portable library? -->
       <_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true'">true</_HasReferenceToSystemRuntime>
-
       <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
       <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetFrameworkIdentifier)' == '.NETStandard' and '%(_ResolvedProjectReferencePaths.TargetFrameworkVersion)' &lt; '2.0'">true</_HasReferenceToSystemRuntime>
 
@@ -100,10 +99,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
       <_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
     </ItemGroup>
+
     <ItemGroup Condition="'$(_HasReferenceToNETStandard)' == 'true' And '$(_HasReferenceToSystemRuntime)' != 'true'">
       <_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)netstandard.dll"
                                    Condition="Exists('%(DesignTimeFacadeDirectories.Identity)netstandard.dll')"/>
     </ItemGroup>
+
     <ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' Or '$(_HasReferenceToNETStandard)' == 'true' ">
       <_DesignTimeFacadeAssemblies_Names Include="@(_DesignTimeFacadeAssemblies->'%(FileName)')">
           <OriginalIdentity>%(_DesignTimeFacadeAssemblies.Identity)</OriginalIdentity>
@@ -120,6 +121,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CopyLocal>false</CopyLocal>
         <ResolvedFrom>ImplicitlyExpandDesignTimeFacades</ResolvedFrom>
       </ReferencePath>
+
       <_ResolveAssemblyReferenceResolvedFiles Include="@(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NETFramework.props
+++ b/src/Tasks/Microsoft.NETFramework.props
@@ -14,18 +14,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <!-- 
-        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed 
-        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead 
-        just used whatever ToolsVersion was in the project file if it existed on the machine, and 
-        only forced 4.0 if that ToolsVersion did not exist.  
+   <!--
+        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
+        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
+        just used whatever ToolsVersion was in the project file if it existed on the machine, and
+        only forced 4.0 if that ToolsVersion did not exist.
 
-        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio, 
-        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected 
-        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved 
-        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist 
+        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio,
+        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected
+        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved
+        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist
         as part of the .NET Framework.  Only if we're using the new MSBuild will we point to the current
-        targets. 
+        targets.
    -->
 
    <Choose>

--- a/src/Tasks/Microsoft.NETFramework.props
+++ b/src/Tasks/Microsoft.NETFramework.props
@@ -14,6 +14,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
         as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead

--- a/src/Tasks/Microsoft.NETFramework.targets
+++ b/src/Tasks/Microsoft.NETFramework.targets
@@ -14,18 +14,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <!-- 
-        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed 
-        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead 
-        just used whatever ToolsVersion was in the project file if it existed on the machine, and 
-        only forced 4.0 if that ToolsVersion did not exist.  
+   <!--
+        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
+        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
+        just used whatever ToolsVersion was in the project file if it existed on the machine, and
+        only forced 4.0 if that ToolsVersion did not exist.
 
-        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio, 
-        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected 
-        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved 
-        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist 
+        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio,
+        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected
+        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved
+        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist
         as part of the .NET Framework.  Only if we're using the new MSBuild will we point to the current
-        targets. 
+        targets.
    -->
 
    <Choose>
@@ -43,8 +43,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <!--
-           Overrides for the Microsoft.NETFramework.targets extension targets.  Used to make sure that only the imports we specify 
-           (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. 
+           Overrides for the Microsoft.NETFramework.targets extension targets.  Used to make sure that only the imports we specify
+           (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default.
        -->
       <ImportByWildcardBefore40MicrosoftNetFrameworkTargets Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkTargets)' == ''">$(ImportByWildcardBeforeMicrosoftNetFrameworkTargets)</ImportByWildcardBefore40MicrosoftNetFrameworkTargets>
       <ImportByWildcardBefore40MicrosoftNetFrameworkTargets Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkTargets)' == ''">true</ImportByWildcardBefore40MicrosoftNetFrameworkTargets>
@@ -67,13 +67,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.targets\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBefore40MicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.targets\ImportBefore')"/>
       <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.targets\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.targets\ImportBefore')"/>
-   </ImportGroup> 
+   </ImportGroup>
 
    <Import Project="$(NetFrameworkTargetsPath)" />
 
    <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfter40MicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.targets\ImportAfter')"/>
       <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.targets\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfter40MicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.targets\ImportAfter')"/>
-   </ImportGroup> 
+   </ImportGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NETFramework.targets
+++ b/src/Tasks/Microsoft.NETFramework.targets
@@ -14,6 +14,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
         as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead

--- a/src/Tasks/Microsoft.ServiceModel.targets
+++ b/src/Tasks/Microsoft.ServiceModel.targets
@@ -1,4 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
         outside of the .NET Framework.  As a result of this, there were several targets files, of which

--- a/src/Tasks/Microsoft.ServiceModel.targets
+++ b/src/Tasks/Microsoft.ServiceModel.targets
@@ -1,12 +1,12 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <!-- 
+   <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
-        outside of the .NET Framework.  As a result of this, there were several targets files, of which 
-        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.  
+        outside of the .NET Framework.  As a result of this, there were several targets files, of which
+        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.
 
-        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that 
-        consumers of them are not broken, but since the targets files themselves are still part of .NET, 
-        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
+        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that
+        consumers of them are not broken, but since the targets files themselves are still part of .NET,
+        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework.
    -->
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.ServiceModel.targets" Condition="Exists('$(MSBuildFrameworkToolsPath)\Microsoft.ServiceModel.targets')" />

--- a/src/Tasks/Microsoft.VisualBasic.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CrossTargeting.targets
@@ -17,6 +17,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
      <VisualBasicDesignTimeTargetsPath Condition="'$(VisualBasicDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.VisualBasic.DesignTime.targets</VisualBasicDesignTimeTargetsPath>
   </PropertyGroup>
+
   <Import Project="$(VisualBasicDesignTimeTargetsPath)" Condition="'$(VisualBasicDesignTimeTargetsPath)' != '' and Exists('$(VisualBasicDesignTimeTargetsPath)')" />
 
   <Import Project="Microsoft.Common.CrossTargeting.targets" />

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -83,15 +83,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     For other project systems, this transformation may be different.
     -->
+
     <PropertyGroup>
         <CreateManifestResourceNamesDependsOn></CreateManifestResourceNamesDependsOn>
     </PropertyGroup>
+
     <Target
         Name="CreateManifestResourceNames"
         Condition="'@(EmbeddedResource)' != ''"
         DependsOnTargets="$(CreateManifestResourceNamesDependsOn)"
         >
-
         <ItemGroup>
             <_Temporary Remove="@(_Temporary)" />
         </ItemGroup>
@@ -102,9 +103,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               RootNamespace="$(RootNamespace)"
               UseDependentUponConvention="$(EmbeddedResourceUseDependentUponConvention)"
               Condition="'%(EmbeddedResource.ManifestResourceName)' == '' and ('%(EmbeddedResource.WithCulture)' == 'false' or '%(EmbeddedResource.Type)' == 'Resx')">
-
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />
-
         </CreateVisualBasicManifestResourceName>
 
         <!-- Create manifest names for all culture non-resx resources -->
@@ -114,9 +113,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               PrependCultureAsDirectory="false"
               UseDependentUponConvention="$(EmbeddedResourceUseDependentUponConvention)"
               Condition="'%(EmbeddedResource.ManifestResourceName)' == '' and '%(EmbeddedResource.WithCulture)' == 'true' and '%(EmbeddedResource.Type)' == 'Non-Resx'">
-
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />
-
         </CreateVisualBasicManifestResourceName>
 
         <ItemGroup>
@@ -124,23 +121,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <EmbeddedResource Include="@(_Temporary)" />
             <_Temporary Remove="@(_Temporary)" />
         </ItemGroup>
-
     </Target>
 
     <Target
         Name="ResolveCodeAnalysisRuleSet"
         Condition="'$(CodeAnalysisRuleSet)' != ''"
         >
-
         <ResolveCodeAnalysisRuleSet
             CodeAnalysisRuleSet="$(CodeAnalysisRuleSet)"
             CodeAnalysisRuleSetDirectories="$(CodeAnalysisRuleSetDirectories)"
             MSBuildProjectDirectory="$(MSBuildProjectDirectory)">
-
             <Output TaskParameter="ResolvedCodeAnalysisRuleSet" PropertyName="ResolvedCodeAnalysisRuleSet" />
-
         </ResolveCodeAnalysisRuleSet>
-
     </Target>
 
     <PropertyGroup>
@@ -328,9 +320,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PropertyGroup>
        <VisualBasicDesignTimeTargetsPath Condition="'$(VisualBasicDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.VisualBasic.DesignTime.targets</VisualBasicDesignTimeTargetsPath>
     </PropertyGroup>
+
     <Import Project="$(VisualBasicDesignTimeTargetsPath)" Condition="'$(VisualBasicDesignTimeTargetsPath)' != '' and Exists('$(VisualBasicDesignTimeTargetsPath)')" />
 
     <Import Project="Microsoft.Common.targets" />
+
     <Import Project="$(MSBuildToolsPath)\Microsoft.ServiceModel.targets" Condition="('$(TargetFrameworkVersion)' != 'v2.0' and '$(TargetFrameworkVersion)' != 'v3.0' and '$(TargetFrameworkVersion)' != 'v3.5') and Exists('$(MSBuildToolsPath)\Microsoft.ServiceModel.targets')"/>
 
     <Target Name="_SetTargetFrameworkMonikerAttribute" BeforeTargets="GenerateTargetFrameworkMonikerAttribute">
@@ -350,7 +344,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <PropertyGroup>
        <Utf8Output Condition="'$(Utf8Output)' == ''">true</Utf8Output>
-
       <!-- NoCompilerStandardLib maps to the compiler's /nostdlib option. By default we always
            want that switch to be passed to the compiler so that either we or the user
            provides the references
@@ -358,7 +351,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
            so only if NoStdLib isn't set to true, will we provide the standard references
       -->
       <NoCompilerStandardLib Condition=" '$(NoCompilerStandardLib)' == '' ">true</NoCompilerStandardLib>
-
        <!-- When building inside VS, by default use the same language for compiler messages as VS itself does. -->
        <PreferredUILang Condition="'$(BuildingInsideVisualStudio)' == 'true' and '$(PreferredUILang)' == ''">$([System.Globalization.CultureInfo]::CurrentUICulture.Name)</PreferredUILang>
     </PropertyGroup>

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -8,7 +8,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 This file defines the steps in the standard build process specific for VB .NET projects.
 For example, it contains the step that actually calls the VB compiler.  The remainder
-of the build process is defined in Microsoft.Common.targets, which is imported by 
+of the build process is defined in Microsoft.Common.targets, which is imported by
 this file.
 
 Copyright (C) Microsoft Corporation. All rights reserved.
@@ -21,7 +21,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
        <ImportByWildcardBeforeMicrosoftVisualBasicTargets Condition="'$(ImportByWildcardBeforeMicrosoftVisualBasicTargets)' == ''">true</ImportByWildcardBeforeMicrosoftVisualBasicTargets>
        <ImportByWildcardAfterMicrosoftVisualBasicTargets Condition="'$(ImportByWildcardAfterMicrosoftVisualBasicTargets)' == ''">true</ImportByWildcardAfterMicrosoftVisualBasicTargets>
        <ImportUserLocationsByWildcardBeforeMicrosoftVisualBasicTargets Condition="'$(ImportUserLocationsByWildcardBeforeMicrosoftVisualBasicTargets)' == ''">true</ImportUserLocationsByWildcardBeforeMicrosoftVisualBasicTargets>
-       <ImportUserLocationsByWildcardAfterMicrosoftVisualBasicTargets Condition="'$(ImportUserLocationsByWildcardAfterMicrosoftVisualBasicTargets)' == ''">true</ImportUserLocationsByWildcardAfterMicrosoftVisualBasicTargets>    
+       <ImportUserLocationsByWildcardAfterMicrosoftVisualBasicTargets Condition="'$(ImportUserLocationsByWildcardAfterMicrosoftVisualBasicTargets)' == ''">true</ImportUserLocationsByWildcardAfterMicrosoftVisualBasicTargets>
     </PropertyGroup>
 
     <Import Project="$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.VisualBasic.targets\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBeforeMicrosoftVisualBasicTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.VisualBasic.targets\ImportBefore')"/>
@@ -65,14 +65,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!--
     The CreateManifestResourceNames target create the manifest resource names from the .RESX
-    files.      
-    
+    files.
+
         [IN]
         @(EmbeddedResource) - The list of EmbeddedResource items that have been pre-processed to add metadata about resource type
                               Expected Metadata "Type" can either be "Resx" or "Non-Resx"
 
         [OUT]
-        @(EmbeddedResource) - EmbeddedResource items with metadata    
+        @(EmbeddedResource) - EmbeddedResource items with metadata
 
     For VB applications the transformation is like:
 
@@ -91,11 +91,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Condition="'@(EmbeddedResource)' != ''"
         DependsOnTargets="$(CreateManifestResourceNamesDependsOn)"
         >
-        
+
         <ItemGroup>
             <_Temporary Remove="@(_Temporary)" />
         </ItemGroup>
-        
+
         <!-- Create manifest names for culture and non-culture Resx files, and for non-culture Non-Resx resources -->
         <CreateVisualBasicManifestResourceName
               ResourceFiles="@(EmbeddedResource)"
@@ -106,7 +106,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />
 
         </CreateVisualBasicManifestResourceName>
-        
+
         <!-- Create manifest names for all culture non-resx resources -->
         <CreateVisualBasicManifestResourceName
               ResourceFiles="@(EmbeddedResource)"
@@ -124,7 +124,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <EmbeddedResource Include="@(_Temporary)" />
             <_Temporary Remove="@(_Temporary)" />
         </ItemGroup>
-      
+
     </Target>
 
     <Target
@@ -205,8 +205,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <PropertyGroup>
             <_NoWarnings Condition=" '$(WarningLevel)' == '0' ">true</_NoWarnings>
             <_NoWarnings Condition=" '$(WarningLevel)' == '1' ">false</_NoWarnings>
-        </PropertyGroup> 
-        
+        </PropertyGroup>
+
         <PropertyGroup>
           <!-- If we are targeting winmdobj we want to specifically set the pdbFile property so that it does not collide with the output of winmdexp which we will run subsequently -->
           <PdbFile Condition="'$(PdbFile)' == '' and '$(OutputType)' == 'winmdobj' and '$(DebugSymbols)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
@@ -227,7 +227,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           <AdditionalFileItems Include="$(AdditionalFileItemNames)" />
           <AdditionalFiles Include="@(%(AdditionalFileItems.Identity))" />
         </ItemGroup>
-      
+
         <!-- Don't run analyzers for Vbc task on XamlPrecompile pass, we only want to run them on core compile. -->
         <!-- Analyzers="@(Analyzer)" -->
 
@@ -272,7 +272,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               OptionExplicit="$(OptionExplicit)"
               OptionInfer="$(OptionInfer)"
               OptionStrict="$(OptionStrict)"
-              OptionStrictType="$(OptionStrictType)" 
+              OptionStrictType="$(OptionStrictType)"
               OutputAssembly="@(XamlIntermediateAssembly)"
               Platform="$(PlatformTarget)"
               Prefer32Bit="$(Prefer32Bit)"
@@ -308,12 +308,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
  <!-- Only Applicable to the regular CoreCompile:
               <ItemGroup>
-                  <_CoreCompileResourceInputs Remove="@(_CoreCompileResourceInputs)" />                  
-              </ItemGroup>    
-              
-              <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''"/>         
- -->         
-        <OnError Condition="'$(OnXamlPreCompileErrorTarget)' != ''" ExecuteTargets="$(OnXamlPreCompileErrorTarget)" />    
+                  <_CoreCompileResourceInputs Remove="@(_CoreCompileResourceInputs)" />
+              </ItemGroup>
+
+              <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''"/>
+ -->
+        <OnError Condition="'$(OnXamlPreCompileErrorTarget)' != ''" ExecuteTargets="$(OnXamlPreCompileErrorTarget)" />
     </Target>
 
     <PropertyGroup>

--- a/src/Tasks/Microsoft.VisualBasic.targets
+++ b/src/Tasks/Microsoft.VisualBasic.targets
@@ -17,6 +17,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
         as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
@@ -35,7 +36,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <When Condition="'$(MSBuildAssemblyVersion)' == ''">
       <PropertyGroup>
         <VisualBasicTargetsPath>$(MSBuildFrameworkToolsPath)\Microsoft.VisualBasic.targets</VisualBasicTargetsPath>
-
         <!-- Same condition as in .NET 4.5 VB targets so that we can override the behavior where it defaults to
              MSBuildToolsPath, which would be incorrect in this case -->
         <VbcToolPath Condition="'$(VbcToolPath)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">$(MsBuildFrameworkToolsPath)</VbcToolPath>
@@ -191,4 +191,5 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>
    </PropertyGroup>
+
 </Project>

--- a/src/Tasks/Microsoft.VisualBasic.targets
+++ b/src/Tasks/Microsoft.VisualBasic.targets
@@ -9,7 +9,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 This file defines the steps in the standard build process specific for VB .NET projects.
 For example, it contains the step that actually calls the VB compiler.  The remainder
-of the build process is defined in Microsoft.Common.targets, which is imported by 
+of the build process is defined in Microsoft.Common.targets, which is imported by
 this file.
 
 Copyright (C) Microsoft Corporation. All rights reserved.
@@ -18,17 +18,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <!--
-        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed 
-        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead 
-        just used whatever ToolsVersion was in the project file if it existed on the machine, and 
-        only forced 4.0 if that ToolsVersion did not exist.  
+        In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed
+        as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead
+        just used whatever ToolsVersion was in the project file if it existed on the machine, and
+        only forced 4.0 if that ToolsVersion did not exist.
 
-        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio, 
-        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected 
-        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved 
-        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist 
+        Moving forward, we do want to enforce a single acting ToolsVersion per version of Visual Studio,
+        but in order to approximate this behavior on VS 2010 SP1 and VS 2012 as well, we've redirected
+        the targets:  If we're building using 4.X MSBuild (which doesn't define the new reserved
+        property, MSBuildAssemblyVersion), we'll point right back at the 4.0 targets, which still exist
         as part of the .NET Framework.  Only if we're using the new MSBuild will we point to the current
-        targets. 
+        targets.
    -->
 
   <Choose>
@@ -36,7 +36,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <PropertyGroup>
         <VisualBasicTargetsPath>$(MSBuildFrameworkToolsPath)\Microsoft.VisualBasic.targets</VisualBasicTargetsPath>
 
-        <!-- Same condition as in .NET 4.5 VB targets so that we can override the behavior where it defaults to 
+        <!-- Same condition as in .NET 4.5 VB targets so that we can override the behavior where it defaults to
              MSBuildToolsPath, which would be incorrect in this case -->
         <VbcToolPath Condition="'$(VbcToolPath)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">$(MsBuildFrameworkToolsPath)</VbcToolPath>
       </PropertyGroup>
@@ -54,14 +54,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Choose>
 
   <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
-    <!-- 
-         Overrides for the Microsoft.Common.targets extension targets. Used to make sure that only the imports we specify 
-         (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Defined here because 
-         Microsoft.VisualBasic.targets imports Microsoft.Common.targets from the current directory rather than using 
+    <!--
+         Overrides for the Microsoft.Common.targets extension targets. Used to make sure that only the imports we specify
+         (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Defined here because
+         Microsoft.VisualBasic.targets imports Microsoft.Common.targets from the current directory rather than using
          MSBuildToolsPath, so defining these in Microsoft.Common.targets alone would not suffice for VB projects.
 
          NOTE: This logic is duplicated in Microsoft.CSharp.targets (C# has the same problem) and in Microsoft.Common.targets
-         (for anyone who DOES import it directly), so for any changes to this logic in this file, please also edit the other two. 
+         (for anyone who DOES import it directly), so for any changes to this logic in this file, please also edit the other two.
      -->
     <ImportByWildcardBefore40MicrosoftCommonTargets Condition="'$(ImportByWildcardBefore40MicrosoftCommonTargets)' == ''">$(ImportByWildcardBeforeMicrosoftCommonTargets)</ImportByWildcardBefore40MicrosoftCommonTargets>
     <ImportByWildcardBefore40MicrosoftCommonTargets Condition="'$(ImportByWildcardBefore40MicrosoftCommonTargets)' == ''">true</ImportByWildcardBefore40MicrosoftCommonTargets>
@@ -106,15 +106,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == '' and ('$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == 'Silverlight' or ('$(TargetFrameworkIdentifier)' == '' and ('$(TargetRuntime)' == 'Managed' or '$(TargetRuntime)' == '')))">
-     <!-- 
-          Overrides for the Microsoft.NETFramework.props extension targets. Used to make sure that only the imports we specify 
-          (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Required because 
-          Microsoft.Common.targets imports it from the current directory, so we don't get a chance to redirect these in its 
+     <!--
+          Overrides for the Microsoft.NETFramework.props extension targets. Used to make sure that only the imports we specify
+          (hard-coded to 4.0 locations) are used, not the 12.0 locations that would be used by default. Required because
+          Microsoft.Common.targets imports it from the current directory, so we don't get a chance to redirect these in its
           own redirection targets.
 
           NOTE: This logic is duplicated in Microsoft.CSharp.targets and in Microsoft.Common.targets because VB and C#
-          import Microsoft.Common.targets from the current directory and thus don't get the benefit of these redirections either, 
-          so for any changes to this logic in this file, please also edit the other two. 
+          import Microsoft.Common.targets from the current directory and thus don't get the benefit of these redirections either,
+          so for any changes to this logic in this file, please also edit the other two.
       -->
     <ImportByWildcardBefore40MicrosoftNetFrameworkProps Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == ''">$(ImportByWildcardBeforeMicrosoftNetFrameworkProps)</ImportByWildcardBefore40MicrosoftNetFrameworkProps>
     <ImportByWildcardBefore40MicrosoftNetFrameworkProps Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == ''">true</ImportByWildcardBefore40MicrosoftNetFrameworkProps>
@@ -137,24 +137,24 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.VisualBasic.targets\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBefore40MicrosoftVisualBasicTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.VisualBasic.targets\ImportBefore')"/>
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.VisualBasic.targets\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftVisualBasicTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.VisualBasic.targets\ImportBefore')"/>
-  </ImportGroup> 
+  </ImportGroup>
 
-  <!-- Really should be imported right before Microsoft.Common.targets, but because Microsoft.VisualBasic.targets imports 
+  <!-- Really should be imported right before Microsoft.Common.targets, but because Microsoft.VisualBasic.targets imports
        Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
-       targets), we're stuck doing it this way instead. --> 
+       targets), we're stuck doing it this way instead. -->
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBefore40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore')"/>
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportBefore')"/>
-  </ImportGroup> 
+  </ImportGroup>
 
-  <!-- Really should be imported right before Microsoft.NETFramework.props, but because Microsoft.VisualBasic.targets imports 
+  <!-- Really should be imported right before Microsoft.NETFramework.props, but because Microsoft.VisualBasic.targets imports
        Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
-       targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this 
-       way instead. --> 
+       targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this
+       way instead. -->
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBefore40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore')"/>
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore')"/>
-  </ImportGroup> 
+  </ImportGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.Before.targets" />
 
@@ -164,29 +164,29 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!-- Really should be imported right after Microsoft.NETFramework.props, but because Microsoft.VisualBasic.targets imports
        Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
-       targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this 
-       way instead. --> 
+       targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this
+       way instead. -->
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter\*" Condition="'$(ImportByWildcardAfter40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter')"/>
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfter40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportAfter')"/>
-  </ImportGroup> 
+  </ImportGroup>
 
-  <!-- Really should be imported right after Microsoft.Common.targets, but because Microsoft.VisualBasic.targets imports 
+  <!-- Really should be imported right after Microsoft.Common.targets, but because Microsoft.VisualBasic.targets imports
        Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
-       targets), we're stuck doing it this way instead. --> 
+       targets), we're stuck doing it this way instead. -->
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfter40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter')"/>
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfter40MicrosoftCommonTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.Common.targets\ImportAfter')"/>
-  </ImportGroup> 
+  </ImportGroup>
 
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.VisualBasic.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfter40MicrosoftVisualBasicTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.VisualBasic.targets\ImportAfter')"/>
     <Import Project="$(MSBuildUserExtensionsPath)\4.0\Microsoft.VisualBasic.targets\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfter40MicrosoftVisualBasicTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\4.0\Microsoft.VisualBasic.targets\ImportAfter')"/>
-  </ImportGroup> 
+  </ImportGroup>
 
-   <!-- Fix up FrameworkPathOverride, which is primarily used to determine the location of mscorlib.dll in the 
-        (relatively uncommon) situation where the reference assemblies, in which it's usually found, are not 
-        installed.  Defined here rather than in Microsoft.Common.targets because the .NET Microsoft.VisualBasic.targets 
+   <!-- Fix up FrameworkPathOverride, which is primarily used to determine the location of mscorlib.dll in the
+        (relatively uncommon) situation where the reference assemblies, in which it's usually found, are not
+        installed.  Defined here rather than in Microsoft.Common.targets because the .NET Microsoft.VisualBasic.targets
         imports Microsoft.Common.targets from the current directory. -->
    <PropertyGroup Condition="'$(MSBuildAssemblyVersion)' == ''">
       <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>

--- a/src/Tasks/Microsoft.WinFx.targets
+++ b/src/Tasks/Microsoft.WinFx.targets
@@ -1,4 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
         outside of the .NET Framework.  As a result of this, there were several targets files, of which

--- a/src/Tasks/Microsoft.WinFx.targets
+++ b/src/Tasks/Microsoft.WinFx.targets
@@ -1,12 +1,12 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <!-- 
+   <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
-        outside of the .NET Framework.  As a result of this, there were several targets files, of which 
-        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.  
+        outside of the .NET Framework.  As a result of this, there were several targets files, of which
+        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.
 
-        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that 
-        consumers of them are not broken, but since the targets files themselves are still part of .NET, 
-        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
+        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that
+        consumers of them are not broken, but since the targets files themselves are still part of .NET,
+        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework.
    -->
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="'$(ImportFrameworkWinFXTargets)' != 'false' and Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets')" />

--- a/src/Tasks/Microsoft.WorkflowBuildExtensions.targets
+++ b/src/Tasks/Microsoft.WorkflowBuildExtensions.targets
@@ -12,14 +12,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-   <!-- 
+   <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
-        outside of the .NET Framework.  As a result of this, there were several targets files, of which 
-        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.  
+        outside of the .NET Framework.  As a result of this, there were several targets files, of which
+        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.
 
-        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that 
-        consumers of them are not broken, but since the targets files themselves are still part of .NET, 
-        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
+        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that
+        consumers of them are not broken, but since the targets files themselves are still part of .NET,
+        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework.
    -->
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WorkflowBuildExtensions.targets" Condition="Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WorkflowBuildExtensions.targets')" />

--- a/src/Tasks/Microsoft.WorkflowBuildExtensions.targets
+++ b/src/Tasks/Microsoft.WorkflowBuildExtensions.targets
@@ -35,4 +35,5 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          overriding it with a no-op implementation here.
    -->
    <Target Name="GenerateCompiledExpressionsTempFile" />
+
 </Project>

--- a/src/Tasks/Microsoft.Xaml.targets
+++ b/src/Tasks/Microsoft.Xaml.targets
@@ -1,17 +1,17 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <!-- 
+   <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
-        outside of the .NET Framework.  As a result of this, there were several targets files, of which 
-        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.  
+        outside of the .NET Framework.  As a result of this, there were several targets files, of which
+        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.
 
-        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that 
-        consumers of them are not broken, but since the targets files themselves are still part of .NET, 
-        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
+        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that
+        consumers of them are not broken, but since the targets files themselves are still part of .NET,
+        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework.
    -->
 
-   <!-- In the original Microsoft.Xaml.targets this is mapped to MSBuildBinPath, which is no longer 
+   <!-- In the original Microsoft.Xaml.targets this is mapped to MSBuildBinPath, which is no longer
         the .NET Framework directory and thus will no longer be the right answer. Override it to point
-        to the correct .NET Framework location. --> 
+        to the correct .NET Framework location. -->
    <PropertyGroup>
       <XamlBuildTaskPath Condition="'$(XamlBuildTaskPath)' == ''">$(MSBuildToolsPath64)</XamlBuildTaskPath>
    </PropertyGroup>

--- a/src/Tasks/Microsoft.Xaml.targets
+++ b/src/Tasks/Microsoft.Xaml.targets
@@ -1,4 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
         outside of the .NET Framework.  As a result of this, there were several targets files, of which

--- a/src/Tasks/Workflow.VisualBasic.targets
+++ b/src/Tasks/Workflow.VisualBasic.targets
@@ -1,4 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
         outside of the .NET Framework.  As a result of this, there were several targets files, of which

--- a/src/Tasks/Workflow.VisualBasic.targets
+++ b/src/Tasks/Workflow.VisualBasic.targets
@@ -1,12 +1,12 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <!-- 
+   <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
-        outside of the .NET Framework.  As a result of this, there were several targets files, of which 
-        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.  
+        outside of the .NET Framework.  As a result of this, there were several targets files, of which
+        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.
 
-        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that 
-        consumers of them are not broken, but since the targets files themselves are still part of .NET, 
-        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
+        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that
+        consumers of them are not broken, but since the targets files themselves are still part of .NET,
+        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework.
    -->
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Workflow.VisualBasic.targets" />

--- a/src/Tasks/Workflow.targets
+++ b/src/Tasks/Workflow.targets
@@ -1,12 +1,12 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <!-- 
+   <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
-        outside of the .NET Framework.  As a result of this, there were several targets files, of which 
-        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.  
+        outside of the .NET Framework.  As a result of this, there were several targets files, of which
+        this was one, that were being referenced as out of MSBuildToolsPath that are now no longer there.
 
-        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that 
-        consumers of them are not broken, but since the targets files themselves are still part of .NET, 
-        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
+        Thus, we are shimming those targets files so that they do still appear in MSBuildToolsPath, so that
+        consumers of them are not broken, but since the targets files themselves are still part of .NET,
+        the shim will internally simply redirect to the real copy of the targets file in the .NET Framework.
    -->
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Workflow.targets" />

--- a/src/Tasks/Workflow.targets
+++ b/src/Tasks/Workflow.targets
@@ -1,4 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory
         outside of the .NET Framework.  As a result of this, there were several targets files, of which


### PR DESCRIPTION
Part of #4779

### Context
Make Common props, targets and tasks easier to read and understand.
Fixup whitespace and new lines only in Common props, targets and tasks files.

Part of the larger refactoring that'll lead into #1686

### Changes Made
 - Remove all trailing spaces
 - Fixup new lines where necessary
   - Add new lines between every block to make it clear.
   - Remove unnecessary new lines to reduce scrolling.

### Testing
NIL

### Notes
I'll also make sure not to mess up the git blame too much.
To make reviewing easier, I had split up the changes logically rather than a file.
Also, please do not that these changes won't make much difference alone but with other formatting and refactors that follow this will make a world of difference in reading these files.