### PR TITLE
Permit direct access to a SolutionFilterName property Fixes #6162

### DIFF
--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -190,6 +190,11 @@ namespace Microsoft.Build.Construction
         public IReadOnlyDictionary<string, ProjectInSolution> ProjectsByGuid => new ReadOnlyDictionary<string, ProjectInSolution>(_projects);
 
         /// <summary>
+        /// This is the read accessor for the solution filter file, if present. Set through FullPath.
+        /// </summary>
+        internal string SolutionFilterFilePath { get => _solutionFilterFile; }
+
+        /// <summary>
         /// This is the read/write accessor for the solution file which we will parse.  This
         /// must be set before calling any other methods on this class.
         /// </summary>

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -2292,7 +2292,7 @@ namespace Microsoft.Build.Construction
             globalProperties.AddProperty("SolutionExt", EscapingUtilities.Escape(Path.GetExtension(_solutionFile.FullPath)));
             globalProperties.AddProperty("SolutionFileName", EscapingUtilities.Escape(Path.GetFileName(_solutionFile.FullPath)));
             globalProperties.AddProperty("SolutionName", EscapingUtilities.Escape(Path.GetFileNameWithoutExtension(_solutionFile.FullPath)));
-            globalProperties.AddProperty("SolutionFilterName", EscapingUtilities.Escape(Path.GetFileNameWithoutExtension(_solutionFile.SolutionFilterFilePath)));
+            globalProperties.AddProperty("SolutionFilterName", EscapingUtilities.Escape(Path.GetFileNameWithoutExtension(_solutionFile.SolutionFilterFilePath ?? string.Empty)));
 
             globalProperties.AddProperty(SolutionPathPropertyName, EscapingUtilities.Escape(Path.Combine(_solutionFile.SolutionFileDirectory, Path.GetFileName(_solutionFile.FullPath))));
 

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Build.Construction
             new Tuple<string, string>("SolutionExt", null),
             new Tuple<string, string>("SolutionFileName", null),
             new Tuple<string, string>("SolutionName", null),
+            new Tuple<string, string>("SolutionFilterName", null),
             new Tuple<string, string>(SolutionPathPropertyName, null)
         };
 
@@ -499,7 +500,7 @@ namespace Microsoft.Build.Construction
 
             string additionalProperties = string.Format(
                 CultureInfo.InvariantCulture,
-                "Configuration={0}; Platform={1}; BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)",
+                "Configuration={0}; Platform={1}; BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionFilterName=$(SolutionFilterName); SolutionPath=$(SolutionPath)",
                 EscapingUtilities.Escape(configurationName),
                 EscapingUtilities.Escape(platformName)
             );
@@ -2291,6 +2292,7 @@ namespace Microsoft.Build.Construction
             globalProperties.AddProperty("SolutionExt", EscapingUtilities.Escape(Path.GetExtension(_solutionFile.FullPath)));
             globalProperties.AddProperty("SolutionFileName", EscapingUtilities.Escape(Path.GetFileName(_solutionFile.FullPath)));
             globalProperties.AddProperty("SolutionName", EscapingUtilities.Escape(Path.GetFileNameWithoutExtension(_solutionFile.FullPath)));
+            globalProperties.AddProperty("SolutionFilterName", EscapingUtilities.Escape(Path.GetFileNameWithoutExtension(_solutionFile.SolutionFilterFilePath)));
 
             globalProperties.AddProperty(SolutionPathPropertyName, EscapingUtilities.Escape(Path.Combine(_solutionFile.SolutionFileDirectory, Path.GetFileName(_solutionFile.FullPath))));
 

--- a/src/Deprecated/Engine/Solution/SolutionWrapperProject.cs
+++ b/src/Deprecated/Engine/Solution/SolutionWrapperProject.cs
@@ -519,7 +519,7 @@ namespace Microsoft.Build.BuildEngine
 
             string additionalProperties = string.Format(
                 CultureInfo.InvariantCulture,
-                "Configuration={0}; Platform={1}; BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)",
+                "Configuration={0}; Platform={1}; BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionFilterName=$(SolutionFilterName); SolutionPath=$(SolutionPath)",
                 EscapingUtilities.Escape(configurationName),
                 EscapingUtilities.Escape(platformName)
             );
@@ -1608,7 +1608,7 @@ namespace Microsoft.Build.BuildEngine
                 BuildTask msbuildTask = newTarget.AddNewTask("MSBuild");
                 msbuildTask.Condition = buildItemReference + " != ''";
                 msbuildTask.SetParameterValue("Projects", buildItemReference);
-                msbuildTask.SetParameterValue("Properties", "Configuration=%(Configuration); Platform=%(Platform); BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)");
+                msbuildTask.SetParameterValue("Properties", "Configuration=%(Configuration); Platform=%(Platform); BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionFilterName=$(SolutionFilterName); SolutionPath=$(SolutionPath)");
 
                 if (!string.IsNullOrEmpty(subTargetName))
                 {

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1796,6 +1796,7 @@ elementFormDefault="qualified">
     <xs:element name="SolutionExt" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="SolutionFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="SolutionName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="SolutionFilterName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="SolutionPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="StartAction" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="StartArguments" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -346,6 +346,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <DevEnvDir Condition="'$(DevEnvDir)'==''">*Undefined*</DevEnvDir>
     <SolutionName Condition="'$(SolutionName)'==''">*Undefined*</SolutionName>
+    <SolutionFilterName Condition="'$(SolutionFilterName)'==''">*Undefined*</SolutionFilterName>
     <!-- Example, MySolution -->
     <SolutionFileName Condition="'$(SolutionFileName)'==''">*Undefined*</SolutionFileName>
     <!-- Example, MySolution.sln -->


### PR DESCRIPTION
Fixes #6162

### Context
There is currently a property to access the solution file from MSBuild. This adds a similar ability to access solution filter file paths, if relevant.

### Changes Made
Added SolutionFilterName as a known property.

### Testing
None yet.

### Notes
This will need docs changes, too.

cc @rcmdh.