### PR TITLE
Revert "Use debug-specific optprof test (#6106)"

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -14,13 +14,13 @@
           "container": "MSBuild",
           "testCases": [
             "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild",
-            "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild_4proc"
+            "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild_4proc",
           ]
         },
         {
           "container": "ManagedLangs",
           "testCases": [
-            "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug"
+            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
         }  
       ]


### PR DESCRIPTION
This reverts commit 27ff9a7b89b0abfbba7dc049acd892f1c59de240.

### Context

The commit has been identified as the source of RefSet perf regression as flagged when inserting MSBuild bits into Visual Studio.

### Changes Made

Reverted the change.

### Testing

Re-ran training scenarios with this change, optimized MSBuild with the resulting OptProf data, and confirmed that it passed Visual Studio insertion gates.

### Notes
