### PR TITLE
Permit specifying that we should use utf-8 in ToolTask

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -333,7 +333,6 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public string StdOutEncoding { get { throw null; } set { } }
         protected override string ToolName { get { throw null; } }
-        public string UseUtf8Encoding { get { throw null; } set { } }
         public string WorkingDirectory { get { throw null; } set { } }
         protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands) { throw null; }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -263,7 +263,6 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public string StdOutEncoding { get { throw null; } set { } }
         protected override string ToolName { get { throw null; } }
-        public string UseUtf8Encoding { get { throw null; } set { } }
         public string WorkingDirectory { get { throw null; } set { } }
         protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands) { throw null; }

--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -555,6 +555,7 @@ namespace Microsoft.Build.Utilities
         protected abstract string ToolName { get; }
         public string ToolPath { get { throw null; } set { } }
         public bool UseCommandProcessor { get { throw null; } set { } }
+        public string UseUtf8Encoding { get { throw null; } set { } }
         public bool YieldDuringToolExecution { get { throw null; } set { } }
         protected virtual string AdjustCommandsForOperatingSystem(string input) { throw null; }
         protected virtual bool CallHostObjectToExecute() { throw null; }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -395,6 +395,7 @@ namespace Microsoft.Build.Utilities
         protected abstract string ToolName { get; }
         public string ToolPath { get { throw null; } set { } }
         public bool UseCommandProcessor { get { throw null; } set { } }
+        public string UseUtf8Encoding { get { throw null; } set { } }
         public bool YieldDuringToolExecution { get { throw null; } set { } }
         protected virtual string AdjustCommandsForOperatingSystem(string input) { throw null; }
         protected virtual bool CallHostObjectToExecute() { throw null; }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -124,14 +124,6 @@ namespace Microsoft.Build.Tasks
         protected override Encoding StandardErrorEncoding => _standardErrorEncoding;
 
         /// <summary>
-        /// Whether or not to use UTF8 encoding for the cmd file and console window.
-        /// Values: Always, Never, Detect
-        /// If set to Detect, the current code page will be used unless it cannot represent 
-        /// the Command string. In that case, UTF-8 is used.
-        /// </summary>
-        public string UseUtf8Encoding { get; set; }
-
-        /// <summary>
         /// Project visible property specifying the encoding of the captured task standard output stream
         /// </summary>
         [Output]

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -183,6 +183,11 @@ namespace Microsoft.Build.Utilities
         public string ToolPath { set; get; }
 
         /// <summary>
+        /// Project-visible property to allow users to override the encoding method.
+        /// </summary>
+        public string UseUtf8Encoding { get; set; } = EncodingUtilities.UseUtf8Detect;
+
+        /// <summary>
         /// Array of equals-separated pairs of environment
         /// variables that should be passed to the spawned executable,
         /// in addition to (or selectively overriding) the regular environment block.
@@ -1373,7 +1378,7 @@ namespace Microsoft.Build.Utilities
                         }
                         else
                         {
-                            encoding = EncodingUtilities.BatchFileEncoding(commandLineCommands + _temporaryBatchFile, EncodingUtilities.UseUtf8Detect);
+                            encoding = EncodingUtilities.BatchFileEncoding(commandLineCommands + _temporaryBatchFile, UseUtf8Encoding);
 
                             if (encoding.CodePage != EncodingUtilities.CurrentSystemOemEncoding.CodePage)
                             {

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -183,7 +183,10 @@ namespace Microsoft.Build.Utilities
         public string ToolPath { set; get; }
 
         /// <summary>
-        /// Project-visible property to allow users to override the encoding method.
+        /// Whether or not to use UTF8 encoding for the cmd file and console window.
+        /// Values: Always, Never, Detect
+        /// If set to Detect, the current code page will be used unless it cannot represent 
+        /// the Command string. In that case, UTF-8 is used.
         /// </summary>
         public string UseUtf8Encoding { get; set; } = EncodingUtilities.UseUtf8Detect;
 


### PR DESCRIPTION
Fixes #5724

### Changes Made
Added UseUtf8Encoding parameter to ToolTask and removed it from Exec. Exec is a ToolTaskExtension, which is clearly an extension of ToolTask, but this may still count as a breaking change, in which case I could add it back to Exec with `new` to make it compile.

### Testing
MrTrillian tried this with a reduced repro solution, and it resolved the problem.