### PR TITLE
Fix Loading of Plugin Assemblies

### DIFF
--- a/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
+++ b/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
@@ -74,4 +74,10 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <Target Name="CreateTaskDir" AfterTargets="Build" Condition="'$(TargetFrameworkIdentifier)' != ''">
+    <ItemGroup>
+      <OutputAssemblyList Include="$(TargetDir)Microsoft.Build.CommandLine.UnitTests.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(OutputAssemblyList)" DestinationFolder="$(TargetDir)Task" />
+  </Target>
 </Project>

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2237,7 +2237,8 @@ namespace Microsoft.Build.UnitTests
 
 #if FEATURE_ASSEMBLYLOADCONTEXT
         /// <summary>
-        /// Ensure that tasks get loaded into their own <see cref="System.Runtime.Loader.AssemblyLoadContext"/>.
+        /// Ensure that tasks get loaded into their own <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
+        /// if they are in a directory other than the MSBuild directory.
         /// </summary>
         /// <remarks>
         /// When loading a task from a test assembly in a test within that assembly, the assembly is already loaded
@@ -2247,7 +2248,10 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TasksGetAssemblyLoadContexts()
         {
-            string customTaskPath = Assembly.GetExecutingAssembly().Location;
+            string customTaskPath = Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "Task",
+                Path.GetFileName(Assembly.GetExecutingAssembly().Location));
 
             string projectContents = $@"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
   <UsingTask TaskName=`ValidateAssemblyLoadContext` AssemblyFile=`{customTaskPath}` />
@@ -2259,7 +2263,6 @@ namespace Microsoft.Build.UnitTests
 
             ExecuteMSBuildExeExpectSuccess(projectContents);
         }
-
 #endif
 
         private string CopyMSBuild()

--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.Shared
 
         private bool _resolvingHandlerHookedUp = false;
 
-        private static string _msbuildDirPath;
+        private static readonly string _msbuildDirPath;
         private static readonly Version _currentAssemblyVersion = new Version(Microsoft.Build.Shared.MSBuildConstants.CurrentAssemblyVersion);
 
         static CoreClrAssemblyLoader()

--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -23,7 +23,13 @@ namespace Microsoft.Build.Shared
 
         private bool _resolvingHandlerHookedUp = false;
 
+        private static string _msbuildDirPath;
         private static readonly Version _currentAssemblyVersion = new Version(Microsoft.Build.Shared.MSBuildConstants.CurrentAssemblyVersion);
+
+        internal CoreClrAssemblyLoader()
+        {
+            _msbuildDirPath = Path.GetDirectoryName(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
+        }
 
         public void AddDependencyLocation(string fullPath)
         {
@@ -52,7 +58,11 @@ namespace Microsoft.Build.Shared
             // folders in a NuGet package).
             fullPath = FileUtilities.NormalizePath(fullPath);
 
-            if (Traits.Instance.EscapeHatches.UseSingleLoadContext)
+            // If the requested load comes from the same directory as MSBuild, assume that
+            // the load is part of the platform, and load it using the Default ALC.
+            string assemblyDir = Path.GetDirectoryName(fullPath);
+
+            if (Traits.Instance.EscapeHatches.UseSingleLoadContext || string.Equals(assemblyDir, _msbuildDirPath))
             {
                 return LoadUsingLegacyDefaultContext(fullPath);
             }

--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Build.Shared
         private static string _msbuildDirPath;
         private static readonly Version _currentAssemblyVersion = new Version(Microsoft.Build.Shared.MSBuildConstants.CurrentAssemblyVersion);
 
-        internal CoreClrAssemblyLoader()
+        static CoreClrAssemblyLoader()
         {
-            _msbuildDirPath = FileUtilities.NormalizePath(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
+            _msbuildDirPath = FileUtilities.NormalizePath(typeof(CoreClrAssemblyLoader).Assembly.Location);
             _msbuildDirPath = Path.GetDirectoryName(_msbuildDirPath);
         }
 
@@ -63,7 +63,8 @@ namespace Microsoft.Build.Shared
             // the load is part of the platform, and load it using the Default ALC.
             string assemblyDir = Path.GetDirectoryName(fullPath);
 
-            if (Traits.Instance.EscapeHatches.UseSingleLoadContext || string.Equals(assemblyDir, _msbuildDirPath))
+            if (Traits.Instance.EscapeHatches.UseSingleLoadContext ||
+                FileUtilities.ComparePathsNoThrow(assemblyDir, _msbuildDirPath, string.Empty))
             {
                 return LoadUsingLegacyDefaultContext(fullPath);
             }

--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Build.Shared
 
         internal CoreClrAssemblyLoader()
         {
-            _msbuildDirPath = Path.GetDirectoryName(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
+            _msbuildDirPath = FileUtilities.NormalizePath(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
+            _msbuildDirPath = Path.GetDirectoryName(_msbuildDirPath);
         }
 
         public void AddDependencyLocation(string fullPath)

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -25,20 +25,8 @@ namespace Microsoft.Build.Shared
                 "MSBuild",
                 "Microsoft.Build",
                 "Microsoft.Build.Framework",
-                "Microsoft.Build.NuGetSdkResolver",
                 "Microsoft.Build.Tasks.Core",
                 "Microsoft.Build.Utilities.Core",
-                "NuGet.Build.Tasks",
-                "NuGet.Common",
-                "NuGet.Configuration",
-                "NuGet.Credentials",
-                "NuGet.DependencyResolver.Core",
-                "NuGet.Frameworks",
-                "NuGet.LibraryModel",
-                "NuGet.Packaging",
-                "NuGet.Protocol",
-                "NuGet.ProjectModel",
-                "NuGet.Versioning",
             }.ToImmutableHashSet();
 
         internal static readonly string[] Extensions = new[] { "ni.dll", "ni.exe", "dll", "exe" };


### PR DESCRIPTION
Fixes #6186 

### Context
#6126 changed the load behavior for NuGet dlls by forcing them to load in the default assembly load context.  This effectively pinned their versions to the SDK, which is not a safe behavior for targets that may wish to carry their own versions of NuGet or other DLLs that they might load.

### Changes Made
Rather than pinning specific DLLs, change the behavior to load all DLLs that are in the MSBuild directory in the default assembly load context.  This allows targets to carry their own versions of dependencies, while avoiding loading assemblies that are packaged with MSBuild into multiple assembly load contexts, and thus losing the benefits of precompilation.

### Testing
Verified that dotnet build hello-world has the correct load and jitting behavior.
Verified that tasks can load their own copies of NuGet binaries into the plugin assembly load context.

### Notes
