### PR TITLE
Make CacheResult members public

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1426,6 +1426,9 @@ namespace Microsoft.Build.Experimental.ProjectCache
     public partial class CacheResult
     {
         internal CacheResult() { }
+        public Microsoft.Build.Execution.BuildResult BuildResult { get { throw null; } }
+        public Microsoft.Build.Experimental.ProjectCache.ProxyTargets ProxyTargets { get { throw null; } }
+        public Microsoft.Build.Experimental.ProjectCache.CacheResultType ResultType { get { throw null; } }
         public static Microsoft.Build.Experimental.ProjectCache.CacheResult IndicateCacheHit(Microsoft.Build.Execution.BuildResult buildResult) { throw null; }
         public static Microsoft.Build.Experimental.ProjectCache.CacheResult IndicateCacheHit(Microsoft.Build.Experimental.ProjectCache.ProxyTargets proxyTargets) { throw null; }
         public static Microsoft.Build.Experimental.ProjectCache.CacheResult IndicateCacheHit(System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.ProjectCache.PluginTargetResult> targetResults) { throw null; }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1420,6 +1420,9 @@ namespace Microsoft.Build.Experimental.ProjectCache
     public partial class CacheResult
     {
         internal CacheResult() { }
+        public Microsoft.Build.Execution.BuildResult BuildResult { get { throw null; } }
+        public Microsoft.Build.Experimental.ProjectCache.ProxyTargets ProxyTargets { get { throw null; } }
+        public Microsoft.Build.Experimental.ProjectCache.CacheResultType ResultType { get { throw null; } }
         public static Microsoft.Build.Experimental.ProjectCache.CacheResult IndicateCacheHit(Microsoft.Build.Execution.BuildResult buildResult) { throw null; }
         public static Microsoft.Build.Experimental.ProjectCache.CacheResult IndicateCacheHit(Microsoft.Build.Experimental.ProjectCache.ProxyTargets proxyTargets) { throw null; }
         public static Microsoft.Build.Experimental.ProjectCache.CacheResult IndicateCacheHit(System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.ProjectCache.PluginTargetResult> targetResults) { throw null; }

--- a/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
@@ -63,9 +63,9 @@ namespace Microsoft.Build.Experimental.ProjectCache
             ProxyTargets = proxyTargets;
         }
 
-        internal CacheResultType ResultType { get; }
-        internal BuildResult? BuildResult { get; }
-        internal ProxyTargets? ProxyTargets { get; }
+        public CacheResultType ResultType { get; }
+        public BuildResult? BuildResult { get; }
+        public ProxyTargets? ProxyTargets { get; }
 
         public static CacheResult IndicateCacheHit(BuildResult buildResult)
         {

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCachePluginBase.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCachePluginBase.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 {
     /// <summary>
     ///     Only one plugin instance can exist for a given BuildManager BeginBuild / EndBuild session.
+    ///     Any exceptions thrown by the plugin will cause MSBuild to fail the build.
     /// </summary>
     public abstract class ProjectCachePluginBase
     {


### PR DESCRIPTION
Turns out it's hard to test the plugin and assert results if CacheResult does not have public members :)