### PR TITLE
Fixes for big-endian systems

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Globalization;
@@ -738,7 +739,7 @@ namespace Microsoft.Build.BackEnd
                     }
 
                     NodePacketType packetType = (NodePacketType)_headerByte[0];
-                    int packetLength = BitConverter.ToInt32(_headerByte, 1);
+                    int packetLength = BinaryPrimitives.ReadInt32LittleEndian(new Span<byte>(_headerByte, 1, 4));
 
                     _readBufferMemoryStream.SetLength(packetLength);
                     byte[] packetData = _readBufferMemoryStream.GetBuffer();
@@ -1027,7 +1028,7 @@ namespace Microsoft.Build.BackEnd
                     return;
                 }
 
-                int packetLength = BitConverter.ToInt32(_headerByte, 1);
+                int packetLength = BinaryPrimitives.ReadInt32LittleEndian(new Span<byte>(_headerByte, 1, 4));
                 MSBuildEventSource.Log.PacketReadSize(packetLength);
 
                 // Ensures the buffer is at least this length.

--- a/src/Shared/MSBuildNameIgnoreCaseComparer.cs
+++ b/src/Shared/MSBuildNameIgnoreCaseComparer.cs
@@ -149,7 +149,14 @@ namespace Microsoft.Build.Collections
                             // the string, and not the null terminator etc.
                             if (length == 1)
                             {
-                                val &= 0xFFFF;
+                                if (BitConverter.IsLittleEndian)
+                                {
+                                    val &= 0xFFFF;
+                                }
+                                else
+                                {
+                                    val &= unchecked((int)0xFFFF0000);
+                                }
                             }
 
                             hash1 = ((hash1 << 5) + hash1 + (hash1 >> 27)) ^ val;
@@ -162,7 +169,14 @@ namespace Microsoft.Build.Collections
                             val = pint[1] & 0x00DF00DF;
                             if (length == 3)
                             {
-                                val &= 0xFFFF;
+                                if (BitConverter.IsLittleEndian)
+                                {
+                                    val &= 0xFFFF;
+                                }
+                                else
+                                {
+                                    val &= unchecked((int)0xFFFF0000);
+                                }
                             }
 
                             hash2 = ((hash2 << 5) + hash2 + (hash2 >> 27)) ^ val;


### PR DESCRIPTION
### Context
We are currently working on bringing up .NET on the IBM Z architecture (s390x-ibm-linux), which uses big-endian byte order.  During that process we have run into a couple of endian-specific bugs in msbuild code.

### Changes Made
* In MSBuildNameIgnoreCaseComparer::GetHashCode, when reading pairs of characters aliased to an int, handle the single last remaining char correctly on big-endian systems.

* In NodeProviderOutOfProcBase, byte-swap the packet length on big-endian systems.

### Testing
On IBM Z, a msbuild package built with this patch successfully builds and executes a "hello world" program.  We were also able to successfully bootstrap msbuild (build it with itself) on IBM Z.  (This of course also requires the work-in-progress dotnet runtime port, and for the bootstrap an endian bugfix to nuget is also required.)
Also verified that "./build.sh --test" still succeeds on a little-endian (Intel) Linux system.
