### PR TITLE
General "switch" description in help message - update for "--" indicator

### DIFF
--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -135,8 +135,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </comment>
   </data>
   <data name="HelpMessage_3_SwitchesHeader" UESanitized="true" Visibility="Public">
-    <value>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+    <value>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </value>
     <comment>
       LOCALIZATION: The following should not be localized:

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -235,10 +235,10 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">Přepínače:            Přepínače můžete zadat ve tvaru
+        <target state="needs-review-translation">Přepínače:            Přepínače můžete zadat ve tvaru
                      -switch i /switch.
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -235,10 +235,10 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">Schalter:            Beachten Sie, dass Sie Schalter über
+        <target state="needs-review-translation">Schalter:            Beachten Sie, dass Sie Schalter über
                      "-schalter" und "/schalter" angeben können.
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.en.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.en.xlf
@@ -245,11 +245,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="new">Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <target state="new">Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </target>
         <note>
       LOCALIZATION: The following should not be localized:

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -235,10 +235,10 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">Modificadores:            Observe que puede especificar modificadores mediante
+        <target state="needs-review-translation">Modificadores:            Observe que puede especificar modificadores mediante
                      "-switch" y "/switch".
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -235,10 +235,10 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">Commutateurs :            Notez que vous pouvez spécifier des commutateurs avec
+        <target state="needs-review-translation">Commutateurs :            Notez que vous pouvez spécifier des commutateurs avec
                      "-switch" et "/switch".
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -242,10 +242,10 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">Opzioni:            Tenere presente che è possibile specificare le opzioni
+        <target state="needs-review-translation">Opzioni:            Tenere presente che è possibile specificare le opzioni
                      usando "-switch" e "/switch".
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -235,10 +235,10 @@ Copyright (C) Microsoft Corporation.All rights reserved.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">スイッチ:            スイッチは "-switch" と "/switch" のどちらを使用して
+        <target state="needs-review-translation">スイッチ:            スイッチは "-switch" と "/switch" のどちらを使用して
                      指定しても構いません。
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -235,10 +235,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">스위치:            스위치를 지정하는 데 "-switch" 및 "/switch"를
+        <target state="needs-review-translation">스위치:            스위치를 지정하는 데 "-switch" 및 "/switch"를
                      둘 다 사용할 수 있습니다.
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -242,10 +242,10 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">Przełączniki:            Należy pamiętać, że przełączniki można określać
+        <target state="needs-review-translation">Przełączniki:            Należy pamiętać, że przełączniki można określać
                      zarówno za pomocą składni „-przełącznik”, jak i „/przełącznik”.
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -236,10 +236,10 @@ isoladamente.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">Switches:            Você pode especificar as opções usando
+        <target state="needs-review-translation">Switches:            Você pode especificar as opções usando
                      "-switch" e "/switch".
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -234,10 +234,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">Параметры:            Вы можете указывать параметры с помощью
+        <target state="needs-review-translation">Параметры:            Вы можете указывать параметры с помощью
                      "-switch" и "/switch".
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -235,10 +235,10 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">Anahtarlar:            Hem "-switch" hem de "/switch" değerini kullanarak
+        <target state="needs-review-translation">Anahtarlar:            Hem "-switch" hem de "/switch" değerini kullanarak
                      anahtar beliretebileceğinizi unutmayın.
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -235,10 +235,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">开关:            请注意，使用 "-switch" 和 "/switch" 均可
+        <target state="needs-review-translation">开关:            请注意，使用 "-switch" 和 "/switch" 均可
                      指定开关。
 </target>
         <note>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -235,10 +235,10 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
-        <source>Switches:            Note that you can specify switches using both
-                     "-switch" and "/switch".
+        <source>Switches:            Note that you can specify switches using
+                     "-switch", "/switch" and "--switch".
 </source>
-        <target state="translated">參數:            請注意，您可以同時使用 "-switch" 和 "/switch"
+        <target state="needs-review-translation">參數:            請注意，您可以同時使用 "-switch" 和 "/switch"
                      來指定參數。
 </target>
         <note>


### PR DESCRIPTION
This pull request updates the general "switch" description in the help message.
This can be considered as a follow-up of #5786 delivery, where double-dash switch indicator has been added.

---

The changes contain:
* Help message update: added third indicator's option and removed "*both*" as it's now invalid
* Applied changes to the localizations

