### PR TITLE
Pass x64 architecture to al.exe when targeting x64

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3736,8 +3736,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           Condition="'@(_SatelliteAssemblyResourceInputs)' != '' and '$(GenerateSatelliteAssembliesForCore)' != 'true'">
 
     <PropertyGroup>
-      <_SdkToolsPathMaybeWithx64Architecture>$(TargetFrameworkSDKToolsDirectory)</_SdkToolsPathMaybeWithx64Architecture>
-      <_SdkToolsPathMaybeWithx64Architecture Condition="'$(PlatformTarget)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</_SdkToolsPathMaybeWithx64Architecture>
+      <ALExeToolPath>$(TargetFrameworkSDKToolsDirectory)</ALExeToolPath>
+      <ALExeToolPath Condition="'$(PlatformTarget)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</ALExeToolPath>
     </PropertyGroup>
 
     <MakeDir

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3735,6 +3735,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           Outputs="$(IntermediateOutputPath)%(Culture)\$(TargetName).resources.dll"
           Condition="'@(_SatelliteAssemblyResourceInputs)' != '' and '$(GenerateSatelliteAssembliesForCore)' != 'true'">
 
+    <PropertyGroup>
+      <SdkToolsPathMaybeWithx64Architecture>$(TargetFrameworkSDKToolsDirectory)</SdkToolsPathMaybeWithx64Architecture>
+      <SdkToolsPathMaybeWithx64Architecture Condition="'$(PlatformTarget)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</SdkToolsPathMaybeWithx64Architecture>
+    </PropertyGroup>
+
     <MakeDir
         Directories="@(EmbeddedResource->'$(IntermediateOutputPath)%(Culture)')" />
 
@@ -3767,7 +3772,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Title="$(Satellite_Title)"
         ToolPath="$(AlToolPath)"
         ToolExe ="$(AlToolExe)"
-        SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)"
+        SdkToolsPath="$(SdkToolsPathMaybeWithx64Architecture)"
         Trademark="$(Satellite_Trademark)"
         Version="$(Satellite_Version)"
         Win32Icon="$(Satellite_Win32Icon)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3736,8 +3736,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           Condition="'@(_SatelliteAssemblyResourceInputs)' != '' and '$(GenerateSatelliteAssembliesForCore)' != 'true'">
 
     <PropertyGroup>
-      <SdkToolsPathMaybeWithx64Architecture>$(TargetFrameworkSDKToolsDirectory)</SdkToolsPathMaybeWithx64Architecture>
-      <SdkToolsPathMaybeWithx64Architecture Condition="'$(PlatformTarget)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</SdkToolsPathMaybeWithx64Architecture>
+      <_SdkToolsPathMaybeWithx64Architecture>$(TargetFrameworkSDKToolsDirectory)</_SdkToolsPathMaybeWithx64Architecture>
+      <_SdkToolsPathMaybeWithx64Architecture Condition="'$(PlatformTarget)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</_SdkToolsPathMaybeWithx64Architecture>
     </PropertyGroup>
 
     <MakeDir

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3736,8 +3736,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           Condition="'@(_SatelliteAssemblyResourceInputs)' != '' and '$(GenerateSatelliteAssembliesForCore)' != 'true'">
 
     <PropertyGroup>
-      <ALExeToolPath>$(TargetFrameworkSDKToolsDirectory)</ALExeToolPath>
-      <ALExeToolPath Condition="'$(PlatformTarget)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</ALExeToolPath>
+      <_ALExeToolPath>$(TargetFrameworkSDKToolsDirectory)</_ALExeToolPath>
+      <_ALExeToolPath Condition="'$(PlatformTarget)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</_ALExeToolPath>
     </PropertyGroup>
 
     <MakeDir


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/5981

### Context
Despite targeting x64 during builds, x86-bitness al.exe runs anyway, throwing a warning because of it.

### Changes Made
Before calling the AL task check if we're targeting x64 and pass it along with the tools sdk path.

### Testing
Create a winforms project (any really), create a _cultured_ resx file (insert monacle emoji here), set it as embedded resource, build the project with /p:Platform=x64. You get `ALINK : warning AL1073: Referenced assembly 'mscorlib.dll' targets a different processor [C:\src\projects\templates\Win
FormApp\WinFormApp\WinFormApp.csproj]` without the fix.

Tested on a bootstrap build on the repro.

### Notes
I took into consideration that changing this logic within the code itself could break a lot of people. Consider that it's a public class that many people could be using. The safest course of action I could see was to toss in the x64 architecture when relevant, for builds that use our sdk's/targets/props/etc.