### PR TITLE
Fix "Object reference not set to..." when removing a database reference

### DIFF
--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3344,8 +3344,6 @@ namespace Microsoft.Build.Evaluation
                     item.SplitOwnItemElement();
                 }
 
-                itemElement.Parent.RemoveChild(itemElement);
-
                 return true;
             }
 


### PR DESCRIPTION
### The Issue
This came up from an internal message.

Create a SQL Server Database project - You may need to install "Data storage and processing" workload in VS
Right click on References and select ‘Add Database Reference…’
Choose System database and select ‘master’ and click ‘OK’
Build the project and Check the .sqlproj file, it should have
```xml
      <ItemGroup>
  <ArtifactReference Include="$(DacPacRootPath)\Extensions\Microsoft\SQLDB\Extensions\SqlServer\130\SqlSchemas\master.dacpac">
    <HintPath>$(DacPacRootPath)\Extensions\Microsoft\SQLDB\Extensions\SqlServer\130\SqlSchemas\master.dacpac</HintPath>
    <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
    <DatabaseVariableLiteralValue>master</DatabaseVariableLiteralValue>
  </ArtifactReference>
</ItemGroup>
```
Right click on ‘master’ reference on Solution Explorer and select Remove
It will throw ‘Object reference not set to an instance of an object’ and removes from UI
Check the .sqlproj and you can see it still has the reference as is.
Right click on References and select ‘Add Database Reference…’ and Choose System database and select ‘msdb’ and click ‘OK’
Build the project and Check the .sqlproj file. It would have something like:
```xml
      <ItemGroup>
  <ArtifactReference Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\Common7\IDE\Extensions\Microsoft\SQLDB\Extensions\SqlServer\130\SqlSchemas\master.dacpac">
    <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\Common7\IDE\Extensions\Microsoft\SQLDB\Extensions\SqlServer\130\SqlSchemas\master.dacpac</HintPath>
    <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
    <DatabaseVariableLiteralValue>master</DatabaseVariableLiteralValue>
  </ArtifactReference>
  <ArtifactReference Include="$(DacPacRootPath)\Extensions\Microsoft\SQLDB\Extensions\SqlServer\130\SqlSchemas\msdb.dacpac">
    <HintPath>$(DacPacRootPath)\Extensions\Microsoft\SQLDB\Extensions\SqlServer\130\SqlSchemas\msdb.dacpac</HintPath>
    <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
    <DatabaseVariableLiteralValue>msdb</DatabaseVariableLiteralValue>
  </ArtifactReference>
</ItemGroup>
```
For master.dacpac, $(DacPacRootPath) is changed C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\Common7\IDE instead of removing the ArtifactReference.

### Changes Made
Prevent `SplitItemElementIfNecessary` from removing the current item from its parent, it's handled in `RemoveItemHelper`.

### Testing
Tested on the repro and it stops the `Object reference not set to an instance of an object` issue.

### Notes
This fixes the error window but not the entire problem, **the item isn't actually removed from the project.**

The logic seems to suggest that when an item can be "split" (it has a semicolon, refers to an item or property), it removes the original item from the XML and replaces it with the expanded forms of each. Not sure I fully understand how this would work because the projects should keep property references but use their expanded forms in memory. Thoughts?