### PR TITLE
jnm2.ReferenceAssemblies.net35 should be a private dependency

### DIFF
--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -5,7 +5,7 @@
   <Import Project="$(RepoRoot)eng\ProducesNoOutput.Settings.props" Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(MonoBuild)' == 'true'" />
 
   <PropertyGroup>
-    <TargetFramework>net35</TargetFramework>    
+    <TargetFramework>net35</TargetFramework>
     <OutputType>Exe</OutputType>
     <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
     <PlatformTarget Condition="'$(Platform)' == 'AnyCPU'">x86</PlatformTarget>
@@ -14,12 +14,12 @@
          This is important for the MSBuild.VSSetup project, which "references" both the x86 and x64
          versions of this project -->
     <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
-    
+
     <EnableDefaultItems>false</EnableDefaultItems>
     <DefineConstants>$(DefineConstants);CLR2COMPATIBILITY</DefineConstants>
     <!-- Need pointers for getting environment block -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- It is vital that msbuildtaskhost.exe is allowed to use the full 4GB on 64 bit machines in order to help avoid 
+    <!-- It is vital that msbuildtaskhost.exe is allowed to use the full 4GB on 64 bit machines in order to help avoid
          out of memory problems on large trees -->
     <LargeAddressAware>true</LargeAddressAware>
     <ApplicationIcon>..\MSBuild\MSBuild.ico</ApplicationIcon>
@@ -209,7 +209,7 @@
     <PackageReference Include="PdbGit" /> -->
     <PackageReference Include="SourceLink.Create.CommandLine" />
     <PackageReference Include="LargeAddressAware" PrivateAssets="All" />
-    <PackageReference Include="jnm2.ReferenceAssemblies.net35" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->

--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="jnm2.ReferenceAssemblies.net35" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">


### PR DESCRIPTION
Fixes #6213