### PR TITLE
Toolset configuration net5.0

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -18,14 +18,15 @@
     <PackageReference Update="SourceLink.Create.CommandLine" Version="2.1.2" />
     <PackageReference Update="System.CodeDom" Version="4.4.0" />
     <PackageReference Update="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Update="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Update="System.Memory" Version="4.5.4" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Resources.Extensions" Version="4.6.0" />
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="5.0.0"/>
     <PackageReference Update="System.Security.Cryptography.Pkcs" Version="4.7.0" />
     <PackageReference Update="System.Security.Cryptography.Xml" Version="4.7.0" />
-    <PackageReference Update="System.Security.Permissions" Version="4.7.0" />
-    <PackageReference Update="System.Security.Principal.Windows" Version="4.7.0" />
+    <PackageReference Update="System.Security.Permissions" Version="5.0.0" />
+    <PackageReference Update="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
     <PackageReference Update="System.Text.Json" Version="4.7.0" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -18,15 +18,15 @@
     <PackageReference Update="SourceLink.Create.CommandLine" Version="2.1.2" />
     <PackageReference Update="System.CodeDom" Version="4.4.0" />
     <PackageReference Update="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Update="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Update="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Update="System.Memory" Version="4.5.4" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Resources.Extensions" Version="4.6.0" />
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="5.0.0"/>
     <PackageReference Update="System.Security.Cryptography.Pkcs" Version="4.7.0" />
     <PackageReference Update="System.Security.Cryptography.Xml" Version="4.7.0" />
-    <PackageReference Update="System.Security.Permissions" Version="5.0.0" />
-    <PackageReference Update="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageReference Update="System.Security.Permissions" Version="4.7.0" />
+    <PackageReference Update="System.Security.Principal.Windows" Version="4.7.0" />
     <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
     <PackageReference Update="System.Text.Json" Version="4.7.0" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />

--- a/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if FEATURE_SYSTEM_CONFIGURATION
 
 using System.Configuration;
-using Microsoft.Win32;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
@@ -683,4 +681,3 @@ namespace Microsoft.Build.UnitTests.Definition
 
     }
 }
-#endif

--- a/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-
 using System.Configuration;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;

--- a/src/Build.UnitTests/Definition/ToolsetReader_Tests.cs
+++ b/src/Build.UnitTests/Definition/ToolsetReader_Tests.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-#if FEATURE_SYSTEM_CONFIGURATION
 using System.Configuration;
-#endif
 using System.IO;
 
 using Microsoft.Build.Collections;

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if FEATURE_SYSTEM_CONFIGURATION
-
-using System.Configuration;
-using Microsoft.Win32;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
@@ -15,7 +11,6 @@ using Xunit;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Build.UnitTests;
 
 namespace Microsoft.Build.UnitTests.Evaluation
 {
@@ -977,4 +972,3 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
     }
 }
-#endif

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -1,13 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if FEATURE_SYSTEM_CONFIGURATION
-// NOTE: This test WOULD work in net5.0 after the System.Configuration.ConfigurationManager change. However, it would
-//       only work if ToolsetDefinitionLocations is set to ConfigurationFile and that ReadApplicationConfiguration in
-//       ToolsetConfigurationReader.cs removes the RunningTests condition since ConfigurationManager.OpenExeConfiguration
-//       would try to get testhost.exe.config instead of the actual configuration file. But those changes seems more 
-//       fitting as a different test rather than making all these changes instead.
-
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
@@ -54,7 +47,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), GetExtensionTargetsFileContent1());
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
 
+#if FEATURE_SYSTEM_CONFIGURATION
                 var projColln = new ProjectCollection();
+#else
+                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
+#endif
                 projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", extnDir1, Path.Combine("tmp", "nonexistent")));
                 var logger = new MockLogger();
                 projColln.RegisterLogger(logger);
@@ -299,7 +296,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent);
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
 
+#if FEATURE_SYSTEM_CONFIGURATION
                 var projColln = new ProjectCollection();
+#else
+                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
+#endif
                 projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", extnDir1,
                                                                                 Path.Combine("tmp", "nonexistent")));
                 var logger = new MockLogger();
@@ -398,7 +399,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             // MSBuildExtensionsPath* property value has highest priority for the lookups
             try {
+#if FEATURE_SYSTEM_CONFIGURATION
                 var projColln = new ProjectCollection();
+#else
+                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
+#endif
                 projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", Path.Combine("tmp", "non-existent"), extnDir1));
                 var logger = new MockLogger();
                 projColln.RegisterLogger(logger);
@@ -487,7 +492,12 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(String.Format(configFileContents, extnDir1, extnDir2, extnDir3));
                 var reader = GetStandardConfigurationReader();
 
+#if FEATURE_SYSTEM_CONFIGURATION
                 var projColln = new ProjectCollection();
+#else
+                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
+#endif
+
                 projColln.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
                 projColln.RegisterLogger(logger);
@@ -561,7 +571,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
                 var reader = GetStandardConfigurationReader();
 
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> {["FallbackExpandDir1"] = extnDir1});
+#if FEATURE_SYSTEM_CONFIGURATION
+                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
+#else
+                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
+#endif
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -622,7 +636,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
                 var reader = GetStandardConfigurationReader();
 
+#if FEATURE_SYSTEM_CONFIGURATION
                 var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
+#else
+                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
+#endif
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -692,7 +710,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
                 var reader = GetStandardConfigurationReader();
 
+#if FEATURE_SYSTEM_CONFIGURATION
                 var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
+#else
+                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
+#endif
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -757,7 +779,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
                 var reader = GetStandardConfigurationReader();
 
+#if FEATURE_SYSTEM_CONFIGURATION
                 var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
+#else
+                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
+#endif
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -816,7 +842,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
                 var reader = GetStandardConfigurationReader();
 
+#if FEATURE_SYSTEM_CONFIGURATION
                 var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
+#else
+                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
+#endif
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -867,7 +897,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 Action<Project, MockLogger> action)
         {
             try {
+#if FEATURE_SYSTEM_CONFIGURATION
                 var projColln = new ProjectCollection();
+#else
+                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
+#endif
                 projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader(extnPathPropertyName, extnDirs));
                 var logger = new MockLogger();
                 projColln.RegisterLogger(logger);
@@ -979,4 +1013,3 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
     }
 }
-#endif

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if FEATURE_SYSTEM_CONFIGURATION
+// NOTE: This test WOULD work in net5.0 after the System.Configuration.ConfigurationManager change. However, it would
+//       only work if ToolsetDefinitionLocations is set to ConfigurationFile and that ReadApplicationConfiguration in
+//       ToolsetConfigurationReader.cs removes the RunningTests condition since ConfigurationManager.OpenExeConfiguration
+//       would try to get testhost.exe.config instead of the actual configuration file. But those changes seems more 
+//       fitting as a different test rather than making all these changes instead.
 
-using System.Configuration;
-using Microsoft.Win32;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
@@ -15,7 +18,6 @@ using Xunit;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Build.UnitTests;
 
 namespace Microsoft.Build.UnitTests.Evaluation
 {

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if FEATURE_SYSTEM_CONFIGURATION
+
+using System.Configuration;
+using Microsoft.Win32;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
@@ -11,6 +15,7 @@ using Xunit;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Build.UnitTests;
 
 namespace Microsoft.Build.UnitTests.Evaluation
 {
@@ -972,3 +977,4 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
     }
 }
+#endif

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -43,15 +43,13 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string extnDir1 = null;
             string mainProjectPath = null;
 
-            try {
+            try
+            {
                 extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), GetExtensionTargetsFileContent1());
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
 
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projColln = new ProjectCollection();
-#else
-                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+                var projColln = GetProjectCollection();
+
                 projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", extnDir1, Path.Combine("tmp", "nonexistent")));
                 var logger = new MockLogger();
                 projColln.RegisterLogger(logger);
@@ -59,7 +57,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 Assert.Throws<InvalidProjectFileException>(() => projColln.LoadProject(mainProjectPath));
 
                 logger.AssertLogContains("MSB4226");
-            } finally {
+            }
+            finally
+            {
                 if (mainProjectPath != null)
                 {
                     FileUtilities.DeleteNoThrow(mainProjectPath);
@@ -90,7 +90,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContentWithCondition);
             string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
 
-            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {extnDir1, Path.Combine("tmp", "nonexistent")},
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] { extnDir1, Path.Combine("tmp", "nonexistent") },
                                                             null,
                                                             (p, l) => {
                                                                 Assert.True(p.Build());
@@ -127,7 +127,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                                                             String.Format(extnTargetsFileContent2, mainProjectPath));
 
             CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath",
-                                                        new string[] {extnDir2, Path.Combine("tmp", "nonexistent"), extnDir1},
+                                                        new string[] { extnDir2, Path.Combine("tmp", "nonexistent"), extnDir1 },
                                                         null,
                                                         (p, l) => l.AssertLogContains("MSB4210"));
         }
@@ -198,7 +198,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
 
             CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath",
-                new[] {extnDir1, Path.Combine("tmp", "nonexistent"), extnDir2},
+                new[] { extnDir1, Path.Combine("tmp", "nonexistent"), extnDir2 },
                 null,
                 (project, logger) =>
                 {
@@ -280,7 +280,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent);
             string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
 
-            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {Path.Combine("tmp", "nonexistent"), extnDir1},
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] { Path.Combine("tmp", "nonexistent"), extnDir1 },
                                                     null, (p, l) => Assert.True(p.Build()));
         }
 
@@ -292,15 +292,12 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string extnDir1 = null;
             string mainProjectPath = null;
 
-            try {
+            try
+            {
                 extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent);
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
 
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projColln = new ProjectCollection();
-#else
-                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+                var projColln = GetProjectCollection();
                 projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", extnDir1,
                                                                                 Path.Combine("tmp", "nonexistent")));
                 var logger = new MockLogger();
@@ -308,7 +305,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 Assert.Throws<InvalidProjectFileException>(() => projColln.LoadProject(mainProjectPath));
                 logger.AssertLogContains("MSB4024");
-            } finally {
+            }
+            finally
+            {
                 if (mainProjectPath != null)
                 {
                     FileUtilities.DeleteNoThrow(mainProjectPath);
@@ -354,7 +353,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("foo", "extn.proj"), extnTargetsFileContent2);
             string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
 
-            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {extnDir2, Path.Combine("tmp", "nonexistent"), extnDir1},
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] { extnDir2, Path.Combine("tmp", "nonexistent"), extnDir1 },
                                                             null,
                                                             (p, l) => {
                                                                 Assert.True(p.Build());
@@ -398,12 +397,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
 
             // MSBuildExtensionsPath* property value has highest priority for the lookups
-            try {
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projColln = new ProjectCollection();
-#else
-                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+            try
+            {
+                var projColln = GetProjectCollection();
                 projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", Path.Combine("tmp", "non-existent"), extnDir1));
                 var logger = new MockLogger();
                 projColln.RegisterLogger(logger);
@@ -415,7 +411,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 logger.AssertLogContains("Running FromExtn");
                 logger.AssertLogContains("PropertyFromExtn1: FromSecondFile");
-            } finally {
+            }
+            finally
+            {
                 if (mainProjectPath != null)
                 {
                     FileUtilities.DeleteNoThrow(mainProjectPath);
@@ -479,7 +477,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string extnDir1 = null, extnDir2 = null, extnDir3 = null;
             string mainProjectPath = null;
 
-            try {
+            try
+            {
                 extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"),
                                 String.Format(extnTargetsFileContentTemplate, String.Empty, "FromExtn2", "<Import Project='$(MSBuildExtensionsPath32)\\bar\\extn2.proj' />"));
                 extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("bar", "extn2.proj"),
@@ -490,13 +489,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
 
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(String.Format(configFileContents, extnDir1, extnDir2, extnDir3));
-                var reader = GetStandardConfigurationReader();
 
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projColln = new ProjectCollection();
-#else
-                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+                var reader = GetStandardConfigurationReader();
+                var projColln = GetProjectCollection();
 
                 projColln.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -507,7 +502,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 logger.AssertLogContains("Running FromExtn3");
                 logger.AssertLogContains("Running FromExtn2");
                 logger.AssertLogContains("Running FromExtn");
-            } finally {
+            }
+            finally
+            {
                 if (mainProjectPath != null)
                 {
                     FileUtilities.DeleteNoThrow(mainProjectPath);
@@ -569,13 +566,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
                     GetMainTargetFileContent());
 
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
-                var reader = GetStandardConfigurationReader();
 
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
-#else
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+                var reader = GetStandardConfigurationReader();
+                var projectCollection = GetProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -634,13 +627,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
                     GetMainTargetFileContent());
 
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
-                var reader = GetStandardConfigurationReader();
 
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
-#else
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+                var reader = GetStandardConfigurationReader();
+                var projectCollection = GetProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -708,13 +697,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
 
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
-                var reader = GetStandardConfigurationReader();
 
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
-#else
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+                var reader = GetStandardConfigurationReader();
+                var projectCollection = GetProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -777,13 +762,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
 
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
-                var reader = GetStandardConfigurationReader();
 
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
-#else
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+                var reader = GetStandardConfigurationReader();
+                var projectCollection = GetProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -840,13 +821,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
 
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
-                var reader = GetStandardConfigurationReader();
 
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
-#else
-                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 }, null, ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+                var reader = GetStandardConfigurationReader();
+                var projectCollection = GetProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
 
                 projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
@@ -866,7 +843,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         void CreateAndBuildProjectForImportFromExtensionsPath(string extnPathPropertyName, Action<Project, MockLogger> action)
         {
             string extnDir1 = null, extnDir2 = null, mainProjectPath = null;
-            try {
+            try
+            {
                 extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"),
                                     GetExtensionTargetsFileContent1(extnPathPropertyName));
                 extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("bar", "extn2.proj"),
@@ -874,10 +852,12 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent(extnPathPropertyName));
 
-                CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, extnPathPropertyName, new string[] {extnDir1, extnDir2},
+                CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, extnPathPropertyName, new string[] { extnDir1, extnDir2 },
                                                                 null,
                                                                 action);
-            } finally {
+            }
+            finally
+            {
                 if (extnDir1 != null)
                 {
                     FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
@@ -896,19 +876,19 @@ namespace Microsoft.Build.UnitTests.Evaluation
         void CreateAndBuildProjectForImportFromExtensionsPath(string mainProjectPath, string extnPathPropertyName, string[] extnDirs, Action<string[]> setExtensionsPath,
                 Action<Project, MockLogger> action)
         {
-            try {
-#if FEATURE_SYSTEM_CONFIGURATION
-                var projColln = new ProjectCollection();
-#else
-                var projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
-#endif
+            try
+            {
+                var projColln = GetProjectCollection();
+
                 projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader(extnPathPropertyName, extnDirs));
                 var logger = new MockLogger();
                 projColln.RegisterLogger(logger);
                 var project = projColln.LoadProject(mainProjectPath);
 
                 action(project, logger);
-            } finally {
+            }
+            finally
+            {
                 if (mainProjectPath != null)
                 {
                     FileUtilities.DeleteNoThrow(mainProjectPath);
@@ -949,6 +929,30 @@ namespace Microsoft.Build.UnitTests.Evaluation
             return GetStandardConfigurationReader();
         }
 
+        private ProjectCollection GetProjectCollection(IDictionary<string, string> globalProperties = null)
+        {
+            ProjectCollection projColln;
+
+            if (globalProperties == null)
+            {
+#if FEATURE_SYSTEM_CONFIGURATION
+                projColln = new ProjectCollection();
+#else
+                projColln = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
+#endif
+            }
+            else
+            {
+#if FEATURE_SYSTEM_CONFIGURATION
+                projColln = new ProjectCollection(globalProperties);
+#else
+                projColln = new ProjectCollection(globalProperties, loggers: null, ToolsetDefinitionLocations.ConfigurationFile);
+#endif
+            }
+
+            return projColln;
+        }
+
         string GetNewExtensionsPathAndCreateFile(string extnDirName, string relativeFilePath, string fileContents)
         {
             var extnDir = Path.Combine(ObjectModelHelpers.TempProjectDir, extnDirName);
@@ -958,7 +962,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             return extnDir;
         }
 
-        string GetMainTargetFileContent(string extensionsPathPropertyName="MSBuildExtensionsPath")
+        string GetMainTargetFileContent(string extensionsPathPropertyName = "MSBuildExtensionsPath")
         {
             string mainTargetsFileContent = @"
                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
@@ -972,7 +976,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             return String.Format(mainTargetsFileContent, extensionsPathPropertyName);
         }
 
-        string GetExtensionTargetsFileContent1(string extensionsPathPropertyName="MSBuildExtensionsPath")
+        string GetExtensionTargetsFileContent1(string extensionsPathPropertyName = "MSBuildExtensionsPath")
         {
             string extnTargetsFileContent1 = @"
                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
@@ -990,7 +994,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             return String.Format(extnTargetsFileContent1, extensionsPathPropertyName);
         }
 
-        string GetExtensionTargetsFileContent2(string extensionsPathPropertyName="MSBuildExtensionsPath")
+        string GetExtensionTargetsFileContent2(string extensionsPathPropertyName = "MSBuildExtensionsPath")
         {
             string extnTargetsFileContent2 = @"
                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >

--- a/src/Build.UnitTests/Evaluation/ToolsetConfigurationNet5_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ToolsetConfigurationNet5_Tests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !FEATURE_SYSTEM_CONFIGURATION
+/*  This test is designed especially to test Configuration parsing in net5.0
+ *  which means it WON'T work in net472 and thus we don't run it in net472 */
+
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+
+using Xunit;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    /// <summary>
+    /// Unit tests for MSBuild Net5.0 Configuration Parsing
+    /// </summary>
+    public class ToolsetConfigurationNet5Test
+    {
+        [Fact]
+        // The default ToolsetDefintionLocations is None, which results in only the local which results in only the several included
+        // paths such as SDK path and RoslynTargetPath and nothing else. This behavior is expected and the exact same as before.
+        public void ToolsetDefinitionLocationsIsDefault()
+        {
+            var projectCollection = new ProjectCollection();
+            IDictionary<string, string> toolsetProperties
+                = new Dictionary<string, string>();
+
+            foreach (Toolset toolset in projectCollection.Toolsets)
+            {
+                foreach (KeyValuePair<string, ProjectPropertyInstance> properties in toolset.Properties)
+                {
+                    toolsetProperties[properties.Value.Name] = properties.Value.EvaluatedValue;
+                }
+            }
+
+            Assert.True(toolsetProperties.ContainsKey("MSBuildSDKsPath"));
+            Assert.True(toolsetProperties.ContainsKey("RoslynTargetsPath"));
+            Assert.Contains("net5.0", toolsetProperties["MSBuildSDKsPath"]);
+            Assert.Contains("net5.0", toolsetProperties["RoslynTargetsPath"]);
+            Assert.False(toolsetProperties.ContainsKey("VCTargetsPath"));
+            Assert.False(toolsetProperties.ContainsKey("MSBuildToolsRoot"));
+            Assert.False(toolsetProperties.ContainsKey("MSBuildExtensionsPath"));
+        }
+
+        [Fact]
+        // With ToolsetDefintionLocations set to ConfigurationFile (Which would only happen in net5.0 if the user decides to set it). 
+        // Most toolsets are available and the MsBuildTools and SDK paths are all in the net5.0 runtime.
+        public void ToolsetDefinitionLocationsIsConfiguration()
+        {
+            var projectCollection = new ProjectCollection(ToolsetDefinitionLocations.ConfigurationFile);
+            IDictionary<string, string> toolsetProperties
+                = new Dictionary<string, string>();
+
+            foreach (Toolset toolset in projectCollection.Toolsets)
+            {
+                foreach (KeyValuePair<string, ProjectPropertyInstance> properties in toolset.Properties)
+                {
+                    toolsetProperties[properties.Value.Name] = properties.Value.EvaluatedValue;
+                }
+            }
+
+            Assert.True(toolsetProperties.ContainsKey("MSBuildSDKsPath"));
+            Assert.True(toolsetProperties.ContainsKey("RoslynTargetsPath"));
+            Assert.Contains("net5.0", toolsetProperties["MSBuildSDKsPath"]);
+            Assert.Contains("net5.0", toolsetProperties["RoslynTargetsPath"]);
+
+            Assert.True(toolsetProperties.ContainsKey("VCTargetsPath"));
+            Assert.True(toolsetProperties.ContainsKey("MSBuildToolsRoot"));
+            Assert.True(toolsetProperties.ContainsKey("MSBuildExtensionsPath"));
+            Assert.Contains("net5.0", toolsetProperties["VCTargetsPath"]);
+            Assert.Contains("net5.0", toolsetProperties["MSBuildExtensionsPath"]);
+        }
+    }
+}
+#endif

--- a/src/Build.UnitTests/Evaluation/ToolsetConfigurationNet5_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ToolsetConfigurationNet5_Tests.cs
@@ -37,8 +37,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             Assert.True(toolsetProperties.ContainsKey("MSBuildSDKsPath"));
             Assert.True(toolsetProperties.ContainsKey("RoslynTargetsPath"));
-            Assert.Contains("net5.0", toolsetProperties["MSBuildSDKsPath"]);
-            Assert.Contains("net5.0", toolsetProperties["RoslynTargetsPath"]);
+            Assert.NotEqual(string.Empty, toolsetProperties["MSBuildSDKsPath"]);
+            Assert.NotEqual(string.Empty, toolsetProperties["RoslynTargetsPath"]);
+
             Assert.False(toolsetProperties.ContainsKey("VCTargetsPath"));
             Assert.False(toolsetProperties.ContainsKey("MSBuildToolsRoot"));
             Assert.False(toolsetProperties.ContainsKey("MSBuildExtensionsPath"));
@@ -63,14 +64,15 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             Assert.True(toolsetProperties.ContainsKey("MSBuildSDKsPath"));
             Assert.True(toolsetProperties.ContainsKey("RoslynTargetsPath"));
-            Assert.Contains("net5.0", toolsetProperties["MSBuildSDKsPath"]);
-            Assert.Contains("net5.0", toolsetProperties["RoslynTargetsPath"]);
+            Assert.NotEqual(string.Empty, toolsetProperties["MSBuildSDKsPath"]);
+            Assert.NotEqual(string.Empty, toolsetProperties["RoslynTargetsPath"]);
 
             Assert.True(toolsetProperties.ContainsKey("VCTargetsPath"));
             Assert.True(toolsetProperties.ContainsKey("MSBuildToolsRoot"));
             Assert.True(toolsetProperties.ContainsKey("MSBuildExtensionsPath"));
-            Assert.Contains("net5.0", toolsetProperties["VCTargetsPath"]);
-            Assert.Contains("net5.0", toolsetProperties["MSBuildExtensionsPath"]);
+            Assert.NotEqual(string.Empty, toolsetProperties["VCTargetsPath"]);
+            Assert.NotEqual(string.Empty, toolsetProperties["MSBuildToolsRoot"]);
+            Assert.NotEqual(string.Empty, toolsetProperties["MSBuildExtensionsPath"]);
         }
     }
 }

--- a/src/Build.UnitTests/Evaluation/ToolsetConfigurationNet5_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ToolsetConfigurationNet5_Tests.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Execution;
 
 using Xunit;
 using System.Collections.Generic;
+using Shouldly;
 
 namespace Microsoft.Build.UnitTests.Evaluation
 {
@@ -35,14 +36,14 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 }
             }
 
-            Assert.True(toolsetProperties.ContainsKey("MSBuildSDKsPath"));
-            Assert.True(toolsetProperties.ContainsKey("RoslynTargetsPath"));
-            Assert.NotEqual(string.Empty, toolsetProperties["MSBuildSDKsPath"]);
-            Assert.NotEqual(string.Empty, toolsetProperties["RoslynTargetsPath"]);
+            toolsetProperties.ShouldContainKey("MSBuildSDKsPath");
+            toolsetProperties.ShouldContainKey("RoslynTargetsPath");
+            toolsetProperties["MSBuildSDKsPath"].ShouldNotBeNullOrEmpty();
+            toolsetProperties["RoslynTargetsPath"].ShouldNotBeNullOrEmpty();
 
-            Assert.False(toolsetProperties.ContainsKey("VCTargetsPath"));
-            Assert.False(toolsetProperties.ContainsKey("MSBuildToolsRoot"));
-            Assert.False(toolsetProperties.ContainsKey("MSBuildExtensionsPath"));
+            toolsetProperties.ShouldNotContainKey("VCTargetsPath");
+            toolsetProperties.ShouldNotContainKey("MSBuildToolsRoot");
+            toolsetProperties.ShouldNotContainKey("MSBuildExtensionsPath");
         }
 
         [Fact]
@@ -62,17 +63,17 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 }
             }
 
-            Assert.True(toolsetProperties.ContainsKey("MSBuildSDKsPath"));
-            Assert.True(toolsetProperties.ContainsKey("RoslynTargetsPath"));
-            Assert.NotEqual(string.Empty, toolsetProperties["MSBuildSDKsPath"]);
-            Assert.NotEqual(string.Empty, toolsetProperties["RoslynTargetsPath"]);
+            toolsetProperties.ShouldContainKey("MSBuildSDKsPath");
+            toolsetProperties.ShouldContainKey("RoslynTargetsPath");
+            toolsetProperties["MSBuildSDKsPath"].ShouldNotBeNullOrEmpty();
+            toolsetProperties["RoslynTargetsPath"].ShouldNotBeNullOrEmpty();
 
-            Assert.True(toolsetProperties.ContainsKey("VCTargetsPath"));
-            Assert.True(toolsetProperties.ContainsKey("MSBuildToolsRoot"));
-            Assert.True(toolsetProperties.ContainsKey("MSBuildExtensionsPath"));
-            Assert.NotEqual(string.Empty, toolsetProperties["VCTargetsPath"]);
-            Assert.NotEqual(string.Empty, toolsetProperties["MSBuildToolsRoot"]);
-            Assert.NotEqual(string.Empty, toolsetProperties["MSBuildExtensionsPath"]);
+            toolsetProperties.ShouldContainKey("VCTargetsPath");
+            toolsetProperties.ShouldContainKey("MSBuildToolsRoot");
+            toolsetProperties.ShouldContainKey("MSBuildExtensionsPath");
+            toolsetProperties["VCTargetsPath"].ShouldNotBeNullOrEmpty();
+            toolsetProperties["MSBuildToolsRoot"].ShouldNotBeNullOrEmpty();
+            toolsetProperties["MSBuildExtensionsPath"].ShouldNotBeNullOrEmpty();
         }
     }
 }

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(RuntimeOutputTargetFrameworks)</TargetFrameworks>

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(RuntimeOutputTargetFrameworks)</TargetFrameworks>
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" />
     <PackageReference Include="NuGet.Frameworks" >
@@ -44,17 +45,12 @@
       <SetTargetFramework Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(MonoBuild)' == 'true'">TargetFramework=$(FullFrameworkTFM)</SetTargetFramework>
       <SetTargetFramework Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
-
-    <Reference Include="System.Configuration" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Shared\FxCopExclusions\Microsoft.Build.Shared.Suppressions.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    
-    <Compile Remove="Definition\ToolsetConfigurationReaderTestHelper.cs" />
-    <Compile Include="Definition\ToolsetConfigurationReaderTestHelper.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
 
     <Compile Include="..\Shared\UnitTests\BuildEventArgsExtension.cs">
       <!-- Extension methods -->

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1729,7 +1729,6 @@ namespace Microsoft.Build.Evaluation
             _loggingService.OnlyLogCriticalEvents = onlyLogCriticalEvents;
         }
 
-#if FEATURE_SYSTEM_CONFIGURATION
         /// <summary>
         /// Reset the toolsets using the provided toolset reader, used by unit tests
         /// </summary>
@@ -1737,7 +1736,6 @@ namespace Microsoft.Build.Evaluation
         {
             InitializeToolsetCollection(configReader:configurationReaderForTestsOnly);
         }
-#endif
 
 #if FEATURE_WIN32_REGISTRY
         /// <summary>
@@ -1757,9 +1755,7 @@ namespace Microsoft.Build.Evaluation
 #if FEATURE_WIN32_REGISTRY
                 ToolsetRegistryReader registryReader = null,
 #endif
-#if FEATURE_SYSTEM_CONFIGURATION
                 ToolsetConfigurationReader configReader = null
-#endif
                 )
         {
             _toolsets = new Dictionary<string, Toolset>(StringComparer.OrdinalIgnoreCase);
@@ -1769,9 +1765,7 @@ namespace Microsoft.Build.Evaluation
 #if FEATURE_WIN32_REGISTRY
                     registryReader,
 #endif
-#if FEATURE_SYSTEM_CONFIGURATION
                     configReader,
-#endif
                     EnvironmentProperties, _globalProperties, ToolsetLocations);
 
             _toolsetsVersion++;

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1737,7 +1737,6 @@ namespace Microsoft.Build.Evaluation
             InitializeToolsetCollection(configReader:configurationReaderForTestsOnly);
         }
 
-#if FEATURE_WIN32_REGISTRY
         /// <summary>
         /// Reset the toolsets using the provided toolset reader, used by unit tests
         /// </summary>
@@ -1745,16 +1744,13 @@ namespace Microsoft.Build.Evaluation
         {
             InitializeToolsetCollection(registryReader:registryReaderForTestsOnly);
         }
-#endif
 
         /// <summary>
         /// Populate Toolsets with a dictionary of (toolset version, Toolset)
         /// using information from the registry and config file, if any.
         /// </summary>
         private void InitializeToolsetCollection(
-#if FEATURE_WIN32_REGISTRY
                 ToolsetRegistryReader registryReader = null,
-#endif
                 ToolsetConfigurationReader configReader = null
                 )
         {
@@ -1762,9 +1758,7 @@ namespace Microsoft.Build.Evaluation
 
             // We only want our local toolset (as defined in MSBuild.exe.config) when we're operating locally...
             _defaultToolsVersion = ToolsetReader.ReadAllToolsets(_toolsets,
-#if FEATURE_WIN32_REGISTRY
                     registryReader,
-#endif
                     configReader,
                     EnvironmentProperties, _globalProperties, ToolsetLocations);
 

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -2032,9 +2032,9 @@ namespace Microsoft.Build.Evaluation
 
                 _includeTaskInputs = true;
             }
-#endregion
+            #endregion
 
-#region ILogger Members
+            #region ILogger Members
 
             /// <summary>
             /// The logger verbosity

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1737,6 +1737,7 @@ namespace Microsoft.Build.Evaluation
             InitializeToolsetCollection(configReader:configurationReaderForTestsOnly);
         }
 
+#if FEATURE_WIN32_REGISTRY
         /// <summary>
         /// Reset the toolsets using the provided toolset reader, used by unit tests
         /// </summary>
@@ -1744,13 +1745,16 @@ namespace Microsoft.Build.Evaluation
         {
             InitializeToolsetCollection(registryReader:registryReaderForTestsOnly);
         }
+#endif
 
         /// <summary>
         /// Populate Toolsets with a dictionary of (toolset version, Toolset)
         /// using information from the registry and config file, if any.
         /// </summary>
         private void InitializeToolsetCollection(
+#if FEATURE_WIN32_REGISTRY
                 ToolsetRegistryReader registryReader = null,
+#endif
                 ToolsetConfigurationReader configReader = null
                 )
         {
@@ -1758,7 +1762,9 @@ namespace Microsoft.Build.Evaluation
 
             // We only want our local toolset (as defined in MSBuild.exe.config) when we're operating locally...
             _defaultToolsVersion = ToolsetReader.ReadAllToolsets(_toolsets,
+#if FEATURE_WIN32_REGISTRY
                     registryReader,
+#endif
                     configReader,
                     EnvironmentProperties, _globalProperties, ToolsetLocations);
 
@@ -2026,9 +2032,9 @@ namespace Microsoft.Build.Evaluation
 
                 _includeTaskInputs = true;
             }
-            #endregion
+#endregion
 
-            #region ILogger Members
+#region ILogger Members
 
             /// <summary>
             /// The logger verbosity

--- a/src/Build/Definition/ToolsetConfigurationReader.cs
+++ b/src/Build/Definition/ToolsetConfigurationReader.cs
@@ -253,6 +253,8 @@ namespace Microsoft.Build.Evaluation
         {
             // When running from the command-line or from VS, use the msbuild.exe.config file.
             if (BuildEnvironmentHelper.Instance.Mode != BuildEnvironmentMode.None &&
+ // This FEATURE_SYSTEM_CONFIGURATION is needed as OpenExeConfiguration for net5.0 works differently, without this condition unit tests won't pass.
+ // OpenExeConfiguration in net5.0 will return testhost.exe which does not contain any configuration and therefore fail.
 #if FEATURE_SYSTEM_CONFIGURATION
                 !BuildEnvironmentHelper.Instance.RunningTests &&
 #endif

--- a/src/Build/Definition/ToolsetConfigurationReader.cs
+++ b/src/Build/Definition/ToolsetConfigurationReader.cs
@@ -253,7 +253,9 @@ namespace Microsoft.Build.Evaluation
         {
             // When running from the command-line or from VS, use the msbuild.exe.config file.
             if (BuildEnvironmentHelper.Instance.Mode != BuildEnvironmentMode.None &&
+#if FEATURE_SYSTEM_CONFIGURATION
                 !BuildEnvironmentHelper.Instance.RunningTests &&
+#endif
                 FileSystems.Default.FileExists(BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile))
             {
                 var configFile = new ExeConfigurationFileMap { ExeConfigFilename = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile };

--- a/src/Build/Definition/ToolsetConfigurationReader.cs
+++ b/src/Build/Definition/ToolsetConfigurationReader.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Build.Evaluation
             // When running from the command-line or from VS, use the msbuild.exe.config file.
             if (BuildEnvironmentHelper.Instance.Mode != BuildEnvironmentMode.None &&
  // This FEATURE_SYSTEM_CONFIGURATION is needed as OpenExeConfiguration for net5.0 works differently, without this condition unit tests won't pass.
- // OpenExeConfiguration in net5.0 will return testhost.exe which does not contain any configuration and therefore fail.
+ // ConfigurationManager.OpenExeConfiguration in net5.0 will find testhost.exe instead which does not contain any configuration and therefore fail.
 #if FEATURE_SYSTEM_CONFIGURATION
                 !BuildEnvironmentHelper.Instance.RunningTests &&
 #endif

--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Build.Evaluation
             get;
         }
 
-#if FEATURE_WIN32_REGISTRY || FEATURE_SYSTEM_CONFIGURATION
         /// <summary>
         /// Gathers toolset data from the registry and configuration file, if any:
         /// allows you to specify which of the registry and configuration file to
@@ -88,12 +87,9 @@ namespace Microsoft.Build.Evaluation
 #if FEATURE_WIN32_REGISTRY
                 null,
 #endif
-#if FEATURE_SYSTEM_CONFIGURATION
                 null,
-#endif
                 environmentProperties, globalProperties, locations);
         }
-#endif
 
         /// <summary>
         /// Gathers toolset data from the registry and configuration file, if any.
@@ -105,9 +101,7 @@ namespace Microsoft.Build.Evaluation
 #if FEATURE_WIN32_REGISTRY
             ToolsetRegistryReader registryReader,
 #endif
-#if FEATURE_SYSTEM_CONFIGURATION
             ToolsetConfigurationReader configurationReader,
-#endif
             PropertyDictionary<ProjectPropertyInstance> environmentProperties,
             PropertyDictionary<ProjectPropertyInstance> globalProperties,
             ToolsetDefinitionLocations locations
@@ -124,7 +118,6 @@ namespace Microsoft.Build.Evaluation
             string overrideTasksPathFromConfiguration = null;
             string defaultOverrideToolsVersionFromConfiguration = null;
 
-#if FEATURE_SYSTEM_CONFIGURATION
             if ((locations & ToolsetDefinitionLocations.ConfigurationFile) == ToolsetDefinitionLocations.ConfigurationFile)
             {
                 if (configurationReader == null)
@@ -137,7 +130,6 @@ namespace Microsoft.Build.Evaluation
                     initialProperties, true /* accumulate properties */, out overrideTasksPathFromConfiguration,
                     out defaultOverrideToolsVersionFromConfiguration);
             }
-#endif
 
             string defaultToolsVersionFromRegistry = null;
             string overrideTasksPathFromRegistry = null;

--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -84,7 +84,9 @@ namespace Microsoft.Build.Evaluation
         internal static string ReadAllToolsets(Dictionary<string, Toolset> toolsets, PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, ToolsetDefinitionLocations locations)
         {
             return ReadAllToolsets(toolsets,
+#if FEATURE_WIN32_REGISTRY
                 null,
+#endif
                 null,
                 environmentProperties, globalProperties, locations);
         }
@@ -96,7 +98,9 @@ namespace Microsoft.Build.Evaluation
         internal static string ReadAllToolsets
             (
             Dictionary<string, Toolset> toolsets,
+#if FEATURE_WIN32_REGISTRY
             ToolsetRegistryReader registryReader,
+#endif
             ToolsetConfigurationReader configurationReader,
             PropertyDictionary<ProjectPropertyInstance> environmentProperties,
             PropertyDictionary<ProjectPropertyInstance> globalProperties,
@@ -133,6 +137,7 @@ namespace Microsoft.Build.Evaluation
 
             if ((locations & ToolsetDefinitionLocations.Registry) == ToolsetDefinitionLocations.Registry)
             {
+#if FEATURE_WIN32_REGISTRY
                 if (NativeMethodsShared.IsWindows || registryReader != null)
                 {
                     // If we haven't been provided a registry reader (i.e. unit tests), create one
@@ -146,6 +151,7 @@ namespace Microsoft.Build.Evaluation
                         out defaultOverrideToolsVersionFromRegistry);
                 }
                 else
+#endif
                 {
                     var currentDir = BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory.TrimEnd(Path.DirectorySeparatorChar);
                     var props = new PropertyDictionary<ProjectPropertyInstance>();

--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -84,9 +84,7 @@ namespace Microsoft.Build.Evaluation
         internal static string ReadAllToolsets(Dictionary<string, Toolset> toolsets, PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, ToolsetDefinitionLocations locations)
         {
             return ReadAllToolsets(toolsets,
-#if FEATURE_WIN32_REGISTRY
                 null,
-#endif
                 null,
                 environmentProperties, globalProperties, locations);
         }
@@ -98,9 +96,7 @@ namespace Microsoft.Build.Evaluation
         internal static string ReadAllToolsets
             (
             Dictionary<string, Toolset> toolsets,
-#if FEATURE_WIN32_REGISTRY
             ToolsetRegistryReader registryReader,
-#endif
             ToolsetConfigurationReader configurationReader,
             PropertyDictionary<ProjectPropertyInstance> environmentProperties,
             PropertyDictionary<ProjectPropertyInstance> globalProperties,
@@ -137,7 +133,6 @@ namespace Microsoft.Build.Evaluation
 
             if ((locations & ToolsetDefinitionLocations.Registry) == ToolsetDefinitionLocations.Registry)
             {
-#if FEATURE_WIN32_REGISTRY
                 if (NativeMethodsShared.IsWindows || registryReader != null)
                 {
                     // If we haven't been provided a registry reader (i.e. unit tests), create one
@@ -151,7 +146,6 @@ namespace Microsoft.Build.Evaluation
                         out defaultOverrideToolsVersionFromRegistry);
                 }
                 else
-#endif
                 {
                     var currentDir = BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory.TrimEnd(Path.DirectorySeparatorChar);
                     var props = new PropertyDictionary<ProjectPropertyInstance>();

--- a/src/Build/Definition/ToolsetRegistryReader.cs
+++ b/src/Build/Definition/ToolsetRegistryReader.cs
@@ -1,13 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if FEATURE_WIN32_REGISTRY
-
-using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Security;
 
 using Microsoft.Build.Shared;
 using error = Microsoft.Build.Shared.ErrorUtilities;
@@ -346,4 +341,3 @@ namespace Microsoft.Build.Evaluation
         }
     }
 }
-#endif

--- a/src/Build/Definition/ToolsetRegistryReader.cs
+++ b/src/Build/Definition/ToolsetRegistryReader.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if FEATURE_WIN32_REGISTRY
+
 using System;
 using System.Collections.Generic;
 
@@ -341,3 +343,4 @@ namespace Microsoft.Build.Evaluation
         }
     }
 }
+#endif

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -259,30 +259,30 @@ namespace Microsoft.Build.Evaluation
             return result;
         }
 
-#else // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors	
+#else // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors
 
-        /// <summary>	
-        /// Get the value of the registry key and value, default value is null	
-        /// </summary>	
+        /// <summary>
+        /// Get the value of the registry key and value, default value is null
+        /// </summary>
         internal static object GetRegistryValue(string keyName, string valueName)
         {
             return null; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors	
         }
 
-        /// <summary>	
-        /// Get the value of the registry key and value	
-        /// </summary>	
+        /// <summary>
+        /// Get the value of the registry key and value
+        /// </summary>
         internal static object GetRegistryValue(string keyName, string valueName, object defaultValue)
         {
-            return defaultValue; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors	
+            return defaultValue; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors
         }
 
-        /// <summary>	
-        /// Get the value of the registry key from one of the RegistryView's specified	
-        /// </summary>	
+        /// <summary>
+        /// Get the value of the registry key from one of the RegistryView's specified
+        /// </summary>
         internal static object GetRegistryValueFromView(string keyName, string valueName, object defaultValue, params object[] views)
         {
-            return defaultValue; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors	
+            return defaultValue; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors
         }
 #endif
 
@@ -569,7 +569,7 @@ namespace Microsoft.Build.Evaluation
             return new List<string> { "A", "B", "C", "D" };
         }
 
-        #endregion
+#endregion
 
 #if FEATURE_WIN32_REGISTRY
         /// <summary>

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -24,11 +24,9 @@ namespace Microsoft.Build.Evaluation
     /// </summary>
     internal static class IntrinsicFunctions
     {
-#if FEATURE_WIN32_REGISTRY
         private static readonly object[] DefaultRegistryViews = new object[] { RegistryView.Default };
 
         private static readonly Lazy<Regex> RegistrySdkRegex = new Lazy<Regex>(() => new Regex(@"^HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs\\Windows\\v(\d+\.\d+)$", RegexOptions.IgnoreCase));
-#endif // FEATURE_WIN32_REGISTRY
 
         private static readonly Lazy<NuGetFrameworkWrapper> NuGetFramework = new Lazy<NuGetFrameworkWrapper>(() => new NuGetFrameworkWrapper());
 
@@ -160,7 +158,6 @@ namespace Microsoft.Build.Evaluation
             return ~first;
         }
 
-#if FEATURE_WIN32_REGISTRY
         /// <summary>
         /// Get the value of the registry key and value, default value is null
         /// </summary>
@@ -258,33 +255,6 @@ namespace Microsoft.Build.Evaluation
             // We will have either found a result or defaultValue if one wasn't found at this point
             return result;
         }
-
-#else // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors
-
-        /// <summary>
-        /// Get the value of the registry key and value, default value is null
-        /// </summary>
-        internal static object GetRegistryValue(string keyName, string valueName)
-        {
-            return null; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors
-        }
-
-        /// <summary>
-        /// Get the value of the registry key and value
-        /// </summary>
-        internal static object GetRegistryValue(string keyName, string valueName, object defaultValue)
-        {
-            return defaultValue; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors
-        }
-
-        /// <summary>
-        /// Get the value of the registry key from one of the RegistryView's specified
-        /// </summary>
-        internal static object GetRegistryValueFromView(string keyName, string valueName, object defaultValue, params object[] views)
-        {
-            return defaultValue; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors
-        }
-#endif
 
         /// <summary>
         /// Given the absolute location of a file, and a disc location, returns relative file path to that disk location.
@@ -571,7 +541,6 @@ namespace Microsoft.Build.Evaluation
 
 #endregion
 
-#if FEATURE_WIN32_REGISTRY
         /// <summary>
         /// Following function will parse a keyName and returns the basekey for it.
         /// It will also store the subkey name in the out parameter.
@@ -640,6 +609,5 @@ namespace Microsoft.Build.Evaluation
 
             return basekey;
         }
-#endif
     }
 }

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -24,9 +24,11 @@ namespace Microsoft.Build.Evaluation
     /// </summary>
     internal static class IntrinsicFunctions
     {
+#if FEATURE_WIN32_REGISTRY
         private static readonly object[] DefaultRegistryViews = new object[] { RegistryView.Default };
 
         private static readonly Lazy<Regex> RegistrySdkRegex = new Lazy<Regex>(() => new Regex(@"^HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs\\Windows\\v(\d+\.\d+)$", RegexOptions.IgnoreCase));
+#endif // FEATURE_WIN32_REGISTRY
 
         private static readonly Lazy<NuGetFrameworkWrapper> NuGetFramework = new Lazy<NuGetFrameworkWrapper>(() => new NuGetFrameworkWrapper());
 
@@ -158,6 +160,7 @@ namespace Microsoft.Build.Evaluation
             return ~first;
         }
 
+#if FEATURE_WIN32_REGISTRY
         /// <summary>
         /// Get the value of the registry key and value, default value is null
         /// </summary>
@@ -255,6 +258,33 @@ namespace Microsoft.Build.Evaluation
             // We will have either found a result or defaultValue if one wasn't found at this point
             return result;
         }
+
+#else // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors	
+
+        /// <summary>	
+        /// Get the value of the registry key and value, default value is null	
+        /// </summary>	
+        internal static object GetRegistryValue(string keyName, string valueName)
+        {
+            return null; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors	
+        }
+
+        /// <summary>	
+        /// Get the value of the registry key and value	
+        /// </summary>	
+        internal static object GetRegistryValue(string keyName, string valueName, object defaultValue)
+        {
+            return defaultValue; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors	
+        }
+
+        /// <summary>	
+        /// Get the value of the registry key from one of the RegistryView's specified	
+        /// </summary>	
+        internal static object GetRegistryValueFromView(string keyName, string valueName, object defaultValue, params object[] views)
+        {
+            return defaultValue; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors	
+        }
+#endif
 
         /// <summary>
         /// Given the absolute location of a file, and a disc location, returns relative file path to that disk location.
@@ -539,8 +569,9 @@ namespace Microsoft.Build.Evaluation
             return new List<string> { "A", "B", "C", "D" };
         }
 
-#endregion
+        #endregion
 
+#if FEATURE_WIN32_REGISTRY
         /// <summary>
         /// Following function will parse a keyName and returns the basekey for it.
         /// It will also store the subkey name in the out parameter.
@@ -609,5 +640,6 @@ namespace Microsoft.Build.Evaluation
 
             return basekey;
         }
+#endif
     }
 }

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal static object GetRegistryValue(string keyName, string valueName)
         {
-            return null; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors	
+            return null; // FEATURE_WIN32_REGISTRY is off, need to mock the function names to let scrips call these property functions and get NULLs rather than fail with errors
         }
 
         /// <summary>

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
 
     <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
     <PackageReference Include="System.Text.Json" />
 
@@ -39,7 +40,6 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.IO.Compression" />
     <PackageReference Include="System.Memory" />
   </ItemGroup>
@@ -419,8 +419,8 @@
     <Compile Include="Definition\ResolvedImport.cs" />
     <Compile Include="Definition\SubToolset.cs" />
     <Compile Include="Definition\Toolset.cs" />
-    <Compile Include="Definition\ToolsetConfigurationReader.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
-    <Compile Include="..\Shared\ToolsetElement.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Compile Include="Definition\ToolsetConfigurationReader.cs" />
+    <Compile Include="..\Shared\ToolsetElement.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Definition\ToolsetPropertyDefinition.cs" />

--- a/src/Build/Utilities/RegistryKeyWrapper.cs
+++ b/src/Build/Utilities/RegistryKeyWrapper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#if FEATURE_WIN32_REGISTRY
 
 using System;
 
@@ -266,3 +267,4 @@ namespace Microsoft.Build.Internal
         }
     }
 }
+#endif

--- a/src/Build/Utilities/RegistryKeyWrapper.cs
+++ b/src/Build/Utilities/RegistryKeyWrapper.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if FEATURE_WIN32_REGISTRY
 
 using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Security;
 
 using Microsoft.Build.Shared;
 using Microsoft.Win32;
@@ -271,4 +266,3 @@ namespace Microsoft.Build.Internal
         }
     }
 }
-#endif

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -221,12 +221,14 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <!-- File for Assemblies we depend on -->
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Configuration" />
     <PackageReference Include="LargeAddressAware" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-#if FEATURE_SYSTEM_CONFIGURATION
 using System.Configuration;
-#endif
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -4,17 +4,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-#if FEATURE_SYSTEM_CONFIGURATION
-using System.Configuration;
-#endif
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using Microsoft.Win32;
 
-#if FEATURE_SYSTEM_CONFIGURATION
-using PropertyElement = Microsoft.Build.Evaluation.ToolsetElement.PropertyElement;
-#endif
 using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Shared

--- a/src/Shared/ToolsetElement.cs
+++ b/src/Shared/ToolsetElement.cs
@@ -3,17 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-#if FEATURE_SYSTEM_CONFIGURATION
 using System.Configuration;
-#endif
 using System.IO;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Evaluation
 {
-#if FEATURE_SYSTEM_CONFIGURATION
-
     /// <summary>
     /// Helper class for reading toolsets out of the configuration file.
     /// </summary>
@@ -708,5 +704,4 @@ namespace Microsoft.Build.Evaluation
             }
         }
     }
-#endif
 }

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2397,9 +2397,9 @@ namespace Microsoft.Build.UnitTests
 
             if (NativeMethodsShared.IsWindows)
             {
-#pragma warning disable CA1416
+#pragma warning disable CA1416 // Suppress Warning saying that WindowsPrincipal might not be compatible on Windows (Which shouldn't be an issue...)
                 if (!new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null)))
-#pragma warning restore CA1416
+#pragma warning restore CA1416 // Suppress Warning saying that WindowsPrincipal might not be compatible on Windows (Which shouldn't be an issue...)
                 {
                     isPrivileged = false;
                     Assert.True(true, "It seems that you don't have the permission to create symbolic links. Try to run this test again with higher privileges");

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2397,7 +2397,9 @@ namespace Microsoft.Build.UnitTests
 
             if (NativeMethodsShared.IsWindows)
             {
+#pragma warning disable CA1416
                 if (!new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null)))
+#pragma warning restore CA1416
                 {
                     isPrivileged = false;
                     Assert.True(true, "It seems that you don't have the permission to create symbolic links. Try to run this test again with higher privileges");

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -22,12 +22,11 @@
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
 
     <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETStandard'">
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
-
-    <Reference Include="System.Configuration" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">


### PR DESCRIPTION
### Context
This change will give NET5.0 MSBuild the option to read toolset information from the configuration file ONLY if ToolsetDefinitionLocation is set to 'ConfigurationFile'. Otherwise everything should work the exact same way as before.

This change is beneficial as it allows net5.0 MSBuild to evaluate projects that only net framework MsBuild could before. Since ConfigurationFile wasn't an option in net5.0 before (Due to System.Configuration being only net472), toolsets available to net5.0 MsBuild was minimal, but with this change a net5.0 MsBuild user could specify ConfigurationFile as the ToolsetDefinitionLocation when creating a ProjectCollection and more toolsets would be available depending on the MsBuild.exe provided. 

### Changes Made
Updated all the System.Configuration references to [System.Configuration.ConfigurationManager](https://www.nuget.org/packages/System.Configuration.ConfigurationManager/) (Which supports netstandard2.0). This change allows net5.0 to read toolset information from configuration file, but the default remains the same.

### Testing
Tested locally to make sure the toolset information remains the same for cases other than when ToolsetDefinitionLocation is set to ConfigurationFile. CI should be good enough to ensure everything else still works as before.

Existing unit tests should be good enough to verify that this change does not affect net472 at all. Freed up a lot of unit tests under FEATURE_SYSTEM_CONFIGURATION which can be used to validate that net5.0 behavior without configuration setting works the same as before. Also added in a couple more tests to ensure setting ToolsetDefinitionLocation to ConfigurationFile actually grabs more configurations comparing to default.