### PR TITLE
Ignore comments and whitespace when parsing read-only XML files

### DIFF
--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Xml;
 using Microsoft.Build.Shared;
@@ -71,6 +73,23 @@ namespace Microsoft.Build.Internal
             _stream?.Dispose();
         }
 
+        private static volatile PropertyInfo _normalizationPropertyInfo;
+
+        private static PropertyInfo GetNormalizationPropertyInfo(Type xmlReaderType)
+        {
+            BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.SetProperty | BindingFlags.Instance;
+            if (_normalizationPropertyInfo == null)
+            {
+                _normalizationPropertyInfo = xmlReaderType.GetProperty("Normalization", bindingFlags);
+            }
+            else if (xmlReaderType != _normalizationPropertyInfo.ReflectedType)
+            {
+                Debug.Fail("GetNormalizationPropertyInfo can only take one type");
+                return xmlReaderType.GetProperty("Normalization", bindingFlags);
+            }
+            return _normalizationPropertyInfo;
+        }
+
         private static XmlReader GetXmlReader(string file, StreamReader input, bool loadAsReadOnly, out Encoding encoding)
         {
             string uri = new UriBuilder(Uri.UriSchemeFile, string.Empty) { Path = file }.ToString();
@@ -78,15 +97,14 @@ namespace Microsoft.Build.Internal
             XmlReader reader;
             if (loadAsReadOnly)
             {
-                XmlReaderSettings xrs = new XmlReaderSettings
+                 XmlReaderSettings xrs = new XmlReaderSettings
                 {
                     DtdProcessing = DtdProcessing.Ignore,
                     IgnoreComments = true,
-                    // Setting IgnoreWhitespace results in whitespace changes of attribute text, specifically newline removal.
-                    // https://github.com/Microsoft/msbuild/issues/4210
-                    // IgnoreWhitespace = true,
+                    IgnoreWhitespace = true,
                 };
                 reader = XmlReader.Create(input, xrs, uri);
+                GetNormalizationPropertyInfo(reader.GetType()).SetValue(reader, false);
             }
             else
             {

--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -28,7 +28,14 @@ namespace Microsoft.Build.Internal
         private readonly Stream _stream;
         private readonly StreamReader _streamReader;
 
+        /// <summary>
+        /// Caches a <see cref="PropertyInfo"/> representing the "Normalization" internal property on the <see cref="XmlReader"/>-derived
+        /// type returned from <see cref="XmlReader.Create(TextReader, XmlReaderSettings, string)"/>. The cache is process/AppDomain-wide
+        /// and lock-free, so we use volatile access for thread safety, i.e. to ensure that when the field is updated the PropertyInfo
+        /// it's pointing to is seen as fully initialized by all CPUs.
+        /// </summary>
         private static volatile PropertyInfo _normalizationPropertyInfo;
+
         private static bool _disableReadOnlyLoad;
 
         private XmlReaderExtension(string file, bool loadAsReadOnly)
@@ -88,6 +95,7 @@ namespace Microsoft.Build.Internal
                 propertyInfo = xmlReaderType.GetProperty("Normalization", bindingFlags);
                 _normalizationPropertyInfo = propertyInfo;
             }
+
             return propertyInfo;
         }
 
@@ -95,18 +103,18 @@ namespace Microsoft.Build.Internal
         {
             string uri = new UriBuilder(Uri.UriSchemeFile, string.Empty) { Path = file }.ToString();
 
-            XmlReader reader;
+            XmlReader reader = null;
             if (loadAsReadOnly && !_disableReadOnlyLoad)
             {
                 // Create an XML reader with IgnoreComments and IgnoreWhitespace set if we know that we won't be asked
                 // to write the DOM back to a file. This is a performance optimization.
-                XmlReaderSettings xrs = new XmlReaderSettings
+                XmlReaderSettings settings = new XmlReaderSettings
                 {
                     DtdProcessing = DtdProcessing.Ignore,
                     IgnoreComments = true,
                     IgnoreWhitespace = true,
                 };
-                reader = XmlReader.Create(input, xrs, uri);
+                reader = XmlReader.Create(input, settings, uri);
 
                 // Try to set Normalization to false. We do this to remain compatible with earlier versions of MSBuild
                 // where we constructed the reader with 'new XmlTextReader()' which has normalization enabled by default.
@@ -122,10 +130,11 @@ namespace Microsoft.Build.Internal
                     _disableReadOnlyLoad = true;
 
                     reader.Dispose();
-                    reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
+                    reader = null;
                 }
             }
-            else
+
+            if (reader == null)
             {
                 reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
             }

--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Build.Internal
         private readonly Stream _stream;
         private readonly StreamReader _streamReader;
 
+        private static volatile PropertyInfo _normalizationPropertyInfo;
+        private static bool _disableReadOnlyLoad;
+
         private XmlReaderExtension(string file, bool loadAsReadOnly)
         {
             try
@@ -73,21 +76,19 @@ namespace Microsoft.Build.Internal
             _stream?.Dispose();
         }
 
-        private static volatile PropertyInfo _normalizationPropertyInfo;
-
+        /// <summary>
+        /// Returns <see cref="PropertyInfo"/> of the "Normalization" internal property on the given <see cref="XmlReader"/>-derived type.
+        /// </summary>
         private static PropertyInfo GetNormalizationPropertyInfo(Type xmlReaderType)
         {
-            BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.SetProperty | BindingFlags.Instance;
-            if (_normalizationPropertyInfo == null)
+            PropertyInfo propertyInfo = _normalizationPropertyInfo;
+            if (propertyInfo == null)
             {
-                _normalizationPropertyInfo = xmlReaderType.GetProperty("Normalization", bindingFlags);
+                BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.SetProperty | BindingFlags.Instance;
+                propertyInfo = xmlReaderType.GetProperty("Normalization", bindingFlags);
+                _normalizationPropertyInfo = propertyInfo;
             }
-            else if (xmlReaderType != _normalizationPropertyInfo.ReflectedType)
-            {
-                Debug.Fail("GetNormalizationPropertyInfo can only take one type");
-                return xmlReaderType.GetProperty("Normalization", bindingFlags);
-            }
-            return _normalizationPropertyInfo;
+            return propertyInfo;
         }
 
         private static XmlReader GetXmlReader(string file, StreamReader input, bool loadAsReadOnly, out Encoding encoding)
@@ -95,8 +96,10 @@ namespace Microsoft.Build.Internal
             string uri = new UriBuilder(Uri.UriSchemeFile, string.Empty) { Path = file }.ToString();
 
             XmlReader reader;
-            if (loadAsReadOnly)
+            if (loadAsReadOnly && !_disableReadOnlyLoad)
             {
+                // Create an XML reader with IgnoreComments and IgnoreWhitespace set if we know that we won't be asked
+                // to write the DOM back to a file. This is a performance optimization.
                 XmlReaderSettings xrs = new XmlReaderSettings
                 {
                     DtdProcessing = DtdProcessing.Ignore,
@@ -104,8 +107,23 @@ namespace Microsoft.Build.Internal
                     IgnoreWhitespace = true,
                 };
                 reader = XmlReader.Create(input, xrs, uri);
-                // HACK: Set Normalization to false to behave the same as XmlTextReader.
-                GetNormalizationPropertyInfo(reader.GetType()).SetValue(reader, false);
+
+                // Try to set Normalization to false. We do this to remain compatible with earlier versions of MSBuild
+                // where we constructed the reader with 'new XmlTextReader()' which has normalization enabled by default.
+                PropertyInfo normalizationPropertyInfo = GetNormalizationPropertyInfo(reader.GetType());
+                if (normalizationPropertyInfo != null)
+                {
+                    normalizationPropertyInfo.SetValue(reader, false);
+                }
+                else
+                {
+                    // Fall back to using XmlTextReader if the prop could not be bound.
+                    Debug.Fail("Could not set Normalization to false on the result of XmlReader.Create");
+                    _disableReadOnlyLoad = true;
+
+                    reader.Dispose();
+                    reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
+                }
             }
             else
             {

--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -75,11 +75,23 @@ namespace Microsoft.Build.Internal
         {
             string uri = new UriBuilder(Uri.UriSchemeFile, string.Empty) { Path = file }.ToString();
 
-            
-            // Ignore loadAsReadOnly for now; using XmlReader.Create results in whitespace changes
-            // of attribute text, specifically newline removal.
-            // https://github.com/Microsoft/msbuild/issues/4210
-            XmlReader reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
+            XmlReader reader;
+            if (loadAsReadOnly)
+            {
+                XmlReaderSettings xrs = new XmlReaderSettings
+                {
+                    DtdProcessing = DtdProcessing.Ignore,
+                    IgnoreComments = true,
+                    // Setting IgnoreWhitespace results in whitespace changes of attribute text, specifically newline removal.
+                    // https://github.com/Microsoft/msbuild/issues/4210
+                    // IgnoreWhitespace = true,
+                };
+                reader = XmlReader.Create(input, xrs, uri);
+            }
+            else
+            {
+                reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
+            }
 
             reader.Read();
             encoding = input.CurrentEncoding;

--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -97,13 +97,14 @@ namespace Microsoft.Build.Internal
             XmlReader reader;
             if (loadAsReadOnly)
             {
-                 XmlReaderSettings xrs = new XmlReaderSettings
+                XmlReaderSettings xrs = new XmlReaderSettings
                 {
                     DtdProcessing = DtdProcessing.Ignore,
                     IgnoreComments = true,
                     IgnoreWhitespace = true,
                 };
                 reader = XmlReader.Create(input, xrs, uri);
+                // HACK: Set Normalization to false to behave the same as XmlTextReader.
                 GetNormalizationPropertyInfo(reader.GetType()).SetValue(reader, false);
             }
             else

--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Build.Internal
             string uri = new UriBuilder(Uri.UriSchemeFile, string.Empty) { Path = file }.ToString();
 
             XmlReader reader = null;
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0) && loadAsReadOnly && !_disableReadOnlyLoad)
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10) && loadAsReadOnly && !_disableReadOnlyLoad)
             {
                 // Create an XML reader with IgnoreComments and IgnoreWhitespace set if we know that we won't be asked
                 // to write the DOM back to a file. This is a performance optimization.

--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Xml;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Internal
 {
@@ -104,7 +105,7 @@ namespace Microsoft.Build.Internal
             string uri = new UriBuilder(Uri.UriSchemeFile, string.Empty) { Path = file }.ToString();
 
             XmlReader reader = null;
-            if (loadAsReadOnly && !_disableReadOnlyLoad)
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0) && loadAsReadOnly && !_disableReadOnlyLoad)
             {
                 // Create an XML reader with IgnoreComments and IgnoreWhitespace set if we know that we won't be asked
                 // to write the DOM back to a file. This is a performance optimization.


### PR DESCRIPTION
Fixes #2576

### Context

The code already has support for parsing project files as read-only when we know that we're not going to be asked to write them back to disk. This flag is currently unused because the initial implementation in #3584 introduced a regression related to whitespace in attribute values (#4210).

### Changes Made

Trivially reverted part of #4213 that addressed the regression and added a hack to make `XmlReader` behave the same as `XmlTextReader`.

### Testing

Existing unit tests for correctness and ETW for performance. `XmlDocumentWithLocation.Load()` is ~26% faster with this change compared to baseline when building .NET Core projects. This translates to about 10 ms per one incremental CLI build of a Hello world application.

### Notes
