### PR TITLE
Make sure that *.* always means all files in FileMatcher

### DIFF
--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Build.Shared
                                     "*",
                                     directory,
                                     false));
-                        IEnumerable<string> filteredEntriesForPath = (pattern != null && pattern != "*")
+                        IEnumerable<string> filteredEntriesForPath = (pattern != null && pattern != "*" && pattern != "*.*")
                             ? allEntriesForPath.Where(o => IsMatch(Path.GetFileName(o), pattern))
                             : allEntriesForPath;
                         return stripProjectDirectory


### PR DESCRIPTION
### Context

#6151 introduced a regression where `FileMatcher` takes the pattern `*.*` too literally and returns only files that have a dot in the name. `*.*` should be special cased to mean all files in the directory, with or without an extension.

### Changes Made

Fixed the regression by explicitly testing for `*.*` and added test coverage.

### Testing

Existing and modified unit tests, repro project from https://github.com/dotnet/sdk/pull/16185#issuecomment-794428841.

### Notes

Testing for both `*` and `*.*` is already happening elsewhere in the class. MSBuild calls `Directory.EnumerateFileSystemEntries` which under the covers uses `MatchType.Win32` and causes this behavior of unifying `*.*` with `*` on all platforms. 