### PR TITLE
Allow Custom CopyToOutputDirectory Location With TargetPath

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -25,6 +25,7 @@ The opt-out comes in the form of setting the environment variable `MSBuildDisabl
 - [Don't expand full drive globs with false condition](https://github.com/dotnet/msbuild/pull/5669)
 ### 16.10
 - [Error when a property expansion in a condition has whitespace](https://github.com/dotnet/msbuild/pull/5672)
+- [Allow Custom CopyToOutputDirectory Location With TargetPath](https://github.com/dotnet/msbuild/pull/6237)
 ### 17.0
 
 ## Change Waves No Longer In Rotation

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -171,6 +171,11 @@ namespace Microsoft.Build.Shared
         /// The output path for a given item.
         /// </summary>
         internal const string targetPath = "TargetPath";
+
+        /// <summary>
+        /// The user-specified override for TargetPath. See the AssignTargetPath task.
+        /// </summary>
+        internal const string targetPathOverride = "TargetPathOverride";
         internal const string dependentUpon = "DependentUpon";
         internal const string msbuildSourceProjectFile = "MSBuildSourceProjectFile";
         internal const string msbuildSourceTargetName = "MSBuildSourceTargetName";

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -171,11 +171,6 @@ namespace Microsoft.Build.Shared
         /// The output path for a given item.
         /// </summary>
         internal const string targetPath = "TargetPath";
-
-        /// <summary>
-        /// The user-specified override for TargetPath. See the AssignTargetPath task.
-        /// </summary>
-        internal const string targetPathOverride = "TargetPathOverride";
         internal const string dependentUpon = "DependentUpon";
         internal const string msbuildSourceProjectFile = "MSBuildSourceProjectFile";
         internal const string msbuildSourceTargetName = "MSBuildSourceTargetName";

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -166,6 +166,10 @@ namespace Microsoft.Build.Shared
         internal const string subType = "SubType";
         internal const string executableExtension = "ExecutableExtension";
         internal const string embedInteropTypes = "EmbedInteropTypes";
+
+        /// <summary>
+        /// The output path for a given item.
+        /// </summary>
         internal const string targetPath = "TargetPath";
         internal const string dependentUpon = "DependentUpon";
         internal const string msbuildSourceProjectFile = "MSBuildSourceProjectFile";

--- a/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
+++ b/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Theory]
+        [InlineData("c:/fully/qualified/path.txt")]
         [InlineData("test/output/file.txt")]
         [InlineData(@"some\dir\to\file.txt")]
         [InlineData("file.txt")]

--- a/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
+++ b/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using System.Collections.Generic;
 using Xunit;
 
@@ -21,15 +22,10 @@ namespace Microsoft.Build.UnitTests
                           { new TaskItem(NativeMethodsShared.IsWindows ? @"c:\bin2\abc.efg" : "/bin2/abc.efg") };
             t.RootFolder = NativeMethodsShared.IsWindows ? @"c:\bin" : "/bin";
 
-            bool success = t.Execute();
-
-            Assert.True(success);
-
-            Assert.Single(t.AssignedFiles);
-            Assert.Equal(
-                NativeMethodsShared.IsWindows ? @"c:\bin2\abc.efg" : "/bin2/abc.efg",
-                t.AssignedFiles[0].ItemSpec);
-            Assert.Equal(@"abc.efg", t.AssignedFiles[0].GetMetadata("TargetPath"));
+            t.Execute().ShouldBeTrue();
+            t.AssignedFiles.Length.ShouldBe(1);
+            t.AssignedFiles[0].ItemSpec.ShouldBe(NativeMethodsShared.IsWindows ? @"c:\bin2\abc.efg" : "/bin2/abc.efg");
+            t.AssignedFiles[0].GetMetadata("TargetPath").ShouldBe("abc.efg");
         }
 
         [Fact]
@@ -41,12 +37,9 @@ namespace Microsoft.Build.UnitTests
                           { new TaskItem(NativeMethodsShared.IsWindows ? @"c:\f1\f2\file.txt" : "/f1/f2/file.txt") };
             t.RootFolder = NativeMethodsShared.IsWindows ? @"c:\f1\f2" : "/f1/f2";
 
-            bool success = t.Execute();
-
-            Assert.True(success);
-
-            Assert.Single(t.AssignedFiles);
-            Assert.Equal(@"file.txt", t.AssignedFiles[0].GetMetadata("TargetPath"));
+            t.Execute().ShouldBeTrue();
+            t.AssignedFiles.Length.ShouldBe(1);
+            t.AssignedFiles[0].GetMetadata("TargetPath").ShouldBe("file.txt");
         }
 
         [Fact]
@@ -65,12 +58,9 @@ namespace Microsoft.Build.UnitTests
             // /f1 to /x1
             t.RootFolder = NativeMethodsShared.IsWindows ? @"c:\f1" : "/x1";
 
-            bool success = t.Execute();
-
-            Assert.True(success);
-
-            Assert.Single(t.AssignedFiles);
-            Assert.Equal("file.txt", t.AssignedFiles[0].GetMetadata("TargetPath"));
+            t.Execute().ShouldBeTrue();
+            t.AssignedFiles.Length.ShouldBe(1);
+            t.AssignedFiles[0].GetMetadata("TargetPath").ShouldBe("file.txt");
         }
 
         [Fact]
@@ -85,14 +75,9 @@ namespace Microsoft.Build.UnitTests
                           };
             t.RootFolder = NativeMethodsShared.IsWindows ? @"c:\f1\f2" : "/f1/f2";
 
-            bool success = t.Execute();
-
-            Assert.True(success);
-
-            Assert.Single(t.AssignedFiles);
-            Assert.Equal(
-                NativeMethodsShared.IsWindows ? @"f3\f4\file.txt" : "f3/f4/file.txt",
-                t.AssignedFiles[0].GetMetadata("TargetPath"));
+            t.Execute().ShouldBeTrue();
+            t.AssignedFiles.Length.ShouldBe(1);
+            t.AssignedFiles[0].GetMetadata("TargetPath").ShouldBe(NativeMethodsShared.IsWindows ? @"f3\f4\file.txt" : "f3/f4/file.txt");
         }
 
         [Theory]
@@ -114,12 +99,9 @@ namespace Microsoft.Build.UnitTests
                           };
             t.RootFolder = NativeMethodsShared.IsWindows ? @"c:\f1\f2" : "/f1/f2";
 
-            bool success = t.Execute();
-
-            Assert.True(success);
-
-            Assert.Single(t.AssignedFiles);
-            Assert.Equal(targetPath, t.AssignedFiles[0].GetMetadata("TargetPath"));
+            t.Execute().ShouldBeTrue();
+            t.AssignedFiles.Length.ShouldBe(1);
+            targetPath.ShouldBe(t.AssignedFiles[0].GetMetadata("TargetPath"));
         }
     }
 }

--- a/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
+++ b/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Build.UnitTests
             string link = "c:/some/path";
 
             ChangeWaves.ResetStateForTests();
-            env.SetEnvironmentVariable("MSBuildDisableFeaturesFromVersion", ChangeWaves.Wave16_10.ToString());
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave16_10.ToString());
             BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
             AssignTargetPath t = new AssignTargetPath();

--- a/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
+++ b/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Shouldly;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests
@@ -85,12 +85,12 @@ namespace Microsoft.Build.UnitTests
         [InlineData(@"some\dir\to\file.txt")]
         [InlineData("file.txt")]
         [InlineData("file")]
-        public void TargetPathAlreadySet(string targetPath)
+        public void TargetPathOverrideSet(string targetPath)
         {
             AssignTargetPath t = new AssignTargetPath();
             t.BuildEngine = new MockEngine();
             Dictionary<string, string> metaData = new Dictionary<string, string>();
-            metaData.Add("TargetPath", targetPath);
+            metaData.Add("TargetPathOverride", targetPath);
             t.Files = new ITaskItem[]
                           {
                               new TaskItem(

--- a/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
+++ b/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Build.UnitTests
             t.Execute().ShouldBeTrue();
             t.AssignedFiles.Length.ShouldBe(1);
             link.ShouldBe(t.AssignedFiles[0].GetMetadata("TargetPath"));
+            ChangeWaves.ResetStateForTests();
         }
     }
 }

--- a/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
+++ b/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
@@ -116,7 +116,11 @@ namespace Microsoft.Build.UnitTests
         {
             using TestEnvironment env = TestEnvironment.Create();
             string link = "c:/some/path";
-            env.SetEnvironmentVariable("MSBuildDisableFeaturesFromVersion", "16.10");
+
+            ChangeWaves.ResetStateForTests();
+            env.SetEnvironmentVariable("MSBuildDisableFeaturesFromVersion", ChangeWaves.Wave16_10.ToString());
+            BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+
             AssignTargetPath t = new AssignTargetPath();
             t.BuildEngine = new MockEngine();
             Dictionary<string, string> metaData = new Dictionary<string, string>();

--- a/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
+++ b/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Build.UnitTests
 
             t.Execute().ShouldBeTrue();
             t.AssignedFiles.Length.ShouldBe(1);
-            targetPath.ShouldBe(t.AssignedFiles[0].GetMetadata("TargetPath"));
+            t.AssignedFiles[0].GetMetadata("TargetPath").ShouldBe(targetPath);
         }
 
         [Theory]
@@ -136,7 +136,7 @@ namespace Microsoft.Build.UnitTests
 
             t.Execute().ShouldBeTrue();
             t.AssignedFiles.Length.ShouldBe(1);
-            link.ShouldBe(t.AssignedFiles[0].GetMetadata("TargetPath"));
+            t.AssignedFiles[0].GetMetadata("TargetPath").ShouldBe(link);
             ChangeWaves.ResetStateForTests();
         }
     }

--- a/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
+++ b/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests
@@ -92,6 +93,33 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(
                 NativeMethodsShared.IsWindows ? @"f3\f4\file.txt" : "f3/f4/file.txt",
                 t.AssignedFiles[0].GetMetadata("TargetPath"));
+        }
+
+        [Theory]
+        [InlineData("test/output/file.txt")]
+        [InlineData(@"some\dir\to\file.txt")]
+        [InlineData("file.txt")]
+        [InlineData("file")]
+        public void TargetPathAlreadySet(string targetPath)
+        {
+            AssignTargetPath t = new AssignTargetPath();
+            t.BuildEngine = new MockEngine();
+            Dictionary<string, string> metaData = new Dictionary<string, string>();
+            metaData.Add("TargetPath", targetPath);
+            t.Files = new ITaskItem[]
+                          {
+                              new TaskItem(
+                                  itemSpec: NativeMethodsShared.IsWindows ? @"c:\f1\f2\file.txt" : "/f1/f2/file.txt",
+                                  itemMetadata: metaData)
+                          };
+            t.RootFolder = NativeMethodsShared.IsWindows ? @"c:\f1\f2" : "/f1/f2";
+
+            bool success = t.Execute();
+
+            Assert.True(success);
+
+            Assert.Single(t.AssignedFiles);
+            Assert.Equal(targetPath, t.AssignedFiles[0].GetMetadata("TargetPath"));
         }
     }
 }

--- a/src/Tasks/AssignTargetPath.cs
+++ b/src/Tasks/AssignTargetPath.cs
@@ -72,9 +72,9 @@ namespace Microsoft.Build.Tasks
                 for (int i = 0; i < Files.Length; ++i)
                 {
                     AssignedFiles[i] = new TaskItem(Files[i]);
-                    string targetPath = Files[i].GetMetadata(ItemMetadataNames.targetPath);
+                    string targetPath = Files[i].GetMetadata(ItemMetadataNames.targetPathOverride);
 
-                    // If TargetPath is already set, copy it over.
+                    // TargetPathOverride takes priority.
                     // https://github.com/dotnet/msbuild/issues/2795
                     if (!string.IsNullOrEmpty(targetPath))
                     {

--- a/src/Tasks/AssignTargetPath.cs
+++ b/src/Tasks/AssignTargetPath.cs
@@ -71,13 +71,20 @@ namespace Microsoft.Build.Tasks
 
                 for (int i = 0; i < Files.Length; ++i)
                 {
-                    string link = Files[i].GetMetadata(ItemMetadataNames.link);
                     AssignedFiles[i] = new TaskItem(Files[i]);
+                    string targetPath = Files[i].GetMetadata(ItemMetadataNames.targetPath);
 
-                    // If file has a link, use that.
-                    string targetPath = link;
+                    // If TargetPath is already set, copy it over.
+                    // https://github.com/dotnet/msbuild/issues/2795
+                    if (!string.IsNullOrEmpty(targetPath))
+                    {
+                        AssignedFiles[i].SetMetadata(ItemMetadataNames.targetPath, EscapingUtilities.Escape(targetPath));
+                        continue;
+                    }
 
-                    if (string.IsNullOrEmpty(link))
+                    targetPath = Files[i].GetMetadata(ItemMetadataNames.link);
+
+                    if (string.IsNullOrEmpty(targetPath))
                     {
                         if (// if the file path is relative
                             !Path.IsPathRooted(Files[i].ItemSpec) &&

--- a/src/Tasks/AssignTargetPath.cs
+++ b/src/Tasks/AssignTargetPath.cs
@@ -73,11 +73,11 @@ namespace Microsoft.Build.Tasks
                 {
                     AssignedFiles[i] = new TaskItem(Files[i]);
 
-                    // TargetPathOverride takes priority.
+                    // If TargetPath is already set, it takes priority.
                     // https://github.com/dotnet/msbuild/issues/2795
-                    string targetPath = Files[i].GetMetadata(ItemMetadataNames.targetPathOverride);
+                    string targetPath =  ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10) ? Files[i].GetMetadata(ItemMetadataNames.targetPath) : null;
 
-                    // If TargetPathOverride not set, fall back to default behavior.
+                    // If TargetPath not already set, fall back to default behavior.
                     if (string.IsNullOrEmpty(targetPath))
                     {
                         targetPath = Files[i].GetMetadata(ItemMetadataNames.link);

--- a/src/Tasks/AssignTargetPath.cs
+++ b/src/Tasks/AssignTargetPath.cs
@@ -72,17 +72,16 @@ namespace Microsoft.Build.Tasks
                 for (int i = 0; i < Files.Length; ++i)
                 {
                     AssignedFiles[i] = new TaskItem(Files[i]);
-                    string targetPath = Files[i].GetMetadata(ItemMetadataNames.targetPathOverride);
 
                     // TargetPathOverride takes priority.
                     // https://github.com/dotnet/msbuild/issues/2795
-                    if (!string.IsNullOrEmpty(targetPath))
-                    {
-                        AssignedFiles[i].SetMetadata(ItemMetadataNames.targetPath, EscapingUtilities.Escape(targetPath));
-                        continue;
-                    }
+                    string targetPath = Files[i].GetMetadata(ItemMetadataNames.targetPathOverride);
 
-                    targetPath = Files[i].GetMetadata(ItemMetadataNames.link);
+                    // If TargetPathOverride not set, fall back to default behavior.
+                    if (string.IsNullOrEmpty(targetPath))
+                    {
+                        targetPath = Files[i].GetMetadata(ItemMetadataNames.link);
+                    }
 
                     if (string.IsNullOrEmpty(targetPath))
                     {


### PR DESCRIPTION
Fixes #2795
and indirectly fixes https://developercommunity.visualstudio.com/t/copytooutputdirectorypreservenewest-ignored-inside/1332219?from=email&viewtype=all#T-ND1363347

### Context
There's currently no way to include items in a project such that:
1. Visual studio sees them in a specific folder (via `<Link>`).
2. They are published to a user-defined path (currently controlled via `<Link>`)

### Changes Made
Modify the `AssignTargetPath` task to return early if `TargetPath` metadata is already set on a particular item.

### Testing
- [x] Need to add one test covering this.
- [x] Tested locally with bootstrapped MSBuild on command line
- [x] Tested locally with a boostrapped msbuild on internal VS

Here's the repro I'm using:
```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netstandard2.0</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <Content Include="Files\**">
      <Link>Files\%(Filename)%(Extension)</Link>
      <TargetPath>%(Filename)%(Extension)</TargetPath>
      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
    </Content>
  </ItemGroup>
</Project>
```

### Notes
The other way of solving this problem has to do with `Microsoft.Common.CurrentVersion.targets`. We modify it so that the `AssignTargetPath` task look something like this:
```xml
    <AssignTargetPath Files="@(Content)" RootFolder="$(MSBuildProjectDirectory)" Condition="'%(Content.TargetPath)'==''">
      <Output TaskParameter="AssignedFiles" ItemName="ContentWithTargetPath" />
    </AssignTargetPath>
    <ItemGroup>
        <ContentWithTargetPath Include="@(Content)" Condition="'%(Content.TargetPath)'!=''"/>
    </ItemGroup>
```
This seems less efficient to me. AssignTargetPath is also called for all `None`, `Content`, and `EmbeddedResource` files. So if we go this batching route and want `None` or `EmbeddedResource` to have this feature, we'd need to batch those as well.