### PR TITLE
Handle unsupported paths in ProjectInSolution.AbsolutePath

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2492,44 +2492,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.31025.194
 MinimumVisualStudioVersion = 10.0.40219.1
 Project(""{{E24C65DC-7377-472B-9ABA-BC803B73C61A}}"") = ""WebSite1"", ""{relativePath}"", ""{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}""
-	ProjectSection(WebsiteProperties) = preProject
-		UseIISExpress = ""true""
-		TargetFrameworkMoniker = "".NETFramework,Version%3Dv4.0""
-		Debug.AspNetCompiler.VirtualPath = ""/localhost_8080""
-		Debug.AspNetCompiler.PhysicalPath = ""C:\Users\UserA\Documents\My Web Sites\WebSite1\""
-		Debug.AspNetCompiler.TargetPath = ""PrecompiledWeb\localhost_8080\""
-		Debug.AspNetCompiler.Updateable = ""true""
-		Debug.AspNetCompiler.ForceOverwrite = ""true""
-		Debug.AspNetCompiler.FixedNames = ""false""
-		Debug.AspNetCompiler.Debug = ""True""
-		Release.AspNetCompiler.VirtualPath = ""/localhost_8080""
-		Release.AspNetCompiler.PhysicalPath = ""C:\Users\UserA\Documents\My Web Sites\WebSite1\""
-		Release.AspNetCompiler.TargetPath = ""PrecompiledWeb\localhost_8080\""
-		Release.AspNetCompiler.Updateable = ""true""
-		Release.AspNetCompiler.ForceOverwrite = ""true""
-		Release.AspNetCompiler.FixedNames = ""false""
-		Release.AspNetCompiler.Debug = ""False""
-		SlnRelativePath = ""C:\Users\UserA\Documents\My Web Sites\WebSite1\""
-	EndProjectSection
-EndProject
-Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}.Release|Any CPU.Build.0 = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {{{{87CFA95B-DF37-4C4B-B629-44656ED585AB}}}}
-	EndGlobalSection
-EndGlobal";
+EndProject";
 
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2477,6 +2477,67 @@ EndGlobal
             }
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/dotnet/msbuild/issues/6236
+        /// </summary>
+        [Theory]
+        [InlineData("http://localhost:8080")]
+        [InlineData("a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-")]
+        public void AbsolutePathWorksForUnsupportedPaths(string relativePath)
+        {
+            string solutionFileContents =
+                $@"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31025.194
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{{E24C65DC-7377-472B-9ABA-BC803B73C61A}}"") = ""WebSite1"", ""{relativePath}"", ""{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}""
+	ProjectSection(WebsiteProperties) = preProject
+		UseIISExpress = ""true""
+		TargetFrameworkMoniker = "".NETFramework,Version%3Dv4.0""
+		Debug.AspNetCompiler.VirtualPath = ""/localhost_8080""
+		Debug.AspNetCompiler.PhysicalPath = ""C:\Users\UserA\Documents\My Web Sites\WebSite1\""
+		Debug.AspNetCompiler.TargetPath = ""PrecompiledWeb\localhost_8080\""
+		Debug.AspNetCompiler.Updateable = ""true""
+		Debug.AspNetCompiler.ForceOverwrite = ""true""
+		Debug.AspNetCompiler.FixedNames = ""false""
+		Debug.AspNetCompiler.Debug = ""True""
+		Release.AspNetCompiler.VirtualPath = ""/localhost_8080""
+		Release.AspNetCompiler.PhysicalPath = ""C:\Users\UserA\Documents\My Web Sites\WebSite1\""
+		Release.AspNetCompiler.TargetPath = ""PrecompiledWeb\localhost_8080\""
+		Release.AspNetCompiler.Updateable = ""true""
+		Release.AspNetCompiler.ForceOverwrite = ""true""
+		Release.AspNetCompiler.FixedNames = ""false""
+		Release.AspNetCompiler.Debug = ""False""
+		SlnRelativePath = ""C:\Users\UserA\Documents\My Web Sites\WebSite1\""
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}.Release|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {{{{87CFA95B-DF37-4C4B-B629-44656ED585AB}}}}
+	EndGlobalSection
+EndGlobal";
+
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
+
+            ProjectInSolution projectInSolution = solution.ProjectsInOrder.ShouldHaveSingleItem();
+
+            projectInSolution.AbsolutePath.ShouldBe(Path.Combine(solution.SolutionFileDirectory, projectInSolution.RelativePath));
+        }
+
         #region Helper Functions
 
         /// <summary>

--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -168,11 +168,21 @@ namespace Microsoft.Build.Construction
             {
                 if (_absolutePath == null)
                 {
+                    _absolutePath = Path.Combine(ParentSolution.SolutionFileDirectory, _relativePath);
+
+                    try
+                    {
 #if NETFRAMEWORK && !MONO
-                    _absolutePath = Path.GetFullPath(Path.Combine(ParentSolution.SolutionFileDirectory, _relativePath));
+                        _absolutePath = Path.GetFullPath(_absolutePath);
 #else
-                    _absolutePath = FileUtilities.NormalizePath(Path.Combine(ParentSolution.SolutionFileDirectory, _relativePath));
+                        _absolutePath = FileUtilities.NormalizePath(_absolutePath);
 #endif
+                    }
+                    catch (Exception)
+                    {
+                        // The call to GetFullPath can throw if the relative path is a URL or the paths are too long for the current file system
+                        // This falls back to previous behavior of returning a path that may not be correct but at least returns some value
+                    }
                 }
 
                 return _absolutePath;
@@ -229,9 +239,9 @@ namespace Microsoft.Build.Construction
 
         internal string TargetFrameworkMoniker { get; set; }
 
-#endregion
+        #endregion
 
-#region Methods
+        #region Methods
 
         private bool _checkedIfCanBeMSBuildProjectFile;
         private bool _canBeMSBuildProjectFile;
@@ -529,13 +539,13 @@ namespace Microsoft.Build.Construction
             return false;
         }
 
-#endregion
+        #endregion
 
-#region Constants
+        #region Constants
 
         internal const int DependencyLevelUnknown = -1;
         internal const int DependencyLevelBeingDetermined = -2;
 
-#endregion
+        #endregion
     }
 }

--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -170,18 +170,23 @@ namespace Microsoft.Build.Construction
                 {
                     _absolutePath = Path.Combine(ParentSolution.SolutionFileDirectory, _relativePath);
 
-                    try
+                    // For web site projects, Visual Studio stores the URL of the site as the relative path so it cannot be normalized.
+                    // Legacy behavior dictates that we must just return the result of Path.Combine()
+                    if (!Uri.TryCreate(_relativePath, UriKind.Absolute, out Uri _))
                     {
+                        try
+                        {
 #if NETFRAMEWORK && !MONO
-                        _absolutePath = Path.GetFullPath(_absolutePath);
+                            _absolutePath = Path.GetFullPath(_absolutePath);
 #else
-                        _absolutePath = FileUtilities.NormalizePath(_absolutePath);
+                            _absolutePath = FileUtilities.NormalizePath(_absolutePath);
 #endif
-                    }
-                    catch (Exception)
-                    {
-                        // The call to GetFullPath can throw if the relative path is a URL or the paths are too long for the current file system
-                        // This falls back to previous behavior of returning a path that may not be correct but at least returns some value
+                        }
+                        catch (Exception)
+                        {
+                            // The call to GetFullPath() can throw if the relative path is some unsupported value or the paths are too long for the current file system
+                            // This falls back to previous behavior of returning a path that may not be correct but at least returns some value
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes #6236

### Context
#5950 introduced a call to `Path.GetFullPath()` to get a path that is normalized.  However, in some cases Visual Studio stores unsupported paths which will cause `Path.GetFullPath()` to throw.

`Path.GetFullPath()` can also throw a `PathTooLongException` which is now handled.

### Changes Made
Revert to legacy code path of just calling `Path.Combine()` then do the `Path.GetFullPath()` in a `try...catch` on a best effort.

### Testing
Regression test added

### Notes
https://developercommunity.visualstudio.com/t/msbuild-failing-with-web-site-project-in/1359528