### PR TITLE
Switch warning to message

### DIFF
--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Build.Tasks
                 // any exception imaginable.  Catch them all here.
                 // Not being able to deserialize the cache is not an error, but we let the user know anyway.
                 // Don't want to hold up processing just because we couldn't read the file.
-                log.LogWarningWithCodeFromResources("General.CouldNotReadStateFile", stateFile, e.Message);
+                log.LogMessageFromResources("General.CouldNotReadStateFile", stateFile, e.Message);
             }
 
             return null;


### PR DESCRIPTION
Fixes internally reported bug

### Context
If we fail to deserialize a statefile, we used to throw a warning. This was expected to happen once when we changed the serialization technology, but it appears some users have regular design time builds from a different version of MSBuild than the one they used for full builds, which meant they were seeing this warning regularly. This demotes it to a message.