### PR TITLE
Fix rar cache incompatibility warning message (#6242)

### DIFF
--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Shared;
 using Xunit;
 using Xunit.Abstractions;
 using System.IO;
+using System.Threading;
 using Shouldly;
 
 namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
@@ -1942,7 +1943,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
                 t.Execute();
 
                 // "cannot read state file (opening for read/write)"
-                Utilities.AssertLogContains(t, "Could not read state file");
+                var x = Thread.CurrentThread.CurrentUICulture;
+                Utilities.AssertLogContainsResourceWithUnspecifiedReplacements(t, "General.CouldNotReadStateFileMessage");
                 // "cannot write state file (opening for read/write)"
                 Utilities.AssertLogContains(t, "MSB3101");
             }

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
@@ -1942,7 +1942,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
                 t.Execute();
 
                 // "cannot read state file (opening for read/write)"
-                Utilities.AssertLogContains(t, "MSB3088");
+                Utilities.AssertLogContains(t, "Could not read state file");
                 // "cannot write state file (opening for read/write)"
                 Utilities.AssertLogContains(t, "MSB3101");
             }

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
@@ -1943,7 +1943,6 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
                 t.Execute();
 
                 // "cannot read state file (opening for read/write)"
-                var x = Thread.CurrentThread.CurrentUICulture;
                 Utilities.AssertLogContainsResourceWithUnspecifiedReplacements(t, "General.CouldNotReadStateFileMessage");
                 // "cannot write state file (opening for read/write)"
                 Utilities.AssertLogContains(t, "MSB3101");

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -2316,7 +2316,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 t.Execute();
 
                 // "cannot read state file (opening for read/write)"
-                Utilities.AssertLogContains(t, "MSB3088");
+                Utilities.AssertLogContains(t, "Could not read state file");
                 // "cannot write state file (opening for read/write)"
                 Utilities.AssertLogContains(t, "MSB3101");
             }

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -15,6 +15,7 @@ using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
 {
@@ -2316,7 +2317,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 t.Execute();
 
                 // "cannot read state file (opening for read/write)"
-                Utilities.AssertLogContains(t, "Could not read state file");
+                Utilities.AssertLogContainsResourceWithUnspecifiedReplacements(t, "General.CouldNotReadStateFileMessage");
                 // "cannot write state file (opening for read/write)"
                 Utilities.AssertLogContains(t, "MSB3101");
             }
@@ -3395,8 +3396,36 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests
         {
             Assert.Contains(
                 String.Format(AssemblyResources.GetString(messageID), replacements),
-                ((MockEngine)t.BuildEngine).Log
-                );
+                ((MockEngine) t.BuildEngine).Log
+            );
+        }
+
+        /// <summary>
+        /// Looks for a formatted message in the output log for the task execution, with unknown formatted parameters.
+        /// If verifies that all constant segments of unformatted message are present.
+        /// </summary>
+        public static void AssertLogContainsResourceWithUnspecifiedReplacements(GenerateResource t, string messageID)
+        {
+            var unformattedMessage = AssemblyResources.GetString(messageID);
+            var matches = Regex.Matches(unformattedMessage, @"\{\d+.*?\}");
+            if (matches.Count > 0)
+            {
+                int i = 0;
+                foreach (Match match in matches)
+                {
+                    string segment = unformattedMessage.Substring(i, match.Index - i);
+                    if (segment.Length > 0)
+                    {
+                        Assert.Contains(segment, ((MockEngine)t.BuildEngine).Log);
+                    }
+
+                    i = match.Index + match.Length;
+                }
+            }
+            else
+            {
+                Assert.Contains(unformattedMessage, ((MockEngine)t.BuildEngine).Log);
+            }
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -3410,17 +3410,23 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests
             var matches = Regex.Matches(unformattedMessage, @"\{\d+.*?\}");
             if (matches.Count > 0)
             {
+                var sb = new StringBuilder();
                 int i = 0;
+
                 foreach (Match match in matches)
                 {
                     string segment = unformattedMessage.Substring(i, match.Index - i);
-                    if (segment.Length > 0)
-                    {
-                        Assert.Contains(segment, ((MockEngine)t.BuildEngine).Log);
-                    }
+                    sb.Append(Regex.Escape(segment));
+                    sb.Append(".*");
 
                     i = match.Index + match.Length;
                 }
+                if (i < unformattedMessage.Length)
+                {
+                    sb.Append(Regex.Escape(unformattedMessage.Substring(i)));
+                }
+
+                Assert.Matches(sb.ToString(), ((MockEngine)t.BuildEngine).Log);
             }
             else
             {

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2156,7 +2156,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         expensive to write the newly created cache file.
         -->
     <PropertyGroup>
-      <ResolveAssemblyReferencesStateFile Condition="'$(DisableRarCache)'!='true' and '$(ResolveAssemblyReferencesStateFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectFile)AssemblyReference.cache</ResolveAssemblyReferencesStateFile>
+      <ResolveAssemblyReferencesStateFile Condition="'$(DisableRarCache)'!='true' and '$(ResolveAssemblyReferencesStateFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectFile)AssemblyReference.bin.cache</ResolveAssemblyReferencesStateFile>
     </PropertyGroup>
 
     <!-- Make an App.Config item that exists when AutoUnify is false. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2156,7 +2156,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         expensive to write the newly created cache file.
         -->
     <PropertyGroup>
-      <ResolveAssemblyReferencesStateFile Condition="'$(DisableRarCache)'!='true' and '$(ResolveAssemblyReferencesStateFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectFile)AssemblyReference.bin.cache</ResolveAssemblyReferencesStateFile>
+      <ResolveAssemblyReferencesStateFile Condition="'$(DisableRarCache)'!='true' and '$(ResolveAssemblyReferencesStateFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectFile).AssemblyReference.cache</ResolveAssemblyReferencesStateFile>
     </PropertyGroup>
 
     <!-- Make an App.Config item that exists when AutoUnify is false. -->

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Tasks
 
                         if ((retVal != null) && (!requiredReturnType.IsInstanceOfType(retVal)))
                         {
-                            log.LogWarningWithCodeFromResources("General.CouldNotReadStateFile", stateFile,
+                            log.LogMessageFromResources("General.CouldNotReadStateFile", stateFile,
                                 log.FormatResourceString("General.IncompatibleStateFileType"));
                             retVal = null;
                         }
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Tasks
                 // any exception imaginable.  Catch them all here.
                 // Not being able to deserialize the cache is not an error, but we let the user know anyway.
                 // Don't want to hold up processing just because we couldn't read the file.
-                log.LogWarningWithCodeFromResources("General.CouldNotReadStateFile", stateFile, e.Message);
+                log.LogMessageFromResources("General.CouldNotReadStateFile", stateFile, e.Message);
             }
 
             return retVal;

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Tasks
 
                         if ((retVal != null) && (!requiredReturnType.IsInstanceOfType(retVal)))
                         {
-                            log.LogMessageFromResources("General.CouldNotReadStateFile", stateFile,
+                            log.LogMessageFromResources("General.CouldNotReadStateFileMessage", stateFile,
                                 log.FormatResourceString("General.IncompatibleStateFileType"));
                             retVal = null;
                         }
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Tasks
                 // any exception imaginable.  Catch them all here.
                 // Not being able to deserialize the cache is not an error, but we let the user know anyway.
                 // Don't want to hold up processing just because we couldn't read the file.
-                log.LogMessageFromResources("General.CouldNotReadStateFile", stateFile, e.Message);
+                log.LogMessageFromResources("General.CouldNotReadStateFileMessage", stateFile, e.Message);
             }
 
             return retVal;

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Build.Tasks
                 // any exception imaginable.  Catch them all here.
                 // Not being able to deserialize the cache is not an error, but we let the user know anyway.
                 // Don't want to hold up processing just because we couldn't read the file.
-                log.LogMessageFromResources("General.CouldNotReadStateFile", stateFile, e.Message);
+                log.LogMessageFromResources("General.CouldNotReadStateFileMessage", stateFile, e.Message);
             }
 
             return null;

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Build.Tasks
                 // any exception imaginable.  Catch them all here.
                 // Not being able to deserialize the cache is not an error, but we let the user know anyway.
                 // Don't want to hold up processing just because we couldn't read the file.
-                log.LogWarningWithCodeFromResources("General.CouldNotReadStateFile", stateFile, e.Message);
+                log.LogMessageFromResources("General.CouldNotReadStateFile", stateFile, e.Message);
             }
 
             return null;


### PR DESCRIPTION
Fixes #6242

### Context
Implementing new binary format of RAR cache can clash between MSBuild versions when version in IDE differs to version used for build from command line.

### Changes Made
- Lower verbosity of 'MSB3088: Could not read state file' message
- Change default naming schema of RAR cache