### PR TITLE
Enable Ready To Run option for ClickOnce publish

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4234,6 +4234,27 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Condition="'$(_DeploymentSignClickOnceManifests)'=='true' and '$(_DeploymentLauncherBased)' == 'true' and '$(PublishSingleFile)' == 'true'"
       />
 
+    <!--
+    If ReadyToRun is enabled in loose files scenario, we need to remove entries of the IL images that have gone through R2R
+    compiler and replace them with the entries for their R2R images. The R2R application image also needs to be signed if necessary.
+    -->
+
+    <ItemGroup Condition="'$(PublishReadyToRun)' == 'true' and '$(PublishSingleFile)' != 'true'">
+      <_ManifestManagedReferences Remove="@(_ReadyToRunCompileList)" />
+      <_ClickOnceFiles Remove="@(_ReadyToRunCompileList)" />
+      <_ClickOnceFiles Include="@(_ReadyToRunFilesToPublish)" />
+      <_ClickOnceTargetFile Include="@(_ReadyToRunFilesToPublish)" Condition="'%(Filename)%(Extension)' == '$(TargetFileName)'" />
+    </ItemGroup>
+
+    <!-- Sign application image created by R2R -->
+    <SignFile
+        CertificateThumbprint="$(_DeploymentResolvedManifestCertificateThumbprint)"
+        TimestampUrl="$(ManifestTimestampUrl)"
+        SigningTarget="@(_ClickOnceTargetFile)"
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+        Condition="'$(_DeploymentSignClickOnceManifests)' == 'true' and '$(PublishReadyToRun)' == 'true' and '$(PublishSingleFile)' != 'true'" />
+
     <!-- Copy the application executable from Obj folder to app.publish folder.
     This is being done to avoid Windows Forms designer memory issues that can arise while operating directly on files located in Obj directory. -->
     <Copy


### PR DESCRIPTION
Fixes #

### Context
VS Publish providers supports an option called ReadyToRun (R2R) by compiling application assemblies as ReadyToRun format.
ClickOnce publishing does not support this option.

### Changes Made
The change adds support for enabling R2R option in ClickOnce publish.

To do so, the _DeploymentComputeClickOnceManifestInfo ClickOnce target checks the PublishReadyToRun property when PublishSingleFile is not enabled (loose files scenario). If it is true, then it will replace the R2R'ed assemblies within ClickOnceFile group with the corresponding R2R assemblies from the obj\...\R2R folder.

In addition, it calls SignFile task to sign the R2R application image.

### Testing
CTI has testing the R2R configuration with top 50 NuGet packages. In addtion, other normal ClickOnce publish scenarios have been tested with top 50 NuGet packages for regresssions.

### Notes
Risk: Low since change are scoped to the ReadyToRun scenario only.
