### PR TITLE
Remove inheritdoc

### DIFF
--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -113,7 +113,6 @@ namespace Microsoft.Build.Tasks
         /// <inheritdoc cref="ITaskFactory.FactoryName"/>
         public string FactoryName => "Roslyn Code Task Factory";
 
-        /// <inheritdoc />
         /// <summary>
         /// Gets the <see cref="T:System.Type" /> of the compiled task.
         /// </summary>


### PR DESCRIPTION
This property has both summary comments and inheritdoc. It causes a docs build warning to have both.

Contributes to dotnet/dotnet-api-docs#5411.