### PR TITLE
Change references from master to main

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -1,5 +1,4 @@
 trigger:
-- master
 - main
 - exp/*
 - vs*

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -16,7 +16,7 @@ variables:
     value: $(IbcSourceBranchName)
   - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/') }}:
     - name: SourceBranch
-      value: master
+      value: main
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -1,5 +1,4 @@
 trigger:
-- master
 - main
 - vs*
 - exp/*

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ For more information on MSBuild, see the [MSBuild documentation](https://docs.mi
 
 ### Build Status
 
-The current development branch is `master`. Changes in `master` will go into a future update of MSBuild, which will release with Visual Studio 16.10 and a corresponding version of the .NET Core SDK.
+The current development branch is `main`. Changes in `main` will go into a future update of MSBuild, which will release with Visual Studio 16.10 and a corresponding version of the .NET Core SDK.
 
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=master)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=master)
+[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=main)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=main)
 
 We have forked for MSBuild 16.9 in the branch [`vs16.9`](https://github.com/Microsoft/msbuild/tree/vs16.9). Changes to that branch need special approval.
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6249

### Context
This should finalize our master to main transition.

### Changes Made
Remove master as a trigger.
exp/ branches should default to `main` for optprof data now.
Rename master to main in our primary readme file.

### Notes
There are plenty of references to master in our documentation, but they'll forward to main so our links won't be broken.