### PR TITLE
Exp/serializable projectevaluation

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1126,6 +1126,7 @@ namespace Microsoft.Build.Execution
         public ProjectInstance(Microsoft.Build.Construction.ProjectRootElement xml) { }
         public ProjectInstance(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public ProjectInstance(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public ProjectInstance(Microsoft.Build.Evaluation.Project project, Microsoft.Build.Execution.ProjectInstanceSettings settings) { }
         public ProjectInstance(string projectFile) { }
         public ProjectInstance(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { }
         public ProjectInstance(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
@@ -1982,6 +1983,7 @@ namespace Microsoft.Build.ObjectModelRemoting
         public abstract bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract Microsoft.Build.Execution.ProjectInstance CreateProjectInstance(Microsoft.Build.Execution.ProjectInstanceSettings settings, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract string ExpandString(string unexpandedValue);
+        public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs();
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(string itemType, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(Microsoft.Build.Evaluation.ProjectItem item, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1120,6 +1120,7 @@ namespace Microsoft.Build.Execution
         public ProjectInstance(Microsoft.Build.Construction.ProjectRootElement xml) { }
         public ProjectInstance(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public ProjectInstance(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public ProjectInstance(Microsoft.Build.Evaluation.Project project, Microsoft.Build.Execution.ProjectInstanceSettings settings) { }
         public ProjectInstance(string projectFile) { }
         public ProjectInstance(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { }
         public ProjectInstance(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
@@ -1976,6 +1977,7 @@ namespace Microsoft.Build.ObjectModelRemoting
         public abstract bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract Microsoft.Build.Execution.ProjectInstance CreateProjectInstance(Microsoft.Build.Execution.ProjectInstanceSettings settings, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract string ExpandString(string unexpandedValue);
+        public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs();
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(string itemType, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(Microsoft.Build.Evaluation.ProjectItem item, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);

--- a/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
@@ -465,7 +465,13 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             projA.AddItem("Compile", "aItem.cs");
             projB.AddItem("Compile", "bItem.cs");
 
-            var projBEval = new Project(projB, null, null, pc);
+            var loadSettings = ProjectLoadSettings.RecordDuplicateButNotCircularImports
+                | ProjectLoadSettings.RejectCircularImports
+                | ProjectLoadSettings.IgnoreEmptyImports
+                | ProjectLoadSettings.IgnoreMissingImports
+                | ProjectLoadSettings.IgnoreInvalidImports;
+
+            var projBEval = new Project(projB, null, null, pc, loadSettings);
             var projBInstance = new ProjectInstance(projBEval, ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var projBInstanceItem = projBInstance.GetItemsByItemTypeAndEvaluatedInclude("Compile", "bItem.cs").Single();
             var projAInstanceItem = projBInstance.GetItemsByItemTypeAndEvaluatedInclude("Compile", "aItem.cs").Single();

--- a/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
@@ -450,6 +450,42 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
+        /// Constructs a new ProjectInstances from Project.
+        /// </summary>
+        [Fact]
+        public void CreateProjectInstanceFromProject()
+        {
+            const string CapturedMetadataName = "DefiningProjectFullPath";
+            var pc = new ProjectCollection();
+            var projA = ProjectRootElement.Create(pc);
+            var projB = ProjectRootElement.Create(pc);
+            projA.FullPath = Path.Combine(Path.GetTempPath(), "a.proj");
+            projB.FullPath = Path.Combine(Path.GetTempPath(), "b.proj");
+            projB.AddImport("a.proj");
+            projA.AddItem("Compile", "aItem.cs");
+            projB.AddItem("Compile", "bItem.cs");
+
+            var projBEval = new Project(projB, null, null, pc);
+            var projBInstance = new ProjectInstance(projBEval, ProjectInstanceSettings.ImmutableWithFastItemLookup);
+            var projBInstanceItem = projBInstance.GetItemsByItemTypeAndEvaluatedInclude("Compile", "bItem.cs").Single();
+            var projAInstanceItem = projBInstance.GetItemsByItemTypeAndEvaluatedInclude("Compile", "aItem.cs").Single();
+            Assert.Equal(projB.FullPath, projBInstanceItem.GetMetadataValue(CapturedMetadataName));
+            Assert.Equal(projA.FullPath, projAInstanceItem.GetMetadataValue(CapturedMetadataName));
+
+            // Although GetMetadataValue returns non-null, GetMetadata returns null...
+            Assert.Null(projAInstanceItem.GetMetadata(CapturedMetadataName));
+
+            // .. Just like built-in metadata does: (this segment just demonstrates similar functionality -- it's not meant to test built-in metadata)
+            Assert.NotNull(projAInstanceItem.GetMetadataValue("Identity"));
+            Assert.Null(projAInstanceItem.GetMetadata("Identity"));
+
+            Assert.True(projAInstanceItem.HasMetadata(CapturedMetadataName));
+            Assert.False(projAInstanceItem.Metadata.Any());
+            Assert.Contains(CapturedMetadataName, projAInstanceItem.MetadataNames);
+            Assert.Equal(projAInstanceItem.MetadataCount, projAInstanceItem.MetadataNames.Count);
+        }
+
+        /// <summary>
         /// Verifies that the built-in metadata for specialized ProjectInstances is present when items are based on wildcards in the construction model.
         /// </summary>
         [Fact]

--- a/src/Build.OM.UnitTests/ObjectModelRemoting/RemoteProjectsProviderMock/EvaluationLinkMocks/MockProjectLink.cs
+++ b/src/Build.OM.UnitTests/ObjectModelRemoting/RemoteProjectsProviderMock/EvaluationLinkMocks/MockProjectLink.cs
@@ -187,7 +187,12 @@ namespace Microsoft.Build.UnitTests.OM.ObjectModelRemoting
 
         public override string ExpandString(string unexpandedValue) => this.Proxy.ExpandString(unexpandedValue);
 
-// TODO: Glob is not needed for the CSproj, but we might want to test it at least 
+        // TODO: Glob is not needed for the CSproj, but we might want to test it at least 
+        public override List<GlobResult> GetAllGlobs()
+        {
+            throw new NotImplementedException();
+        }
+
         public override List<GlobResult> GetAllGlobs(EvaluationContext evaluationContext)
         {
             throw new NotImplementedException();

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2422,6 +2422,14 @@ namespace Microsoft.Build.Evaluation
             internal ILoggingService LoggingService => ProjectCollection.LoggingService;
 
             /// <summary>
+            /// See <see cref="ProjectLink.GetAllGlobs()"/>.
+            /// </summary>
+            public override List<GlobResult> GetAllGlobs()
+            {
+                return GetAllGlobs(evaluationContext: null);
+            }
+
+            /// <summary>
             /// See <see cref="ProjectLink.GetAllGlobs(EvaluationContext)"/>.
             /// </summary>
             /// <param name="evaluationContext">

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2790,8 +2790,8 @@ namespace Microsoft.Build.Execution
             // ProjectTargetInstances are immutable so only the dictionary must be cloned
             _targets = CreateCloneDictionary(targets);
 
-            this.DefaultTargets = new List<string>(defaultTargets);
-            this.InitialTargets = new List<string>(initialTargets);
+            this.DefaultTargets = defaultTargets == null ? new List<string>(0) : new List<string>(defaultTargets);
+            this.InitialTargets = defaultTargets == null ? new List<string>(0) : new List<string>(initialTargets);
             ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)this).BeforeTargets = CreateCloneDictionary(beforeTargets, StringComparer.OrdinalIgnoreCase);
             ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)this).AfterTargets = CreateCloneDictionary(afterTargets, StringComparer.OrdinalIgnoreCase);
         }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2872,9 +2872,9 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Create Items snapshot
         /// </summary>
-        private Dictionary<ProjectItem, ProjectItemInstance> CreateItemsSnapshot(ICollection<ProjectItem> items, int itemTypecount, bool keepEvaluationCache)
+        private Dictionary<ProjectItem, ProjectItemInstance> CreateItemsSnapshot(ICollection<ProjectItem> items, int itemTypeCount, bool keepEvaluationCache)
         {
-            _items = new ItemDictionary<ProjectItemInstance>(itemTypecount);
+            _items = new ItemDictionary<ProjectItemInstance>(itemTypeCount);
 
             var projectItemToInstanceMap = keepEvaluationCache ? new Dictionary<ProjectItem, ProjectItemInstance>(items.Count) : null;
 
@@ -2906,6 +2906,7 @@ namespace Microsoft.Build.Execution
                     }
                 }
 
+                // For externally constructed ProjectItem, fall back to the publicly available EvaluateInclude
                 var evaluatedIncludeEscaped = ((IItem)item).EvaluatedIncludeEscaped;
                 evaluatedIncludeEscaped ??= item.EvaluatedInclude;
                 var evaluatedIncludeBeforeWildcardExpansionEscaped = item.EvaluatedIncludeBeforeWildcardExpansionEscaped;

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -327,6 +327,59 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Creates a ProjectInstance from an external created <see cref="Project"/>.
+        /// Properties and items are cloned immediately and only the instance data is stored.
+        /// </summary>
+        public ProjectInstance(Project project, ProjectInstanceSettings settings)
+        {
+            ErrorUtilities.VerifyThrowInternalNull(project, nameof(project));
+
+            var projectPath = project.FullPath;
+            _directory = Path.GetDirectoryName(projectPath);
+            _projectFileLocation = ElementLocation.Create(projectPath);
+            _hostServices = project.ProjectCollection.HostServices;
+
+            EvaluationId = project.EvaluationCounter;
+
+            var immutable = (settings & ProjectInstanceSettings.Immutable) == ProjectInstanceSettings.Immutable;
+            this.CreatePropertiesSnapshot(project.Properties, immutable);
+            this.CreateItemDefinitionsSnapshot(project.ItemDefinitions);
+
+            var keepEvaluationCache = (settings & ProjectInstanceSettings.ImmutableWithFastItemLookup) == ProjectInstanceSettings.ImmutableWithFastItemLookup;
+            var projectItemToInstanceMap = this.CreateItemsSnapshot(project.Items, project.ItemTypes.Count, keepEvaluationCache);
+
+            this.CreateEvaluatedIncludeSnapshotIfRequested(keepEvaluationCache, project.Items, projectItemToInstanceMap);
+
+            _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(project.GlobalProperties.Count);
+            foreach (var property in project.GlobalProperties)
+            {
+                _globalProperties.Set(ProjectPropertyInstance.Create(property.Key, property.Value));
+            }
+
+            this.CreateEnvironmentVariablePropertiesSnapshot(project.ProjectCollection.EnvironmentProperties);
+            this.CreateTargetsSnapshot(project.Targets, null, null, null, null);
+            this.CreateImportsSnapshot(project.Imports, project.ImportsIncludingDuplicates);
+
+            this.Toolset = project.ProjectCollection.GetToolset(project.ToolsVersion);
+            this.SubToolsetVersion = project.SubToolsetVersion;
+            this.TaskRegistry = new TaskRegistry(Toolset, project.ProjectCollection.ProjectRootElementCache);
+
+            this.ProjectRootElementCache = project.ProjectCollection.ProjectRootElementCache;
+
+            this.EvaluatedItemElements = new List<ProjectItemElement>(project.Items.Count);
+            foreach (var item in project.Items)
+            {
+                this.EvaluatedItemElements.Add(item.Xml);
+            }
+
+            _usingDifferentToolsVersionFromProjectFile = false;
+            _originalProjectToolsVersion = project.ToolsVersion;
+            _explicitToolsVersionSpecified = project.SubToolsetVersion != null;
+
+            _isImmutable = immutable;
+        }
+
+        /// <summary>
         /// Creates a ProjectInstance directly.
         /// No intermediate Project object is created.
         /// This is ideal if the project is simply going to be built, and not displayed or edited.
@@ -461,18 +514,18 @@ namespace Microsoft.Build.Execution
             EvaluationId = data.EvaluationId;
 
             var immutable = (settings & ProjectInstanceSettings.Immutable) == ProjectInstanceSettings.Immutable;
-            this.CreatePropertiesSnapshot(data, immutable);
+            this.CreatePropertiesSnapshot(new ReadOnlyCollection<ProjectProperty>(data.Properties), immutable);
 
-            this.CreateItemDefinitionsSnapshot(data);
+            this.CreateItemDefinitionsSnapshot(data.ItemDefinitions);
 
             var keepEvaluationCache = (settings & ProjectInstanceSettings.ImmutableWithFastItemLookup) == ProjectInstanceSettings.ImmutableWithFastItemLookup;
-            var projectItemToInstanceMap = this.CreateItemsSnapshot(data, keepEvaluationCache);
+            var projectItemToInstanceMap = this.CreateItemsSnapshot(new ReadOnlyCollection<ProjectItem>(data.Items), data.ItemTypes.Count, keepEvaluationCache);
 
-            this.CreateEvaluatedIncludeSnapshotIfRequested(keepEvaluationCache, data, projectItemToInstanceMap);
-            this.CreateGlobalPropertiesSnapshot(data);
+            this.CreateEvaluatedIncludeSnapshotIfRequested(keepEvaluationCache, new ReadOnlyCollection<ProjectItem>(data.Items), projectItemToInstanceMap);
+            this.CreateGlobalPropertiesSnapshot(data.GlobalPropertiesDictionary);
             this.CreateEnvironmentVariablePropertiesSnapshot(environmentVariableProperties);
-            this.CreateTargetsSnapshot(data);
-            this.CreateImportsSnapshot(data);
+            this.CreateTargetsSnapshot(data.Targets, data.DefaultTargets, data.InitialTargets, data.BeforeTargets, data.AfterTargets);
+            this.CreateImportsSnapshot(data.ImportClosure, data.ImportClosureWithDuplicates);
 
             this.Toolset = data.Toolset; // UNDONE: This isn't immutable, should be cloned or made immutable; it currently has a pointer to project collection
             this.SubToolsetVersion = data.SubToolsetVersion;
@@ -548,13 +601,13 @@ namespace Microsoft.Build.Execution
                 this.DefaultTargets = new List<string>(that.DefaultTargets);
                 this.InitialTargets = new List<string>(that.InitialTargets);
                 ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance,
-                    ProjectItemDefinitionInstance>) this).BeforeTargets = CreateCloneDictionary(
+                    ProjectItemDefinitionInstance>)this).BeforeTargets = CreateCloneDictionary(
                     ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance,
-                        ProjectItemDefinitionInstance>) that).BeforeTargets, StringComparer.OrdinalIgnoreCase);
+                        ProjectItemDefinitionInstance>)that).BeforeTargets, StringComparer.OrdinalIgnoreCase);
                 ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance,
-                    ProjectItemDefinitionInstance>) this).AfterTargets = CreateCloneDictionary(
+                    ProjectItemDefinitionInstance>)this).AfterTargets = CreateCloneDictionary(
                     ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance,
-                        ProjectItemDefinitionInstance>) that).AfterTargets, StringComparer.OrdinalIgnoreCase);
+                        ProjectItemDefinitionInstance>)that).AfterTargets, StringComparer.OrdinalIgnoreCase);
                 this.TaskRegistry =
                     that.TaskRegistry; // UNDONE: This isn't immutable, should be cloned or made immutable; it currently has a pointer to project collection
 
@@ -2023,7 +2076,7 @@ namespace Microsoft.Build.Execution
             translator.TranslateDictionary(ref _globalProperties, ProjectPropertyInstance.FactoryForDeserialization);
             translator.TranslateDictionary(ref _properties, ProjectPropertyInstance.FactoryForDeserialization);
 
-            var globalPropertiesToTreatAsLocal = (HashSet<string>) _globalPropertiesToTreatAsLocal;
+            var globalPropertiesToTreatAsLocal = (HashSet<string>)_globalPropertiesToTreatAsLocal;
             translator.Translate(ref globalPropertiesToTreatAsLocal);
 
             if (translator.Mode == TranslationDirection.ReadFromStream)
@@ -2727,24 +2780,29 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Create various target snapshots
         /// </summary>
-        private void CreateTargetsSnapshot(Evaluation.Project.Data data)
+        private void CreateTargetsSnapshot(
+            IDictionary<string, ProjectTargetInstance> targets,
+            List<string> defaultTargets,
+            List<string> initialTargets,
+            IDictionary<string, List<TargetSpecification>> beforeTargets,
+            IDictionary<string, List<TargetSpecification>> afterTargets)
         {
-            this.DefaultTargets = new List<string>(data.DefaultTargets);
-            this.InitialTargets = new List<string>(data.InitialTargets);
-            ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)this).BeforeTargets = CreateCloneDictionary(data.BeforeTargets, StringComparer.OrdinalIgnoreCase);
-            ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)this).AfterTargets = CreateCloneDictionary(data.AfterTargets, StringComparer.OrdinalIgnoreCase);
-
             // ProjectTargetInstances are immutable so only the dictionary must be cloned
-            _targets = CreateCloneDictionary(data.Targets);
+            _targets = CreateCloneDictionary(targets);
+
+            this.DefaultTargets = new List<string>(defaultTargets);
+            this.InitialTargets = new List<string>(initialTargets);
+            ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)this).BeforeTargets = CreateCloneDictionary(beforeTargets, StringComparer.OrdinalIgnoreCase);
+            ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)this).AfterTargets = CreateCloneDictionary(afterTargets, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
         /// Create various imports snapshots
         /// </summary>
-        private void CreateImportsSnapshot(Evaluation.Project.Data data)
+        private void CreateImportsSnapshot(IList<ResolvedImport> importClosure, IList<ResolvedImport> importClosureWithDuplicates)
         {
-            _importPaths = new List<string>(data.ImportClosure.Count - 1 /* outer project */);
-            foreach (var resolvedImport in data.ImportClosure)
+            _importPaths = new List<string>(importClosure.Count - 1 /* outer project */);
+            foreach (var resolvedImport in importClosure)
             {
                 // Exclude outer project itself
                 if (resolvedImport.ImportingElement != null)
@@ -2755,8 +2813,8 @@ namespace Microsoft.Build.Execution
 
             ImportPaths = _importPaths.AsReadOnly();
 
-            _importPathsIncludingDuplicates = new List<string>(data.ImportClosureWithDuplicates.Count - 1 /* outer project */);
-            foreach (var resolvedImport in data.ImportClosureWithDuplicates)
+            _importPathsIncludingDuplicates = new List<string>(importClosureWithDuplicates.Count - 1 /* outer project */);
+            foreach (var resolvedImport in importClosureWithDuplicates)
             {
                 // Exclude outer project itself
                 if (resolvedImport.ImportingElement != null)
@@ -2784,11 +2842,11 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Create global properties snapshot
         /// </summary>
-        private void CreateGlobalPropertiesSnapshot(Evaluation.Project.Data data)
+        private void CreateGlobalPropertiesSnapshot(PropertyDictionary<ProjectPropertyInstance> globalPropertiesDictionary)
         {
-            _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(data.GlobalPropertiesDictionary.Count);
+            _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(globalPropertiesDictionary.Count);
 
-            foreach (ProjectPropertyInstance globalProperty in data.GlobalPropertiesDictionary)
+            foreach (ProjectPropertyInstance globalProperty in globalPropertiesDictionary)
             {
                 _globalProperties.Set(globalProperty.DeepClone());
             }
@@ -2797,7 +2855,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Create evaluated include cache snapshot
         /// </summary>
-        private void CreateEvaluatedIncludeSnapshotIfRequested(bool keepEvaluationCache, Evaluation.Project.Data data, Dictionary<ProjectItem, ProjectItemInstance> projectItemToInstanceMap)
+        private void CreateEvaluatedIncludeSnapshotIfRequested(bool keepEvaluationCache, ICollection<ProjectItem> items, Dictionary<ProjectItem, ProjectItemInstance> projectItemToInstanceMap)
         {
             if (!keepEvaluationCache)
             {
@@ -2805,26 +2863,22 @@ namespace Microsoft.Build.Execution
             }
 
             _itemsByEvaluatedInclude = new MultiDictionary<string, ProjectItemInstance>(StringComparer.OrdinalIgnoreCase);
-            foreach (var key in data.ItemsByEvaluatedIncludeCache.Keys)
+            foreach (var item in items)
             {
-                var projectItems = data.ItemsByEvaluatedIncludeCache[key];
-                foreach (var projectItem in projectItems)
-                {
-                    _itemsByEvaluatedInclude.Add(key, projectItemToInstanceMap[projectItem]);
-                }
+                _itemsByEvaluatedInclude.Add(item.EvaluatedInclude, projectItemToInstanceMap[item]);
             }
         }
 
         /// <summary>
         /// Create Items snapshot
         /// </summary>
-        private Dictionary<ProjectItem, ProjectItemInstance> CreateItemsSnapshot(Evaluation.Project.Data data, bool keepEvaluationCache)
+        private Dictionary<ProjectItem, ProjectItemInstance> CreateItemsSnapshot(ICollection<ProjectItem> items, int itemTypecount, bool keepEvaluationCache)
         {
-            _items = new ItemDictionary<ProjectItemInstance>(data.ItemTypes.Count);
+            _items = new ItemDictionary<ProjectItemInstance>(itemTypecount);
 
-            var projectItemToInstanceMap = keepEvaluationCache ? new Dictionary<ProjectItem, ProjectItemInstance>(data.Items.Count) : null;
+            var projectItemToInstanceMap = keepEvaluationCache ? new Dictionary<ProjectItem, ProjectItemInstance>(items.Count) : null;
 
-            foreach (ProjectItem item in data.Items)
+            foreach (ProjectItem item in items)
             {
                 List<ProjectItemDefinitionInstance> inheritedItemDefinitions = null;
 
@@ -2865,11 +2919,11 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Create ItemDefinitions snapshot
         /// </summary>
-        private void CreateItemDefinitionsSnapshot(Evaluation.Project.Data data)
+        private void CreateItemDefinitionsSnapshot(IDictionary<string, ProjectItemDefinition> itemDefinitions)
         {
             _itemDefinitions = new RetrievableEntryHashSet<ProjectItemDefinitionInstance>(MSBuildNameIgnoreCaseComparer.Default);
 
-            foreach (ProjectItemDefinition definition in data.ItemDefinitions.Values)
+            foreach (ProjectItemDefinition definition in itemDefinitions.Values)
             {
                 _itemDefinitions.Add(new ProjectItemDefinitionInstance(definition));
             }
@@ -2878,11 +2932,11 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// create property snapshot
         /// </summary>
-        private void CreatePropertiesSnapshot(Evaluation.Project.Data data, bool isImmutable)
+        private void CreatePropertiesSnapshot(ICollection<ProjectProperty> properties, bool isImmutable)
         {
-            _properties = new PropertyDictionary<ProjectPropertyInstance>(data.Properties.Count);
+            _properties = new PropertyDictionary<ProjectPropertyInstance>(properties.Count);
 
-            foreach (ProjectProperty property in data.Properties)
+            foreach (ProjectProperty property in properties)
             {
                 // Allow reserved property names, since this is how they are added to the project instance. 
                 // The caller has prevented users setting them themselves.

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2636,7 +2636,7 @@ namespace Microsoft.Build.Execution
             }
             else
             {
-                return new RetrievableEntryHashSet<TValue>(dictionary, StringComparer.OrdinalIgnoreCase, readOnly: true);
+                return new ObjectModel.ReadOnlyDictionary<string, TValue>(dictionary);
             }
         }
 
@@ -2906,7 +2906,12 @@ namespace Microsoft.Build.Execution
                     }
                 }
 
-                ProjectItemInstance instance = new ProjectItemInstance(this, item.ItemType, ((IItem)item).EvaluatedIncludeEscaped, item.EvaluatedIncludeBeforeWildcardExpansionEscaped, directMetadata, inheritedItemDefinitions, item.Xml.ContainingProject.EscapedFullPath);
+                var evaluatedIncludeEscaped = ((IItem)item).EvaluatedIncludeEscaped;
+                evaluatedIncludeEscaped ??= item.EvaluatedInclude;
+                var evaluatedIncludeBeforeWildcardExpansionEscaped = item.EvaluatedIncludeBeforeWildcardExpansionEscaped;
+                evaluatedIncludeBeforeWildcardExpansionEscaped ??= item.EvaluatedInclude;
+
+                ProjectItemInstance instance = new ProjectItemInstance(this, item.ItemType, evaluatedIncludeEscaped, evaluatedIncludeBeforeWildcardExpansionEscaped, directMetadata, inheritedItemDefinitions, item.Xml.ContainingProject.EscapedFullPath);
 
                 _items.Add(instance);
 

--- a/src/Build/ObjectModelRemoting/DefinitionObjectsLinks/ProjectLink.cs
+++ b/src/Build/ObjectModelRemoting/DefinitionObjectsLinks/ProjectLink.cs
@@ -129,6 +129,11 @@ namespace Microsoft.Build.ObjectModelRemoting
         public abstract int LastEvaluationId { get; }
 
         /// <summary>
+        /// Facilitate remoting the <see cref="Project.GetAllGlobs()"/>.
+        /// </summary>
+        public abstract List<GlobResult> GetAllGlobs();
+
+        /// <summary>
         /// Facilitate remoting the <see cref="Project.GetAllGlobs(EvaluationContext)"/>.
         /// </summary>
         public abstract List<GlobResult> GetAllGlobs(EvaluationContext evaluationContext);


### PR DESCRIPTION
Fixes #6260

### Context
The evaluation result is being cached now on the CPS side to speed up solution load. For the cases where CPS has it's linked read-only Project, we would like to create a ProjectInstance as well from it, instead of triggering a evaluation for the sake of creating a ProjectInstance

### Changes Made
- Add a constructor to ProjectInstance that builds itself from the Project.
- Also exposed the existing GetAllGlobs override to ProjectLink. Previously never exposed since ProjectLink was used only for csproj that does not really care about globs.

### Testing
Added a test for the new constructor.

### Notes
