### PR TITLE
Change ProjectInstanceFactoryFunc to use IDictionary instead of Dictionary

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1647,7 +1647,7 @@ namespace Microsoft.Build.Graph
             public int EdgeCount { get { throw null; } }
             public int NodeCount { get { throw null; } }
         }
-        public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.Dictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
+        public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ProjectGraphEntryPoint

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1641,7 +1641,7 @@ namespace Microsoft.Build.Graph
             public int EdgeCount { get { throw null; } }
             public int NodeCount { get { throw null; } }
         }
-        public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.Dictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
+        public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ProjectGraphEntryPoint

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.Graph
         /// </remarks>
         public delegate ProjectInstance ProjectInstanceFactoryFunc(
             string projectPath,
-            Dictionary<string, string> globalProperties,
+            IDictionary<string, string> globalProperties,
             ProjectCollection projectCollection);
 
         private readonly Lazy<IReadOnlyCollection<ProjectGraphNode>> _projectNodesTopologicallySorted;
@@ -718,7 +718,7 @@ namespace Microsoft.Build.Graph
 
         internal static ProjectInstance DefaultProjectInstanceFactory(
             string projectPath,
-            Dictionary<string, string> globalProperties,
+            IDictionary<string, string> globalProperties,
             ProjectCollection projectCollection)
         {
             return new ProjectInstance(


### PR DESCRIPTION
Fixes #6252 

This is an API breaking change.  The API users that rely on type inference shouldn't be affected when they update their msbuild version. The rest have to change their custom `ProjectInstanceFactoryFunc` delegates to use IDictionaries instead of Dictionaries for global properties.

I found the following API users on `Index`:
- [quickbuild](http://index/?rightProject=DBS.EnlistmentLibrary&file=DependencyParserV2.cs&line=181), compilation error. @dfederm
- [nuget static graph restore](http://index/?rightProject=NuGet.Build.Tasks.Console&file=MSBuildStaticGraphRestore.cs&line=903), no compilation error. @jeffkl @nkolev92 
- [BuildXL](http://index/?rightProject=ProjectGraphBuilder&file=MsBuildGraphBuilder.cs&line=151), compilation error. @smera 

As far as I can tell the impact isn't that big, just replacing a declared type. Let me know if I'm missing other failure modes.