### PR TITLE
Verify that a key is in the warningsAsErrors dictionary before using it

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -541,7 +541,10 @@ namespace Microsoft.Build.BackEnd.Logging
 
             int key = GetWarningsAsErrorOrMessageKey(context);
 
-            HashSet<string> warningsAsErrorsExcludingMessages = new HashSet<string>(_warningsAsErrorsByProject[key]);
+            if (!_warningsAsErrorsByProject.TryGetValue(key, out ISet<string> warningsAsErrorsExcludingMessages))
+            {
+                return null;
+            }
 
             if (_warningsAsMessagesByProject != null)
             {


### PR DESCRIPTION
Customers reported issues like:
```
Error The "ResolveAssemblyReference" task failed unexpectedly.
System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at System.Collections.Concurrent.ConcurrentDictionary`2.get_Item(TKey key)
   at Microsoft.Build.BackEnd.Logging.LoggingService.GetWarningsToBeLoggedAsErrorsByProject(BuildEventContext context)
   at Microsoft.Build.BackEnd.Logging.TaskLoggingContext.GetWarningsAsErrors()
   at Microsoft.Build.BackEnd.TaskHost.get_WarningsAsErrors()
   at Microsoft.Build.BackEnd.TaskHost.ShouldTreatWarningAsError(String warningCode)
   at Microsoft.Build.Utilities.TaskLoggingHelper.LogWarning(String subcategory, String warningCode, String helpKeyword, String helpLink, String file, Int32 lineNumber, Int32 columnNumber, Int32 endLineNumber, Int32 endColumnNumber, String message, Object[] messageArgs)
   at Microsoft.Build.Utilities.TaskLoggingHelper.LogWarningWithCodeFromResources(String messageResourceName, Object[] messageArgs)
   at Microsoft.Build.Tasks.ReferenceTable.LogHigherVersionUnresolveDueToAttribute(Boolean displayPrimaryReferenceMessage, AssemblyNameExtension assemblyName, Reference reference, ITaskItem referenceItem, String targetedFramework)
   at Microsoft.Build.Tasks.ReferenceTable.RemovePrimaryReferenceMarkedForExclusion(LogExclusionReason logExclusionReason, Boolean removeOnlyNoWarning, String subsetName, List`1 removedReferences, AssemblyNameExtension assemblyName, Reference assemblyReference)
   at Microsoft.Build.Tasks.ReferenceTable.RemoveReferencesMarkedForExclusion(Boolean removeOnlyNoWarning, String subsetName)
   at Microsoft.Build.Tasks.ResolveAssemblyReference.Execute(FileExists fileExists, DirectoryExists directoryExists, GetDirectories getDirectories, GetAssemblyName getAssemblyName, GetAssemblyMetadata getAssemblyMetadata, GetRegistrySubKeyNames getRegistrySubKeyNames, GetRegistrySubKeyDefaultValue getRegistrySubKeyDefaultValue, GetLastWriteTime getLastWriteTime, GetAssemblyRuntimeVersion getRuntimeVersion, OpenBaseKey openBaseKey, GetAssemblyPathInGac getAssemblyPathInGac, IsWinMDFile isWinMDFile, ReadMachineTypeFromPEHeader readMachineTypeFromPEHeader)
   at Microsoft.Build.Tasks.ResolveAssemblyReference.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() NetFxOldStyle.Test
```

Looking at it, we access a dictionary [here](https://github.com/dotnet/msbuild/blob/13522d2466ae1634177e2a6a40fefaedff95139c/src/Build/BackEnd/Components/Logging/LoggingService.cs#L544) without verifying that the key (project ID) is in the dictionary. This fixes that and defaults to "no warnings as errors" if relevant.

Currently untested.