### PR TITLE
Throw BadImageFormatException when missing PE metadata

### DIFF
--- a/src/Tasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyInformation.cs
@@ -361,6 +361,21 @@ namespace Microsoft.Build.Tasks
                 using (var stream = File.OpenRead(_sourceFile))
                 using (var peFile = new PEReader(stream))
                 {
+                    bool hasMetadata = false;
+                    try
+                    {
+                        hasMetadata = peFile.HasMetadata;
+                    }
+                    finally
+                    {
+                        if (!hasMetadata)
+                        {
+                            throw new BadImageFormatException(string.Format(CultureInfo.CurrentCulture,
+                                AssemblyResources.GetString("ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata"),
+                                _sourceFile));
+                        }
+                    }
+
                     var metadataReader = peFile.GetMetadataReader();
 
                     var assemblyReferences = metadataReader.AssemblyReferences;

--- a/src/Tasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -364,10 +364,14 @@ namespace Microsoft.Build.Tasks
                     bool hasMetadata = false;
                     try
                     {
+                        // This can throw if the stream is too small, which means
+                        // the assembly doesn't have metadata.
                         hasMetadata = peFile.HasMetadata;
                     }
                     finally
                     {
+                        // If the file does not contain PE metadata, throw BadImageFormatException to preserve
+                        // behavior from AssemblyName.GetAssemblyName(). RAR will deal with this correctly.
                         if (!hasMetadata)
                         {
                             throw new BadImageFormatException(string.Format(CultureInfo.CurrentCulture,


### PR DESCRIPTION
Fixes #6200 

### Context
`InvalidOperationException` was being thrown by `AssemblyInformation.CorePopulateMetadata`, causing the ResolveAssemblyReference task to fail rather than disregarding the file.

### Changes Made
I copied the code from AssemblyNameExtension to ensure there is metadata present before getting a metadata reader: https://github.com/dotnet/msbuild/blob/6819f7ab06c3f43e83ff4059d417395e0af06c01/src/Shared/AssemblyNameExtension.cs#L214-L231

### Testing
I looked for unit tests for AssemblyInformation, but could not find any, so I didn't add a unit test for this case. However, I successfully built the project that was reproducing the error in #6200, indicating that the change did indeed fix the issue.