### PR TITLE
Handle unsupported paths in ProjectInSolution.AbsolutePath (#6238)

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2477,6 +2477,30 @@ EndGlobal
             }
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/dotnet/msbuild/issues/6236
+        /// </summary>
+        [Theory]
+        [InlineData("http://localhost:8080")]
+        [InlineData("a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-")]
+        public void AbsolutePathWorksForUnsupportedPaths(string relativePath)
+        {
+            string solutionFileContents =
+                $@"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31025.194
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{{E24C65DC-7377-472B-9ABA-BC803B73C61A}}"") = ""WebSite1"", ""{relativePath}"", ""{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}""
+EndProject";
+
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
+
+            ProjectInSolution projectInSolution = solution.ProjectsInOrder.ShouldHaveSingleItem();
+
+            projectInSolution.AbsolutePath.ShouldBe(Path.Combine(solution.SolutionFileDirectory, projectInSolution.RelativePath));
+        }
+
         #region Helper Functions
 
         /// <summary>

--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -168,11 +168,26 @@ namespace Microsoft.Build.Construction
             {
                 if (_absolutePath == null)
                 {
+                    _absolutePath = Path.Combine(ParentSolution.SolutionFileDirectory, _relativePath);
+
+                    // For web site projects, Visual Studio stores the URL of the site as the relative path so it cannot be normalized.
+                    // Legacy behavior dictates that we must just return the result of Path.Combine()
+                    if (!Uri.TryCreate(_relativePath, UriKind.Absolute, out Uri _))
+                    {
+                        try
+                        {
 #if NETFRAMEWORK && !MONO
-                    _absolutePath = Path.GetFullPath(Path.Combine(ParentSolution.SolutionFileDirectory, _relativePath));
+                            _absolutePath = Path.GetFullPath(_absolutePath);
 #else
-                    _absolutePath = FileUtilities.NormalizePath(Path.Combine(ParentSolution.SolutionFileDirectory, _relativePath));
+                            _absolutePath = FileUtilities.NormalizePath(_absolutePath);
 #endif
+                        }
+                        catch (Exception)
+                        {
+                            // The call to GetFullPath() can throw if the relative path is some unsupported value or the paths are too long for the current file system
+                            // This falls back to previous behavior of returning a path that may not be correct but at least returns some value
+                        }
+                    }
                 }
 
                 return _absolutePath;
@@ -229,9 +244,9 @@ namespace Microsoft.Build.Construction
 
         internal string TargetFrameworkMoniker { get; set; }
 
-#endregion
+        #endregion
 
-#region Methods
+        #region Methods
 
         private bool _checkedIfCanBeMSBuildProjectFile;
         private bool _canBeMSBuildProjectFile;
@@ -529,13 +544,13 @@ namespace Microsoft.Build.Construction
             return false;
         }
 
-#endregion
+        #endregion
 
-#region Constants
+        #region Constants
 
         internal const int DependencyLevelUnknown = -1;
         internal const int DependencyLevelBeingDetermined = -2;
 
-#endregion
+        #endregion
     }
 }


### PR DESCRIPTION
## Customer Impact
Trying to build a solution with MSBuild.exe that contains a web site project causes MSBuild.exe to crash. This only affects the command line but includes _dotnet build_. It requires a relative path in the solution file and we've received 2 customer reports so far.

In those cases, we would return "C:\foo\http://localhost:8080" as an absolute path and then crash msbuild.

## Testing
New unit test added. We will reach out to manual test team and compat test team to find out if website projects are included in their matrix.

## Risk
Low, new code path has a `try...catch` and falls back to previous behavior.

## Code Reviewers
@Forgind @cdmihai @BenVillalobos 

## Description of fix
Previously a property in the MSBuild API would return a string containing an "absolute path" but did not expand path segments like `..\`.  We changed the code to call `Path.GetFullPath()` to expand these segments but did not realize that in some contexts, Visual Studio stores URLs in field that we were expecting to see a relative path.  URLs contain characters that `Path.GetFullPath()` will throw a NotSupportedException for.

To fix this, we're not calling `Path.GetFullPath()` if the specified path is a URL and placed the call to `Path.GetFullPath()` inside a `try...catch` to fall back to previous behavior if that call fails