### PR TITLE
Support runtime-specific SDK resolver test hook

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -22,7 +22,15 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
         private readonly string IncludeDefaultResolver = Environment.GetEnvironmentVariable("MSBUILDINCLUDEDEFAULTSDKRESOLVER");
 
-        private readonly string AdditionalResolversFolder = Environment.GetEnvironmentVariable("MSBUILDADDITIONALSDKRESOLVERSFOLDER");
+        //  Test hook for loading SDK Resolvers from additional folders.  Support runtime-specific test hook environment variables,
+        //  as an SDK resolver built for .NET Framework probably won't work on .NET Core, and vice versa.
+        private readonly string AdditionalResolversFolder = Environment.GetEnvironmentVariable(
+#if NETFRAMEWORK
+            "MSBUILDADDITIONALSDKRESOLVERSFOLDER_NETFRAMEWORK"
+#elif NET
+            "MSBUILDADDITIONALSDKRESOLVERSFOLDER_NET"
+#endif
+            ) ?? Environment.GetEnvironmentVariable("MSBUILDADDITIONALSDKRESOLVERSFOLDER");
 
         internal virtual IList<SdkResolver> LoadResolvers(LoggingContext loggingContext,
             ElementLocation location)


### PR DESCRIPTION
We have the `MSBUILDADDITIONALSDKRESOLVERSFOLDER` environment variable as a test hook to specify where SDK Resolvers should be loaded from.  However, SDK resolvers need to be multi-targeted between .NET Framework and .NET (Core).  So setting this environment variable to where you have a .NET Framework SDK resolver means that `dotnet` builds will fail, and setting it to a .NET resolver means `msbuild` builds will fail.

So this adds runtime-specific test hook environment variables: `MSBUILDADDITIONALSDKRESOLVERSFOLDER_NETFRAMEWORK` and `MSBUILDADDITIONALSDKRESOLVERSFOLDER_NET`.