### PR TITLE
Remove ContainsKey where relevant

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2423,10 +2423,8 @@ namespace Microsoft.Build.Execution
             lock (_syncLock)
             {
                 // The build submission has not already been completed.
-                if (_buildSubmissions.ContainsKey(result.SubmissionId))
+                if (_buildSubmissions.TryGetValue(result.SubmissionId, out BuildSubmission submission))
                 {
-                    BuildSubmission submission = _buildSubmissions[result.SubmissionId];
-
                     /* If the request failed because we caught an exception from the loggers, we can assume we will receive no more logging messages for
                      * this submission, therefore set the logging as complete. InternalLoggerExceptions are unhandled exceptions from the logger. If the logger author does
                      * not handle an exception the eventsource wraps all exceptions (except a logging exception) into an internal logging exception.
@@ -2459,9 +2457,8 @@ namespace Microsoft.Build.Execution
             lock (_syncLock)
             {
                 // The build submission has not already been completed.
-                if (_graphBuildSubmissions.ContainsKey(result.SubmissionId))
+                if (_graphBuildSubmissions.TryGetValue(result.SubmissionId, out GraphBuildSubmission submission))
                 {
-                    GraphBuildSubmission submission = _graphBuildSubmissions[result.SubmissionId];
                     submission.CompleteResults(result);
 
                     _overallBuildSuccess &= submission.BuildResult.OverallResult == BuildResultCode.Success;

--- a/src/Build/BackEnd/BuildManager/LegacyThreadingData.cs
+++ b/src/Build/BackEnd/BuildManager/LegacyThreadingData.cs
@@ -104,10 +104,7 @@ namespace Microsoft.Build.Execution
             {
                 ErrorUtilities.VerifyThrow(_legacyThreadingEventsById.ContainsKey(submissionId), "Submission {0} should have been previously registered with LegacyThreadingData", submissionId);
 
-                if (_legacyThreadingEventsById.ContainsKey(submissionId))
-                {
-                    _legacyThreadingEventsById.Remove(submissionId);
-                }
+                _legacyThreadingEventsById.Remove(submissionId);
             }
         }
 

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEntry.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEntry.cs
@@ -230,12 +230,12 @@ namespace Microsoft.Build.BackEnd
         {
             lock (GlobalLock)
             {
-                if (_unresolvedConfigurations?.ContainsKey(unresolvedConfigId) != true)
+                List<BuildRequest> requests = null;
+                if (_unresolvedConfigurations?.TryGetValue(unresolvedConfigId, out requests) != true)
                 {
                     return false;
                 }
 
-                List<BuildRequest> requests = _unresolvedConfigurations[unresolvedConfigId];
                 _unresolvedConfigurations.Remove(unresolvedConfigId);
 
                 if (_unresolvedConfigurations.Count == 0)

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -55,15 +55,15 @@ namespace Microsoft.Build.BackEnd
         {
             lock (_resultsByConfiguration)
             {
-                if (_resultsByConfiguration.ContainsKey(result.ConfigurationId))
+                if (_resultsByConfiguration.TryGetValue(result.ConfigurationId, out BuildResult buildResult))
                 {
-                    if (Object.ReferenceEquals(_resultsByConfiguration[result.ConfigurationId], result))
+                    if (Object.ReferenceEquals(buildResult, result))
                     {
                         // Merging results would be meaningless as we would be merging the object with itself.
                         return;
                     }
 
-                    _resultsByConfiguration[result.ConfigurationId].MergeResults(result);
+                    buildResult.MergeResults(result);
                 }
                 else
                 {
@@ -105,9 +105,8 @@ namespace Microsoft.Build.BackEnd
 
             lock (_resultsByConfiguration)
             {
-                if (_resultsByConfiguration.ContainsKey(request.ConfigurationId))
+                if (_resultsByConfiguration.TryGetValue(request.ConfigurationId, out BuildResult result))
                 {
-                    BuildResult result = _resultsByConfiguration[request.ConfigurationId];
                     foreach (string target in request.Targets)
                     {
                         ErrorUtilities.VerifyThrow(result.HasResultsForTarget(target), "No results in cache for target " + target);
@@ -159,10 +158,8 @@ namespace Microsoft.Build.BackEnd
 
             lock (_resultsByConfiguration)
             {
-                if (_resultsByConfiguration.ContainsKey(request.ConfigurationId))
+                if (_resultsByConfiguration.TryGetValue(request.ConfigurationId, out BuildResult allResults))
                 {
-                    BuildResult allResults = _resultsByConfiguration[request.ConfigurationId];
-
                     // Check for targets explicitly specified.
                     bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, response.ExplicitTargetsToBuild, skippedResultsDoNotCauseCacheMiss);
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -484,7 +484,10 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal void DisconnectFromHost(HandshakeOptions hostContext)
         {
-            ErrorUtilities.VerifyThrow(_nodeIdToPacketFactory.Remove((int)hostContext) && _nodeIdToPacketHandler.Remove((int)hostContext), "Why are we trying to disconnect from a context that we already disconnected from?  Did we call DisconnectFromHost twice?");
+            ErrorUtilities.VerifyThrow(_nodeIdToPacketFactory.ContainsKey((int)hostContext) && _nodeIdToPacketHandler.ContainsKey((int)hostContext), "Why are we trying to disconnect from a context that we already disconnected from?  Did we call DisconnectFromHost twice?");
+
+            _nodeIdToPacketFactory.Remove((int)hostContext);
+            _nodeIdToPacketHandler.Remove((int)hostContext);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -265,9 +265,9 @@ namespace Microsoft.Build.BackEnd
         /// <param name="translator">The translator containing the data from which the packet should be reconstructed.</param>
         public void DeserializeAndRoutePacket(int nodeId, NodePacketType packetType, ITranslator translator)
         {
-            if (_nodeIdToPacketFactory.ContainsKey(nodeId))
+            if (_nodeIdToPacketFactory.TryGetValue(nodeId, out INodePacketFactory nodePacketFactory))
             {
-                _nodeIdToPacketFactory[nodeId].DeserializeAndRoutePacket(nodeId, packetType, translator);
+                nodePacketFactory.DeserializeAndRoutePacket(nodeId, packetType, translator);
             }
             else
             {
@@ -282,9 +282,9 @@ namespace Microsoft.Build.BackEnd
         /// <param name="packet">The packet to route.</param>
         public void RoutePacket(int nodeId, INodePacket packet)
         {
-            if (_nodeIdToPacketFactory.ContainsKey(nodeId))
+            if (_nodeIdToPacketFactory.TryGetValue(nodeId, out INodePacketFactory nodePacketFactory))
             {
-                _nodeIdToPacketFactory[nodeId].RoutePacket(nodeId, packet);
+                nodePacketFactory.RoutePacket(nodeId, packet);
             }
             else
             {
@@ -304,9 +304,9 @@ namespace Microsoft.Build.BackEnd
         /// <param name="packet">The packet.</param>
         public void PacketReceived(int node, INodePacket packet)
         {
-            if (_nodeIdToPacketHandler.ContainsKey(node))
+            if (_nodeIdToPacketHandler.TryGetValue(node, out INodePacketHandler packetHandler))
             {
-                _nodeIdToPacketHandler[node].PacketReceived(node, packet);
+                packetHandler.PacketReceived(node, packet);
             }
             else
             {
@@ -484,10 +484,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal void DisconnectFromHost(HandshakeOptions hostContext)
         {
-            ErrorUtilities.VerifyThrow(_nodeIdToPacketFactory.ContainsKey((int)hostContext) && _nodeIdToPacketHandler.ContainsKey((int)hostContext), "Why are we trying to disconnect from a context that we already disconnected from?  Did we call DisconnectFromHost twice?");
-
-            _nodeIdToPacketFactory.Remove((int)hostContext);
-            _nodeIdToPacketHandler.Remove((int)hostContext);
+            ErrorUtilities.VerifyThrow(_nodeIdToPacketFactory.Remove((int)hostContext) && _nodeIdToPacketHandler.Remove((int)hostContext), "Why are we trying to disconnect from a context that we already disconnected from?  Did we call DisconnectFromHost twice?");
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -626,12 +626,10 @@ namespace Microsoft.Build.BackEnd.Logging
                 ProcessLoggingEvent(buildEvent);
 
                 // PERF: Not using VerifyThrow to avoid boxing of projectBuildEventContext.ProjectContextId in the non-error case.
-                if (!_projectFileMap.ContainsKey(projectBuildEventContext.ProjectContextId))
+                if (!_projectFileMap.Remove(projectBuildEventContext.ProjectContextId))
                 {
                     ErrorUtilities.ThrowInternalError("ContextID {0} for project {1} should be in the ID-to-file mapping!", projectBuildEventContext.ProjectContextId, projectFile);
                 }
-
-                _projectFileMap.Remove(projectBuildEventContext.ProjectContextId);
             }
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/MSBuild.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/MSBuild.cs
@@ -661,10 +661,8 @@ namespace Microsoft.Build.BackEnd
 
                         foreach (string targetName in nonNullTargetList)
                         {
-                            if (targetOutputsPerProject[i].ContainsKey(targetName))
+                            if (targetOutputsPerProject[i].TryGetValue(targetName, out ITaskItem[] outputItemsFromTarget))
                             {
-                                ITaskItem[] outputItemsFromTarget = targetOutputsPerProject[i][targetName];
-
                                 foreach (ITaskItem outputItemFromTarget in outputItemsFromTarget)
                                 {
                                     // No need to rebase if the calling project is the same as the callee project 

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -210,13 +210,13 @@ namespace Microsoft.Build.BackEnd
 
                     string propertyName = property.Name;
                     // If the hash contains the property name, output a messages that displays the previous property value and the new property value
-                    if (lookupHash.ContainsKey(propertyName))
+                    if (lookupHash.TryGetValue(propertyName, out string propertyValue))
                     {
                         if (errorMessages == null)
                         {
                             errorMessages = new List<string>();
                         }
-                        errorMessages.Add(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("PropertyOutputOverridden", propertyName, EscapingUtilities.UnescapeAll(lookupHash[propertyName]), property.EvaluatedValue));
+                        errorMessages.Add(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("PropertyOutputOverridden", propertyName, EscapingUtilities.UnescapeAll(propertyValue), property.EvaluatedValue));
                     }
 
                     // Set the value of the hash to the new property value
@@ -945,10 +945,10 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void MustNotBeInTable(ItemTypeToItemsMetadataUpdateDictionary table, ProjectItemInstance item)
         {
-            if (table?.ContainsKey(item.ItemType) == true)
+            ItemsMetadataUpdateDictionary tableOfItemsOfSameType = null;
+            if (table?.TryGetValue(item.ItemType, out tableOfItemsOfSameType) == true)
             {
-                ItemsMetadataUpdateDictionary tableOfItemsOfSameType = table[item.ItemType];
-                if (tableOfItemsOfSameType != null)
+                if (tableOfItemsOfSameType is not null)
                 {
                     ErrorUtilities.VerifyThrow(!tableOfItemsOfSameType.ContainsKey(item), "Item should not be in table");
                 }

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -142,16 +142,16 @@ namespace Microsoft.Build.BackEnd
 
             foreach (string targetName in targetNames)
             {
-                var targetExists = _projectInstance.Targets.ContainsKey(targetName);
+                var targetExists = _projectInstance.Targets.TryGetValue(targetName, out ProjectTargetInstance targetInstance);
                 if (!targetExists && entry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.SkipNonexistentTargets))
                 {
                     _projectLoggingContext.LogComment(Framework.MessageImportance.Low,
                         "TargetSkippedWhenSkipNonexistentTargets", targetName);
-
-                    continue;
                 }
-
-                targets.Add(new TargetSpecification(targetName, targetExists ? _projectInstance.Targets[targetName].Location : _projectInstance.ProjectFileLocation));
+                else
+                {
+                    targets.Add(new TargetSpecification(targetName, targetExists ? targetInstance.Location : _projectInstance.ProjectFileLocation));
+                }
             }
 
             // Push targets onto the stack.  This method will reverse their push order so that they
@@ -484,13 +484,7 @@ namespace Microsoft.Build.BackEnd
                             }
                             catch
                             {
-                                if (_requestEntry.RequestConfiguration.ActivelyBuildingTargets.ContainsKey(
-                                    currentTargetEntry.Name))
-                                {
-                                    _requestEntry.RequestConfiguration.ActivelyBuildingTargets.Remove(currentTargetEntry
-                                        .Name);
-                                }
-
+                                _requestEntry.RequestConfiguration.ActivelyBuildingTargets.Remove(currentTargetEntry.Name);
                                 throw;
                             }
                         }
@@ -764,7 +758,7 @@ namespace Microsoft.Build.BackEnd
         {
             foreach (string targetName in targetNames)
             {
-                if (_buildResult.ResultsByTarget.ContainsKey(targetName))
+                if (_buildResult.ResultsByTarget.TryGetValue(targetName, out TargetResult targetBuildResult))
                 {
                     // Queue of targets waiting to be processed, seeded with the specific target for which we're computing AfterTargetsHaveFailed.
                     var targetsToCheckForAfterTargets = new Queue<string>();
@@ -785,7 +779,7 @@ namespace Microsoft.Build.BackEnd
                             if (result?.ResultCode == TargetResultCode.Failure && !result.TargetFailureDoesntCauseBuildFailure)
                             {
                                 // Mark the target as having an after target failed, and break the loop to move to the next target.
-                                _buildResult.ResultsByTarget[targetName].AfterTargetsHaveFailed = true;
+                                targetBuildResult.AfterTargetsHaveFailed = true;
                                 targetsToCheckForAfterTargets = null;
                                 break;
                             }

--- a/src/Build/BackEnd/Components/Scheduler/SchedulableRequest.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulableRequest.cs
@@ -629,9 +629,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal void DisconnectRequestWeAreBlockedBy(BlockingRequestKey blockingRequestKey)
         {
-            ErrorUtilities.VerifyThrow(_requestsWeAreBlockedBy.ContainsKey(blockingRequestKey), "We are not blocked by the specified request.");
-
-            SchedulableRequest unblockingRequest = _requestsWeAreBlockedBy[blockingRequestKey];
+            ErrorUtilities.VerifyThrow(_requestsWeAreBlockedBy.TryGetValue(blockingRequestKey, out SchedulableRequest unblockingRequest), "We are not blocked by the specified request.");
             ErrorUtilities.VerifyThrow(unblockingRequest._requestsWeAreBlocking.Contains(this), "The request unblocking us doesn't think it is blocking us.");
 
             _requestsWeAreBlockedBy.Remove(blockingRequestKey);

--- a/src/Build/BackEnd/Components/Scheduler/SchedulingData.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulingData.cs
@@ -360,9 +360,9 @@ namespace Microsoft.Build.BackEnd
                     ErrorUtilities.VerifyThrow(_configurationToRequests.ContainsKey(request.BuildRequest.ConfigurationId), "Configuration {0} never had requests assigned to it.", request.BuildRequest.ConfigurationId);
                     ErrorUtilities.VerifyThrow(_configurationToRequests[request.BuildRequest.ConfigurationId].Count > 0, "Configuration {0} has no requests assigned to it.", request.BuildRequest.ConfigurationId);
                     _configurationToRequests[request.BuildRequest.ConfigurationId].Remove(request);
-                    if (_scheduledRequestsByNode.ContainsKey(request.AssignedNode))
+                    if (_scheduledRequestsByNode.TryGetValue(request.AssignedNode, out var requests))
                     {
-                        _scheduledRequestsByNode[request.AssignedNode].Remove(request);
+                        requests.Remove(request);
                     }
 
                     request.EndTime = EventTime;

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -470,9 +470,9 @@ namespace Microsoft.Build.Execution
                 _resultsByTarget ??= CreateTargetResultDictionary(1);
             }
 
-            if (_resultsByTarget.ContainsKey(target))
+            if (_resultsByTarget.TryGetValue(target, out TargetResult targetResult))
             {
-                ErrorUtilities.VerifyThrow(_resultsByTarget[target].ResultCode == TargetResultCode.Skipped, "Items already exist for target {0}.", target);
+                ErrorUtilities.VerifyThrow(targetResult.ResultCode == TargetResultCode.Skipped, "Items already exist for target {0}.", target);
             }
 
             _resultsByTarget[target] = result;

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -617,7 +617,7 @@ namespace Microsoft.Build.Construction
                 }
 
                 // Detect collision caused by unique name's normalization
-                if (projectsByUniqueName.ContainsKey(uniqueName))
+                if (projectsByUniqueName.TryGetValue(uniqueName, out ProjectInSolution project))
                 {
                     // Did normalization occur in the current project?
                     if (uniqueName != proj.ProjectName)
@@ -628,16 +628,14 @@ namespace Microsoft.Build.Construction
                         uniqueName = tempUniqueName;
                     }
                     // Did normalization occur in a previous project?
-                    else if (uniqueName != projectsByUniqueName[uniqueName].ProjectName)
+                    else if (uniqueName != project.ProjectName)
                     {
-                        var projTemp = projectsByUniqueName[uniqueName];
-
                         // Generates a new unique name
-                        string tempUniqueName = $"{uniqueName}_{projTemp.GetProjectGuidWithoutCurlyBrackets()}";
-                        projTemp.UpdateUniqueProjectName(tempUniqueName);
+                        string tempUniqueName = $"{uniqueName}_{project.GetProjectGuidWithoutCurlyBrackets()}";
+                        project.UpdateUniqueProjectName(tempUniqueName);
 
                         projectsByUniqueName.Remove(uniqueName);
-                        projectsByUniqueName.Add(tempUniqueName, projTemp);
+                        projectsByUniqueName.Add(tempUniqueName, project);
                     }
                 }
 

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -783,7 +783,7 @@ namespace Microsoft.Build.Construction
                 AddTraversalTargetForProject(traversalInstance, project, projectConfiguration, "Publish", null, canBuildDirectly);
 
                 // Add any other targets specified by the user that were not already added
-                foreach (string targetName in _targetNames.Where(i => !traversalInstance.Targets.ContainsKey(i)))
+                foreach (string targetName in _targetNames.Except(traversalInstance.Targets.Keys, StringComparer.OrdinalIgnoreCase))
                 {
                     AddTraversalTargetForProject(traversalInstance, project, projectConfiguration, targetName, null, canBuildDirectly);
                 }
@@ -797,7 +797,7 @@ namespace Microsoft.Build.Construction
             }
 
             // Add any other targets specified by the user that were not already added
-            foreach (string targetName in _targetNames.Where(i => !traversalInstance.Targets.ContainsKey(i)))
+            foreach (string targetName in _targetNames.Except(traversalInstance.Targets.Keys, StringComparer.OrdinalIgnoreCase))
             {
                 AddTraversalReferencesTarget(traversalInstance, targetName, null);
             }
@@ -1202,7 +1202,7 @@ namespace Microsoft.Build.Construction
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, "Rebuild");
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, "Publish");
 
-                foreach (string targetName in _targetNames.Where(i => !metaprojectInstance.Targets.ContainsKey(i)))
+                foreach (string targetName in _targetNames.Except(metaprojectInstance.Targets.Keys, StringComparer.OrdinalIgnoreCase))
                 {
                     AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, targetName);
                 }
@@ -1222,7 +1222,7 @@ namespace Microsoft.Build.Construction
                 AddMetaprojectTargetForManagedProject(traversalProject, metaprojectInstance, project, projectConfiguration, "Rebuild", targetOutputItemName);
                 AddMetaprojectTargetForManagedProject(traversalProject, metaprojectInstance, project, projectConfiguration, "Publish", null);
 
-                foreach (string targetName in _targetNames.Where(i => !metaprojectInstance.Targets.ContainsKey(i)))
+                foreach (string targetName in _targetNames.Except(metaprojectInstance.Targets.Keys, StringComparer.OrdinalIgnoreCase))
                 {
                     AddMetaprojectTargetForManagedProject(traversalProject, metaprojectInstance, project, projectConfiguration, targetName, null);
                 }
@@ -1234,7 +1234,7 @@ namespace Microsoft.Build.Construction
                 AddMetaprojectTargetForUnknownProjectType(traversalProject, metaprojectInstance, project, "Rebuild", unknownProjectTypeErrorMessage);
                 AddMetaprojectTargetForUnknownProjectType(traversalProject, metaprojectInstance, project, "Publish", unknownProjectTypeErrorMessage);
 
-                foreach (string targetName in _targetNames.Where(i => !metaprojectInstance.Targets.ContainsKey(i)))
+                foreach (string targetName in _targetNames.Except(metaprojectInstance.Targets.Keys, StringComparer.OrdinalIgnoreCase))
                 {
                     AddMetaprojectTargetForUnknownProjectType(traversalProject, metaprojectInstance, project, targetName, unknownProjectTypeErrorMessage);
                 }

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1615,12 +1615,11 @@ namespace Microsoft.Build.Evaluation
         {
             Debug.Assert(_locker.IsWriteLockHeld);
 
-            if (!_toolsets.ContainsKey(toolsVersion))
+            if (!_toolsets.Remove(toolsVersion))
             {
                 return false;
             }
 
-            _toolsets.Remove(toolsVersion);
             _toolsetsVersion++;
             return true;
         }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -852,7 +852,7 @@ namespace Microsoft.Build.Evaluation
                             // Defaults to false
                             _projectSupportsReturnsAttribute.TryGetValue(currentProjectOrImport, out NGen<bool> projectSupportsReturnsAttribute);
 
-                            _projectSupportsReturnsAttribute[currentProjectOrImport] = projectSupportsReturnsAttribute | (target.Returns != null);
+                            _projectSupportsReturnsAttribute[currentProjectOrImport] = projectSupportsReturnsAttribute || (target.Returns != null);
                             _targetElements.Add(target);
                             break;
                         case ProjectImportElement import:

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -849,14 +849,10 @@ namespace Microsoft.Build.Evaluation
                             _itemDefinitionGroupElements.Add(itemDefinitionGroup);
                             break;
                         case ProjectTargetElement target:
-                            if (_projectSupportsReturnsAttribute.ContainsKey(currentProjectOrImport))
-                            {
-                                _projectSupportsReturnsAttribute[currentProjectOrImport] |= (target.Returns != null);
-                            }
-                            else
-                            {
-                                _projectSupportsReturnsAttribute[currentProjectOrImport] = (target.Returns != null);
-                            }
+                            // Defaults to false
+                            _projectSupportsReturnsAttribute.TryGetValue(currentProjectOrImport, out NGen<bool> projectSupportsReturnsAttribute);
+
+                            _projectSupportsReturnsAttribute[currentProjectOrImport] = projectSupportsReturnsAttribute | (target.Returns != null);
                             _targetElements.Add(target);
                             break;
                         case ProjectImportElement import:

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -162,10 +162,8 @@ namespace Microsoft.Build.Evaluation
                     {
                         return getEscapedValueFunc(_operationItem, itemType, name);
                     }
-                    else if (_capturedItems.ContainsKey(itemType))
+                    else if (_capturedItems.TryGetValue(itemType, out var item))
                     {
-                        var item = _capturedItems[itemType];
-
                         return getEscapedValueFunc(item, itemType, name);
                     }
                     else

--- a/src/Build/Instance/HostServices.cs
+++ b/src/Build/Instance/HostServices.cs
@@ -181,15 +181,8 @@ After:
         {
             if (projectFullPath != null)
             {
-                if (_hostObjectMap?.ContainsKey(projectFullPath) == true)
-                {
-                    _hostObjectMap.Remove(projectFullPath);
-                }
-
-                if (_projectAffinities?.ContainsKey(projectFullPath) == true)
-                {
-                    _projectAffinities.Remove(projectFullPath);
-                }
+                _hostObjectMap?.Remove(projectFullPath);
+                _projectAffinities?.Remove(projectFullPath);
             }
         }
 
@@ -323,14 +316,15 @@ After:
                     var hostObjectMapPairKeyTaskName = translator.Reader.ReadString();
                     var hostObjectMapPairValueMonikerName = translator.Reader.ReadString();
                     var targetTaskKey = new HostObjects.TargetTaskKey(hostObjectMapPairKeyTargetName, hostObjectMapPairKeyTaskName);
-                    if (!hostObjectMap.ContainsKey(pairKey))
+                    if (!hostObjectMap.TryGetValue(pairKey, out HostObjects hostObject))
                     {
-                        hostObjectMap[pairKey] = new HostObjects();
+                        hostObject = new HostObjects();
+                        hostObjectMap[pairKey] = hostObject;
                     }
 
-                    if (!hostObjectMap[pairKey]._hostObjects.ContainsKey(targetTaskKey))
+                    if (!hostObject._hostObjects.ContainsKey(targetTaskKey))
                     {
-                        hostObjectMap[pairKey]._hostObjects.Add(targetTaskKey, new MonikerNameOrITaskHost(hostObjectMapPairValueMonikerName));
+                        hostObject._hostObjects.Add(targetTaskKey, new MonikerNameOrITaskHost(hostObjectMapPairValueMonikerName));
                     }
                 }
                 _hostObjectMap = hostObjectMap;

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2378,7 +2378,7 @@ namespace Microsoft.Build.Execution
                 parentProjectSupportsReturnsAttribute
                 );
 
-            _actualTargets[target.Name] = target;
+            _actualTargets[targetName] = target;
 
             return target;
         }

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -197,10 +197,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public object GetPropertyValue(TaskPropertyInfo property)
         {
-            if (_setParameters.ContainsKey(property.Name))
+            if (_setParameters.TryGetValue(property.Name, out object value))
             {
-                object value = _setParameters[property.Name];
-
                 // If we returned an exception, then we want to throw it when we 
                 // do the get.  
                 if (value is Exception)
@@ -208,7 +206,7 @@ namespace Microsoft.Build.BackEnd
                     throw (Exception)value;
                 }
 
-                return _setParameters[property.Name];
+                return value;
             }
             else
             {

--- a/src/Build/Logging/ParallelLogger/ParallelLoggerHelpers.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelLoggerHelpers.cs
@@ -47,23 +47,18 @@ namespace Microsoft.Build.BackEnd.Logging
                     int projectTargetKeyLocal = 1;
                     int projectIncrementKeyLocal;
                     // If we haven't seen this project before (by full path) then
-                    // allocate a new key for it and save it away
-                    if (!_projectKey.ContainsKey(e.ProjectFile))
+                    // allocate a new key for it and save it away. Otherwise, retrive it.
+                    if (!_projectKey.TryGetValue(e.ProjectFile, out projectIncrementKeyLocal))
                     {
                         _projectIncrementKey++;
 
                         _projectKey[e.ProjectFile] = _projectIncrementKey;
                         projectIncrementKeyLocal = _projectIncrementKey;
                     }
-                    else
-                    {
-                        // We've seen this project before, so retrieve it
-                        projectIncrementKeyLocal = _projectKey[e.ProjectFile];
-                    }
 
                     // If we haven't seen any entrypoint for the current project (by full path) then
                     // allocate a new entry point key
-                    if (!_projectTargetKey.ContainsKey(e.ProjectFile))
+                    if (!_projectTargetKey.TryGetValue(e.ProjectFile, out int tempProjectTargetKeyLocal))
                     {
                         _projectTargetKey[e.ProjectFile] = projectTargetKeyLocal;
                     }
@@ -71,7 +66,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     {
                         // We've seen this project before, but not this entrypoint, so increment
                         // the entrypoint key that we have.
-                        projectTargetKeyLocal = _projectTargetKey[e.ProjectFile] + 1;
+                        projectTargetKeyLocal = tempProjectTargetKeyLocal + 1;
                         _projectTargetKey[e.ProjectFile] = projectTargetKeyLocal;
                     }
 
@@ -173,15 +168,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal ProjectStartedEventMinimumFields GetProjectStartedEvent(BuildEventContext e)
         {
-            ProjectStartedEventMinimumFields buildEvent;
-            if (_projectStartedEvents.ContainsKey(e))
-            {
-                buildEvent = _projectStartedEvents[e];
-            }
-            else
-            {
-                buildEvent = null;
-            }
+            _projectStartedEvents.TryGetValue(e, out ProjectStartedEventMinimumFields buildEvent);
             return buildEvent;
         }
 
@@ -190,15 +177,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal TargetStartedEventMinimumFields GetTargetStartedEvent(BuildEventContext e)
         {
-            TargetStartedEventMinimumFields buildEvent;
-            if (_targetStartedEvents.ContainsKey(e))
-            {
-                buildEvent = _targetStartedEvents[e];
-            }
-            else
-            {
-                buildEvent = null;
-            }
+            _targetStartedEvents.TryGetValue(e, out TargetStartedEventMinimumFields buildEvent);
             return buildEvent;
         }
 

--- a/src/Build/Logging/ParallelLogger/ParallelLoggerHelpers.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelLoggerHelpers.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     int projectTargetKeyLocal = 1;
                     int projectIncrementKeyLocal;
                     // If we haven't seen this project before (by full path) then
-                    // allocate a new key for it and save it away. Otherwise, retrive it.
+                    // allocate a new key for it and save it away. Otherwise, retrieve it.
                     if (!_projectKey.TryGetValue(e.ProjectFile, out projectIncrementKeyLocal))
                     {
                         _projectIncrementKey++;

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -478,11 +478,11 @@ namespace Microsoft.Build.Internal
                 }
                 else
                 {
-                    ErrorUtilities.VerifyThrow(taskHostParameters.ContainsKey(XMakeAttributes.runtime), "Should always have an explicit runtime when we call this method.");
-                    ErrorUtilities.VerifyThrow(taskHostParameters.ContainsKey(XMakeAttributes.architecture), "Should always have an explicit architecture when we call this method.");
+                    ErrorUtilities.VerifyThrow(taskHostParameters.TryGetValue(XMakeAttributes.runtime, out string runtimeVersion), "Should always have an explicit runtime when we call this method.");
+                    ErrorUtilities.VerifyThrow(taskHostParameters.TryGetValue(XMakeAttributes.architecture, out string architecture), "Should always have an explicit architecture when we call this method.");
 
-                    clrVersion = taskHostParameters[XMakeAttributes.runtime].Equals(XMakeAttributes.MSBuildRuntimeValues.clr4, StringComparison.OrdinalIgnoreCase) ? 4 : 2;
-                    is64Bit = taskHostParameters[XMakeAttributes.architecture].Equals(XMakeAttributes.MSBuildArchitectureValues.x64);
+                    clrVersion = runtimeVersion.Equals(XMakeAttributes.MSBuildRuntimeValues.clr4, StringComparison.OrdinalIgnoreCase) ? 4 : 2;
+                    is64Bit = architecture.Equals(XMakeAttributes.MSBuildArchitectureValues.x64);
                 }
             }
 

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -1068,14 +1068,14 @@ namespace Microsoft.Build.Shared
 
         private static VisualStudioSpec GetVisualStudioSpec(Version version)
         {
-            ErrorUtilities.VerifyThrowArgument(s_visualStudioSpecDict.ContainsKey(version), "FrameworkLocationHelper.UnsupportedVisualStudioVersion", version);
-            return s_visualStudioSpecDict[version];
+            ErrorUtilities.VerifyThrowArgument(s_visualStudioSpecDict.TryGetValue(version, out VisualStudioSpec spec), "FrameworkLocationHelper.UnsupportedVisualStudioVersion", version);
+            return spec;
         }
 
         private static DotNetFrameworkSpec GetDotNetFrameworkSpec(Version version)
         {
-            ErrorUtilities.VerifyThrowArgument(s_dotNetFrameworkSpecDict.ContainsKey(version), "FrameworkLocationHelper.UnsupportedFrameworkVersion", version);
-            return s_dotNetFrameworkSpecDict[version];
+            ErrorUtilities.VerifyThrowArgument(s_dotNetFrameworkSpecDict.TryGetValue(version, out DotNetFrameworkSpec spec), "FrameworkLocationHelper.UnsupportedFrameworkVersion", version);
+            return spec;
         }
 
         /// <summary>

--- a/src/Shared/NodePacketFactory.cs
+++ b/src/Shared/NodePacketFactory.cs
@@ -48,12 +48,11 @@ namespace Microsoft.Build.BackEnd
         public void DeserializeAndRoutePacket(int nodeId, NodePacketType packetType, ITranslator translator)
         {
             // PERF: Not using VerifyThrow to avoid boxing of packetType in the non-error case
-            if (!_packetFactories.ContainsKey(packetType))
+            if (!_packetFactories.TryGetValue(packetType, out PacketFactoryRecord record))
             {
                 ErrorUtilities.ThrowInternalError("No packet handler for type {0}", packetType);
             }
 
-            PacketFactoryRecord record = _packetFactories[packetType];
             record.DeserializeAndRoutePacket(nodeId, translator);
         }
 

--- a/src/Shared/VersionUtilities.cs
+++ b/src/Shared/VersionUtilities.cs
@@ -39,9 +39,8 @@ namespace Microsoft.Build.Shared
 
                     if (candidateVersion != null && (targetPlatformVersion == null || (candidateVersion <= targetPlatformVersion)))
                     {
-                        if (versionValues.ContainsKey(candidateVersion))
+                        if (versionValues.TryGetValue(candidateVersion, out List<string> versionList))
                         {
-                            List<string> versionList = versionValues[candidateVersion];
                             if (!versionList.Contains(version))
                             {
                                 versionList.Add(version);

--- a/src/Tasks/AssemblyDependency/GlobalAssemblyCache.cs
+++ b/src/Tasks/AssemblyDependency/GlobalAssemblyCache.cs
@@ -280,9 +280,8 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
-                    if (fusionNameToResolvedPath.ContainsKey(strongName))
+                    if (fusionNameToResolvedPath.TryGetValue(strongName, out string fusionName))
                     {
-                        fusionNameToResolvedPath.TryGetValue(strongName, out string fusionName);
                         return fusionName;
                     }
                 }

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -148,8 +148,7 @@ namespace Microsoft.Build.Tasks
         internal void AddSourceItem(ITaskItem sourceItem)
         {
             string itemSpec = sourceItem.ItemSpec;
-            bool sourceItemAlreadyInList = _sourceItems.ContainsKey(itemSpec);
-            if (!sourceItemAlreadyInList)
+            if (!_sourceItems.ContainsKey(itemSpec))
             {
                 _sourceItems[itemSpec] = sourceItem;
                 PropagateSourceItems(sourceItem);

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -327,14 +327,7 @@ namespace Microsoft.Build.Tasks
 
                     if (sdkName.Length > 0)
                     {
-                        if (!_resolvedSDKReferences.ContainsKey(sdkName))
-                        {
-                            _resolvedSDKReferences.Add(sdkName, resolvedSDK);
-                        }
-                        else
-                        {
-                            _resolvedSDKReferences[sdkName] = resolvedSDK;
-                        }
+                        _resolvedSDKReferences[sdkName] = resolvedSDK;
                     }
                 }
             }
@@ -406,9 +399,8 @@ namespace Microsoft.Build.Tasks
         internal void AddReference(AssemblyNameExtension assemblyName, Reference reference)
         {
             ErrorUtilities.VerifyThrow(assemblyName.Name != null, "Got an empty assembly name.");
-            if (References.ContainsKey(assemblyName))
+            if (References.TryGetValue(assemblyName, out Reference referenceGoingToBeReplaced))
             {
-                Reference referenceGoingToBeReplaced = References[assemblyName];
                 foreach (AssemblyRemapping pair in referenceGoingToBeReplaced.RemappedAssemblyNames())
                 {
                     reference.AddRemapping(pair.From, pair.To);
@@ -3197,15 +3189,12 @@ namespace Microsoft.Build.Tasks
                 if (!reference.CheckForSpecificVersionMetadataOnParentsReference(false))
                 {
                     // Check to see if the reference is not in a profile or subset
-                    if (exclusionList != null)
+                    if (exclusionList?.ContainsKey(assemblyFullName) == true)
                     {
-                        if (exclusionList.ContainsKey(assemblyFullName))
-                        {
-                            anyMarkedReference = true;
-                            reference.ExclusionListLoggingProperties.ExclusionReasonLogDelegate = LogProfileExclusionUnresolve;
-                            reference.ExclusionListLoggingProperties.IsInExclusionList = true;
-                            ListOfExcludedAssemblies.Add(assemblyFullName);
-                        }
+                        anyMarkedReference = true;
+                        reference.ExclusionListLoggingProperties.ExclusionReasonLogDelegate = LogProfileExclusionUnresolve;
+                        reference.ExclusionListLoggingProperties.IsInExclusionList = true;
+                        ListOfExcludedAssemblies.Add(assemblyFullName);
                     }
 
                     // Check to see if the reference is in the current target framework but has a higher version than what exists in the target framework

--- a/src/Tasks/GenerateBootstrapper.cs
+++ b/src/Tasks/GenerateBootstrapper.cs
@@ -118,10 +118,9 @@ namespace Microsoft.Build.Tasks
 
                 foreach (Product product in products)
                 {
-                    if (items.ContainsKey(product.ProductCode))
+                    if (items.Remove(product.ProductCode))
                     {
                         settings.ProductBuilders.Add(product.ProductBuilder);
-                        items.Remove(product.ProductCode);
                     }
                 }
 

--- a/src/Tasks/InstalledSDKResolver.cs
+++ b/src/Tasks/InstalledSDKResolver.cs
@@ -52,10 +52,8 @@ namespace Microsoft.Build.Tasks
             if (assemblyName != null)
             {
                 // We have found a resolved SDK item that matches the one on the reference items.
-                if (_resolvedSDKs.ContainsKey(sdkName))
+                if (_resolvedSDKs.TryGetValue(sdkName, out ITaskItem resolvedSDK))
                 {
-                    ITaskItem resolvedSDK = _resolvedSDKs[sdkName];
-
                     string sdkDirectory = resolvedSDK.ItemSpec;
                     string configuration = resolvedSDK.GetMetadata("TargetedSDKConfiguration");
                     string architecture = resolvedSDK.GetMetadata("TargetedSDKArchitecture");

--- a/src/Tasks/MSBuild.cs
+++ b/src/Tasks/MSBuild.cs
@@ -611,10 +611,8 @@ namespace Microsoft.Build.Tasks
 
                         foreach (string targetName in nonNullTargetList)
                         {
-                            if (targetOutputsPerProject[i].ContainsKey(targetName))
+                            if (targetOutputsPerProject[i].TryGetValue(targetName, out ITaskItem[] outputItemsFromTarget))
                             {
-                                ITaskItem[] outputItemsFromTarget = targetOutputsPerProject[i][targetName];
-
                                 foreach (ITaskItem outputItemFromTarget in outputItemsFromTarget)
                                 {
                                     // No need to rebase if the calling project is the same as the callee project 

--- a/src/Tasks/ManifestUtil/ApplicationManifest.cs
+++ b/src/Tasks/ManifestUtil/ApplicationManifest.cs
@@ -421,25 +421,25 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                             if (!String.IsNullOrEmpty(comInfo.ClsId))
                             {
                                 string key = comInfo.ClsId.ToLowerInvariant();
-                                if (!clsidList.ContainsKey(key))
+                                if (!clsidList.TryGetValue(key, out ComInfo info))
                                 {
                                     clsidList.Add(key, comInfo);
                                 }
                                 else
                                 {
-                                    OutputMessages.AddErrorMessage("GenerateManifest.DuplicateComDefinition", "clsid", comInfo.ComponentFileName, comInfo.ClsId, comInfo.ManifestFileName, clsidList[key].ManifestFileName);
+                                    OutputMessages.AddErrorMessage("GenerateManifest.DuplicateComDefinition", "clsid", comInfo.ComponentFileName, comInfo.ClsId, comInfo.ManifestFileName, info.ManifestFileName);
                                 }
                             }
                             if (!String.IsNullOrEmpty(comInfo.TlbId))
                             {
                                 string key = comInfo.TlbId.ToLowerInvariant();
-                                if (!tlbidList.ContainsKey(key))
+                                if (!tlbidList.TryGetValue(key, out ComInfo info))
                                 {
                                     tlbidList.Add(key, comInfo);
                                 }
                                 else
                                 {
-                                    OutputMessages.AddErrorMessage("GenerateManifest.DuplicateComDefinition", "tlbid", comInfo.ComponentFileName, comInfo.TlbId, comInfo.ManifestFileName, tlbidList[key].ManifestFileName);
+                                    OutputMessages.AddErrorMessage("GenerateManifest.DuplicateComDefinition", "tlbid", comInfo.ComponentFileName, comInfo.TlbId, comInfo.ManifestFileName, info.ManifestFileName);
                                 }
                             }
                         }
@@ -455,13 +455,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     foreach (ComClass comClass in file.ComClasses)
                     {
                         string key = comClass.ClsId.ToLowerInvariant();
-                        if (!clsidList.ContainsKey(key))
+                        if (!clsidList.TryGetValue(key, out ComInfo info))
                         {
                             clsidList.Add(key, new ComInfo(outputFileName, file.TargetPath, comClass.ClsId, null));
                         }
                         else
                         {
-                            OutputMessages.AddErrorMessage("GenerateManifest.DuplicateComDefinition", "clsid", file.ToString(), comClass.ClsId, outputFileName, clsidList[key].ManifestFileName);
+                            OutputMessages.AddErrorMessage("GenerateManifest.DuplicateComDefinition", "clsid", file.ToString(), comClass.ClsId, outputFileName, info.ManifestFileName);
                         }
                     }
                 }
@@ -470,13 +470,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     foreach (TypeLib typeLib in file.TypeLibs)
                     {
                         string key = typeLib.TlbId.ToLowerInvariant();
-                        if (!tlbidList.ContainsKey(key))
+                        if (!tlbidList.TryGetValue(key, out ComInfo info))
                         {
                             tlbidList.Add(key, new ComInfo(outputFileName, file.TargetPath, null, typeLib.TlbId));
                         }
                         else
                         {
-                            OutputMessages.AddErrorMessage("GenerateManifest.DuplicateComDefinition", "tlbid", file.ToString(), typeLib.TlbId, outputFileName, tlbidList[key].ManifestFileName);
+                            OutputMessages.AddErrorMessage("GenerateManifest.DuplicateComDefinition", "tlbid", file.ToString(), typeLib.TlbId, outputFileName, info.ManifestFileName);
                         }
                     }
                 }

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -467,11 +467,11 @@ namespace Microsoft.Build.Tasks
                     bool foundValidCodeLanguage = false;
 
                     // Attempt to map the user specified value as an alias to our vernacular for code languages
-                    foreach (string validLanguage in ValidCodeLanguages.Keys)
+                    foreach (KeyValuePair<string, ISet<string>> validLanguage in ValidCodeLanguages)
                     {
-                        if (ValidCodeLanguages[validLanguage].Contains(languageAttribute.Value))
+                        if (validLanguage.Value.Contains(languageAttribute.Value))
                         {
-                            taskInfo.CodeLanguage = validLanguage;
+                            taskInfo.CodeLanguage = validLanguage.Key;
                             foundValidCodeLanguage = true;
                             break;
                         }

--- a/src/Tasks/XamlTaskFactory/RelationsParser.cs
+++ b/src/Tasks/XamlTaskFactory/RelationsParser.cs
@@ -416,10 +416,7 @@ namespace Microsoft.Build.Tasks.Xaml
             }
 
             // generate the list of parameters in order
-            if (!switchRelationsList.ContainsKey(switchRelationsToAdd.SwitchValue))
-            {
-                switchRelationsList.Remove(switchRelationsToAdd.SwitchValue);
-            }
+            switchRelationsList.Remove(switchRelationsToAdd.SwitchValue);
 
             // build the dependencies and the values for a parameter
             XmlNode child = node.FirstChild;
@@ -463,14 +460,14 @@ namespace Microsoft.Build.Tasks.Xaml
                         }
                         else
                         {
-                            if (!switchRelationsToAdd.ExternalRequires.ContainsKey(tool))
+                            if (!switchRelationsToAdd.ExternalRequires.TryGetValue(tool, out List<string> switches))
                             {
-                                var switches = new List<string> { Switch };
+                                switches = new List<string> { Switch };
                                 switchRelationsToAdd.ExternalRequires.Add(tool, switches);
                             }
                             else
                             {
-                                switchRelationsToAdd.ExternalRequires[tool].Add(Switch);
+                                switches.Add(Switch);
                             }
                         }
                     }

--- a/src/Tasks/XamlTaskFactory/TaskGenerator.cs
+++ b/src/Tasks/XamlTaskFactory/TaskGenerator.cs
@@ -966,9 +966,8 @@ namespace Microsoft.Build.Tasks.Xaml
             if (Platform == null)
                 return true;
 
-            if (_relationsParser.SwitchRelationsList.ContainsKey(SwitchValue))
+            if (_relationsParser.SwitchRelationsList.TryGetValue(SwitchValue, out SwitchRelations rel))
             {
-                SwitchRelations rel = _relationsParser.SwitchRelationsList[SwitchValue];
                 if (rel.ExcludedPlatforms.Count > 0)
                 {
                     foreach (string excludedPlatform in rel.ExcludedPlatforms)
@@ -996,9 +995,8 @@ namespace Microsoft.Build.Tasks.Xaml
         /// </summary>
         private void GenerateOverrides(Property property, CodeMemberProperty propertyName)
         {
-            if (_relationsParser.SwitchRelationsList.ContainsKey(property.SwitchName))
+            if (_relationsParser.SwitchRelationsList.TryGetValue(property.SwitchName, out SwitchRelations rel))
             {
-                SwitchRelations rel = _relationsParser.SwitchRelationsList[property.SwitchName];
                 if (rel.Overrides.Count > 0)
                 {
                     foreach (string overrided in rel.Overrides)

--- a/src/Tasks/XamlTaskFactory/XamlDataDrivenToolTask.cs
+++ b/src/Tasks/XamlTaskFactory/XamlDataDrivenToolTask.cs
@@ -102,12 +102,7 @@ namespace Microsoft.Build.Tasks.Xaml
         /// </summary>
         public bool IsPropertySet(string propertyName)
         {
-            if (!String.IsNullOrEmpty(propertyName))
-            {
-                return ActiveToolSwitches.ContainsKey(propertyName);
-            }
-
-            return false;
+            return !String.IsNullOrEmpty(propertyName) && ActiveToolSwitches.ContainsKey(propertyName);
         }
 
         /// <summary>

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -302,10 +302,7 @@ namespace Microsoft.Build.Utilities
                 _submissionProjectsInProgress.Remove(e.BuildEventContext.SubmissionId);
                 lock (_submissionRecords)
                 {
-                    if (_submissionRecords.ContainsKey(e.BuildEventContext.SubmissionId))
-                    {
-                        _submissionRecords.Remove(e.BuildEventContext.SubmissionId);
-                    }
+                    _submissionRecords.Remove(e.BuildEventContext.SubmissionId);
                 }
             }
             else

--- a/src/Utilities/TrackedDependencies/CanonicalTrackedInputFiles.cs
+++ b/src/Utilities/TrackedDependencies/CanonicalTrackedInputFiles.cs
@@ -605,10 +605,7 @@ namespace Microsoft.Build.Utilities
                 {
                     // The tracking logs are not available, they may have been deleted at some point.
                     // Be safe and remove any references from the cache.
-                    if (DependencyTableCache.DependencyTable.ContainsKey(tLogRootingMarker))
-                    {
-                        DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
-                    }
+                    DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
                 }
                 return;
             }
@@ -832,11 +829,7 @@ namespace Microsoft.Build.Utilities
                 // sure that we essentially force a rebuild of this particular root.
                 if (encounteredInvalidTLogContents || exceptionCaught)
                 {
-                    if (DependencyTableCache.DependencyTable.ContainsKey(tLogRootingMarker))
-                    {
-                        DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
-                    }
-
+                    DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
                     DependencyTable = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
                 }
                 else
@@ -874,10 +867,7 @@ namespace Microsoft.Build.Utilities
                 {
                     // The tracking logs in the cache will be invalidated by this compaction
                     // remove the cached entries
-                    if (DependencyTableCache.DependencyTable.ContainsKey(tLogRootingMarker))
-                    {
-                        DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
-                    }
+                    DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
                 }
 
                 string firstTlog = _tlogFiles[0].ItemSpec;

--- a/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
+++ b/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
@@ -116,10 +116,7 @@ namespace Microsoft.Build.Utilities
                 {
                     // The tracking logs are not available, they may have been deleted at some point.
                     // Be safe and remove any references from the cache.
-                    if (DependencyTableCache.DependencyTable.ContainsKey(tLogRootingMarker))
-                    {
-                        DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
-                    }
+                    DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
                 }
                 return;
             }
@@ -246,11 +243,7 @@ namespace Microsoft.Build.Utilities
                 // sure that we essentially force a rebuild of this particular root.
                 if (encounteredInvalidTLogContents)
                 {
-                    if (DependencyTableCache.DependencyTable.ContainsKey(tLogRootingMarker))
-                    {
-                        DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
-                    }
-
+                    DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
                     DependencyTable = new Dictionary<string, Dictionary<string, DateTime>>(StringComparer.OrdinalIgnoreCase);
                 }
                 else
@@ -320,9 +313,9 @@ namespace Microsoft.Build.Utilities
         /// <param name="outputPathToRemove">The output path to be removed</param>
         public bool RemoveOutputForSourceRoot(string sourceRoot, string outputPathToRemove)
         {
-            if (DependencyTable.ContainsKey(sourceRoot))
+            if (DependencyTable.TryGetValue(sourceRoot, out var outputPaths))
             {
-                bool removed = DependencyTable[sourceRoot].Remove(outputPathToRemove);
+                bool removed = outputPaths.Remove(outputPathToRemove);
                 // If we just removed the last entry for this root, remove the root.
                 if (DependencyTable[sourceRoot].Count == 0)
                 {
@@ -584,10 +577,7 @@ namespace Microsoft.Build.Utilities
                 {
                     // The tracking logs in the cache will be invalidated by this compaction
                     // remove the cached entries to be sure
-                    if (DependencyTableCache.DependencyTable.ContainsKey(tLogRootingMarker))
-                    {
-                        DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
-                    }
+                    DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
                 }
 
                 string firstTlog = _tlogFiles[0].ItemSpec;

--- a/src/Utilities/TrackedDependencies/DependencyTableCache.cs
+++ b/src/Utilities/TrackedDependencies/DependencyTableCache.cs
@@ -60,9 +60,8 @@ namespace Microsoft.Build.Utilities
         /// <returns>The cached table entry</returns>
         internal static DependencyTableCacheEntry GetCachedEntry(string tLogRootingMarker)
         {
-            if (DependencyTable.ContainsKey(tLogRootingMarker))
+            if (DependencyTable.TryGetValue(tLogRootingMarker, out DependencyTableCacheEntry cacheEntry))
             {
-                DependencyTableCacheEntry cacheEntry = DependencyTable[tLogRootingMarker];
                 if (DependencyTableIsUpToDate(cacheEntry))
                 {
                     return cacheEntry;

--- a/src/Utilities/TrackedDependencies/FlatTrackingData.cs
+++ b/src/Utilities/TrackedDependencies/FlatTrackingData.cs
@@ -359,10 +359,7 @@ namespace Microsoft.Build.Utilities
                 {
                     // The tracking logs are not available, they may have been deleted at some point.
                     // Be safe and remove any references from the cache.
-                    if (DependencyTableCache.DependencyTable.ContainsKey(tLogRootingMarker))
-                    {
-                        DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
-                    }
+                    DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
                 }
                 return;
             }
@@ -480,11 +477,7 @@ namespace Microsoft.Build.Utilities
                 // sure that we essentially force a rebuild of this particular root. 
                 if (encounteredInvalidTLogContents)
                 {
-                    if (DependencyTableCache.DependencyTable.ContainsKey(tLogRootingMarker))
-                    {
-                        DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
-                    }
-
+                    DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
                     DependencyTable = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
                 }
                 else
@@ -619,10 +612,7 @@ namespace Microsoft.Build.Utilities
                 {
                     // The tracking logs in the cache will be invalidated by this write
                     // remove the cached entries to be sure
-                    if (DependencyTableCache.DependencyTable.ContainsKey(tLogRootingMarker))
-                    {
-                        DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
-                    }
+                    DependencyTableCache.DependencyTable.Remove(tLogRootingMarker);
                 }
 
                 string firstTlog = TlogFiles[0].ItemSpec;


### PR DESCRIPTION
Each instance of ContainsKey that I deleted was followed by querying the same dictionary for the same key. These can be done at the same time, so I replaced them.

I do not expect that this will have any substantial user impact, but it theoretically improves perf, and it's a pet peeve of mine.