### PR TITLE
Log properties and items on ProjectEvaluationFinished

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
-    <PackageReference Update="LargeAddressAware" Version="1.0.3" />
+    <PackageReference Update="LargeAddressAware" Version="1.0.5" />
     <PackageReference Update="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetBuildTasksVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="$(MicrosoftNetCompilersToolsetVersion)" />
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="2.1.0-prerelease-02404-02" />

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Framework
         public Microsoft.Build.Framework.BuildEventContext BuildEventContext { get { throw null; } set { } }
         public string HelpKeyword { get { throw null; } }
         public virtual string Message { get { throw null; } protected set { } }
-        protected System.DateTime RawTimestamp { get { throw null; } set { } }
+        protected internal System.DateTime RawTimestamp { get { throw null; } set { } }
         public string SenderName { get { throw null; } }
         public int ThreadId { get { throw null; } }
         public System.DateTime Timestamp { get { throw null; } }
@@ -253,6 +253,10 @@ namespace Microsoft.Build.Framework
         void IncludeEvaluationProfiles();
         void IncludeTaskInputs();
     }
+    public partial interface IEventSource4 : Microsoft.Build.Framework.IEventSource, Microsoft.Build.Framework.IEventSource2, Microsoft.Build.Framework.IEventSource3
+    {
+        void IncludeEvaluationPropertiesAndItems();
+    }
     public partial interface IForwardingLogger : Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
     {
         Microsoft.Build.Framework.IEventRedirector BuildEventRedirector { get; set; }
@@ -382,8 +386,11 @@ namespace Microsoft.Build.Framework
     {
         public ProjectEvaluationFinishedEventArgs() { }
         public ProjectEvaluationFinishedEventArgs(string message, params object[] messageArgs) { }
+        public System.Collections.IEnumerable GlobalProperties { get { throw null; } set { } }
+        public System.Collections.IEnumerable Items { get { throw null; } set { } }
         public Microsoft.Build.Framework.Profiler.ProfilerResult? ProfilerResult { get { throw null; } set { } }
         public string ProjectFile { get { throw null; } set { } }
+        public System.Collections.IEnumerable Properties { get { throw null; } set { } }
     }
     public partial class ProjectEvaluationStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Framework
         public Microsoft.Build.Framework.BuildEventContext BuildEventContext { get { throw null; } set { } }
         public string HelpKeyword { get { throw null; } }
         public virtual string Message { get { throw null; } protected set { } }
-        protected System.DateTime RawTimestamp { get { throw null; } set { } }
+        protected internal System.DateTime RawTimestamp { get { throw null; } set { } }
         public string SenderName { get { throw null; } }
         public int ThreadId { get { throw null; } }
         public System.DateTime Timestamp { get { throw null; } }
@@ -253,6 +253,10 @@ namespace Microsoft.Build.Framework
         void IncludeEvaluationProfiles();
         void IncludeTaskInputs();
     }
+    public partial interface IEventSource4 : Microsoft.Build.Framework.IEventSource, Microsoft.Build.Framework.IEventSource2, Microsoft.Build.Framework.IEventSource3
+    {
+        void IncludeEvaluationPropertiesAndItems();
+    }
     public partial interface IForwardingLogger : Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
     {
         Microsoft.Build.Framework.IEventRedirector BuildEventRedirector { get; set; }
@@ -381,8 +385,11 @@ namespace Microsoft.Build.Framework
     {
         public ProjectEvaluationFinishedEventArgs() { }
         public ProjectEvaluationFinishedEventArgs(string message, params object[] messageArgs) { }
+        public System.Collections.IEnumerable GlobalProperties { get { throw null; } set { } }
+        public System.Collections.IEnumerable Items { get { throw null; } set { } }
         public Microsoft.Build.Framework.Profiler.ProfilerResult? ProfilerResult { get { throw null; } set { } }
         public string ProjectFile { get { throw null; } set { } }
+        public System.Collections.IEnumerable Properties { get { throw null; } set { } }
     }
     public partial class ProjectEvaluationStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {

--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -227,6 +227,7 @@ namespace Microsoft.Build.Utilities
         public MuxLogger() { }
         public bool IncludeEvaluationMetaprojects { get { throw null; } set { } }
         public bool IncludeEvaluationProfiles { get { throw null; } set { } }
+        public bool IncludeEvaluationPropertiesAndItems { get { throw null; } set { } }
         public bool IncludeTaskInputs { get { throw null; } set { } }
         public string Parameters { get { throw null; } set { } }
         public Microsoft.Build.Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Build.Utilities
         public MuxLogger() { }
         public bool IncludeEvaluationMetaprojects { get { throw null; } set { } }
         public bool IncludeEvaluationProfiles { get { throw null; } set { } }
+        public bool IncludeEvaluationPropertiesAndItems { get { throw null; } set { } }
         public bool IncludeTaskInputs { get { throw null; } set { } }
         public string Parameters { get { throw null; } set { } }
         public Microsoft.Build.Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
@@ -198,6 +199,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// Should evaluation events include profiling information?
         /// </summary>
         public bool IncludeEvaluationProfile
+        {
+            get => false;
+            set { }
+        }
+
+        /// <summary>
+        /// Log properties and items on ProjectEvaluationFinishedEventArgs
+        /// instead of ProjectStartedEventArgs.
+        /// </summary>
+        public bool IncludeEvaluationPropertiesAndItems
         {
             get => false;
             set { }
@@ -459,7 +470,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <summary>
         /// Logs a project evaluation finished event
         /// </summary>
-        public void LogProjectEvaluationFinished(BuildEventContext projectEvaluationEventContext, string projectFile)
+        public void LogProjectEvaluationFinished(
+            BuildEventContext projectEvaluationEventContext,
+            string projectFile,
+            IEnumerable globalProperties,
+            IEnumerable properties,
+            IEnumerable items,
+            ProfilerResult? profilerResult)
         {
         }
 

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -254,7 +254,6 @@ namespace Microsoft.Build.UnitTests
 
             pc.Collection.RegisterLogger(logger);
 
-
             var p = pc.Collection.LoadProject(project.ProjectFile);
 
             BuildManager.DefaultBuildManager.Build(
@@ -266,12 +265,19 @@ namespace Microsoft.Build.UnitTests
             sc.ToString().ShouldContain("source_of_error : error : Hello from project 2 [" + project.ProjectFile + ":: Number=2]");
         }
 
-        [Fact]
-        public void ErrorMessageWithMultiplePropertiesInMessage()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ErrorMessageWithMultiplePropertiesInMessage(bool includeEvaluationPropertiesAndItems)
         {
             using var env = TestEnvironment.Create(_output);
 
             var pc = env.CreateProjectCollection();
+
+            if (includeEvaluationPropertiesAndItems)
+            {
+                pc.Collection.LoggingService.IncludeEvaluationPropertiesAndItems = true;
+            }
 
             var project = env.CreateTestProjectWithFiles(@"
          <Project>
@@ -300,7 +306,6 @@ namespace Microsoft.Build.UnitTests
 
             pc.Collection.RegisterLogger(logger);
 
-
             var p = pc.Collection.LoadProject(project.ProjectFile);
 
             BuildManager.DefaultBuildManager.Build(
@@ -308,8 +313,9 @@ namespace Microsoft.Build.UnitTests
                 new BuildRequestData(p.CreateProjectInstance(), new[] { "Spawn" }));
 
             p.Build().ShouldBeFalse();
-            sc.ToString().ShouldContain("source_of_error : error : Hello from project 1 [" + project.ProjectFile + ":: Number=1 TargetFramework=netcoreapp2.1]");
-            sc.ToString().ShouldContain("source_of_error : error : Hello from project 2 [" + project.ProjectFile + ":: Number=2 TargetFramework=netcoreapp2.1]");
+            string output = sc.ToString();
+            output.ShouldContain("source_of_error : error : Hello from project 1 [" + project.ProjectFile + ":: Number=1 TargetFramework=netcoreapp2.1]");
+            output.ShouldContain("source_of_error : error : Hello from project 2 [" + project.ProjectFile + ":: Number=2 TargetFramework=netcoreapp2.1]");
         }
 
         [Fact]

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2551,7 +2551,11 @@ namespace Microsoft.Build.Execution
 #if FEATURE_APPDOMAIN
                 , AppDomain.CurrentDomain.SetupInformation
 #endif
-                , new LoggingNodeConfiguration(loggingService.IncludeEvaluationMetaprojects, loggingService.IncludeEvaluationProfile, loggingService.IncludeTaskInputs)
+                , new LoggingNodeConfiguration(
+                    loggingService.IncludeEvaluationMetaprojects,
+                    loggingService.IncludeEvaluationProfile,
+                    loggingService.IncludeEvaluationPropertiesAndItems,
+                    loggingService.IncludeTaskInputs)
                 );
             }
 

--- a/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.BackEnd.Components.Logging
@@ -31,10 +34,10 @@ namespace Microsoft.Build.BackEnd.Components.Logging
         /// <summary>
         /// Log that the project has finished
         /// </summary>
-        internal void LogProjectEvaluationFinished()
+        internal void LogProjectEvaluationFinished(IEnumerable globalProperties, IEnumerable properties, IEnumerable items, ProfilerResult? profilerResult)
         {
             ErrorUtilities.VerifyThrow(IsValid, "invalid");
-            LoggingService.LogProjectEvaluationFinished(BuildEventContext, _projectFile);
+            LoggingService.LogProjectEvaluationFinished(BuildEventContext, _projectFile, globalProperties, properties, items, profilerResult);
             IsValid = false;
         }
     }

--- a/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.BackEnd.Logging
 #if FEATURE_APPDOMAIN
         MarshalByRefObject,
 #endif
-        IEventSource3, IBuildEventSink
+        IEventSource4, IBuildEventSink
     {
         #region Events
 
@@ -138,7 +138,6 @@ namespace Microsoft.Build.BackEnd.Logging
             private set;
         }
 
-
         /// <summary>
         /// Should evaluation events include profiling information?
         /// </summary>
@@ -152,6 +151,16 @@ namespace Microsoft.Build.BackEnd.Logging
         /// Should task events include task inputs?
         /// </summary>
         public bool IncludeTaskInputs
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Determines whether properties and items should be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
+        /// instead of <see cref="ProjectStartedEventArgs"/>
+        /// </summary>
+        public bool IncludeEvaluationPropertiesAndItems
         {
             get;
             private set;
@@ -176,6 +185,15 @@ namespace Microsoft.Build.BackEnd.Logging
         void IEventSource3.IncludeTaskInputs()
         {
             IncludeTaskInputs = true;
+        }
+
+        #endregion
+
+        #region IEventSource4 Methods
+
+        void IEventSource4.IncludeEvaluationPropertiesAndItems()
+        {
+            IncludeEvaluationPropertiesAndItems = true;
         }
 
         #endregion

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.Shared;
 
 using LoggerDescription = Microsoft.Build.Logging.LoggerDescription;
@@ -182,6 +183,16 @@ namespace Microsoft.Build.BackEnd.Logging
         /// Should evaluation events include profiling information?
         /// </summary>
         bool IncludeEvaluationProfile
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Should properties and items be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
+        /// instead of <see cref="ProjectStartedEventArgs"/>?
+        /// </summary>
+        bool IncludeEvaluationPropertiesAndItems
         {
             get;
             set;
@@ -421,8 +432,18 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         /// <param name="projectEvaluationEventContext">Event context for the project.</param>
         /// <param name="projectFile">Project file being built</param>
+        /// <param name="globalProperties">Global properties used for the evaluation.</param>
+        /// <param name="properties">Properties produced by the evaluation.</param>
+        /// <param name="items">Items produced by the evaluation.</param>
+        /// <param name="profilerResult">Profiler results if evaluation profiling was enabled.</param>
         /// <exception cref="InternalErrorException">BuildEventContext is null</exception>
-        void LogProjectEvaluationFinished(BuildEventContext projectEvaluationEventContext, string projectFile);
+        void LogProjectEvaluationFinished(
+            BuildEventContext projectEvaluationEventContext,
+            string projectFile,
+            IEnumerable globalProperties,
+            IEnumerable properties,
+            IEnumerable items,
+            ProfilerResult? profilerResult);
 
         /// <summary>
         /// Log that a project has started

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -197,6 +197,12 @@ namespace Microsoft.Build.BackEnd.Logging
         private bool? _includeEvaluationProfile;
 
         /// <summary>
+        /// Whether properties and items should be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
+        /// instead of <see cref="ProjectStartedEventArgs"/>.
+        /// </summary>
+        private bool? _includeEvaluationPropertiesAndItems;
+
+        /// <summary>
         /// Whether to include task inputs in task events.
         /// </summary>
         private bool? _includeTaskInputs;
@@ -500,6 +506,16 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             get => _includeTaskInputs ??= _eventSinkDictionary.Values.OfType<EventSourceSink>().Any(sink => sink.IncludeTaskInputs);
             set => _includeTaskInputs = value;
+        }
+
+        /// <summary>
+        /// Should properties and items be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
+        /// instead of <see cref="ProjectStartedEventArgs"/>?
+        /// </summary>
+        public bool IncludeEvaluationPropertiesAndItems
+        {
+            get => _includeEvaluationPropertiesAndItems ??= _eventSinkDictionary.Values.OfType<EventSourceSink>().Any(sink => sink.IncludeEvaluationPropertiesAndItems);
+            set => _includeEvaluationPropertiesAndItems = value;
         }
 
         /// <summary>
@@ -1151,7 +1167,11 @@ namespace Microsoft.Build.BackEnd.Logging
                 {
                     ErrorUtilities.VerifyThrow(_configCache.Value.HasConfiguration(projectStartedEventArgs.ProjectId), "Cannot find the project configuration while injecting non-serialized data from out-of-proc node.");
                     BuildRequestConfiguration buildRequestConfiguration = _configCache.Value[projectStartedEventArgs.ProjectId];
-                    s_projectStartedEventArgsGlobalProperties.Value.SetValue(projectStartedEventArgs, buildRequestConfiguration.GlobalProperties.ToDictionary(), null);
+                    if (!IncludeEvaluationPropertiesAndItems)
+                    {
+                        s_projectStartedEventArgsGlobalProperties.Value.SetValue(projectStartedEventArgs, buildRequestConfiguration.GlobalProperties.ToDictionary(), null);
+                    }
+
                     s_projectStartedEventArgsToolsVersion.Value.SetValue(projectStartedEventArgs, buildRequestConfiguration.ToolsVersion, null);
                 }
             }

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -9,6 +9,7 @@ using System.Collections;
 using Microsoft.Build.Shared;
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 using Microsoft.Build.Collections;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.BackEnd.Logging
 {
@@ -85,7 +86,9 @@ namespace Microsoft.Build.BackEnd.Logging
             string[] propertiesToSerialize = LoggingService.PropertiesToSerialize;
 
             // If we are only logging critical events lets not pass back the items or properties
-            if (!LoggingService.OnlyLogCriticalEvents && (!LoggingService.RunningOnRemoteNode || LoggingService.SerializeAllProperties))
+            if (!LoggingService.OnlyLogCriticalEvents &&
+                !LoggingService.IncludeEvaluationPropertiesAndItems &&
+                (!LoggingService.RunningOnRemoteNode || LoggingService.SerializeAllProperties))
             {
                 if (projectProperties != null)
                 {
@@ -101,7 +104,10 @@ namespace Microsoft.Build.BackEnd.Logging
                 items = new ProjectItemInstanceEnumeratorProxy(projectItemsEnumerator);
             }
 
-            if (projectProperties != null && propertiesToSerialize?.Length > 0 && !LoggingService.SerializeAllProperties)
+            if (projectProperties != null &&
+                !LoggingService.IncludeEvaluationPropertiesAndItems &&
+                propertiesToSerialize?.Length > 0 &&
+                !LoggingService.SerializeAllProperties)
             {
                 PropertyDictionary<ProjectPropertyInstance> projectPropertiesToSerialize = new PropertyDictionary<ProjectPropertyInstance>();
                 foreach (string propertyToGet in propertiesToSerialize)

--- a/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
+++ b/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
@@ -11,22 +11,27 @@ namespace Microsoft.Build.BackEnd
     {
         private bool _includeEvaluationMetaprojects;
         private bool _includeEvaluationProfiles;
+        private bool _includeEvaluationPropertiesAndItems;
         private bool _includeTaskInputs;
 
         public bool IncludeEvaluationMetaprojects => _includeEvaluationMetaprojects;
-
         public bool IncludeEvaluationProfiles => _includeEvaluationProfiles;
-
+        public bool IncludeEvaluationPropertiesAndItems => _includeEvaluationPropertiesAndItems;
         public bool IncludeTaskInputs => _includeTaskInputs;
 
         public LoggingNodeConfiguration()
         {
         }
 
-        public LoggingNodeConfiguration(bool includeEvaluationMetaprojects, bool includeEvaluationProfiles, bool includeTaskInputs)
+        public LoggingNodeConfiguration(
+            bool includeEvaluationMetaprojects,
+            bool includeEvaluationProfiles,
+            bool includeEvaluationPropertiesAndItems,
+            bool includeTaskInputs)
         {
             _includeEvaluationMetaprojects = includeEvaluationMetaprojects;
             _includeEvaluationProfiles = includeEvaluationProfiles;
+            _includeEvaluationPropertiesAndItems = includeEvaluationPropertiesAndItems;
             _includeTaskInputs = includeTaskInputs;
         }
 
@@ -34,6 +39,7 @@ namespace Microsoft.Build.BackEnd
         {
             translator.Translate(ref _includeEvaluationMetaprojects);
             translator.Translate(ref _includeEvaluationProfiles);
+            translator.Translate(ref _includeEvaluationPropertiesAndItems);
             translator.Translate(ref _includeTaskInputs);
         }
     }

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -716,6 +716,7 @@ namespace Microsoft.Build.Execution
             {
                 _loggingService.IncludeEvaluationMetaprojects = true;
             }
+
             if (configuration.LoggingNodeConfiguration.IncludeEvaluationProfiles)
             {
                 _loggingService.IncludeEvaluationProfile = true;
@@ -724,6 +725,11 @@ namespace Microsoft.Build.Execution
             if (configuration.LoggingNodeConfiguration.IncludeTaskInputs)
             {
                 _loggingService.IncludeTaskInputs = true;
+            }
+
+            if (configuration.LoggingNodeConfiguration.IncludeEvaluationPropertiesAndItems)
+            {
+                _loggingService.IncludeEvaluationPropertiesAndItems = true;
             }
 
             try

--- a/src/Build/Collections/ArrayDictionary.cs
+++ b/src/Build/Collections/ArrayDictionary.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Collections
     /// </summary>
     /// <typeparam name="TKey">Type of keys</typeparam>
     /// <typeparam name="TValue">Type of values</typeparam>
-    internal class ArrayDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary
+    internal class ArrayDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
     {
         private TKey[] keys;
         private TValue[] values;
@@ -64,6 +64,10 @@ namespace Microsoft.Build.Collections
         }
 
         public ICollection<TKey> Keys => keys;
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => values;
 
         ICollection IDictionary.Keys => keys;
 

--- a/src/Build/Collections/ItemDictionary.cs
+++ b/src/Build/Collections/ItemDictionary.cs
@@ -167,6 +167,30 @@ namespace Microsoft.Build.Collections
             return _itemLists.GetEnumerator();
         }
 
+        /// <summary>
+        /// Enumerates item lists per each item type under the lock.
+        /// </summary>
+        /// <param name="itemTypeCallback">
+        /// A delegate that accepts the item type string and a list of items of that type.
+        /// Will be called for each item type in the list.
+        /// </param>
+        internal void EnumerateItemsPerType(Action<string, IEnumerable<T>> itemTypeCallback)
+        {
+            lock (_itemLists)
+            {
+                foreach (var itemTypeBucket in _itemLists)
+                {
+                    if (itemTypeBucket.Value == null || itemTypeBucket.Value.Count == 0)
+                    {
+                        // skip empty markers
+                        continue;
+                    }
+
+                    itemTypeCallback(itemTypeBucket.Key, itemTypeBucket.Value);
+                }
+            }
+        }
+
         #region ItemDictionary<T> Members
 
         /// <summary>

--- a/src/Build/Collections/ItemDictionary.cs
+++ b/src/Build/Collections/ItemDictionary.cs
@@ -180,13 +180,10 @@ namespace Microsoft.Build.Collections
             {
                 foreach (var itemTypeBucket in _itemLists)
                 {
-                    if (itemTypeBucket.Value == null || itemTypeBucket.Value.Count == 0)
+                    if (itemTypeBucket.Value?.Any())
                     {
-                        // skip empty markers
-                        continue;
+                        itemTypeCallback(itemTypeBucket.Key, itemTypeBucket.Value);
                     }
-
-                    itemTypeCallback(itemTypeBucket.Key, itemTypeBucket.Value);
                 }
             }
         }

--- a/src/Build/Collections/ItemDictionary.cs
+++ b/src/Build/Collections/ItemDictionary.cs
@@ -180,10 +180,13 @@ namespace Microsoft.Build.Collections
             {
                 foreach (var itemTypeBucket in _itemLists)
                 {
-                    if (itemTypeBucket.Value?.Any())
+                    if (itemTypeBucket.Value == null || itemTypeBucket.Value.Count == 0)
                     {
-                        itemTypeCallback(itemTypeBucket.Key, itemTypeBucket.Value);
+                        // skip empty markers
+                        continue;
                     }
+
+                    itemTypeCallback(itemTypeBucket.Key, itemTypeBucket.Value);
                 }
             }
         }

--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -492,22 +492,33 @@ namespace Microsoft.Build.Collections
 
         /// <summary>
         /// Helper to convert into a read-only dictionary of string, string.
+        /// TODO: for performance, consider switching to returning IDictionary
+        /// and returning ArrayDictionary if lookup of results is not needed.
         /// </summary>
         internal Dictionary<string, string> ToDictionary()
         {
-            Dictionary<string, string> dictionary;
-
             lock (_properties)
             {
-                dictionary = new Dictionary<string, string>(_properties.Count, MSBuildNameIgnoreCaseComparer.Default);
+                var dictionary = new Dictionary<string, string>(_properties.Count, MSBuildNameIgnoreCaseComparer.Default);
 
                 foreach (T property in this)
                 {
                     dictionary[property.Key] = property.EscapedValue;
                 }
-            }
 
-            return dictionary;
+                return dictionary;
+            }
+        }
+
+        internal void Enumerate(Action<string, string> keyValueCallback)
+        {
+            lock (_properties)
+            {
+                foreach (var kvp in _properties)
+                {
+                    keyValueCallback(kvp.Key, EscapingUtilities.UnescapeAll(kvp.EscapedValue));
+                }
+            }
         }
     }
 }

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1795,7 +1795,7 @@ namespace Microsoft.Build.Evaluation
         /// The ReusableLogger wraps a logger and allows it to be used for both design-time and build-time.  It internally swaps
         /// between the design-time and build-time event sources in response to Initialize and Shutdown events.
         /// </summary>
-        internal class ReusableLogger : INodeLogger, IEventSource3
+        internal class ReusableLogger : INodeLogger, IEventSource4
         {
             /// <summary>
             /// The logger we are wrapping.
@@ -1892,6 +1892,8 @@ namespace Microsoft.Build.Evaluation
             private bool _includeEvaluationProfiles;
 
             private bool _includeTaskInputs;
+
+            private bool _includeEvaluationPropertiesAndItems;
 
             /// <summary>
             /// Constructor.
@@ -2032,6 +2034,22 @@ namespace Microsoft.Build.Evaluation
 
                 _includeTaskInputs = true;
             }
+
+            public void IncludeEvaluationPropertiesAndItems()
+            {
+                if (_buildTimeEventSource is IEventSource4 buildEventSource4)
+                {
+                    buildEventSource4.IncludeEvaluationPropertiesAndItems();
+                }
+
+                if (_designTimeEventSource is IEventSource4 designTimeEventSource4)
+                {
+                    designTimeEventSource4.IncludeEvaluationPropertiesAndItems();
+                }
+
+                _includeEvaluationPropertiesAndItems = true;
+            }
+
             #endregion
 
             #region ILogger Members
@@ -2164,6 +2182,7 @@ namespace Microsoft.Build.Evaluation
                     {
                         eventSource3.IncludeEvaluationMetaprojects();
                     }
+
                     if (_includeEvaluationProfiles)
                     {
                         eventSource3.IncludeEvaluationProfiles();
@@ -2172,6 +2191,14 @@ namespace Microsoft.Build.Evaluation
                     if (_includeTaskInputs)
                     {
                         eventSource3.IncludeTaskInputs();
+                    }
+                }
+
+                if (eventSource is IEventSource4 eventSource4)
+                {
+                    if (_includeEvaluationPropertiesAndItems)
+                    {
+                        eventSource4.IncludeEvaluationPropertiesAndItems();
                     }
                 }
             }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using ObjectModel = System.Collections.ObjectModel;
@@ -777,12 +778,23 @@ namespace Microsoft.Build.Evaluation
             }
 
             ErrorUtilities.VerifyThrow(_evaluationProfiler.IsEmpty(), "Evaluation profiler stack is not empty.");
-            _evaluationLoggingContext.LogBuildEvent(new ProjectEvaluationFinishedEventArgs(ResourceUtilities.GetResourceString("EvaluationFinished"), projectFile)
+
+            IEnumerable globalProperties = null;
+            IEnumerable properties = null;
+            IEnumerable items = null;
+
+            if (this._evaluationLoggingContext.LoggingService.IncludeEvaluationPropertiesAndItems)
             {
-                BuildEventContext = _evaluationLoggingContext.BuildEventContext,
-                ProjectFile = projectFile,
-                ProfilerResult = _evaluationProfiler.ProfiledResult
-            });
+                if (_data.GlobalPropertiesDictionary.Count > 0)
+                {
+                    globalProperties = _data.GlobalPropertiesDictionary;
+                }
+
+                properties = _data.Properties;
+                items = _data.Items;
+            }
+
+            _evaluationLoggingContext.LogProjectEvaluationFinished(globalProperties, properties, items, _evaluationProfiler.ProfiledResult);
         }
 
         private void CollectProjectCachePlugins()

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -999,7 +999,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Gets the global properties
+        /// Gets the properties
         /// </summary>
         PropertyDictionary<ProjectPropertyInstance> IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.Properties
         {
@@ -1009,7 +1009,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Gets the global properties
+        /// Gets the item definitions
         /// </summary>
         IEnumerable<ProjectItemDefinitionInstance> IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.ItemDefinitionsEnumerable
         {

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -527,10 +527,9 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             // Gather a sorted list of all the properties.
             var list = new List<DictionaryEntry>(properties.FastCountOrZero());
-            foreach (DictionaryEntry prop in properties)
-            {
-                list.Add(prop);
-            }
+
+            Internal.Utilities.EnumerateProperties(properties, kvp => list.Add(new DictionaryEntry(kvp.Key, kvp.Value)));
+
             list.Sort(new DictionaryEntryKeyComparer());
             return list;
         }
@@ -620,18 +619,19 @@ namespace Microsoft.Build.BackEnd.Logging
             // Use a SortedList instead of an ArrayList (because we need to lookup fast)
             // and instead of a Hashtable (because we need to sort it)
             SortedList itemTypes = new SortedList(CaseInsensitiveComparer.Default);
-            foreach (DictionaryEntry item in items)
+
+            Internal.Utilities.EnumerateItems(items, item =>
             {
-                // Create a new list for this itemtype, if we haven't already
-                if (itemTypes[(string)item.Key] == null)
+                string key = (string)item.Key;
+                var bucket = itemTypes[key] as ArrayList;
+                if (bucket == null)
                 {
-                    itemTypes[(string)item.Key] = new ArrayList();
+                    bucket = new ArrayList();
+                    itemTypes[key] = bucket;
                 }
 
-                // Add the item to the list for its itemtype
-                ArrayList itemsOfAType = (ArrayList)itemTypes[(string)item.Key];
-                itemsOfAType.Add(item.Value);
-            }
+                bucket.Add(item.Value);
+            });
 
             return itemTypes;
         }

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -43,7 +43,9 @@ namespace Microsoft.Build.Logging
         //                        where a list used to be written in-place
         // version 11:
         //   - new record kind: TaskParameterEventArgs
-        internal const int FileFormatVersion = 11;
+        // version 12:
+        //   - add GlobalProperties, Properties and Items on ProjectEvaluationFinished
+        internal const int FileFormatVersion = 12;
 
         private Stream stream;
         private BinaryWriter binaryWriter;
@@ -103,6 +105,7 @@ namespace Microsoft.Build.Logging
             Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", "true");
             Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", "1");
             Traits.Instance.EscapeHatches.LogProjectImports = true;
+            bool logPropertiesAndItemsAfterEvaluation = Traits.Instance.EscapeHatches.LogPropertiesAndItemsAfterEvaluation ?? true;
 
             ProcessParameters();
 
@@ -134,6 +137,11 @@ namespace Microsoft.Build.Logging
                 if (eventSource is IEventSource3 eventSource3)
                 {
                     eventSource3.IncludeEvaluationMetaprojects();
+                }
+
+                if (logPropertiesAndItemsAfterEvaluation && eventSource is IEventSource4 eventSource4)
+                {
+                    eventSource4.IncludeEvaluationPropertiesAndItems();
                 }
             }
             catch (Exception e)

--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -571,24 +571,35 @@ namespace Microsoft.Build.BackEnd.Logging
 
         public override void StatusEventHandler(object sender, BuildStatusEventArgs e)
         {
-            if (showPerfSummary)
+            if (e is ProjectEvaluationStartedEventArgs projectEvaluationStarted)
             {
-                ProjectEvaluationStartedEventArgs projectEvaluationStarted = e as ProjectEvaluationStartedEventArgs;
-
-                if (projectEvaluationStarted != null)
+                if (showPerfSummary)
                 {
                     PerformanceCounter counter = GetPerformanceCounter(projectEvaluationStarted.ProjectFile, ref projectEvaluationPerformanceCounters);
                     counter.InScope = true;
-
-                    return;
                 }
-
-                ProjectEvaluationFinishedEventArgs projectEvaluationFinished = e as ProjectEvaluationFinishedEventArgs;
-
-                if (projectEvaluationFinished != null)
+            }
+            else if (e is ProjectEvaluationFinishedEventArgs projectEvaluationFinished)
+            {
+                if (showPerfSummary)
                 {
                     PerformanceCounter counter = GetPerformanceCounter(projectEvaluationFinished.ProjectFile, ref projectEvaluationPerformanceCounters);
                     counter.InScope = false;
+                }
+
+                if (Verbosity == LoggerVerbosity.Diagnostic && showItemAndPropertyList)
+                {
+                    if (projectEvaluationFinished.Properties != null)
+                    {
+                        var propertyList = ExtractPropertyList(projectEvaluationFinished.Properties);
+                        WriteProperties(propertyList);
+                    }
+
+                    if (projectEvaluationFinished.Items != null)
+                    {
+                        SortedList itemList = ExtractItemList(projectEvaluationFinished.Items);
+                        WriteItems(itemList);
+                    }
                 }
             }
         }

--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -719,12 +719,10 @@ namespace Microsoft.Build.Internal
                         }
                     }
 
-                    if (string.IsNullOrEmpty(itemType))
+                    if (!String.IsNullOrEmpty(itemType))
                     {
-                        continue;
+                        callback(new DictionaryEntry(itemType, itemValue));
                     }
-
-                    callback(new DictionaryEntry(itemType, itemValue));
                 }
             }
         }

--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -2,16 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Xml;
+using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml;
 
 using Microsoft.Build.Collections;
-using Microsoft.Build.Execution;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
 using Toolset = Microsoft.Build.Evaluation.Toolset;
 using XmlElementWithLocation = Microsoft.Build.Construction.XmlElementWithLocation;
@@ -654,6 +655,14 @@ namespace Microsoft.Build.Internal
                     }
                     else
                     {
+                        if (item == null)
+                        {
+                            Debug.Fail($"In {nameof(EnumerateProperties)}(): Unexpected: property is null");
+                        }
+                        else
+                        {
+                            Debug.Fail($"In {nameof(EnumerateProperties)}(): Unexpected property {item} of type {item?.GetType().ToString()}");
+                        }
                     }
                 }
             }
@@ -700,6 +709,14 @@ namespace Microsoft.Build.Internal
                     }
                     else
                     {
+                        if (item == null)
+                        {
+                            Debug.Fail($"In {nameof(EnumerateProperties)}(): Unexpected: {nameof(item)} is null");
+                        }
+                        else
+                        {
+                            Debug.Fail($"In {nameof(EnumerateProperties)}(): Unexpected {nameof(item)} {item} of type {item?.GetType().ToString()}");
+                        }
                     }
 
                     if (string.IsNullOrEmpty(itemType))

--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -711,11 +711,11 @@ namespace Microsoft.Build.Internal
                     {
                         if (item == null)
                         {
-                            Debug.Fail($"In {nameof(EnumerateProperties)}(): Unexpected: {nameof(item)} is null");
+                            Debug.Fail($"In {nameof(EnumerateItems)}(): Unexpected: {nameof(item)} is null");
                         }
                         else
                         {
-                            Debug.Fail($"In {nameof(EnumerateProperties)}(): Unexpected {nameof(item)} {item} of type {item?.GetType().ToString()}");
+                            Debug.Fail($"In {nameof(EnumerateItems)}(): Unexpected {nameof(item)} {item} of type {item?.GetType().ToString()}");
                         }
                     }
 

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Framework
         /// Used for serialization. Avoids the side effects of calling the
         /// <see cref="Timestamp"/> getter.
         /// </summary>
-        protected DateTime RawTimestamp
+        protected internal DateTime RawTimestamp
         {
             get => timestamp;
             set => timestamp = value;

--- a/src/Framework/IEventSource4.cs
+++ b/src/Framework/IEventSource4.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// This interface defines the events raised by the build engine.
+    /// Loggers use this interface to subscribe to the events they
+    /// are interested in receiving.
+    /// </summary>
+    public interface IEventSource4 : IEventSource3
+    {
+        /// <summary>
+        /// Determines whether properties and items should be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
+        /// instead of <see cref="ProjectStartedEventArgs"/>.
+        /// </summary>
+        void IncludeEvaluationPropertiesAndItems();
+    }
+}

--- a/src/Framework/ProjectEvaluationFinishedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationFinishedEventArgs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using Microsoft.Build.Framework.Profiler;
 
 namespace Microsoft.Build.Framework
@@ -23,7 +24,7 @@ namespace Microsoft.Build.Framework
         /// Initializes a new instance of the ProjectEvaluationFinishedEventArgs class.
         /// </summary>
         public ProjectEvaluationFinishedEventArgs(string message, params object[] messageArgs)
-            : base(message, null, null, DateTime.UtcNow, messageArgs)
+            : base(message, helpKeyword: null, senderName: null, DateTime.UtcNow, messageArgs)
         {
         }
 
@@ -33,11 +34,26 @@ namespace Microsoft.Build.Framework
         public string ProjectFile { get; set; }
 
         /// <summary>
+        /// Global properties used during this evaluation.
+        /// </summary>
+        public IEnumerable GlobalProperties { get; set; }
+
+        /// <summary>
+        /// Final set of properties produced by this evaluation.
+        /// </summary>
+        public IEnumerable Properties { get; set; }
+
+        /// <summary>
+        /// Final set of items produced by this evaluation.
+        /// </summary>
+        public IEnumerable Items { get; set; }
+
+        /// <summary>
         /// The result of profiling a project.
         /// </summary>
         /// <remarks>
         /// Null if profiling is not turned on
         /// </remarks>
-        public ProfilerResult? ProfilerResult { get; set; } 
+        public ProfilerResult? ProfilerResult { get; set; }
     }
 }

--- a/src/Framework/ProjectEvaluationStartedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationStartedEventArgs.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Framework
         /// Initializes a new instance of the ProjectEvaluationStartedEventArgs class.
         /// </summary>
         public ProjectEvaluationStartedEventArgs(string message, params object[] messageArgs)
-            : base(message, null, null, DateTime.UtcNow, messageArgs)
+            : base(message, helpKeyword: null, senderName: null, DateTime.UtcNow, messageArgs)
         {
         }
 

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -40,6 +40,7 @@
     <AddAppConfigToBuildOutputs>false</AddAppConfigToBuildOutputs>
 
     <DebugType Condition="'$(Platform)' == 'x64'">full</DebugType><!-- Setting DebugType here goes hand in hand with eng\AfterSigning.targets. This is to prompt the x64 build to produce a 'full' .pdb that's `more compatible` then 'portable' and 'embedded' .pdbs. This doesn't get set on 32 bit architecture, which will default to 'embedded' and 'pdb2pdb' will convert those as needed. See https://github.com/microsoft/msbuild/pull/5070 for context. -->
+    <DefineConstants>$(DefineConstants);MSBUILDENTRYPOINTEXE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -2,12 +2,21 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 
-using Microsoft.Build.Framework;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Framework;
+
+#if !TASKHOST
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework.Profiler;
+using Microsoft.Build.Execution;
+#endif
+
 #if FEATURE_APPDOMAIN
 using TaskEngineAssemblyResolver = Microsoft.Build.BackEnd.Logging.TaskEngineAssemblyResolver;
 #endif
@@ -95,6 +104,16 @@ namespace Microsoft.Build.Shared
         /// Event is a TaskParameterEventArgs
         /// </summary>
         TaskParameterEvent = 13,
+
+        /// <summary>
+        /// Event is a ProjectEvaluationStartedEventArgs
+        /// </summary>
+        ProjectEvaluationStartedEvent = 14,
+
+        /// <summary>
+        /// Event is a ProjectEvaluationFinishedEventArgs
+        /// </summary>
+        ProjectEvaluationFinishedEvent = 15
     }
     #endregion
 
@@ -296,6 +315,17 @@ namespace Microsoft.Build.Shared
                 translator.Translate(ref packetVersion);
 
                 bool eventCanSerializeItself = methodInfo != null;
+
+#if !TASKHOST && !MSBUILDENTRYPOINTEXE
+                if (_buildEvent is ProjectEvaluationStartedEventArgs ||
+                    _buildEvent is ProjectEvaluationFinishedEventArgs)
+                {
+                    // switch to serialization methods that we provide in this file
+                    // and don't use the WriteToStream inherited from LazyFormattedBuildEventArgs
+                    eventCanSerializeItself = false;
+                }
+#endif
+
                 translator.Translate(ref eventCanSerializeItself);
 
                 if (eventCanSerializeItself)
@@ -493,6 +523,10 @@ namespace Microsoft.Build.Shared
 #if !TASKHOST // MSBuildTaskHost is targeting Microsoft.Build.Framework.dll 3.5
                 case LoggingEventType.TaskParameterEvent:
                     return new TaskParameterEventArgs(0, null, null, true, default);
+                case LoggingEventType.ProjectEvaluationStartedEvent:
+                    return new ProjectEvaluationStartedEventArgs();
+                case LoggingEventType.ProjectEvaluationFinishedEvent:
+                    return new ProjectEvaluationFinishedEventArgs();
 #endif
                 default:
                     ErrorUtilities.VerifyThrow(false, "Should not get to the default of GetBuildEventArgFromId ID: " + _eventType);
@@ -532,6 +566,16 @@ namespace Microsoft.Build.Shared
             {
                 return LoggingEventType.ProjectStartedEvent;
             }
+#if !TASKHOST
+            else if (eventType == typeof(ProjectEvaluationFinishedEventArgs))
+            {
+                return LoggingEventType.ProjectEvaluationFinishedEvent;
+            }
+            else if (eventType == typeof(ProjectEvaluationStartedEventArgs))
+            {
+                return LoggingEventType.ProjectEvaluationStartedEvent;
+            }
+#endif
             else if (eventType == typeof(TargetStartedEventArgs))
             {
                 return LoggingEventType.TargetStartedEvent;
@@ -576,6 +620,19 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private void WriteEventToStream(BuildEventArgs buildEvent, LoggingEventType eventType, ITranslator translator)
         {
+#if !TASKHOST && !MSBUILDENTRYPOINTEXE
+            if (eventType == LoggingEventType.ProjectEvaluationStartedEvent)
+            {
+                WriteProjectEvaluationStartedEventToStream((ProjectEvaluationStartedEventArgs)buildEvent, translator);
+                return;
+            }
+            else if (eventType == LoggingEventType.ProjectEvaluationFinishedEvent)
+            {
+                WriteProjectEvaluationFinishedEventToStream((ProjectEvaluationFinishedEventArgs)buildEvent, translator);
+                return;
+            }
+#endif
+
             string message = buildEvent.Message;
             string helpKeyword = buildEvent.HelpKeyword;
             string senderName = buildEvent.SenderName;
@@ -715,6 +772,207 @@ namespace Microsoft.Build.Shared
             translator.TranslateEnum(ref importance, (int)importance);
         }
 
+#if !TASKHOST && !MSBUILDENTRYPOINTEXE
+        private void WriteProjectEvaluationStartedEventToStream(ProjectEvaluationStartedEventArgs args, ITranslator translator)
+        {
+            WriteEvaluationEvent(args, args.ProjectFile, args.RawTimestamp, translator);
+        }
+
+        private void WriteProjectEvaluationFinishedEventToStream(ProjectEvaluationFinishedEventArgs args, ITranslator translator)
+        {
+            WriteEvaluationEvent(args, args.ProjectFile, args.RawTimestamp, translator);
+
+            WriteProperties(args.GlobalProperties, translator);
+            WriteProperties(args.Properties, translator);
+            WriteItems(args.Items, translator);
+            WriteProfileResult(args.ProfilerResult, translator);
+        }
+
+        private static void WriteEvaluationEvent(BuildStatusEventArgs args, string projectFile, DateTime timestamp, ITranslator translator)
+        {
+            var buildEventContext = args.BuildEventContext;
+            translator.Translate(ref buildEventContext);
+            translator.Translate(ref timestamp);
+            translator.Translate(ref projectFile);
+        }
+
+        private void WriteProfileResult(ProfilerResult? result, ITranslator translator)
+        {
+            bool hasValue = result.HasValue;
+            translator.Translate(ref hasValue);
+            if (hasValue)
+            {
+                var value = result.Value;
+                var count = value.ProfiledLocations.Count;
+                translator.Translate(ref count);
+
+                foreach (var item in value.ProfiledLocations)
+                {
+                    WriteEvaluationLocation(translator, item.Key);
+                    WriteProfiledLocation(translator, item.Value);
+                }
+            }
+        }
+
+        private void WriteEvaluationLocation(ITranslator translator, EvaluationLocation evaluationLocation)
+        {
+            string elementName = evaluationLocation.ElementName;
+            string elementDescription = evaluationLocation.ElementDescription;
+            string evaluationPassDescription = evaluationLocation.EvaluationPassDescription;
+            string file = evaluationLocation.File;
+            int kind = (int)evaluationLocation.Kind;
+            int evaluationPass = (int)evaluationLocation.EvaluationPass;
+            bool lineHasValue = evaluationLocation.Line.HasValue;
+            int line = lineHasValue ? evaluationLocation.Line.Value : 0;
+            long id = evaluationLocation.Id;
+            bool parentIdHasValue = evaluationLocation.ParentId.HasValue;
+            long parentId = parentIdHasValue ? evaluationLocation.ParentId.Value : 0;
+
+            translator.Translate(ref elementName);
+            translator.Translate(ref elementDescription);
+            translator.Translate(ref evaluationPassDescription);
+            translator.Translate(ref file);
+
+            translator.Translate(ref kind);
+            translator.Translate(ref evaluationPass);
+
+            translator.Translate(ref lineHasValue);
+            if (lineHasValue)
+            {
+                translator.Translate(ref line);
+            }
+
+            translator.Translate(ref id);
+            translator.Translate(ref parentIdHasValue);
+            if (parentIdHasValue)
+            {
+                translator.Translate(ref parentId);
+            }
+        }
+
+        private void WriteProfiledLocation(ITranslator translator, ProfiledLocation profiledLocation)
+        {
+            int numberOfHits = profiledLocation.NumberOfHits;
+            TimeSpan exclusiveTime = profiledLocation.ExclusiveTime;
+            TimeSpan inclusiveTime = profiledLocation.InclusiveTime;
+            translator.Translate(ref numberOfHits);
+            translator.Translate(ref exclusiveTime);
+            translator.Translate(ref inclusiveTime);
+        }
+
+        [ThreadStatic]
+        private static List<KeyValuePair<string, string>> reusablePropertyList;
+
+        [ThreadStatic]
+        private static List<(string itemType, object item)> reusableItemList;
+
+        private void WriteProperties(IEnumerable properties, ITranslator translator)
+        {
+            var writer = translator.Writer;
+            if (properties == null)
+            {
+                writer.Write((byte)0);
+                return;
+            }
+
+            if (reusablePropertyList == null)
+            {
+                reusablePropertyList = new List<KeyValuePair<string, string>>();
+            }
+
+            // it is expensive to access a ThreadStatic field every time
+            var list = reusablePropertyList;
+
+            Internal.Utilities.EnumerateProperties(properties, kvp => list.Add(kvp));
+
+            BinaryWriterExtensions.Write7BitEncodedInt(writer, list.Count);
+
+            foreach (var item in list)
+            {
+                writer.Write(item.Key);
+                writer.Write(item.Value);
+            }
+
+            list.Clear();
+        }
+
+        private void WriteItems(IEnumerable items, ITranslator translator)
+        {
+            var writer = translator.Writer;
+            if (items == null)
+            {
+                writer.Write((byte)0);
+                return;
+            }
+
+            if (reusableItemList == null)
+            {
+                reusableItemList = new List<(string itemType, object item)>();
+            }
+
+            var list = reusableItemList;
+
+            Internal.Utilities.EnumerateItems(items, dictionaryEntry =>
+            {
+                list.Add((dictionaryEntry.Key as string, dictionaryEntry.Value));
+            });
+
+            BinaryWriterExtensions.Write7BitEncodedInt(writer, list.Count);
+
+            foreach (var kvp in list)
+            {
+                writer.Write(kvp.itemType);
+                if (kvp.item is ITaskItem taskItem)
+                {
+                    writer.Write(taskItem.ItemSpec);
+                    WriteMetadata(taskItem, writer);
+                }
+                else
+                {
+                    writer.Write(kvp.item?.ToString() ?? "");
+                    writer.Write((byte)0);
+                }
+            }
+
+            list.Clear();
+        }
+
+        private void WriteMetadata(object metadataContainer, BinaryWriter writer)
+        {
+            if (metadataContainer is ITaskItem taskItem)
+            {
+                var metadata = taskItem.EnumerateMetadata();
+
+                if (reusablePropertyList == null)
+                {
+                    reusablePropertyList = new List<KeyValuePair<string, string>>();
+                }
+
+                // it is expensive to access a ThreadStatic field every time
+                var list = reusablePropertyList;
+
+                foreach (var item in metadata)
+                {
+                    list.Add(item);
+                }
+
+                BinaryWriterExtensions.Write7BitEncodedInt(writer, list.Count);
+                foreach (var kvp in list)
+                {
+                    writer.Write(kvp.Key ?? string.Empty);
+                    writer.Write(kvp.Value ?? string.Empty);
+                }
+
+                list.Clear();
+            }
+            else
+            {
+                writer.Write((byte)0);
+            }
+        }
+
+#endif
+
         #endregion
 
         #region Reads from Stream
@@ -725,6 +983,17 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private BuildEventArgs ReadEventFromStream(LoggingEventType eventType, ITranslator translator)
         {
+#if !TASKHOST && !MSBUILDENTRYPOINTEXE
+            if (eventType == LoggingEventType.ProjectEvaluationStartedEvent)
+            {
+                return ReadProjectEvaluationStartedEventFromStream(translator);
+            }
+            else if (eventType == LoggingEventType.ProjectEvaluationFinishedEvent)
+            {
+                return ReadProjectEvaluationFinishedEventFromStream(translator);
+            }
+#endif
+
             string message = null;
             string helpKeyword = null;
             string senderName = null;
@@ -920,6 +1189,213 @@ namespace Microsoft.Build.Shared
             BuildMessageEventArgs buildEvent = new BuildMessageEventArgs(message, helpKeyword, senderName, importance);
             return buildEvent;
         }
+
+#if !TASKHOST && !MSBUILDENTRYPOINTEXE
+        private ProjectEvaluationStartedEventArgs ReadProjectEvaluationStartedEventFromStream(ITranslator translator)
+        {
+            var (buildEventContext, timestamp, projectFile) = ReadEvaluationEvent(translator);
+
+            var args = new ProjectEvaluationStartedEventArgs(
+                ResourceUtilities.GetResourceString("EvaluationStarted"), projectFile);
+
+            args.BuildEventContext = buildEventContext;
+            args.RawTimestamp = timestamp;
+            args.ProjectFile = projectFile;
+
+            return args;
+        }
+
+        private ProjectEvaluationFinishedEventArgs ReadProjectEvaluationFinishedEventFromStream(ITranslator translator)
+        {
+            var (buildEventContext, timestamp, projectFile) = ReadEvaluationEvent(translator);
+
+            var args = new ProjectEvaluationFinishedEventArgs(
+                ResourceUtilities.GetResourceString("EvaluationFinished"), projectFile);
+
+            args.BuildEventContext = buildEventContext;
+            args.RawTimestamp = timestamp;
+            args.ProjectFile = projectFile;
+
+            args.GlobalProperties = ReadProperties(translator);
+            args.Properties = ReadProperties(translator);
+            args.Items = ReadItems(translator);
+            args.ProfilerResult = ReadProfileResult(translator);
+
+            return args;
+        }
+
+        private (BuildEventContext buildEventContext, DateTime timestamp, string projectFile)
+            ReadEvaluationEvent(ITranslator translator)
+        {
+            BuildEventContext buildEventContext = null;
+            translator.Translate(ref buildEventContext);
+
+            DateTime timestamp = default;
+            translator.Translate(ref timestamp);
+
+            string projectFile = null;
+            translator.Translate(ref projectFile);
+
+            return (buildEventContext, timestamp, projectFile);
+        }
+
+        private IEnumerable ReadProperties(ITranslator translator)
+        {
+            var reader = translator.Reader;
+            int count = BinaryReaderExtensions.Read7BitEncodedInt(reader);
+            if (count == 0)
+            {
+                return Array.Empty<DictionaryEntry>();
+            }
+
+            var list = new ArrayList(count);
+            for (int i = 0; i < count; i++)
+            {
+                string key = reader.ReadString();
+                string value = reader.ReadString();
+                var entry = new DictionaryEntry(key, value);
+                list.Add(entry);
+            }
+
+            return list;
+        }
+
+        private IEnumerable ReadItems(ITranslator translator)
+        {
+            var reader = translator.Reader;
+
+            int count = BinaryReaderExtensions.Read7BitEncodedInt(reader);
+            if (count == 0)
+            {
+                return Array.Empty<DictionaryEntry>();
+            }
+
+            var list = new ArrayList(count);
+            for (int i = 0; i < count; i++)
+            {
+                string itemType = reader.ReadString();
+                string evaluatedValue = reader.ReadString();
+                var metadata = ReadMetadata(reader);
+                var taskItemData = new TaskItemData(evaluatedValue, metadata);
+                var entry = new DictionaryEntry(itemType, taskItemData);
+                list.Add(entry);
+            }
+
+            return list;
+        }
+
+        private IDictionary<string, string> ReadMetadata(BinaryReader reader)
+        {
+            int count = BinaryReaderExtensions.Read7BitEncodedInt(reader);
+            if (count == 0)
+            {
+                return null;
+            }
+
+            var list = ArrayDictionary<string, string>.Create(count);
+            for (int i = 0; i < count; i++)
+            {
+                string key = reader.ReadString();
+                string value = reader.ReadString();
+                list.Add(key, value);
+            }
+
+            return list;
+        }
+
+        private ProfilerResult? ReadProfileResult(ITranslator translator)
+        {
+            bool hasValue = false;
+            translator.Translate(ref hasValue);
+            if (!hasValue)
+            {
+                return null;
+            }
+
+            int count = 0;
+            translator.Translate(ref count);
+
+            var dictionary = new ArrayDictionary<EvaluationLocation, ProfiledLocation>(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                var evaluationLocation = ReadEvaluationLocation(translator);
+                var profiledLocation = ReadProfiledLocation(translator);
+                dictionary.Add(evaluationLocation, profiledLocation);
+            }
+
+            var result = new ProfilerResult(dictionary);
+            return result;
+        }
+
+        private EvaluationLocation ReadEvaluationLocation(ITranslator translator)
+        {
+            string elementName = default;
+            string elementDescription = default;
+            string evaluationPassDescription = default;
+            string file = default;
+            int kind = default;
+            int evaluationPass = default;
+            bool lineHasValue = default;
+            int line = default;
+            long id = default;
+            bool parentIdHasValue = default;
+            long parentId = default;
+
+            translator.Translate(ref elementName);
+            translator.Translate(ref elementDescription);
+            translator.Translate(ref evaluationPassDescription);
+            translator.Translate(ref file);
+
+            translator.Translate(ref kind);
+            translator.Translate(ref evaluationPass);
+
+            translator.Translate(ref lineHasValue);
+            if (lineHasValue)
+            {
+                translator.Translate(ref line);
+            }
+
+            translator.Translate(ref id);
+            translator.Translate(ref parentIdHasValue);
+            if (parentIdHasValue)
+            {
+                translator.Translate(ref parentId);
+            }
+
+            var evaluationLocation = new EvaluationLocation(
+                id,
+                parentIdHasValue ? parentId : null,
+                (EvaluationPass)evaluationPass,
+                evaluationPassDescription,
+                file,
+                lineHasValue ? line : null,
+                elementName,
+                elementDescription,
+                (EvaluationLocationKind)kind);
+
+            return evaluationLocation;
+        }
+
+        private ProfiledLocation ReadProfiledLocation(ITranslator translator)
+        {
+            int numberOfHits = default;
+            TimeSpan exclusiveTime = default;
+            TimeSpan inclusiveTime = default;
+
+            translator.Translate(ref numberOfHits);
+            translator.Translate(ref exclusiveTime);
+            translator.Translate(ref inclusiveTime);
+
+            var profiledLocation = new ProfiledLocation(
+                inclusiveTime,
+                exclusiveTime,
+                numberOfHits);
+
+            return profiledLocation;
+        }
+
+#endif
 
         #endregion
 

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -494,44 +494,27 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private BuildEventArgs GetBuildEventArgFromId()
         {
-            switch (_eventType)
+            return _eventType switch
             {
-                case LoggingEventType.BuildErrorEvent:
-                    return new BuildErrorEventArgs(null, null, null, -1, -1, -1, -1, null, null, null);
-                case LoggingEventType.BuildFinishedEvent:
-                    return new BuildFinishedEventArgs(null, null, false);
-                case LoggingEventType.BuildMessageEvent:
-                    return new BuildMessageEventArgs(null, null, null, MessageImportance.Normal);
-                case LoggingEventType.BuildStartedEvent:
-                    return new BuildStartedEventArgs(null, null);
-                case LoggingEventType.BuildWarningEvent:
-                    return new BuildWarningEventArgs(null, null, null, -1, -1, -1, -1, null, null, null);
-                case LoggingEventType.ProjectFinishedEvent:
-                    return new ProjectFinishedEventArgs(null, null, null, false);
-                case LoggingEventType.ProjectStartedEvent:
-                    return new ProjectStartedEventArgs(null, null, null, null, null, null);
-                case LoggingEventType.TargetStartedEvent:
-                    return new TargetStartedEventArgs(null, null, null, null, null);
-                case LoggingEventType.TargetFinishedEvent:
-                    return new TargetFinishedEventArgs(null, null, null, null, null, false);
-                case LoggingEventType.TaskStartedEvent:
-                    return new TaskStartedEventArgs(null, null, null, null, null);
-                case LoggingEventType.TaskFinishedEvent:
-                    return new TaskFinishedEventArgs(null, null, null, null, null, false);
-                case LoggingEventType.TaskCommandLineEvent:
-                    return new TaskCommandLineEventArgs(null, null, MessageImportance.Normal);
+                LoggingEventType.BuildErrorEvent => new BuildErrorEventArgs(null, null, null, -1, -1, -1, -1, null, null, null),
+                LoggingEventType.BuildFinishedEvent => new BuildFinishedEventArgs(null, null, false),
+                LoggingEventType.BuildMessageEvent => new BuildMessageEventArgs(null, null, null, MessageImportance.Normal),
+                LoggingEventType.BuildStartedEvent => new BuildStartedEventArgs(null, null),
+                LoggingEventType.BuildWarningEvent => new BuildWarningEventArgs(null, null, null, -1, -1, -1, -1, null, null, null),
+                LoggingEventType.ProjectFinishedEvent => new ProjectFinishedEventArgs(null, null, null, false),
+                LoggingEventType.ProjectStartedEvent => new ProjectStartedEventArgs(null, null, null, null, null, null),
+                LoggingEventType.TargetStartedEvent => new TargetStartedEventArgs(null, null, null, null, null),
+                LoggingEventType.TargetFinishedEvent => new TargetFinishedEventArgs(null, null, null, null, null, false),
+                LoggingEventType.TaskStartedEvent => new TaskStartedEventArgs(null, null, null, null, null),
+                LoggingEventType.TaskFinishedEvent => new TaskFinishedEventArgs(null, null, null, null, null, false),
+                LoggingEventType.TaskCommandLineEvent => new TaskCommandLineEventArgs(null, null, MessageImportance.Normal),
 #if !TASKHOST // MSBuildTaskHost is targeting Microsoft.Build.Framework.dll 3.5
-                case LoggingEventType.TaskParameterEvent:
-                    return new TaskParameterEventArgs(0, null, null, true, default);
-                case LoggingEventType.ProjectEvaluationStartedEvent:
-                    return new ProjectEvaluationStartedEventArgs();
-                case LoggingEventType.ProjectEvaluationFinishedEvent:
-                    return new ProjectEvaluationFinishedEventArgs();
+                LoggingEventType.TaskParameterEvent => new TaskParameterEventArgs(0, null, null, true, default),
+                LoggingEventType.ProjectEvaluationStartedEvent => new ProjectEvaluationStartedEventArgs(),
+                LoggingEventType.ProjectEvaluationFinishedEvent => new ProjectEvaluationFinishedEventArgs(),
 #endif
-                default:
-                    ErrorUtilities.VerifyThrow(false, "Should not get to the default of GetBuildEventArgFromId ID: " + _eventType);
-                    return null;
-            }
+                _ => throw new InternalErrorException("Should not get to the default of GetBuildEventArgFromId ID: " + _eventType)
+            };
         }
 
         /// <summary>

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -175,6 +175,32 @@ namespace Microsoft.Build.Utilities
             }
         }
 
+        private bool? _logPropertiesAndItemsAfterEvaluation;
+        private bool _logPropertiesAndItemsAfterEvaluationInitialized = false;
+        public bool? LogPropertiesAndItemsAfterEvaluation
+        {
+            get
+            {
+                if (!_logPropertiesAndItemsAfterEvaluationInitialized)
+                {
+                    _logPropertiesAndItemsAfterEvaluationInitialized = true;
+                    var variable = Environment.GetEnvironmentVariable("MSBUILDLOGPROPERTIESANDITEMSAFTEREVALUATION");
+                    if (!string.IsNullOrEmpty(variable))
+                    {
+                        _logPropertiesAndItemsAfterEvaluation = variable == "1" || string.Equals(variable, "true", StringComparison.OrdinalIgnoreCase);
+                    }
+                }
+
+                return _logPropertiesAndItemsAfterEvaluation;
+            }
+
+            set
+            {
+                _logPropertiesAndItemsAfterEvaluationInitialized = true;
+                _logPropertiesAndItemsAfterEvaluation = value;
+            }
+        }
+
         /// <summary>
         /// Read information only once per file per ResolveAssemblyReference invocation.
         /// </summary>

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -131,6 +131,12 @@ namespace Microsoft.Build.Utilities
         public bool IncludeTaskInputs { get; set; }
 
         /// <summary>
+        /// Should properties and items be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
+        /// instead of <see cref="ProjectStartedEventArgs"/>?
+        /// </summary>
+        public bool IncludeEvaluationPropertiesAndItems { get; set; }
+
+        /// <summary>
         /// Initialize the logger.
         /// </summary>
         public void Initialize(IEventSource eventSource) => Initialize(eventSource, 1);
@@ -159,6 +165,7 @@ namespace Microsoft.Build.Utilities
                 {
                     eventSource3.IncludeEvaluationMetaprojects();
                 }
+
                 if (IncludeEvaluationProfiles)
                 {
                     eventSource3.IncludeEvaluationProfiles();
@@ -167,6 +174,14 @@ namespace Microsoft.Build.Utilities
                 if (IncludeTaskInputs)
                 {
                     eventSource3.IncludeTaskInputs();
+                }
+            }
+
+            if (_eventSourceForBuild is IEventSource4 eventSource4)
+            {
+                if (IncludeEvaluationPropertiesAndItems)
+                {
+                    eventSource4.IncludeEvaluationPropertiesAndItems();
                 }
             }
         }


### PR DESCRIPTION
Add an option to log global properties, properties and items on ProjectEvaluationFinishedEventArgs instead of ProjectStartedEventArgs. This option is currently only turned on by the BinaryLogger.

This has several advantages. Currently only the projects that are built by the central node log their properties and items (properties are translated across nodes only if a special flag is set, and items are never translated). This resulted in properties and items not being available for projects built on other nodes. Now we log them after every evaluation and translate across nodes if needed. Together with the fact that we now log EvaluationId for each ProjectStarted, we can now recover properties and items for all project started events. This is the main purpose of this PR - to not lose properties and items like we currently do. We will still not log for project results that are satisfied by cache, because we don't keep track of evaluation for these. Presumably it will have already been logged previously.

In addition, if more than one project are built from the same evaluation, we do not duplicate properties and items, only logging them once. This results in logging more information, but storing it more efficiently. Together with string and dictionary deduplication we see very significant savings in binlog size and some reduction in build time.

This change has several large parts:

 1. add a way to enumerate evaluation properties and items directly at the end of Evaluate() for PropertyDictionary<ProjectPropertyInstance> and ItemDictionary<ProjectItemInstance>
 2. manual translation logic for ProjectEvaluationStarted and ProjectEvaluationFinished (instead of relying on TranslateDotNet/BinaryFormatter)
 3. reading and writing ProjectEvaluationFinished GlobalProperties, Properties and Items in BuildEventArgsReader/Writer (used by BinaryLogger)
 4. adding IEventSource4 with IncludeEvaluationPropertiesAndItems, to propagate this setting across nodes and threading it through the LoggingService
 5. update the ParallelConsoleLogger and SerialConsoleLogger to print the new data, if present
 6. tests

One controversial design decision here is storing a reference to live evaluation data in ProjectEvaluationFinishedEventArgs. It does not make a snapshot of the data to avoid very significant allocations. It does take the lock on the PropertyDictionary<T>/ItemDictionary<T> when enumerating, because logging is asynchronous and the logging consumer (BinaryLogger) will enumerate the data potentially after the build has already started and the data is being mutated. I did see exceptions when enumerating without the lock. We had the same problem when the data was logged on ProjectStartedEventArgs though. In addition, there's a slight risk of logging not the exact data as it was at the end of evaluation, but the mutated data after some target has modified it. However given that the previous behavior was to not log anything for out-of-proc projects, and given the very significant allocation reduction, I think it's worth it.

To mitigate, we could capture a snapshot at the end of evaluation, so we don't hold a reference to live data. This won't need a lock to enumerate. Ideally we also rely on the immutable collections to avoid allocations, but I didn't see an easy way to do that currently. We can investigate this in a future change.

For items, it doesn't concatenate items of different types into a single large item stream, but keeps multiple lists, one per item type, to reflect the internal representation. Not flattening item types results in savings because we don't have to mention the item type for each item.

This change increments the BinaryLogger file format to 12, to serialize GlobalProperties, Properties and Items on ProjectEvaluationFinishedEventArgs. It also stores items more efficiently, without having to know the number of item types in advance and enumerate in a single pass. It writes the item type and all items of that type, and it writes 0 to signal there are no more item types. It also no longer writes the Message for args as it can be recovered upon reading.

New EnumerateProperties() and EnumerateItems() methods are added to Utilities, to consolidate the logic to enumerate the new data structures in a single location, used by packet translation logic, binary logger and the console loggers.

Perf wise, I'm seeing no significant change on binlog size for small builds (it's a wash, because we log properties/items for all projects now, but they are no longer duplicated). For large projects I expect very significant savings though, as ProjectStarted is the most heavy-weight event in large binlogs.
Build performance with /bl on small-ish builds is improved 27 s -> 24 s for single-core and 18 s -> 17 s for parallel. No observable change without /bl.

Fixes
https://github.com/dotnet/msbuild/issues/5316
https://github.com/dotnet/msbuild/issues/3616