### PR TITLE
Remove unused GetAllGlobs override in ProjectLink

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1983,7 +1983,6 @@ namespace Microsoft.Build.ObjectModelRemoting
         public abstract bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract Microsoft.Build.Execution.ProjectInstance CreateProjectInstance(Microsoft.Build.Execution.ProjectInstanceSettings settings, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract string ExpandString(string unexpandedValue);
-        public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs();
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(string itemType, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(Microsoft.Build.Evaluation.ProjectItem item, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1977,7 +1977,6 @@ namespace Microsoft.Build.ObjectModelRemoting
         public abstract bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract Microsoft.Build.Execution.ProjectInstance CreateProjectInstance(Microsoft.Build.Execution.ProjectInstanceSettings settings, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract string ExpandString(string unexpandedValue);
-        public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs();
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(string itemType, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);
         public abstract System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(Microsoft.Build.Evaluation.ProjectItem item, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext);

--- a/src/Build.OM.UnitTests/ObjectModelRemoting/RemoteProjectsProviderMock/EvaluationLinkMocks/MockProjectLink.cs
+++ b/src/Build.OM.UnitTests/ObjectModelRemoting/RemoteProjectsProviderMock/EvaluationLinkMocks/MockProjectLink.cs
@@ -187,12 +187,6 @@ namespace Microsoft.Build.UnitTests.OM.ObjectModelRemoting
 
         public override string ExpandString(string unexpandedValue) => this.Proxy.ExpandString(unexpandedValue);
 
-        // TODO: Glob is not needed for the CSproj, but we might want to test it at least 
-        public override List<GlobResult> GetAllGlobs()
-        {
-            throw new NotImplementedException();
-        }
-
         public override List<GlobResult> GetAllGlobs(EvaluationContext evaluationContext)
         {
             throw new NotImplementedException();

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2422,14 +2422,6 @@ namespace Microsoft.Build.Evaluation
             internal ILoggingService LoggingService => ProjectCollection.LoggingService;
 
             /// <summary>
-            /// See <see cref="ProjectLink.GetAllGlobs()"/>.
-            /// </summary>
-            public override List<GlobResult> GetAllGlobs()
-            {
-                return GetAllGlobs(evaluationContext: null);
-            }
-
-            /// <summary>
             /// See <see cref="ProjectLink.GetAllGlobs(EvaluationContext)"/>.
             /// </summary>
             /// <param name="evaluationContext">

--- a/src/Build/ObjectModelRemoting/DefinitionObjectsLinks/ProjectLink.cs
+++ b/src/Build/ObjectModelRemoting/DefinitionObjectsLinks/ProjectLink.cs
@@ -129,11 +129,6 @@ namespace Microsoft.Build.ObjectModelRemoting
         public abstract int LastEvaluationId { get; }
 
         /// <summary>
-        /// Facilitate remoting the <see cref="Project.GetAllGlobs()"/>.
-        /// </summary>
-        public abstract List<GlobResult> GetAllGlobs();
-
-        /// <summary>
         /// Facilitate remoting the <see cref="Project.GetAllGlobs(EvaluationContext)"/>.
         /// </summary>
         public abstract List<GlobResult> GetAllGlobs(EvaluationContext evaluationContext);


### PR DESCRIPTION
Fixes #
Perf ddrits regression in ProjectServices implementation of this.
### Context
This GetAllGlobs override is unused anymore since CPS has been changed to use the GetAllGlobs(evaluationContext)

### Changes Made
Remove newly added GetAllGlobs override.

### Testing


### Notes
