### PR TITLE
Properly Consider WarningsAsMessages In TaskLoggingHelper's `HasLoggedErrors`

### DIFF
--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -557,7 +557,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
             return false;
         }
 
-        public ICollection<string> GetWarningsToBeLoggedAsErrorsByProject(BuildEventContext context)
+        public ICollection<string> GetWarningsAsErrors(BuildEventContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICollection<string> GetWarningsAsMessages(BuildEventContext context)
         {
             throw new NotImplementedException();
         }

--- a/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
@@ -639,7 +639,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             Assert.NotNull(deserializedConfig.WarningsAsMessages);
             config.WarningsAsMessages.SequenceEqual(deserializedConfig.WarningsAsMessages, StringComparer.Ordinal).ShouldBeTrue();
-
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     taskLocation: @"c:\my tasks\mytask.dll",
                     taskParameters: null,
                     globalParameters: null,
-                    warningsAsErrors: null);
+                    warningsAsErrors: null,
+                    warningsAsMessages: null);
             }
            );
         }
@@ -90,7 +91,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     taskLocation: @"c:\my tasks\mytask.dll",
                     taskParameters: null,
                     globalParameters: null,
-                    warningsAsErrors: null);
+                    warningsAsErrors: null,
+                    warningsAsMessages: null);
             }
            );
         }
@@ -123,7 +125,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     taskLocation: null,
                     taskParameters: null,
                     globalParameters: null,
-                    warningsAsErrors: null);
+                    warningsAsErrors: null,
+                    warningsAsMessages: null);
             }
            );
         }
@@ -158,7 +161,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     taskLocation: String.Empty,
                     taskParameters: null,
                     globalParameters: null,
-                    warningsAsErrors: null);
+                    warningsAsErrors: null,
+                    warningsAsMessages: null);
             }
            );
         }
@@ -191,26 +195,32 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: null,
                 globalParameters: null,
-                warningsAsErrors: null);
+                warningsAsErrors: null,
+                warningsAsMessages: null);
 
             TaskHostConfiguration config2 = new TaskHostConfiguration(
-                1,
-                Directory.GetCurrentDirectory(),
-                null,
-                Thread.CurrentThread.CurrentCulture,
-                Thread.CurrentThread.CurrentUICulture,
+                nodeId: 1,
+                startupDirectory: Directory.GetCurrentDirectory(),
+                buildProcessEnvironment: null,
+                culture: Thread.CurrentThread.CurrentCulture,
+                uiCulture: Thread.CurrentThread.CurrentUICulture,
+#if FEATURE_APPDOMAIN
+                appDomainSetup:
 #if FEATURE_APPDOMAIN
                 null,
 #endif
+                lineNumberOfTask:
+#endif
                 1,
-                1,
-                @"c:\my project\myproj.proj",
-                _continueOnErrorDefault,
-                "TaskName",
-                @"c:\MyTasks\MyTask.dll",
-                null,
-                null,
-                null);
+                columnNumberOfTask: 1,
+                projectFileOfTask: @"c:\my project\myproj.proj",
+                continueOnError: _continueOnErrorDefault,
+                taskName: "TaskName",
+                taskLocation: @"c:\MyTasks\MyTask.dll",
+                taskParameters: null,
+                globalParameters: null,
+                warningsAsErrors: null,
+                warningsAsMessages: null);
 
             IDictionary<string, object> parameters = new Dictionary<string, object>();
             TaskHostConfiguration config3 = new TaskHostConfiguration(
@@ -234,7 +244,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: parameters,
                 globalParameters: null,
-                warningsAsErrors: null);
+                warningsAsErrors: null,
+                warningsAsMessages: null);
 
             IDictionary<string, object> parameters2 = new Dictionary<string, object>();
             parameters2.Add("Text", "Hello!");
@@ -263,7 +274,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: parameters2,
                 globalParameters: null,
-                warningsAsErrors: null);
+                warningsAsErrors: null,
+                warningsAsMessages: null);
 
             HashSet<string> WarningsAsErrors = new HashSet<string>();
             WarningsAsErrors.Add("MSB1234");
@@ -292,7 +304,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: parameters2,
                 globalParameters: null,
-                warningsAsErrors: WarningsAsErrors);
+                warningsAsErrors: WarningsAsErrors,
+                warningsAsMessages: null);
         }
 
         /// <summary>
@@ -328,7 +341,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: null,
                 globalParameters: expectedGlobalProperties,
-                warningsAsErrors: null);
+                warningsAsErrors: null,
+                warningsAsMessages: null);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -371,7 +385,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: new Dictionary<string, object>(),
                 globalParameters: new Dictionary<string, string>(),
-                warningsAsErrors: null);
+                warningsAsErrors: null,
+                warningsAsMessages: null);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -419,7 +434,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: parameters,
                 globalParameters: null,
-                warningsAsErrors: null);
+                warningsAsErrors: null,
+                warningsAsMessages: null);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -465,7 +481,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: parameters,
                 globalParameters: null,
-                warningsAsErrors: null);
+                warningsAsErrors: null,
+                warningsAsMessages: null);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -510,7 +527,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: parameters,
                 globalParameters: null,
-                warningsAsErrors: null);
+                warningsAsErrors: null,
+                warningsAsMessages: null);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -562,7 +580,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskLocation: @"c:\MyTasks\MyTask.dll",
                 taskParameters: null,
                 globalParameters: null,
-                warningsAsErrors: WarningsAsErrors);
+                warningsAsErrors: WarningsAsErrors,
+                warningsAsMessages: null);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());

--- a/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
@@ -598,6 +598,51 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// Test serialization / deserialization when the parameter dictionary contains warningsasmessages
+        /// </summary>
+        [Fact]
+        public void TestTranslationWithWarningsAsMessages()
+        {
+            HashSet<string> WarningsAsMessages = new HashSet<string>();
+            WarningsAsMessages.Add("MSB1234");
+            WarningsAsMessages.Add("MSB1235");
+            WarningsAsMessages.Add("MSB1236");
+            WarningsAsMessages.Add("MSB1237");
+            TaskHostConfiguration config = new TaskHostConfiguration(
+                nodeId: 1,
+                startupDirectory: Directory.GetCurrentDirectory(),
+                buildProcessEnvironment: null,
+                culture: Thread.CurrentThread.CurrentCulture,
+                uiCulture: Thread.CurrentThread.CurrentUICulture,
+#if FEATURE_APPDOMAIN
+                appDomainSetup:
+#if FEATURE_APPDOMAIN
+                null,
+#endif
+                lineNumberOfTask:
+#endif
+                1,
+                columnNumberOfTask: 1,
+                projectFileOfTask: @"c:\my project\myproj.proj",
+                continueOnError: _continueOnErrorDefault,
+                taskName: "TaskName",
+                taskLocation: @"c:\MyTasks\MyTask.dll",
+                taskParameters: null,
+                globalParameters: null,
+                warningsAsErrors: null,
+                warningsAsMessages: WarningsAsMessages);
+
+            ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
+            INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            TaskHostConfiguration deserializedConfig = packet as TaskHostConfiguration;
+
+            Assert.NotNull(deserializedConfig.WarningsAsMessages);
+            config.WarningsAsMessages.SequenceEqual(deserializedConfig.WarningsAsMessages, StringComparer.Ordinal).ShouldBeTrue();
+
+        }
+
+        /// <summary>
         /// Helper methods for testing the task host-related packets. 
         /// </summary>
         internal static class TaskHostPacketHelpers

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -368,9 +368,9 @@ namespace Microsoft.Build.Engine.UnitTests
         /// Both builds should continue despite logging errors.
         /// </summary>
         [Theory]
-        [InlineData("MSB1234", false)]
-        [InlineData("MSB0000", true)]
-        public void TaskReturnsTrue_Tests(string warningsAsErrors, bool treatAllWarningsAsErrors)
+        [InlineData("MSB1234", false, 1, 1)]
+        [InlineData("MSB0000", true, 0, 2)]
+        public void TaskReturnsTrue_Tests(string warningsAsErrors, bool treatAllWarningsAsErrors, int warningCountShouldBe, int errorCountShouldBe)
         {
             using (TestEnvironment env = TestEnvironment.Create(_output))
             {
@@ -390,8 +390,8 @@ namespace Microsoft.Build.Engine.UnitTests
 
                 MockLogger logger = proj.BuildProjectExpectFailure();
 
-                logger.WarningCount.ShouldBe(1);
-                logger.ErrorCount.ShouldBe(1);
+                logger.WarningCount.ShouldBe(warningCountShouldBe);
+                logger.ErrorCount.ShouldBe(errorCountShouldBe);
 
                 // The build will continue so we should see the warning MSB1235
                 logger.AssertLogContains("MSB1235");

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -315,6 +315,116 @@ namespace Microsoft.Build.Engine.UnitTests
             }
         }
 
+        [Fact]
+        public void TaskReturnsHasLoggedErrorAndLogsWarningAsError_WarningIsAlsoMessage_BuildShouldContinue()
+        {
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <PropertyGroup>
+                        <MSBuildWarningsAsErrors>MSB1234</MSBuildWarningsAsErrors>
+                        <MSBuildWarningsAsMessages>MSB1234</MSBuildWarningsAsMessages>
+                    </PropertyGroup>
+                    <ItemGroup>
+                        <SomeItem Include=""Item1"">
+                            <Return>true</Return>
+                            <ReturnHasLoggedErrors>true</ReturnHasLoggedErrors>
+                            <WarningCode>MSB1234</WarningCode>
+                        </SomeItem>
+                    </ItemGroup>
+                    <Target Name='Build'>
+                        <CustomLogAndReturnTask Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""MSB1234""/>
+                        <ReturnFailureWithoutLoggingErrorTask/>
+                    </Target>
+                </Project>");
+
+                MockLogger logger = proj.BuildProjectExpectFailure();
+
+                logger.WarningCount.ShouldBe(0);
+                logger.ErrorCount.ShouldBe(1);
+
+                // The build should CONTINUE when it logs a message that should be treated as an error and also a message.
+                // Message takes precedence.
+                logger.AssertLogContains("MSB4181");
+            }
+        }
+
+        [Fact]
+        public void TaskReturnsHasLoggedErrorAndLogsWarningAsError_MessageOverridesTreatAllWarningsAsErrors_BuildShouldContinue()
+        {
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <PropertyGroup>
+                        <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+                        <MSBuildWarningsAsMessages>MSB1234</MSBuildWarningsAsMessages>
+                    </PropertyGroup>
+                    <ItemGroup>
+                        <SomeItem Include=""Item1"">
+                            <Return>true</Return>
+                            <ReturnHasLoggedErrors>true</ReturnHasLoggedErrors>
+                            <WarningCode>MSB1234</WarningCode>
+                        </SomeItem>
+                    </ItemGroup>
+                    <Target Name='Build'>
+                        <CustomLogAndReturnTask Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""MSB1234""/>
+                        <ReturnFailureWithoutLoggingErrorTask/>
+                    </Target>
+                </Project>");
+
+                MockLogger logger = proj.BuildProjectExpectFailure();
+
+                logger.WarningCount.ShouldBe(0);
+                logger.ErrorCount.ShouldBe(1);
+
+                // The build should CONTINUE when it logs a message that should be treated as an error and also a message.
+                // Message takes precedence.
+                logger.AssertLogContains("MSB4181");
+            }
+        }
+
+        [Fact]
+        public void TaskReturnsHasLoggedErrorAndLogsWarningAsError_LoggedWarningIsNotTreatedAsMessage_TreatAllWarningsAsErrors_BuildShouldStop()
+        {
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <PropertyGroup>
+                        <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+                        <MSBuildWarningsAsMessages>MSB1235</MSBuildWarningsAsMessages>
+                    </PropertyGroup>
+                    <ItemGroup>
+                        <SomeItem Include=""Item1"">
+                            <Return>true</Return>
+                            <ReturnHasLoggedErrors>true</ReturnHasLoggedErrors>
+                            <WarningCode>MSB1234</WarningCode>
+                        </SomeItem>
+                    </ItemGroup>
+                    <Target Name='Build'>
+                        <CustomLogAndReturnTask Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""MSB1234""/>
+                        <ReturnFailureWithoutLoggingErrorTask/>
+                    </Target>
+                </Project>");
+
+                MockLogger logger = proj.BuildProjectExpectFailure();
+
+                logger.WarningCount.ShouldBe(0);
+                logger.ErrorCount.ShouldBe(1);
+
+                // The build should STOP when it logs an error due to MSBuildTreatWarningsAsErrors
+                logger.AssertLogContains("MSB1234");
+            }
+        }
+
         /// <summary>
         /// Item1 and Item2 log warnings and continue, item 3 logs a warn-> error and prevents item 4 from running in the batched build.
         /// </summary>

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -272,11 +272,16 @@ namespace Microsoft.Build.Engine.UnitTests
             </Project>";
         }
 
-        /// <summary>
-        /// We have a unique task host per bucket. Show that in these scenarios the build will stop if one sees an error.
-        /// </summary>
-        [Fact]
-        public void TaskReturnsHasLoggedErrorAndLogsWarningAsError_BuildShouldStopAndFail_BatchedBuild()
+        [Theory]
+        
+        [InlineData("MSB1235", "MSB1234", "MSB1234", "MSB1234", false)] // Log MSB1234, treat as error via MSBuildWarningsAsErrors
+        [InlineData("MSB1235", "", "MSB1234", "MSB1234", true)] // Log MSB1234, expect MSB1234 as error via MSBuildTreatWarningsAsErrors
+        [InlineData("MSB1234", "MSB1234", "MSB1234", "MSB4181", true)]// Log MSB1234, MSBuildWarningsAsMessages takes priority
+        public void WarningsAsErrorsAndMessages_Tests(string WarningsAsMessages,
+                                                      string WarningsAsErrors,
+                                                      string WarningToLog,
+                                                      string LogShouldContain,
+                                                      bool allWarningsAreErrors = false)
         {
             using (TestEnvironment env = TestEnvironment.Create(_output))
             {
@@ -285,22 +290,12 @@ namespace Microsoft.Build.Engine.UnitTests
                     <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
                     <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
                     <PropertyGroup>
-                        <MSBuildWarningsAsErrors>MSB1234</MSBuildWarningsAsErrors>
+                        <MSBuildTreatWarningsAsErrors>{allWarningsAreErrors}</MSBuildTreatWarningsAsErrors>
+                        <MSBuildWarningsAsMessages>{WarningsAsMessages}</MSBuildWarningsAsMessages>
+                        <MSBuildWarningsAsErrors>{WarningsAsErrors}</MSBuildWarningsAsErrors>
                     </PropertyGroup>
-                    <ItemGroup>
-                        <SomeItem Include=""Item1"">
-                            <Return>true</Return>
-                            <ReturnHasLoggedErrors>true</ReturnHasLoggedErrors>
-                            <WarningCode>MSB1234</WarningCode>
-                        </SomeItem>
-                        <SomeItem Include=""Item2"">
-                            <Return>true</Return>
-                            <ReturnHasLoggedErrors>true</ReturnHasLoggedErrors>
-                            <WarningCode>MSB1235</WarningCode>
-                        </SomeItem>
-                    </ItemGroup>
                     <Target Name='Build'>
-                        <CustomLogAndReturnTask Sources=""@(SomeItem)"" Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""%(WarningCode)""/>
+                        <CustomLogAndReturnTask Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""{WarningToLog}""/>
                         <ReturnFailureWithoutLoggingErrorTask/>
                     </Target>
                 </Project>");
@@ -310,118 +305,7 @@ namespace Microsoft.Build.Engine.UnitTests
                 logger.WarningCount.ShouldBe(0);
                 logger.ErrorCount.ShouldBe(1);
 
-                // The build should STOP when a task logs an error, make sure ReturnFailureWithoutLoggingErrorTask doesn't run. 
-                logger.AssertLogDoesntContain("MSB4181");
-            }
-        }
-
-        [Fact]
-        public void TaskReturnsHasLoggedErrorAndLogsWarningAsError_WarningIsAlsoMessage_BuildShouldContinue()
-        {
-            using (TestEnvironment env = TestEnvironment.Create(_output))
-            {
-                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
-                <Project>
-                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <PropertyGroup>
-                        <MSBuildWarningsAsErrors>MSB1234</MSBuildWarningsAsErrors>
-                        <MSBuildWarningsAsMessages>MSB1234</MSBuildWarningsAsMessages>
-                    </PropertyGroup>
-                    <ItemGroup>
-                        <SomeItem Include=""Item1"">
-                            <Return>true</Return>
-                            <ReturnHasLoggedErrors>true</ReturnHasLoggedErrors>
-                            <WarningCode>MSB1234</WarningCode>
-                        </SomeItem>
-                    </ItemGroup>
-                    <Target Name='Build'>
-                        <CustomLogAndReturnTask Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""MSB1234""/>
-                        <ReturnFailureWithoutLoggingErrorTask/>
-                    </Target>
-                </Project>");
-
-                MockLogger logger = proj.BuildProjectExpectFailure();
-
-                logger.WarningCount.ShouldBe(0);
-                logger.ErrorCount.ShouldBe(1);
-
-                // The build should CONTINUE when it logs a message that should be treated as an error and also a message.
-                // Message takes precedence.
-                logger.AssertLogContains("MSB4181");
-            }
-        }
-
-        [Fact]
-        public void TaskReturnsHasLoggedErrorAndLogsWarningAsError_MessageOverridesTreatAllWarningsAsErrors_BuildShouldContinue()
-        {
-            using (TestEnvironment env = TestEnvironment.Create(_output))
-            {
-                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
-                <Project>
-                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <PropertyGroup>
-                        <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
-                        <MSBuildWarningsAsMessages>MSB1234</MSBuildWarningsAsMessages>
-                    </PropertyGroup>
-                    <ItemGroup>
-                        <SomeItem Include=""Item1"">
-                            <Return>true</Return>
-                            <ReturnHasLoggedErrors>true</ReturnHasLoggedErrors>
-                            <WarningCode>MSB1234</WarningCode>
-                        </SomeItem>
-                    </ItemGroup>
-                    <Target Name='Build'>
-                        <CustomLogAndReturnTask Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""MSB1234""/>
-                        <ReturnFailureWithoutLoggingErrorTask/>
-                    </Target>
-                </Project>");
-
-                MockLogger logger = proj.BuildProjectExpectFailure();
-
-                logger.WarningCount.ShouldBe(0);
-                logger.ErrorCount.ShouldBe(1);
-
-                // The build should CONTINUE when it logs a message that should be treated as an error and also a message.
-                // Message takes precedence.
-                logger.AssertLogContains("MSB4181");
-            }
-        }
-
-        [Fact]
-        public void TaskReturnsHasLoggedErrorAndLogsWarningAsError_LoggedWarningIsNotTreatedAsMessage_TreatAllWarningsAsErrors_BuildShouldStop()
-        {
-            using (TestEnvironment env = TestEnvironment.Create(_output))
-            {
-                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
-                <Project>
-                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <PropertyGroup>
-                        <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
-                        <MSBuildWarningsAsMessages>MSB1235</MSBuildWarningsAsMessages>
-                    </PropertyGroup>
-                    <ItemGroup>
-                        <SomeItem Include=""Item1"">
-                            <Return>true</Return>
-                            <ReturnHasLoggedErrors>true</ReturnHasLoggedErrors>
-                            <WarningCode>MSB1234</WarningCode>
-                        </SomeItem>
-                    </ItemGroup>
-                    <Target Name='Build'>
-                        <CustomLogAndReturnTask Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""MSB1234""/>
-                        <ReturnFailureWithoutLoggingErrorTask/>
-                    </Target>
-                </Project>");
-
-                MockLogger logger = proj.BuildProjectExpectFailure();
-
-                logger.WarningCount.ShouldBe(0);
-                logger.ErrorCount.ShouldBe(1);
-
-                // The build should STOP when it logs an error due to MSBuildTreatWarningsAsErrors
-                logger.AssertLogContains("MSB1234");
+                logger.AssertLogContains(LogShouldContain);
             }
         }
 
@@ -429,7 +313,7 @@ namespace Microsoft.Build.Engine.UnitTests
         /// Item1 and Item2 log warnings and continue, item 3 logs a warn-> error and prevents item 4 from running in the batched build.
         /// </summary>
         [Fact]
-        public void TaskReturnsHasLoggedErrorAndLogsWarningAsError_BuildShouldStopOnceItLogsWarningAsErrorAndFail_BatchedBuild()
+        public void TaskLogsWarningAsError_BatchedBuild()
         {
             using (TestEnvironment env = TestEnvironment.Create(_output))
             {
@@ -478,40 +362,15 @@ namespace Microsoft.Build.Engine.UnitTests
             }
         }
 
-        [Fact]
-        public void TaskReturnsHasLoggedErrorAndLogsWarningAsError_BuildShouldFinishAndFail()
-        {
-            using (TestEnvironment env = TestEnvironment.Create(_output))
-            {
-                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
-                <Project>
-                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <PropertyGroup>
-                        <MSBuildWarningsAsErrors>MSB1234</MSBuildWarningsAsErrors>
-                    </PropertyGroup>
-                    <Target Name='Build'>
-                        <CustomLogAndReturnTask Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""MSB1234""/>
-                        <ReturnFailureWithoutLoggingErrorTask/>
-                    </Target>
-                </Project>");
-
-                MockLogger logger = proj.BuildProjectExpectFailure();
-
-                logger.WarningCount.ShouldBe(0);
-                logger.ErrorCount.ShouldBe(1);
-
-                // The build should STOP when a task logs an error, make sure ReturnFailureWithoutLoggingErrorTask doesn't run. 
-                logger.AssertLogDoesntContain("MSB4181");
-            }
-        }
-
         /// <summary>
-        /// MSBuild behavior as of 16.10: As long as a task returns true, the build will continue despite logging a warning as error.
-        /// This tests MSBuildWarningsAsErrors
+        /// Task logs MSB1234 as a warning and returns true.
+        /// Test behavior with MSBuildWarningsAsErrors & MSBuildTreatWarningsAsErrors
+        /// Both builds should continue despite logging errors.
         /// </summary>
-        [Fact]
-        public void TaskReturnsTrueButLogsWarningAsError_BuildShouldFinishAndFail()
+        [Theory]
+        [InlineData("MSB1234", false)]
+        [InlineData("MSB0000", true)]
+        public void TaskReturnsTrue_Tests(string warningsAsErrors, bool treatAllWarningsAsErrors)
         {
             using (TestEnvironment env = TestEnvironment.Create(_output))
             {
@@ -519,9 +378,9 @@ namespace Microsoft.Build.Engine.UnitTests
                 <Project>
                     <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
                     <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <UsingTask TaskName = ""LogWarningReturnHasLoggedError"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
                     <PropertyGroup>
-                        <MSBuildWarningsAsErrors>MSB1234</MSBuildWarningsAsErrors>
+                        <MSBuildTreatWarningsAsErrors>{treatAllWarningsAsErrors}</MSBuildTreatWarningsAsErrors>
+                        <MSBuildWarningsAsErrors>{warningsAsErrors}</MSBuildWarningsAsErrors>
                     </PropertyGroup>
                     <Target Name='Build'>
                         <CustomLogAndReturnTask Return=""true"" WarningCode=""MSB1234""/>
@@ -535,40 +394,6 @@ namespace Microsoft.Build.Engine.UnitTests
                 logger.ErrorCount.ShouldBe(1);
 
                 // The build will continue so we should see the warning MSB1235
-                logger.AssertLogContains("MSB1235");
-            }
-        }
-
-
-        /// <summary>
-        /// MSBuild behavior as of 16.10: As long as a task returns true, the build will continue despite logging warning as error.
-        /// This test specifically tests the MSBuildTreatWarningsAsErrors flag as opposed to MSBuildWarningsAsErrors
-        /// </summary>
-        [Fact]
-        public void TaskReturnsTrueButLogsWarning_TreatWarningsAsErrors_BuildShouldFinishAndFail()
-        {
-            using (TestEnvironment env = TestEnvironment.Create(_output))
-            {
-                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
-                <Project>
-                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <UsingTask TaskName = ""LogWarningReturnHasLoggedError"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
-                    <PropertyGroup>
-                        <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
-                    </PropertyGroup>
-                    <Target Name='Build'>
-                        <CustomLogAndReturnTask Return=""true"" WarningCode=""MSB1234""/>
-                        <CustomLogAndReturnTask Return=""true"" WarningCode=""MSB1235""/>
-                    </Target>
-                </Project>");
-
-                MockLogger logger = proj.BuildProjectExpectFailure();
-
-                logger.WarningCount.ShouldBe(0);
-                logger.ErrorCount.ShouldBe(2);
-
-                // The build will continue so we should see the error MSB1235
                 logger.AssertLogContains("MSB1235");
             }
         }

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -221,11 +221,17 @@ namespace Microsoft.Build.BackEnd.Logging
 
         /// <summary>
         /// Returns a hashset of warnings to be logged as errors for the specified project instance ID.
-        /// Note that WarningsAsMessages takes priority over WarningsAsErrors and are excluded from the set.
         /// </summary>
         /// <param name="context">The build context through which warnings will be logged as errors.</param>
-        /// <returns>A Hashset containing warning codes that should be treated as warnings that will not be treated as messages.</returns>
-        ICollection<string> GetWarningsToBeLoggedAsErrorsByProject(BuildEventContext context);
+        /// <returns>A Hashset containing warning codes that should be treated as errors.</returns>
+        ICollection<string> GetWarningsAsErrors(BuildEventContext context);
+
+        /// <summary>
+        /// Returns a hashset of warnings to be logged as messages for the specified project instance ID.
+        /// </summary>
+        /// <param name="context">The build context through which warnings will be logged as errors.</param>
+        /// <returns>A Hashset containing warning codes that should be treated as messages.</returns>
+        ICollection<string> GetWarningsAsMessages(BuildEventContext context);
 
         #region Register
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -529,56 +529,38 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             int key = GetWarningsAsErrorOrMessageKey(context);
 
-            // If there is definitely nothing to convert into an error, return early.
-            if (WarningsAsErrors == null && (_warningsAsErrorsByProject == null || !_warningsAsErrorsByProject.ContainsKey(key)))
+            if (_warningsAsErrorsByProject != null && _warningsAsErrorsByProject.TryGetValue(key, out ISet<string> warningsAsErrors))
             {
-                return null;
-            }
-
-            HashSet<string> allWarningsAsErrors = new HashSet<string>();
-
-            if (WarningsAsErrors != null)
-            {
-                allWarningsAsErrors.UnionWith(WarningsAsErrors);
-            }
-
-            if (_warningsAsErrorsByProject != null)
-            {
-                if (_warningsAsErrorsByProject.TryGetValue(key, out ISet<string> warningsAsErrors))
+                if (WarningsAsErrors != null)
                 {
-                    allWarningsAsErrors.UnionWith(warningsAsErrors);
+                    warningsAsErrors.UnionWith(WarningsAsErrors);
                 }
-            }
 
-            return allWarningsAsErrors;
+                return warningsAsErrors;
+            }
+            else
+            {
+                return WarningsAsErrors;
+            }
         }
 
         public ICollection<string> GetWarningsAsMessages(BuildEventContext context)
         {
             int key = GetWarningsAsErrorOrMessageKey(context);
 
-            // If there is definitely nothing to convert into an message, return early.
-            if (WarningsAsMessages == null && (_warningsAsMessagesByProject == null || !_warningsAsMessagesByProject.ContainsKey(key)))
+            if (_warningsAsMessagesByProject != null && _warningsAsMessagesByProject.TryGetValue(key, out ISet<string> warningsAsMessages))
             {
-                return null;
-            }
-
-            HashSet<string> allWarningsAsMessages = new HashSet<string>();
-
-            if (WarningsAsMessages != null)
-            {
-                allWarningsAsMessages.UnionWith(WarningsAsMessages);
-            }
-
-            if (_warningsAsMessagesByProject != null)
-            {
-                if (_warningsAsMessagesByProject.TryGetValue(key, out ISet<string> warningsAsMessages))
+                if (WarningsAsMessages != null)
                 {
-                    allWarningsAsMessages.UnionWith(warningsAsMessages);
+                    warningsAsMessages.UnionWith(WarningsAsMessages);
                 }
-            }
 
-            return allWarningsAsMessages;
+                return warningsAsMessages;
+            }
+            else
+            {
+                return WarningsAsMessages;
+            }
         }
 
         public void AddWarningsAsErrors(BuildEventContext buildEventContext, ISet<string> codes)

--- a/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
@@ -148,7 +148,12 @@ namespace Microsoft.Build.BackEnd.Logging
 
         internal ICollection<string> GetWarningsAsErrors()
         {
-            return LoggingService.GetWarningsToBeLoggedAsErrorsByProject(BuildEventContext);
+            return LoggingService.GetWarningsAsErrors(BuildEventContext);
+        }
+
+        internal ICollection<string> GetWarningsAsMessages()
+        {
+            return LoggingService.GetWarningsAsMessages(BuildEventContext);
         }
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -725,7 +725,7 @@ namespace Microsoft.Build.BackEnd
         public bool ShouldTreatWarningAsError(string warningCode)
         {
             // Warnings as messages overrides warnings as errors.
-            if (WarningsAsErrors == null || (WarningsAsMessages != null && WarningsAsMessages.Contains(warningCode)))
+            if (WarningsAsErrors == null || WarningsAsMessages?.Contains(warningCode) == true)
             {
                 return false;
             }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -724,6 +724,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>True if the warning should not be treated as a message and WarningsAsErrors is an empty set or contains the given warning code.</returns>
         public bool ShouldTreatWarningAsError(string warningCode)
         {
+            // Warnings as messages overrides warnings as errors.
             if (WarningsAsErrors == null || (WarningsAsMessages != null && WarningsAsMessages.Contains(warningCode)))
             {
                 return false;

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -697,14 +697,34 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
+        private ICollection<string> _warningsAsMessages;
+
+        /// <summary>
+        /// Contains all warnings that should be logged as errors.
+        /// Non-null empty set when all warnings should be treated as errors.
+        /// </summary>
+        private ICollection<string> WarningsAsMessages
+        {
+            get
+            {
+                // Test compatibility
+                if (_taskLoggingContext == null)
+                {
+                    return null;
+                }
+
+                return _warningsAsMessages ??= _taskLoggingContext.GetWarningsAsMessages();
+            }
+        }
+
         /// <summary>
         /// Determines if the given warning should be treated as an error.
         /// </summary>
         /// <param name="warningCode"></param>
-        /// <returns>True if WarningsAsErrors is an empty set or contains the given warning code.</returns>
+        /// <returns>True if the warning should not be treated as a message and WarningsAsErrors is an empty set or contains the given warning code.</returns>
         public bool ShouldTreatWarningAsError(string warningCode)
         {
-            if (WarningsAsErrors == null)
+            if (WarningsAsErrors == null || (WarningsAsMessages != null && WarningsAsMessages.Contains(warningCode)))
             {
                 return false;
             }

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -272,7 +272,8 @@ namespace Microsoft.Build.BackEnd
                         AssemblyUtilities.GetAssemblyLocation(_taskType.Type.GetTypeInfo().Assembly),
                         _setParameters,
                         new Dictionary<string, string>(_buildComponentHost.BuildParameters.GlobalProperties),
-                        _taskLoggingContext.GetWarningsAsErrors()
+                        _taskLoggingContext.GetWarningsAsErrors(),
+                        _taskLoggingContext.GetWarningsAsMessages()
                         
                     );
 

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -815,6 +815,7 @@ namespace Microsoft.Build.CommandLine
             _updateEnvironment = !taskConfiguration.BuildProcessEnvironment.ContainsValueAndIsEqual("MSBuildTaskHostDoNotUpdateEnvironment", "1", StringComparison.OrdinalIgnoreCase);
             _updateEnvironmentAndLog = taskConfiguration.BuildProcessEnvironment.ContainsValueAndIsEqual("MSBuildTaskHostUpdateEnvironmentAndLog", "1", StringComparison.OrdinalIgnoreCase);
             WarningsAsErrors = taskConfiguration.WarningsAsErrors;
+            WarningsAsMessages = taskConfiguration.WarningsAsMessages;
             try
             {
                 // Change to the startup directory

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Build.CommandLine
         public bool ShouldTreatWarningAsError(string warningCode)
         {
             // Warnings as messages overrides warnings as errors.
-            if (WarningsAsErrors == null || (WarningsAsMessages != null && WarningsAsMessages.Contains(warningCode)))
+            if (WarningsAsErrors == null || WarningsAsMessages?.Contains(warningCode) == true)
             {
                 return false;
             }

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -279,12 +279,13 @@ namespace Microsoft.Build.CommandLine
 
         public bool ShouldTreatWarningAsError(string warningCode)
         {
-            if (WarningsAsMessages != null && WarningsAsMessages.Contains(warningCode))
+            // Warnings as messages overrides warnings as errors.
+            if (WarningsAsErrors == null || (WarningsAsMessages != null && WarningsAsMessages.Contains(warningCode)))
             {
                 return false;
             }
 
-            return WarningsAsErrors != null && (WarningsAsErrors.Count == 0 || WarningsAsErrors.Contains(warningCode));
+            return WarningsAsErrors.Count == 0 || WarningsAsErrors.Contains(warningCode);
         }
         #endregion
 

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -275,8 +275,15 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private ICollection<string> WarningsAsErrors { get; set; }
 
+        private ICollection<string> WarningsAsMessages { get; set; }
+
         public bool ShouldTreatWarningAsError(string warningCode)
         {
+            if (WarningsAsMessages != null && WarningsAsMessages.Contains(warningCode))
+            {
+                return false;
+            }
+
             return WarningsAsErrors != null && (WarningsAsErrors.Count == 0 || WarningsAsErrors.Contains(warningCode));
         }
         #endregion

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -397,14 +397,14 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(collection: ref _warningsAsErrors,
                                  objectTranslator: (ITranslator t, ref string s) => t.Translate(ref s),
 #if CLR2COMPATIBILITY
-                                 collectionFactory: count => new HashSet<string>());
+                                 collectionFactory: count => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
 #else
                                  collectionFactory: count => new HashSet<string>(count, StringComparer.OrdinalIgnoreCase));
 #endif
             translator.Translate(collection: ref _warningsAsMessages,
                                  objectTranslator: (ITranslator t, ref string s) => t.Translate(ref s),
 #if CLR2COMPATIBILITY
-                                 collectionFactory: count => new HashSet<string>());
+                                 collectionFactory: count => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
 #else
                                  collectionFactory: count => new HashSet<string>(count, StringComparer.OrdinalIgnoreCase));
 #endif

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -87,6 +87,8 @@ namespace Microsoft.Build.BackEnd
 
         private ICollection<string> _warningsAsErrors;
 
+        private ICollection<string> _warningsAsMessages;
+
 #if FEATURE_APPDOMAIN
         /// <summary>
         /// Constructor
@@ -105,7 +107,8 @@ namespace Microsoft.Build.BackEnd
         /// <param name="taskLocation">Location of the assembly the task is to be loaded from.</param>
         /// <param name="taskParameters">Parameters to apply to the task.</param>
         /// <param name="globalParameters">global properties for the current project.</param>
-        /// <param name="warningsAsErrors">Warning codes to be thrown as errors for the current project.</param>
+        /// <param name="warningsAsErrors">Warning codes to be treated as errors for the current project.</param>
+        /// <param name="warningsAsMessages">Warning codes to be treated as messages for the current project.</param>
 #else
         /// <summary>
         /// Constructor
@@ -124,6 +127,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="taskParameters">Parameters to apply to the task.</param>
         /// <param name="globalParameters">global properties for the current project.</param>
         /// <param name="warningsAsErrors">Warning codes to be logged as errors for the current project.</param>
+        /// <param name="warningsAsMessages">Warning codes to be treated as messages for the current project.</param>
 #endif
         public TaskHostConfiguration
             (
@@ -143,7 +147,8 @@ namespace Microsoft.Build.BackEnd
                 string taskLocation,
                 IDictionary<string, object> taskParameters,
                 Dictionary<string, string> globalParameters,
-                ICollection<string> warningsAsErrors
+                ICollection<string> warningsAsErrors,
+                ICollection<string> warningsAsMessages
             )
         {
             ErrorUtilities.VerifyThrowInternalLength(taskName, nameof(taskName));
@@ -174,6 +179,7 @@ namespace Microsoft.Build.BackEnd
             _taskName = taskName;
             _taskLocation = taskLocation;
             _warningsAsErrors = warningsAsErrors;
+            _warningsAsMessages = warningsAsMessages;
 
             if (taskParameters != null)
             {
@@ -357,6 +363,15 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
+        public ICollection<string> WarningsAsMessages
+        {
+            [DebuggerStepThrough]
+            get
+            {
+                return _warningsAsMessages;
+            }
+        }
+
         /// <summary>
         /// Translates the packet to/from binary form.
         /// </summary>
@@ -380,6 +395,13 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _continueOnError);
             translator.TranslateDictionary(ref _globalParameters, StringComparer.OrdinalIgnoreCase);
             translator.Translate(collection: ref _warningsAsErrors,
+                                 objectTranslator: (ITranslator t, ref string s) => t.Translate(ref s),
+#if CLR2COMPATIBILITY
+                                 collectionFactory: count => new HashSet<string>());
+#else
+                                 collectionFactory: count => new HashSet<string>(count, StringComparer.OrdinalIgnoreCase));
+#endif
+            translator.Translate(collection: ref _warningsAsMessages,
                                  objectTranslator: (ITranslator t, ref string s) => t.Translate(ref s),
 #if CLR2COMPATIBILITY
                                  collectionFactory: count => new HashSet<string>());


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6306

### Context
https://github.com/dotnet/msbuild/pull/6174 didn't properly account for warningsaserrors and warningsasmessages together. This PR makes each taskhost aware of both WarningsAsMessages and WarningsAsErrors when telling tasks whether or not an error should be treated as a warning.

### Changes Made
LoggingService and TaskLoggingContext expose a `GetWarningsAsMessages` to each taskhost for them to store.
No changes to IBE8 API
Taskhosts first check if a warning would be treated as a message when telling tasks whether or not a warning should be treated as a warning.

### Testing
Added test cases for WarningsAsMessages getting translated properly for the OOPTHN.
Added test cases for WarningsAsErrors and WarningsAsMessages for the same warning code.
Added test case for MSBuildTreatWarningsAsErrors and WarningsAsMessages on a logged warning (WAM takes priority)

### Notes
Does `MSBuildTreatWarningsAsMessages` exist as a property a user can set?
If `WarningsAsMessages` is an empty set, does it follow the rules of `WarningsAsErrors`? (empty set = all warnings as errors) /cc: @jeffkl 