### PR TITLE
Change relative path calculation

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1034,8 +1034,8 @@ namespace Microsoft.Build.Shared
             string fullBase = Path.GetFullPath(basePath);
             string fullPath = Path.GetFullPath(path);
 
-            string[] splitBase = fullBase.Split(new char[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
-            string[] splitPath = fullPath.Split(new char[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+            string[] splitBase = fullBase.Split(MSBuildConstants.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+            string[] splitPath = fullPath.Split(MSBuildConstants.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
 
             ErrorUtilities.VerifyThrow(splitPath.Length > 0, "Cannot call MakeRelative on a path of only slashes.");
 
@@ -1053,38 +1053,24 @@ namespace Microsoft.Build.Shared
 
             int baseI = 0;
             int pathI = 0;
-            while (true)
+            while (baseI < splitBase.Length && pathI < splitPath.Length && splitBase[baseI].Equals(splitPath[pathI], PathComparison))
             {
-                if (baseI == splitBase.Length)
-                {
-                    if (pathI == splitPath.Length)
-                    {
-                        return ".";
-                    }
-                    break;
-                }
-                else if (pathI == splitPath.Length)
-                {
-                    break;
-                }
-                else if (splitBase[baseI].Equals(splitPath[pathI], PathComparison))
-                {
-                    baseI++;
-                    pathI++;
-                }
-                else
-                {
-                    break;
-                }
+                baseI++;
+                pathI++;
             }
 
-            StringBuilder sb = StringBuilderCache.Acquire();
-
+            if (baseI == splitBase.Length && pathI == splitPath.Length)
+            {
+                return ".";
+            }
             // If the paths have no component in common, the only valid relative path is the full path.
             if (baseI == 0)
             {
                 return fullPath;
             }
+
+            StringBuilder sb = StringBuilderCache.Acquire();
+
             while (baseI < splitBase.Length)
             {
                 sb.Append("..").Append(Path.DirectorySeparatorChar);
@@ -1095,7 +1081,7 @@ namespace Microsoft.Build.Shared
                 sb.Append(splitPath[pathI]).Append(Path.DirectorySeparatorChar);
                 pathI++;
             }
-            sb.Remove(sb.Length - 1, 1);
+            sb.Length--;
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1051,35 +1051,31 @@ namespace Microsoft.Build.Shared
                 return FixFilePath(path);
             }
 
-            int baseI = 0;
-            int pathI = 0;
-            while (baseI < splitBase.Length && pathI < splitPath.Length && splitBase[baseI].Equals(splitPath[pathI], PathComparison))
+            int index = 0;
+            while (index < splitBase.Length && index < splitPath.Length && splitBase[index].Equals(splitPath[index], PathComparison))
             {
-                baseI++;
-                pathI++;
+                index++;
             }
 
-            if (baseI == splitBase.Length && pathI == splitPath.Length)
+            if (index == splitBase.Length && index == splitPath.Length)
             {
                 return ".";
             }
             // If the paths have no component in common, the only valid relative path is the full path.
-            if (baseI == 0)
+            if (index == 0)
             {
                 return fullPath;
             }
 
             StringBuilder sb = StringBuilderCache.Acquire();
 
-            while (baseI < splitBase.Length)
+            for (int i = index; i < splitBase.Length; i++)
             {
                 sb.Append("..").Append(Path.DirectorySeparatorChar);
-                baseI++;
             }
-            while (pathI < splitPath.Length)
+            for (int i = index; i < splitPath.Length; i++)
             {
-                sb.Append(splitPath[pathI]).Append(Path.DirectorySeparatorChar);
-                pathI++;
+                sb.Append(splitPath[index]).Append(Path.DirectorySeparatorChar);
             }
             sb.Length--;
             return StringBuilderCache.GetStringAndRelease(sb);

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1061,6 +1061,7 @@ namespace Microsoft.Build.Shared
             {
                 return ".";
             }
+            
             // If the paths have no component in common, the only valid relative path is the full path.
             if (index == 0)
             {

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1034,14 +1034,14 @@ namespace Microsoft.Build.Shared
             string fullBase = Path.GetFullPath(basePath);
             string fullPath = Path.GetFullPath(path);
 
-            string[] splitBase = fullBase.Split(Path.DirectorySeparatorChar).Where(x => !String.IsNullOrEmpty(x)).ToArray();
-            string[] splitPath = fullPath.Split(Path.DirectorySeparatorChar).Where(x => !String.IsNullOrEmpty(x)).ToArray();
+            string[] splitBase = fullBase.Split(new char[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+            string[] splitPath = fullPath.Split(new char[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
 
             ErrorUtilities.VerifyThrow(splitPath.Length > 0, "Cannot call MakeRelative on a path of only slashes.");
 
             // On a mac, the path could start with any number of slashes and still be valid. We have to check them all.
             int indexOfFirstNonSlashChar = 0;
-            while (IsSlash(path[indexOfFirstNonSlashChar]))
+            while (path[indexOfFirstNonSlashChar] == Path.DirectorySeparatorChar)
             {
                 indexOfFirstNonSlashChar++;
             }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1075,7 +1075,7 @@ namespace Microsoft.Build.Shared
             }
             for (int i = index; i < splitPath.Length; i++)
             {
-                sb.Append(splitPath[index]).Append(Path.DirectorySeparatorChar);
+                sb.Append(splitPath[i]).Append(Path.DirectorySeparatorChar);
             }
             sb.Length--;
             return StringBuilderCache.GetStringAndRelease(sb);

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -83,9 +83,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        [Trait("Category", "mono-osx-failing")]
-        [Trait("Category", "netcore-osx-failing")]
-        [Trait("Category", "netcore-linux-failing")]
         public void MakeRelativeTests()
         {
             if (NativeMethodsShared.IsWindows)
@@ -97,20 +94,17 @@ namespace Microsoft.Build.UnitTests
                 Assert.Equal(@"e:\abc\def\foo.cpp", FileUtilities.MakeRelative(@"c:\abc\def", @"e:\abc\def\foo.cpp"));
                 Assert.Equal(@"foo.cpp", FileUtilities.MakeRelative(@"\\aaa\abc\def", @"\\aaa\abc\def\foo.cpp"));
                 Assert.Equal(@"foo.cpp", FileUtilities.MakeRelative(@"c:\abc\def", @"foo.cpp"));
-                Assert.Equal(@"foo.cpp", FileUtilities.MakeRelative(@"c:\abc\def", @"..\def\foo.cpp"));
                 Assert.Equal(@"\\host\path\file", FileUtilities.MakeRelative(@"c:\abc\def", @"\\host\path\file"));
                 Assert.Equal(@"\\host\d$\file", FileUtilities.MakeRelative(@"c:\abc\def", @"\\host\d$\file"));
                 Assert.Equal(@"..\fff\ggg.hh", FileUtilities.MakeRelative(@"c:\foo\bar\..\abc\cde", @"c:\foo\bar\..\abc\fff\ggg.hh"));
             }
             else
             {
-                Assert.Equal(@"foo.cpp", FileUtilities.MakeRelative(@"/abc/def", @"/abc/def/foo.cpp"));
+                Assert.Equal(@"bar.cpp", FileUtilities.MakeRelative(@"/abc/def", @"/abc/def/bar.cpp"));
                 Assert.Equal(@"def/foo.cpp", FileUtilities.MakeRelative(@"/abc/", @"/abc/def/foo.cpp"));
-                Assert.Equal(@"..\foo.cpp", FileUtilities.MakeRelative(@"/abc/def/xyz", @"/abc/def/foo.cpp"));
-                Assert.Equal(@"..\ttt\foo.cpp", FileUtilities.MakeRelative(@"/abc/def/xyz/", @"/abc/def/ttt/foo.cpp"));
-                Assert.Equal(@"/abc/def/foo.cpp", FileUtilities.MakeRelative(@"/abc/def", @"/abc/def/foo.cpp"));
+                Assert.Equal(@"../foo.cpp", FileUtilities.MakeRelative(@"/abc/def/xyz", @"/abc/def/foo.cpp"));
+                Assert.Equal(@"../ttt/foo.cpp", FileUtilities.MakeRelative(@"/abc/def/xyz/", @"/abc/def/ttt/foo.cpp"));
                 Assert.Equal(@"foo.cpp", FileUtilities.MakeRelative(@"/abc/def", @"foo.cpp"));
-                Assert.Equal(@"foo.cpp", FileUtilities.MakeRelative(@"/abc/def", @"../def/foo.cpp"));
                 Assert.Equal(@"../fff/ggg.hh", FileUtilities.MakeRelative(@"/foo/bar/../abc/cde", @"/foo/bar/../abc/fff/ggg.hh"));
             }
         }


### PR DESCRIPTION
For some reason, the pre-caching change seems to fail in the installer repo at the build step because of a failing relative path calculation. This version seems to work.
