### PR TITLE
Fail Restore when an SDK is unresolved or entry target does not exist

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1048,7 +1048,7 @@ namespace Microsoft.Build.Execution
         SkipNonexistentTargets = 16,
         ProvideSubsetOfStateAfterBuild = 32,
         IgnoreMissingEmptyAndInvalidImports = 64,
-        SkipNonexistentNonTopLevelTargets = 128,
+        SkipNonexistentNonEntryTargets = 128,
         FailOnUnresolvedSdk = 256,
     }
     public partial class BuildResult

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -772,6 +772,7 @@ namespace Microsoft.Build.Evaluation
         DoNotEvaluateElementsWithFalseCondition = 32,
         IgnoreInvalidImports = 64,
         ProfileEvaluation = 128,
+        FailOnUnresolvedSdk = 256,
     }
     public partial class ProjectMetadata : System.IEquatable<Microsoft.Build.Evaluation.ProjectMetadata>
     {
@@ -1047,6 +1048,8 @@ namespace Microsoft.Build.Execution
         SkipNonexistentTargets = 16,
         ProvideSubsetOfStateAfterBuild = 32,
         IgnoreMissingEmptyAndInvalidImports = 64,
+        SkipNonexistentNonTopLevelTargets = 128,
+        FailOnUnresolvedSdk = 256,
     }
     public partial class BuildResult
     {

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1043,7 +1043,7 @@ namespace Microsoft.Build.Execution
         SkipNonexistentTargets = 16,
         ProvideSubsetOfStateAfterBuild = 32,
         IgnoreMissingEmptyAndInvalidImports = 64,
-        SkipNonexistentNonTopLevelTargets = 128,
+        SkipNonexistentNonEntryTargets = 128,
         FailOnUnresolvedSdk = 256,
     }
     public partial class BuildResult

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -772,6 +772,7 @@ namespace Microsoft.Build.Evaluation
         DoNotEvaluateElementsWithFalseCondition = 32,
         IgnoreInvalidImports = 64,
         ProfileEvaluation = 128,
+        FailOnUnresolvedSdk = 256,
     }
     public partial class ProjectMetadata : System.IEquatable<Microsoft.Build.Evaluation.ProjectMetadata>
     {
@@ -1042,6 +1043,8 @@ namespace Microsoft.Build.Execution
         SkipNonexistentTargets = 16,
         ProvideSubsetOfStateAfterBuild = 32,
         IgnoreMissingEmptyAndInvalidImports = 64,
+        SkipNonexistentNonTopLevelTargets = 128,
+        FailOnUnresolvedSdk = 256,
     }
     public partial class BuildResult
     {

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1702,6 +1702,11 @@ namespace Microsoft.Build.Execution
                                 projectLoadSettings |= ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreEmptyImports;
                             }
 
+                            if (submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.FailOnUnresolvedSdk))
+                            {
+                                projectLoadSettings |= ProjectLoadSettings.FailOnUnresolvedSdk;
+                            }
+
                             return new ProjectInstance(
                                 path,
                                 properties,

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -77,12 +77,12 @@ namespace Microsoft.Build.Execution
         IgnoreMissingEmptyAndInvalidImports = 1 << 6,
 
         /// <summary>
-        /// When this flag is present, non top level target(s) in the build request will be skipped if those targets
-        /// are not defined in the Project to build. The build will still fail if a top lvel target does not exist.
+        /// When this flag is present, non entry target(s) in the build request will be skipped if those targets
+        /// are not defined in the Project to build. The build will still fail if an entry target does not exist.
         /// This only applies to this build request (if another target calls the "missing target" at any other point
         /// this will still result in an error).
         /// </summary>
-        SkipNonexistentNonTopLevelTargets = 1 << 7,
+        SkipNonexistentNonEntryTargets = 1 << 7,
 
         /// <summary>
         /// When this flag is present, an unresolved MSBuild project SDK will fail the build.  This flag is used to

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -75,6 +75,21 @@ namespace Microsoft.Build.Execution
         /// This is especially useful during a restore since some imports might come from packages that haven't been restored yet.
         /// </summary>
         IgnoreMissingEmptyAndInvalidImports = 1 << 6,
+
+        /// <summary>
+        /// When this flag is present, non top level target(s) in the build request will be skipped if those targets
+        /// are not defined in the Project to build. The build will still fail if a top lvel target does not exist.
+        /// This only applies to this build request (if another target calls the "missing target" at any other point
+        /// this will still result in an error).
+        /// </summary>
+        SkipNonexistentNonTopLevelTargets = 1 << 7,
+
+        /// <summary>
+        /// When this flag is present, an unresolved MSBuild project SDK will fail the build.  This flag is used to
+        /// change the <see cref="IgnoreMissingEmptyAndInvalidImports" /> behavior to still fail when an SDK is missing
+        /// because those are more fatal.
+        /// </summary>
+        FailOnUnresolvedSdk = 1 << 8,
     }
 
     /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -143,21 +143,24 @@ namespace Microsoft.Build.BackEnd
             foreach (string targetName in targetNames)
             {
                 var targetExists = _projectInstance.Targets.TryGetValue(targetName, out ProjectTargetInstance targetInstance);
-                // Ignore the missing target if:
-                //  SkipNonexistentTargets is set
-                //  -or-
-                //  SkipNonexistentNonTopLevelTargets and the target is is not a top level target
-                if (!targetExists
-                    && entry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.SkipNonexistentTargets)
-                    || entry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.SkipNonexistentNonTopLevelTargets) && !entry.Request.Targets.Contains(targetName))
+                
+                if (!targetExists)
                 {
-                    _projectLoggingContext.LogComment(Framework.MessageImportance.Low,
-                    "TargetSkippedWhenSkipNonexistentTargets", targetName);
+                    // Ignore the missing target if:
+                    //  SkipNonexistentTargets is set
+                    //  -or-
+                    //  SkipNonexistentNonEntryTargets and the target is is not a top level target
+                    if (entry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.SkipNonexistentTargets)
+                        || entry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.SkipNonexistentNonEntryTargets) && !entry.Request.Targets.Contains(targetName))
+                    {
+                        _projectLoggingContext.LogComment(Framework.MessageImportance.Low,
+                            "TargetSkippedWhenSkipNonexistentTargets", targetName);
+
+                        continue;
+                    }
                 }
-                else
-                {
-                    targets.Add(new TargetSpecification(targetName, targetExists ? targetInstance.Location : _projectInstance.ProjectFileLocation));
-                }
+
+                targets.Add(new TargetSpecification(targetName, targetExists ? targetInstance.Location : _projectInstance.ProjectFileLocation));
             }
 
             // Push targets onto the stack.  This method will reverse their push order so that they

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -143,10 +143,16 @@ namespace Microsoft.Build.BackEnd
             foreach (string targetName in targetNames)
             {
                 var targetExists = _projectInstance.Targets.TryGetValue(targetName, out ProjectTargetInstance targetInstance);
-                if (!targetExists && entry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.SkipNonexistentTargets))
+                // Ignore the missing target if:
+                //  SkipNonexistentTargets is set
+                //  -or-
+                //  SkipNonexistentNonTopLevelTargets and the target is is not a top level target
+                if (!targetExists
+                    && entry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.SkipNonexistentTargets)
+                    || entry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.SkipNonexistentNonTopLevelTargets) && !entry.Request.Targets.Contains(targetName))
                 {
                     _projectLoggingContext.LogComment(Framework.MessageImportance.Low,
-                        "TargetSkippedWhenSkipNonexistentTargets", targetName);
+                    "TargetSkippedWhenSkipNonexistentTargets", targetName);
                 }
                 else
                 {

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -466,6 +466,11 @@ namespace Microsoft.Build.BackEnd
                     projectLoadSettings |= ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreEmptyImports;
                 }
 
+                if (buildRequestDataFlags.HasFlag(buildRequestDataFlags & BuildRequestDataFlags.FailOnUnresolvedSdk))
+                {
+                    projectLoadSettings |= ProjectLoadSettings.FailOnUnresolvedSdk;
+                }
+
                 return new ProjectInstance(
                     ProjectFullPath,
                     globalProperties,

--- a/src/Build/Definition/ProjectLoadSettings.cs
+++ b/src/Build/Definition/ProjectLoadSettings.cs
@@ -59,5 +59,10 @@ namespace Microsoft.Build.Evaluation
         /// Whether to profile the evaluation
         /// </summary>
         ProfileEvaluation = 128,
+
+        /// <summary>
+        /// Used in combination with <see cref="IgnoreMissingImports" /> to still treat an unresolved MSBuild project SDK as an error.
+        /// </summary>
+        FailOnUnresolvedSdk = 256,
     }
 }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1761,7 +1761,8 @@ namespace Microsoft.Build.Evaluation
 
                 if (!sdkResult.Success)
                 {
-                    if (_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports))
+                    // Ignore the missing import if IgnoreMissingImports is set unless FailOnUnresolvedSdk is also set
+                    if (_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) && !_loadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk))
                     {
                         ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
                             importElement.Location.Line,

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2128,10 +2128,10 @@ $@"<Project>
         }
 
         /// <summary>
-        /// Verifies a non-existent target doesn't fail restore as long as its not considered "top-level" or a target that we're directly executing, in this case Restore.
+        /// Verifies a non-existent target doesn't fail restore as long as its not considered an entry target, in this case Restore.
         /// </summary>
         [Fact]
-        public void RestoreSkipsNonExistentNonTopLevelTargets()
+        public void RestoreSkipsNonExistentNonEntryTargets()
         {
             string restoreFirstProps = $"{Guid.NewGuid():N}.props";
 
@@ -2164,10 +2164,10 @@ $@"<Project DefaultTargets=""Build"" InitialTargets=""TargetThatComesFromRestore
         }
 
         /// <summary>
-        /// Verifies restore will fail if the "top-level" target doesn't exist, in this case Restore.
+        /// Verifies restore will fail if the entry target doesn't exist, in this case Restore.
         /// </summary>
         [Fact]
-        public void RestoreFailsWhenTopLevelTargetIsNonExistent()
+        public void RestoreFailsWhenEntryTargetIsNonExistent()
         {
             string projectContents = ObjectModelHelpers.CleanupFileContents(
 @"<Project DefaultTargets=""Build"">
@@ -2179,6 +2179,33 @@ $@"<Project DefaultTargets=""Build"" InitialTargets=""TargetThatComesFromRestore
             string logContents = ExecuteMSBuildExeExpectFailure(projectContents, arguments: "/t:restore");
             
             logContents.ShouldContain("error MSB4057: The target \"Restore\" does not exist in the project.");
+        }
+
+        /// <summary>
+        /// Verifies restore will run InitialTargets.
+        /// </summary>
+        [Fact]
+        public void RestoreRunsInitialTargets()
+        {
+            string projectContents = ObjectModelHelpers.CleanupFileContents(
+                @"<Project DefaultTargets=""Build"" InitialTargets=""InitialTarget"">
+  <Target Name=""InitialTarget"">
+    <Message Text=""InitialTarget target ran&quot;"" />
+  </Target>
+
+  <Target Name=""Restore"">
+    <Message Text=""Restore target ran&quot;"" />
+  </Target>
+
+  <Target Name=""Build"">
+    <Message Text=""Build target ran&quot;"" />
+  </Target>
+</Project>");
+
+            string logContents = ExecuteMSBuildExeExpectSuccess(projectContents, arguments: "/t:restore");
+
+            logContents.ShouldContain("InitialTarget target ran");
+            logContents.ShouldContain("Restore target ran");
         }
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1422,7 +1422,7 @@ namespace Microsoft.Build.CommandLine
 
             // Create a new request with a Restore target only and specify:
             //  - BuildRequestDataFlags.ClearCachesAfterBuild to ensure the projects will be reloaded from disk for subsequent builds
-            //  - BuildRequestDataFlags.SkipNonexistentNonTopLevelTargets to ignore missing non-top-level targets since Restore does not require that all targets
+            //  - BuildRequestDataFlags.SkipNonexistentNonEntryTargets to ignore missing non-entry targets since Restore does not require that all targets
             //      exist, only top-level ones like Restore itself
             //  - BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports to ignore imports that don't exist, are empty, or are invalid because restore might
             //     make available an import that doesn't exist yet and the <Import /> might be missing a condition.
@@ -1434,7 +1434,7 @@ namespace Microsoft.Build.CommandLine
                 toolsVersion,
                 targetsToBuild: new[] { MSBuildConstants.RestoreTargetName },
                 hostServices: null,
-                flags: BuildRequestDataFlags.ClearCachesAfterBuild | BuildRequestDataFlags.SkipNonexistentNonTopLevelTargets | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports | BuildRequestDataFlags.FailOnUnresolvedSdk);
+                flags: BuildRequestDataFlags.ClearCachesAfterBuild | BuildRequestDataFlags.SkipNonexistentNonEntryTargets | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports | BuildRequestDataFlags.FailOnUnresolvedSdk);
 
             return ExecuteBuild(buildManager, restoreRequest);
         }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1422,16 +1422,19 @@ namespace Microsoft.Build.CommandLine
 
             // Create a new request with a Restore target only and specify:
             //  - BuildRequestDataFlags.ClearCachesAfterBuild to ensure the projects will be reloaded from disk for subsequent builds
-            //  - BuildRequestDataFlags.SkipNonexistentTargets to ignore missing targets since Restore does not require that all targets exist
+            //  - BuildRequestDataFlags.SkipNonexistentNonTopLevelTargets to ignore missing non-top-level targets since Restore does not require that all targets
+            //      exist, only top-level ones like Restore itself
             //  - BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports to ignore imports that don't exist, are empty, or are invalid because restore might
             //     make available an import that doesn't exist yet and the <Import /> might be missing a condition.
+            //  - BuildRequestDataFlags.FailOnUnresolvedSdk to still fail in the case when an MSBuild project SDK can't be resolved since this is fatal and should
+            //     fail the build.
             BuildRequestData restoreRequest = new BuildRequestData(
                 projectFile,
                 restoreGlobalProperties,
                 toolsVersion,
                 targetsToBuild: new[] { MSBuildConstants.RestoreTargetName },
                 hostServices: null,
-                flags: BuildRequestDataFlags.ClearCachesAfterBuild | BuildRequestDataFlags.SkipNonexistentTargets | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports);
+                flags: BuildRequestDataFlags.ClearCachesAfterBuild | BuildRequestDataFlags.SkipNonexistentNonTopLevelTargets | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports | BuildRequestDataFlags.FailOnUnresolvedSdk);
 
             return ExecuteBuild(buildManager, restoreRequest);
         }


### PR DESCRIPTION
Fixes #6281

### Context
`BuildRequestDataFlags` and `ProjectLoadSettings` are set during `/t:restore` in a best effort to run the Restore target in hopes that it will correct the potentially bad state that a project is in.  Visual Studio also sets `ProjectLoadSettings.IgnoreMissingImports` so that an unresolved MSBuild project SDK doesn't prevent loading of a bad project so it can give the user an error and let them edit the file.

However, this means that from the command-line an unresolved SDK doesn't fail `/t:restore`.  This is because the missing "import" is ignored and non-existent targets are ignored so the build succeeds.

### Changes Made
Introduced two new `BuildRequestDataFlags`:

* `SkipNonexistentNonTopLevelTargets` - A new flag to be used in this context to tell the build to ignore non-existent targets but not top level ones.  In this case we're specifying `/t:restore` so if the Restore target doesn't exist, that should be an error.  Only other targets that are trying to run are ignored (like InitialTargets, Before/AfterTargets, etc).
* `FailOnUnresolvedSdk` - We still need to ignore missing imports and I can't introduce a new flag to split the implementation now since Visual Studio sets `ProjectLoadSettings.IgnoreMissingImports` as a way to ignore unresolved SDKs.  So this flag tells the evaluator to fail on an unresolved SDK but to continue ignoring other missing imports.

### Testing
Added three new unit tests:
* Restore fails when an SDK can't be resolved
* Restore fails if a top-level target like Restore doesn't exist
* Restore succeeds if a non-top-level target doesn't exist