### PR TITLE
Add ARM32 & ARM64 As AvailablePlatforms

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -62,6 +62,21 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <AvailablePlatforms Condition="'$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' > '10.0'">Any CPU,x86,x64</AvailablePlatforms>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32</AvailablePlatforms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(AvailablePlatforms),ARM32</AvailablePlatforms>
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">
+    <!-- Need to check console and windows here. -->
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
+  </PropertyGroup>
+
   <!-- Import depends on if it is .NETCore. Imports for .NETFramework is a superset of that for .NETCore-->
   <Import Project="Microsoft.NETFramework.props" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == 'Silverlight'"/>
   <Import Project="Microsoft.NET.props" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"/>


### PR DESCRIPTION
Fixes #5951

### Context
Summary: .NET 5 is adding support for Windows ARM64. Visual Studio .NET Core projects should allow you target ARM64 in addition to x86/x64/arm32.

This is planned to be based off of the `AvailablePlatforms` property.

### Changes Made
In Microsoft.Common.CurrentVersion.targets, added conditional propertygroups based on TargetFramework to add ARM32/64 as a platform.

### Testing
Needs https://github.com/dotnet/project-system/issues/7081 to account for `AvailablePlatforms` so we can see it in the Platform Target dropdown under project properties.

### Notes
What we're trying to apply ARM to:
| Version | Windows | Linux | macOS
| --- | --- | --- | ---
| [.NET Core 2.1](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md) | x86, x64 | x86, x64, arm32 | x64
| [.NET Core 3.1](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) | x86, x64, arm32 | x86, x64, arm32, arm64 | x64
| [.NET 5](https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0-supported-os.md) | x86, x64, arm64 (console only) | x86, x64, arm32, arm64 | x64