### PR TITLE
Remove BinaryFormatter from GetSDKReferenceFiles

### DIFF
--- a/src/Shared/TranslatorHelpers.cs
+++ b/src/Shared/TranslatorHelpers.cs
@@ -111,23 +111,6 @@ namespace Microsoft.Build.BackEnd
             translator.TranslateDictionary(ref dictionary, AdaptFactory(valueFactory), collectionCreator);
         }
 
-#if NET40_OR_GREATER
-        public static void TranslateConcurrentDictionary<T>(
-            this ITranslator translator,
-            ref ConcurrentDictionary<string, T> dictionary,
-            ObjectTranslator<T> objTranslator)
-        {
-            foreach (KeyValuePair<string, T> kvp in dictionary)
-            {
-                string key = kvp.Key;
-                T value = kvp.Value;
-                translator.Translate(ref key);
-                objTranslator(translator, ref value);
-
-            }
-        }
-#endif
-
         public static void TranslateHashSet<T>(
             this ITranslator translator,
             ref HashSet<T> hashSet,

--- a/src/Shared/TranslatorHelpers.cs
+++ b/src/Shared/TranslatorHelpers.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-#if NET40_OR_GREATER
-using System.Collections.Concurrent;
-#endif
 using System.Collections.Generic;
 using System.Configuration.Assemblies;
 using System.Globalization;

--- a/src/Shared/TranslatorHelpers.cs
+++ b/src/Shared/TranslatorHelpers.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+#if NET40_OR_GREATER
+using System.Collections.Concurrent;
+#endif
 using System.Collections.Generic;
 using System.Configuration.Assemblies;
 using System.Globalization;
@@ -107,6 +110,23 @@ namespace Microsoft.Build.BackEnd
         {
             translator.TranslateDictionary(ref dictionary, AdaptFactory(valueFactory), collectionCreator);
         }
+
+#if NET40_OR_GREATER
+        public static void TranslateConcurrentDictionary<T>(
+            this ITranslator translator,
+            ref ConcurrentDictionary<string, T> dictionary,
+            ObjectTranslator<T> objTranslator)
+        {
+            foreach (KeyValuePair<string, T> kvp in dictionary)
+            {
+                string key = kvp.Key;
+                T value = kvp.Value;
+                translator.Translate(ref key);
+                objTranslator(translator, ref value);
+
+            }
+        }
+#endif
 
         public static void TranslateHashSet<T>(
             this ITranslator translator,

--- a/src/Tasks.UnitTests/GetSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/GetSDKReference_Tests.cs
@@ -491,14 +491,14 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
             ITaskItem item1 = new TaskItem(_sdkDirectory);
             item1.SetMetadata("ExpandReferenceAssemblies", "true");
             item1.SetMetadata("TargetedSDKConfiguration", "Retail");
-            item1.SetMetadata("TargetedSDKArchitecture", "X86");
+            item1.SetMetadata("TargetedSDKArchitecture", "x86");
             item1.SetMetadata("CopyLocalExpandedReferenceAssemblies", "false");
             item1.SetMetadata("OriginalItemSpec", "SDKWithManifest, Version=2.0");
 
             ITaskItem item2 = new TaskItem(_sdkDirectory);
             item2.SetMetadata("ExpandReferenceAssemblies", "true");
             item2.SetMetadata("TargetedSDKConfiguration", "Retail");
-            item2.SetMetadata("TargetedSDKArchitecture", "X86");
+            item2.SetMetadata("TargetedSDKArchitecture", "x86");
             item2.SetMetadata("CopyLocalExpandedReferenceAssemblies", "false");
             item2.SetMetadata("OriginalItemSpec", "SDKWithManifest, Version=2.0");
             item2.SetMetadata("RuntimeReferenceOnly", "true");

--- a/src/Tasks.UnitTests/GetSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/GetSDKReference_Tests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -257,6 +258,38 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
             var getReferenceFolders2 = new GetSDKFolders2(ToolLocationHelper.GetSDKReferenceFolders);
 
             VerifySDKFolders(getReferenceFolders, getReferenceFolders2, "References", _sdkDirectory);
+        }
+
+        [Fact]
+        public void VerifyGetSdkReferenceTranslator()
+        {
+            ConcurrentDictionary<string, GetSDKReferenceFiles.SdkReferenceInfo> pathToReferenceMetadata = new();
+            pathToReferenceMetadata.TryAdd("first", new("dat", "dat2", true, false));
+            pathToReferenceMetadata.TryAdd("second", new("inf", "inf2", false, false));
+            ConcurrentDictionary<string, List<string>> directoryToFileList = new();
+            directoryToFileList.TryAdd("third", new List<string>() { "a", "b", "c" });
+            directoryToFileList.TryAdd("fourth", new List<string>() { "1", "2", "3" });
+            GetSDKReferenceFiles.SDKInfo writeInfo = new(pathToReferenceMetadata, directoryToFileList, 47);
+            GetSDKReferenceFiles.SaveContext contextWriter = new("d", "n", writeInfo);
+            GetSDKReferenceFiles.SDKInfo readInfo = null;
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                TransientTestFolder folder = env.CreateFolder();
+                GetSDKReferenceFiles.SDKFilesCache cache = new(null, folder.Path, null, null, null);
+                cache.SaveAssemblyListToCacheFile(contextWriter);
+                GetSDKReferenceFiles.SDKFilesCache cache2 = new(null, folder.Path, null, null, null);
+                readInfo = cache2.LoadAssemblyListFromCacheFile("d", "n");
+            }
+            readInfo.DirectoryToFileList.Count.ShouldBe(2);
+            readInfo.DirectoryToFileList["fourth"].Count.ShouldBe(3);
+            readInfo.DirectoryToFileList["fourth"][1].ShouldBe("2");
+            readInfo.DirectoryToFileList["third"][0].ShouldBe("a");
+            readInfo.Hash.ShouldBe(47);
+            readInfo.PathToReferenceMetadata.Count.ShouldBe(2);
+            readInfo.PathToReferenceMetadata["first"].FusionName.ShouldBe("dat");
+            readInfo.PathToReferenceMetadata["first"].IsManagedWinmd.ShouldBeFalse();
+            readInfo.PathToReferenceMetadata["first"].IsWinMD.ShouldBeTrue();
+            readInfo.PathToReferenceMetadata["second"].ImageRuntime.ShouldBe("inf2");
         }
 
         private static void VerifySDKFolders(GetSDKFolders singleParamDelegate, GetSDKFolders2 multiParamDelegate, string folderName, string sdkDirectory)

--- a/src/Tasks.UnitTests/GetSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/GetSDKReference_Tests.cs
@@ -263,12 +263,12 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Fact]
         public void VerifyGetSdkReferenceTranslator()
         {
-            ConcurrentDictionary<string, GetSDKReferenceFiles.SdkReferenceInfo> pathToReferenceMetadata = new();
-            pathToReferenceMetadata.TryAdd("first", new("dat", "dat2", true, false));
-            pathToReferenceMetadata.TryAdd("second", new("inf", "inf2", false, false));
-            ConcurrentDictionary<string, List<string>> directoryToFileList = new();
-            directoryToFileList.TryAdd("third", new List<string>() { "a", "b", "c" });
-            directoryToFileList.TryAdd("fourth", new List<string>() { "1", "2", "3" });
+            Dictionary<string, GetSDKReferenceFiles.SdkReferenceInfo> pathToReferenceMetadata = new();
+            pathToReferenceMetadata.Add("first", new("dat", "dat2", true, false));
+            pathToReferenceMetadata.Add("second", new("inf", "inf2", false, false));
+            Dictionary<string, List<string>> directoryToFileList = new();
+            directoryToFileList.Add("third", new List<string>() { "a", "b", "c" });
+            directoryToFileList.Add("fourth", new List<string>() { "1", "2", "3" });
             GetSDKReferenceFiles.SDKInfo writeInfo = new(pathToReferenceMetadata, directoryToFileList, 47);
             GetSDKReferenceFiles.SaveContext contextWriter = new("d", "n", writeInfo);
             GetSDKReferenceFiles.SDKInfo readInfo = null;

--- a/src/Tasks.UnitTests/GetSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/GetSDKReference_Tests.cs
@@ -491,14 +491,14 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
             ITaskItem item1 = new TaskItem(_sdkDirectory);
             item1.SetMetadata("ExpandReferenceAssemblies", "true");
             item1.SetMetadata("TargetedSDKConfiguration", "Retail");
-            item1.SetMetadata("TargetedSDKArchitecture", "x86");
+            item1.SetMetadata("TargetedSDKArchitecture", "X86");
             item1.SetMetadata("CopyLocalExpandedReferenceAssemblies", "false");
             item1.SetMetadata("OriginalItemSpec", "SDKWithManifest, Version=2.0");
 
             ITaskItem item2 = new TaskItem(_sdkDirectory);
             item2.SetMetadata("ExpandReferenceAssemblies", "true");
             item2.SetMetadata("TargetedSDKConfiguration", "Retail");
-            item2.SetMetadata("TargetedSDKArchitecture", "x86");
+            item2.SetMetadata("TargetedSDKArchitecture", "X86");
             item2.SetMetadata("CopyLocalExpandedReferenceAssemblies", "false");
             item2.SetMetadata("OriginalItemSpec", "SDKWithManifest, Version=2.0");
             item2.SetMetadata("RuntimeReferenceOnly", "true");

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.BackEnd;
@@ -1238,7 +1237,12 @@ namespace Microsoft.Build.Tasks
             private ConcurrentDictionary<string, List<string>> directoryToFileList;
             private int hash;
 
-            internal SDKInfo() { }
+            internal SDKInfo()
+            {
+                pathToReferenceMetadata = new();
+                directoryToFileList = new();
+                hash = 0;
+            }
 
             public SDKInfo(ITranslator translator) : this()
             {
@@ -1295,12 +1299,25 @@ namespace Microsoft.Build.Tasks
 
         private static void TranslateConcurrentDictionary<T>(ITranslator translator, ref ConcurrentDictionary<string, T> dictionary, ObjectTranslator<T> objTranslator)
         {
-            foreach (KeyValuePair<string, T> kvp in dictionary)
+            int count = dictionary.Count;
+            translator.Translate(ref count);
+            string[] keys = dictionary.Keys.ToArray();
+            for (int i = 0; i < count; i++)
             {
-                string key = kvp.Key;
-                T value = kvp.Value;
-                translator.Translate(ref key);
-                objTranslator(translator, ref value);
+                if (i < keys.Length)
+                {
+                    translator.Translate(ref keys[i]);
+                    T value = dictionary[keys[i]];
+                    objTranslator(translator, ref value);
+                }
+                else
+                {
+                    string key = null;
+                    translator.Translate(ref key);
+                    T value = default;
+                    objTranslator(translator, ref value);
+                    dictionary[key] = value;
+                }                
             }
         }
 

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -1272,7 +1272,7 @@ namespace Microsoft.Build.Tasks
 
             public void Translate(ITranslator translator)
             {
-                translator.TranslateConcurrentDictionary<SdkReferenceInfo>(ref pathToReferenceMetadata, (ITranslator t, ref SdkReferenceInfo info) =>
+                TranslateConcurrentDictionary<SdkReferenceInfo>(translator, ref pathToReferenceMetadata, (ITranslator t, ref SdkReferenceInfo info) =>
                 {
                     string fusionName = info.FusionName;
                     string imageRuntime = info.ImageRuntime;
@@ -1284,12 +1284,23 @@ namespace Microsoft.Build.Tasks
                     t.Translate(ref isWinmd);
                 });
 
-                translator.TranslateConcurrentDictionary<List<string>>(ref directoryToFileList, (ITranslator t, ref List<string> fileList) =>
+                TranslateConcurrentDictionary<List<string>>(translator, ref directoryToFileList, (ITranslator t, ref List<string> fileList) =>
                 {
                     t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
                 });
 
                 translator.Translate(ref hash);
+            }
+        }
+
+        private static void TranslateConcurrentDictionary<T>(ITranslator translator, ref ConcurrentDictionary<string, T> dictionary, ObjectTranslator<T> objTranslator)
+        {
+            foreach (KeyValuePair<string, T> kvp in dictionary)
+            {
+                string key = kvp.Key;
+                T value = kvp.Value;
+                translator.Translate(ref key);
+                objTranslator(translator, ref value);
             }
         }
 

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
@@ -927,7 +928,11 @@ namespace Microsoft.Build.Tasks
                 {
                     if (!string.IsNullOrEmpty(cacheFile))
                     {
-                        return SDKInfo.Deserialize(cacheFile);
+                        using FileStream fs = new FileStream(cacheFile, FileMode.Open);
+                        var translator = BinaryTranslator.GetReadTranslator(fs, buffer: null);
+                        SDKInfo sdkInfo = new SDKInfo();
+                        sdkInfo.Translate(translator);
+                        return sdkInfo;
                     }
                 }
                 catch (Exception e)
@@ -977,19 +982,14 @@ namespace Microsoft.Build.Tasks
                         }
                     }
 
-                    var formatter = new BinaryFormatter();
                     using (var fs = new FileStream(referencesCacheFile, FileMode.Create))
                     {
-                        formatter.Serialize(fs, cacheFileInfo);
+                        var translator = BinaryTranslator.GetWriteTranslator(fs);
+                        cacheFileInfo.Translate(translator);
                     }
                 }
-                catch (Exception e)
+                catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
                 {
-                    if (ExceptionHandling.IsCriticalException(e))
-                    {
-                        throw;
-                    }
-
                     // Queue up for later logging, does not matter if the cache got written
                     _exceptionMessages.Enqueue(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("GetSDKReferenceFiles.ProblemWritingCacheFile", referencesCacheFile, e.Message));
                 }
@@ -1219,24 +1219,10 @@ namespace Microsoft.Build.Tasks
             }
 
             #region Properties
-            /// <summary>
-            /// The fusionName
-            /// </summary>
+
             public string FusionName { get; }
-
-            /// <summary>
-            /// Is the file a winmd or not
-            /// </summary>
             public bool IsWinMD { get; }
-
-            /// <summary>
-            /// Is the file a managed winmd or not
-            /// </summary>
             public bool IsManagedWinmd { get; }
-
-            /// <summary>
-            /// What is the imageruntime information on it.
-            /// </summary>
             public string ImageRuntime { get; }
 
             #endregion
@@ -1246,56 +1232,64 @@ namespace Microsoft.Build.Tasks
         /// Structure that contains the on disk representation of the SDK in memory.
         /// </summary>
         /// <remarks>This is a serialization format. Do not change member naming.</remarks>
-        [Serializable]
-        private class SDKInfo
+        private class SDKInfo : ITranslatable
         {
-            // Current version for serialization. This should be changed when breaking changes
-            // are made to this class.
-            private const byte CurrentSerializationVersion = 1;
+            private ConcurrentDictionary<string, SdkReferenceInfo> pathToReferenceMetadata;
+            private ConcurrentDictionary<string, List<string>> directoryToFileList;
+            private int hash;
 
-            // Version this instance is serialized with.
-            private byte _serializedVersion = CurrentSerializationVersion;
+            internal SDKInfo() { }
+
+            public SDKInfo(ITranslator translator) : this()
+            {
+                Translate(translator);
+            }
 
             /// <summary>
             /// Constructor
             /// </summary>
             public SDKInfo(ConcurrentDictionary<string, SdkReferenceInfo> pathToReferenceMetadata, ConcurrentDictionary<string, List<string>> directoryToFileList, int cacheHash)
             {
-                PathToReferenceMetadata = pathToReferenceMetadata;
-                DirectoryToFileList = directoryToFileList;
-                Hash = cacheHash;
+                this.pathToReferenceMetadata = pathToReferenceMetadata;
+                this.directoryToFileList = directoryToFileList;
+                this.hash = cacheHash;
             }
 
             /// <summary>
             /// A dictionary which maps a file path to a structure that contain some metadata information about that file.
             /// </summary>
-            public ConcurrentDictionary<string, SdkReferenceInfo> PathToReferenceMetadata { get; }
+            public ConcurrentDictionary<string, SdkReferenceInfo> PathToReferenceMetadata { get { return pathToReferenceMetadata; } }
 
             /// <summary>
             /// Dictionary which maps a directory to a list of file names within that directory. This is used to shortcut hitting the disk for the list of files inside of it.
             /// </summary>
-            public ConcurrentDictionary<string, List<string>> DirectoryToFileList { get; }
+            public ConcurrentDictionary<string, List<string>> DirectoryToFileList { get { return directoryToFileList; } }
 
             /// <summary>
             /// Hashset
             /// </summary>
-            public int Hash { get; }
+            public int Hash { get { return hash; } }
 
-            public static SDKInfo Deserialize(string cacheFile)
+            public void Translate(ITranslator translator)
             {
-                using (var fs = new FileStream(cacheFile, FileMode.Open))
+                translator.TranslateConcurrentDictionary<SdkReferenceInfo>(ref pathToReferenceMetadata, (ITranslator t, ref SdkReferenceInfo info) =>
                 {
-                    var formatter = new BinaryFormatter();
-                    var info = (SDKInfo)formatter.Deserialize(fs);
+                    string fusionName = info.FusionName;
+                    string imageRuntime = info.ImageRuntime;
+                    bool isManagedWinmd = info.IsManagedWinmd;
+                    bool isWinmd = info.IsWinMD;
+                    t.Translate(ref fusionName);
+                    t.Translate(ref imageRuntime);
+                    t.Translate(ref isManagedWinmd);
+                    t.Translate(ref isWinmd);
+                });
 
-                    // If the serialization versions don't match, don't use the cache
-                    if (info != null && info._serializedVersion != CurrentSerializationVersion)
-                    {
-                        return null;
-                    }
+                translator.TranslateConcurrentDictionary<List<string>>(ref directoryToFileList, (ITranslator t, ref List<string> fileList) =>
+                {
+                    t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
+                });
 
-                    return info;
-                }
+                translator.Translate(ref hash);
             }
         }
 

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -1257,7 +1257,7 @@ namespace Microsoft.Build.Tasks
 
             public void Translate(ITranslator translator)
             {
-                translator.TranslateDictionary(ref pathToReferenceMetadata, (ITranslator t, ref SdkReferenceInfo info) =>
+                translator.TranslateDictionary(ref pathToReferenceMetadata, StringComparer.OrdinalIgnoreCase, (ITranslator t, ref SdkReferenceInfo info) =>
                 {
                     info ??= new SdkReferenceInfo(null, null, false, false);
                     string fusionName = info.FusionName;
@@ -1274,11 +1274,11 @@ namespace Microsoft.Build.Tasks
                     info.IsWinMD = isWinmd;
                 });
 
-                translator.TranslateDictionary(ref directoryToFileList, (ITranslator t, ref List<string> fileList) =>
+                translator.TranslateDictionary(ref directoryToFileList, StringComparer.OrdinalIgnoreCase, (ITranslator t, ref List<string> fileList) =>
                 {
                     t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
                 });
-                translator.TranslateDictionary(ref directoryToFileList, (ITranslator t, ref List<string> fileList) =>
+                translator.TranslateDictionary(ref directoryToFileList, StringComparer.OrdinalIgnoreCase, (ITranslator t, ref List<string> fileList) =>
                 {
                     t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
                 });

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -1226,8 +1226,9 @@ namespace Microsoft.Build.Tasks
 
             internal SDKInfo()
             {
-                pathToReferenceMetadata = new();
-                directoryToFileList = new();
+                IEqualityComparer<string> comparer = FileUtilities.PathComparison == StringComparison.Ordinal ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+                pathToReferenceMetadata = new(comparer);
+                directoryToFileList = new(comparer);
                 hash = 0;
             }
 
@@ -1287,8 +1288,7 @@ namespace Microsoft.Build.Tasks
         {
             int count = dictionary.Count;
             translator.Translate(ref count);
-            string[] keys = dictionary.Keys.ToArray();
-            if (keys.Length == 0)
+            if (translator.Mode == TranslationDirection.ReadFromStream)
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -1301,10 +1301,11 @@ namespace Microsoft.Build.Tasks
             }
             else
             {
-                for (int i = 0; i < count; i++)
+                foreach (KeyValuePair<string, T> kvp in dictionary)
                 {
-                    translator.Translate(ref keys[i]);
-                    T value = dictionary[keys[i]];
+                    string key = kvp.Key;
+                    translator.Translate(ref key);
+                    T value = kvp.Value;
                     objTranslator(translator, ref value);
                 }
             }

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -1012,7 +1012,7 @@ namespace Microsoft.Build.Tasks
 
                 PopulateRedistDictionaryFromPaths(directoryToFileList, redistDirectories);
 
-                var cacheInfo = new SDKInfo(references.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase), directoryToFileList.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase), FileUtilities.GetPathsHash(directoriesToHash));
+                var cacheInfo = new SDKInfo(references, directoryToFileList, FileUtilities.GetPathsHash(directoriesToHash));
                 return cacheInfo;
             }
 
@@ -1217,18 +1217,17 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Structure that contains the on disk representation of the SDK in memory.
         /// </summary>
-        /// <remarks>This is a serialization format. Do not change member naming.</remarks>
         internal class SDKInfo : ITranslatable
         {
-            private Dictionary<string, SdkReferenceInfo> pathToReferenceMetadata;
-            private Dictionary<string, List<string>> directoryToFileList;
-            private int hash;
+            private IDictionary<string, SdkReferenceInfo> _pathToReferenceMetadata;
+            private IDictionary<string, List<string>> _directoryToFileList;
+            private int _hash;
 
             internal SDKInfo()
             {
-                pathToReferenceMetadata = new(StringComparer.OrdinalIgnoreCase);
-                directoryToFileList = new(StringComparer.OrdinalIgnoreCase);
-                hash = 0;
+                _pathToReferenceMetadata = new Dictionary<string, SdkReferenceInfo>(StringComparer.OrdinalIgnoreCase);
+                _directoryToFileList = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+                _hash = 0;
             }
 
             public SDKInfo(ITranslator translator) : this()
@@ -1236,28 +1235,28 @@ namespace Microsoft.Build.Tasks
                 Translate(translator);
             }
 
-            public SDKInfo(Dictionary<string, SdkReferenceInfo> pathToReferenceMetadata, Dictionary<string, List<string>> directoryToFileList, int cacheHash)
+            public SDKInfo(IDictionary<string, SdkReferenceInfo> pathToReferenceMetadata, IDictionary<string, List<string>> directoryToFileList, int cacheHash)
             {
-                this.pathToReferenceMetadata = pathToReferenceMetadata;
-                this.directoryToFileList = directoryToFileList;
-                this.hash = cacheHash;
+                this._pathToReferenceMetadata = pathToReferenceMetadata;
+                this._directoryToFileList = directoryToFileList;
+                this._hash = cacheHash;
             }
 
             /// <summary>
             /// A dictionary which maps a file path to a structure that contain some metadata information about that file.
             /// </summary>
-            public Dictionary<string, SdkReferenceInfo> PathToReferenceMetadata { get { return pathToReferenceMetadata; } }
+            public IDictionary<string, SdkReferenceInfo> PathToReferenceMetadata { get { return _pathToReferenceMetadata; } }
 
-            public Dictionary<string, List<string>> DirectoryToFileList { get { return directoryToFileList; } }
+            public IDictionary<string, List<string>> DirectoryToFileList { get { return _directoryToFileList; } }
 
             /// <summary>
             /// Hashset
             /// </summary>
-            public int Hash { get { return hash; } }
+            public int Hash { get { return _hash; } }
 
             public void Translate(ITranslator translator)
             {
-                translator.TranslateDictionary(ref pathToReferenceMetadata, StringComparer.OrdinalIgnoreCase, (ITranslator t, ref SdkReferenceInfo info) =>
+                translator.TranslateDictionary(ref _pathToReferenceMetadata, (ITranslator t, ref string s) => t.Translate(ref s), (ITranslator t, ref SdkReferenceInfo info) =>
                 {
                     info ??= new SdkReferenceInfo(null, null, false, false);
                     string fusionName = info.FusionName;
@@ -1272,18 +1271,18 @@ namespace Microsoft.Build.Tasks
                     info.ImageRuntime = imageRuntime;
                     info.IsManagedWinmd = isManagedWinmd;
                     info.IsWinMD = isWinmd;
-                });
+                }, count => new Dictionary<string, SdkReferenceInfo>(count));
 
-                translator.TranslateDictionary(ref directoryToFileList, StringComparer.OrdinalIgnoreCase, (ITranslator t, ref List<string> fileList) =>
+                translator.TranslateDictionary(ref _directoryToFileList, (ITranslator t, ref string s) => t.Translate(ref s), (ITranslator t, ref List<string> fileList) =>
                 {
                     t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
-                });
-                translator.TranslateDictionary(ref directoryToFileList, StringComparer.OrdinalIgnoreCase, (ITranslator t, ref List<string> fileList) =>
+                }, count => new Dictionary<string, List<string>>(count));
+                translator.TranslateDictionary(ref _directoryToFileList, (ITranslator t, ref string s) => t.Translate(ref s), (ITranslator t, ref List<string> fileList) =>
                 {
                     t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
-                });
+                }, count => new Dictionary<string, List<string>>(count));
 
-                translator.Translate(ref hash);
+                translator.Translate(ref _hash);
             }
         }
 

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -1271,16 +1271,16 @@ namespace Microsoft.Build.Tasks
                     info.ImageRuntime = imageRuntime;
                     info.IsManagedWinmd = isManagedWinmd;
                     info.IsWinMD = isWinmd;
-                }, count => new Dictionary<string, SdkReferenceInfo>(count));
+                }, count => new Dictionary<string, SdkReferenceInfo>(count, StringComparer.OrdinalIgnoreCase));
 
                 translator.TranslateDictionary(ref _directoryToFileList, (ITranslator t, ref string s) => t.Translate(ref s), (ITranslator t, ref List<string> fileList) =>
                 {
                     t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
-                }, count => new Dictionary<string, List<string>>(count));
+                }, count => new Dictionary<string, List<string>>(count, StringComparer.OrdinalIgnoreCase));
                 translator.TranslateDictionary(ref _directoryToFileList, (ITranslator t, ref string s) => t.Translate(ref s), (ITranslator t, ref List<string> fileList) =>
                 {
                     t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
-                }, count => new Dictionary<string, List<string>>(count));
+                }, count => new Dictionary<string, List<string>>(count, StringComparer.OrdinalIgnoreCase));
 
                 translator.Translate(ref _hash);
             }

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -1196,9 +1196,6 @@ namespace Microsoft.Build.Tasks
         [Serializable]
         internal class SdkReferenceInfo
         {
-            /// <summary>
-            /// Constructor
-            /// </summary>
             public SdkReferenceInfo(string fusionName, string imageRuntime, bool isWinMD, bool isManagedWinmd)
             {
                 FusionName = fusionName;
@@ -1239,9 +1236,6 @@ namespace Microsoft.Build.Tasks
                 Translate(translator);
             }
 
-            /// <summary>
-            /// Constructor
-            /// </summary>
             public SDKInfo(ConcurrentDictionary<string, SdkReferenceInfo> pathToReferenceMetadata, ConcurrentDictionary<string, List<string>> directoryToFileList, int cacheHash)
             {
                 this.pathToReferenceMetadata = pathToReferenceMetadata;
@@ -1252,11 +1246,8 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             /// A dictionary which maps a file path to a structure that contain some metadata information about that file.
             /// </summary>
-            internal ConcurrentDictionary<string, SdkReferenceInfo> PathToReferenceMetadata { get { return pathToReferenceMetadata; } }
+            public ConcurrentDictionary<string, SdkReferenceInfo> PathToReferenceMetadata { get { return pathToReferenceMetadata; } }
 
-            /// <summary>
-            /// Dictionary which maps a directory to a list of file names within that directory. This is used to shortcut hitting the disk for the list of files inside of it.
-            /// </summary>
             public ConcurrentDictionary<string, List<string>> DirectoryToFileList { get { return directoryToFileList; } }
 
             /// <summary>
@@ -1297,22 +1288,25 @@ namespace Microsoft.Build.Tasks
             int count = dictionary.Count;
             translator.Translate(ref count);
             string[] keys = dictionary.Keys.ToArray();
-            for (int i = 0; i < count; i++)
+            if (keys.Length == 0)
             {
-                if (i < keys.Length)
-                {
-                    translator.Translate(ref keys[i]);
-                    T value = dictionary[keys[i]];
-                    objTranslator(translator, ref value);
-                }
-                else
+                for (int i = 0; i < count; i++)
                 {
                     string key = null;
                     translator.Translate(ref key);
                     T value = default;
                     objTranslator(translator, ref value);
                     dictionary[key] = value;
-                }                
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    translator.Translate(ref keys[i]);
+                    T value = dictionary[keys[i]];
+                    objTranslator(translator, ref value);
+                }
             }
         }
 

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -1277,10 +1277,6 @@ namespace Microsoft.Build.Tasks
                 {
                     t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
                 }, count => new Dictionary<string, List<string>>(count, StringComparer.OrdinalIgnoreCase));
-                translator.TranslateDictionary(ref _directoryToFileList, (ITranslator t, ref string s) => t.Translate(ref s), (ITranslator t, ref List<string> fileList) =>
-                {
-                    t.Translate(ref fileList, (ITranslator t, ref string str) => { t.Translate(ref str); });
-                }, count => new Dictionary<string, List<string>>(count, StringComparer.OrdinalIgnoreCase));
 
                 translator.Translate(ref _hash);
             }


### PR DESCRIPTION
I think this is almost right, but TranslatorHelpers needs System.Collections.Concurrent on .NET 3.5, or I need to be able to translate a concurrent dictionary without translating it. (?) Any idea on how I can get around that?
