### PR TITLE
Add binding redirects for all assemblies redistributed by MSBuild

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <!--
-    Make sure to update the binding redirects (in src\MSBuild\app.config) for any changes to
+    Make sure to update the binding redirects (in src\MSBuild\app.config and src\MSBuild\app.amd64.config) for any changes to
     the list of assemblies redistributed by MSBuild (non-MSBuild assemblies in the .vsix package).
      -->
   <ItemGroup>

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,4 +1,8 @@
 <Project>
+  <!--
+    Make sure to update the binding redirects (in src\MSBuild\app.config) for any changes to
+    the list of assemblies redistributed by MSBuild (non-MSBuild assemblies in the .vsix package).
+     -->
   <ItemGroup>
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -52,10 +52,63 @@
           <codeBase version="16.10.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
+        <!-- Redirects for assemblies redistributed by MSBuild (in the .vsix). -->
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.NET.StringTools" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.NET.StringTools.net35" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        </dependentAssembly>
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
         <dependentAssembly>
           <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
           <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Resources.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.6.3.0" newVersion="4.6.3.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
         </dependentAssembly>
 
         <!-- Redirects for components dropped by Visual Studio -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -41,10 +41,63 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
         </dependentAssembly>
 
+        <!-- Redirects for assemblies redistributed by MSBuild (in the .vsix). -->
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.NET.StringTools" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.NET.StringTools.net35" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        </dependentAssembly>
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
         <dependentAssembly>
           <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
           <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Resources.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.6.3.0" newVersion="4.6.3.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
         </dependentAssembly>
 
         <!-- Redirects for components dropped by Visual Studio -->


### PR DESCRIPTION
MSBuild redistributes System.Memory but does not binding redirect it. This causes the QB cache plugin to fail (qb.exe works because it has binding redirects, but the plugin fails because it's a dll and dlls don't have binding redirects).
Both MSBuild and VS ship with System.Memory 4.0.1.1 so this should not have any negative consequences.

In general, shouldn't MSBuild add binding redirects for [all the assemblies that it redistributes](https://github.com/dotnet/msbuild/blob/9bcc06cbe19ae2482ab18eab90a82fd079b26897/src/Package/MSBuild.VSSetup/files.swr#L39-L52)? I see that MSBuild redistributes a bunch of assemblies but does not binding redirect them. @danmoseley @ericstj 