### PR TITLE
Make GenerateResource look up resgen.exe in 10.0 SDK

### DIFF
--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -321,11 +321,11 @@ namespace Microsoft.Build.Utilities
         Version461 = 8,
         Version452 = 9,
         Version462 = 10,
-        VersionLatest = 10,
         Version47 = 11,
         Version471 = 12,
         Version472 = 13,
         Version48 = 14,
+        VersionLatest = 14,
         Latest = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
@@ -599,6 +599,8 @@ namespace Microsoft.Build.Utilities
         Version120 = 2,
         Version140 = 3,
         Version150 = 4,
-        VersionLatest = 4,
+        Version160 = 5,
+        VersionLatest = 5,
+        Version170 = 6,
     }
 }

--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -321,11 +321,11 @@ namespace Microsoft.Build.Utilities
         Version461 = 8,
         Version452 = 9,
         Version462 = 10,
+        VersionLatest = 10,
         Version47 = 11,
         Version471 = 12,
         Version472 = 13,
         Version48 = 14,
-        VersionLatest = 14,
         Latest = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
@@ -599,8 +599,8 @@ namespace Microsoft.Build.Utilities
         Version120 = 2,
         Version140 = 3,
         Version150 = 4,
+        VersionLatest = 4,
         Version160 = 5,
-        VersionLatest = 5,
         Version170 = 6,
     }
 }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -166,11 +166,11 @@ namespace Microsoft.Build.Utilities
         Version461 = 8,
         Version452 = 9,
         Version462 = 10,
-        VersionLatest = 10,
         Version47 = 11,
         Version471 = 12,
         Version472 = 13,
         Version48 = 14,
+        VersionLatest = 14,
         Latest = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
@@ -433,6 +433,8 @@ namespace Microsoft.Build.Utilities
         Version120 = 2,
         Version140 = 3,
         Version150 = 4,
-        VersionLatest = 4,
+        Version160 = 5,
+        VersionLatest = 5,
+        Version170 = 6,
     }
 }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -166,11 +166,11 @@ namespace Microsoft.Build.Utilities
         Version461 = 8,
         Version452 = 9,
         Version462 = 10,
+        VersionLatest = 10,
         Version47 = 11,
         Version471 = 12,
         Version472 = 13,
         Version48 = 14,
-        VersionLatest = 14,
         Latest = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
@@ -433,8 +433,8 @@ namespace Microsoft.Build.Utilities
         Version120 = 2,
         Version140 = 3,
         Version150 = 4,
+        VersionLatest = 4,
         Version160 = 5,
-        VersionLatest = 5,
         Version170 = 6,
     }
 }

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -66,9 +66,11 @@ namespace Microsoft.Build.Shared
         internal static readonly Version visualStudioVersion120 = new Version(12, 0);
         internal static readonly Version visualStudioVersion140 = new Version(14, 0);
         internal static readonly Version visualStudioVersion150 = new Version(15, 0);
+        internal static readonly Version visualStudioVersion160 = new Version(16, 0);
+        internal static readonly Version visualStudioVersion170 = new Version(17, 0);
 
         // keep this up-to-date; always point to the latest visual studio version.
-        internal static readonly Version visualStudioVersionLatest = visualStudioVersion150;
+        internal static readonly Version visualStudioVersionLatest = visualStudioVersion160;
 
         private const string dotNetFrameworkRegistryPath = "SOFTWARE\\Microsoft\\.NETFramework";
         private const string dotNetFrameworkSetupRegistryPath = "SOFTWARE\\Microsoft\\NET Framework Setup\\NDP";
@@ -286,6 +288,25 @@ namespace Microsoft.Build.Shared
                 dotNetFrameworkVersion472,
                 dotNetFrameworkVersion48,
             }),
+
+            // VS16
+            new VisualStudioSpec(visualStudioVersion160, "NETFXSDK\\{0}", "v10.0", "InstallationFolder", new []
+            {
+                dotNetFrameworkVersion11,
+                dotNetFrameworkVersion20,
+                dotNetFrameworkVersion35,
+                dotNetFrameworkVersion40,
+                dotNetFrameworkVersion45,
+                dotNetFrameworkVersion451,
+                dotNetFrameworkVersion452,
+                dotNetFrameworkVersion46,
+                dotNetFrameworkVersion461,
+                dotNetFrameworkVersion462,
+                dotNetFrameworkVersion47,
+                dotNetFrameworkVersion471,
+                dotNetFrameworkVersion472,
+                dotNetFrameworkVersion48,
+            }),
         };
 
 #if FEATURE_WIN32_REGISTRY
@@ -320,6 +341,17 @@ namespace Microsoft.Build.Shared
             { (dotNetFrameworkVersion471, visualStudioVersion150), (dotNetFrameworkVersion47, visualStudioVersion150) },
             { (dotNetFrameworkVersion472, visualStudioVersion150), (dotNetFrameworkVersion471, visualStudioVersion150) },
             { (dotNetFrameworkVersion48, visualStudioVersion150), (dotNetFrameworkVersion472, visualStudioVersion150) },
+
+            // VS16
+            { (dotNetFrameworkVersion451, visualStudioVersion160), (dotNetFrameworkVersion45, visualStudioVersion160) },
+            { (dotNetFrameworkVersion452, visualStudioVersion160), (dotNetFrameworkVersion451, visualStudioVersion160) },
+            { (dotNetFrameworkVersion46, visualStudioVersion160), (dotNetFrameworkVersion451, visualStudioVersion160) },
+            { (dotNetFrameworkVersion461, visualStudioVersion160), (dotNetFrameworkVersion46, visualStudioVersion160) },
+            { (dotNetFrameworkVersion462, visualStudioVersion160), (dotNetFrameworkVersion461, visualStudioVersion160) },
+            { (dotNetFrameworkVersion47, visualStudioVersion160), (dotNetFrameworkVersion462, visualStudioVersion160) },
+            { (dotNetFrameworkVersion471, visualStudioVersion160), (dotNetFrameworkVersion47, visualStudioVersion160) },
+            { (dotNetFrameworkVersion472, visualStudioVersion160), (dotNetFrameworkVersion471, visualStudioVersion160) },
+            { (dotNetFrameworkVersion48, visualStudioVersion160), (dotNetFrameworkVersion472, visualStudioVersion160) },
        };
 #endif // FEATURE_WIN32_REGISTRY
 

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
@@ -3015,7 +3015,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests
         {
             GenerateResource t = CreateTask(output);
             t.ExecuteAsTool = true;
-            t.SdkToolsPath = ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.VersionLatest);
+            t.SdkToolsPath = ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version48);
 
             return t;
         }

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -1065,7 +1065,13 @@ namespace Microsoft.Build.Tasks
 
             if (String.IsNullOrEmpty(_sdkToolsPath))
             {
-                var version = TargetDotNetFrameworkVersion.VersionLatest;
+                // Important: the GenerateResource task is declared twice in Microsoft.Common.CurrentVersion.targets:
+                // https://github.com/dotnet/msbuild/blob/369631b4b21ef485f4d6f35e16b0c839a971b0e9/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3177-L3178
+                // First for CLR >= 4.0, where SdkToolsPath is passed $(ResgenToolPath) which in turn is set to
+                // $(TargetFrameworkSDKToolsDirectory).
+                // But for CLR < 4.0 the SdkToolsPath is not passed, so we need to explicitly assume 3.5:
+                var version = TargetDotNetFrameworkVersion.Version35;
+
                 _resgenPath = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("resgen.exe", version);
 
                 if (_resgenPath == null && ExecuteAsTool)

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -1065,13 +1065,14 @@ namespace Microsoft.Build.Tasks
 
             if (String.IsNullOrEmpty(_sdkToolsPath))
             {
-                _resgenPath = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("resgen.exe", TargetDotNetFrameworkVersion.Version35);
+                var version = TargetDotNetFrameworkVersion.VersionLatest;
+                _resgenPath = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("resgen.exe", version);
 
                 if (_resgenPath == null && ExecuteAsTool)
                 {
                     Log.LogErrorWithCodeFromResources("General.PlatformSDKFileNotFound", "resgen.exe",
-                        ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version35),
-                        ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version35));
+                        ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(version),
+                        ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(version));
                 }
             }
             else

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Build.Utilities
         /// breaking change. Use 'Latest' if possible, but note the
         /// compatibility implications.
         /// </summary>
-        VersionLatest = Version462,
+        VersionLatest = Version48,
 
         /// <summary>
         /// Sentinel value for the latest version that this version of MSBuild is aware of. Similar
@@ -130,35 +130,45 @@ namespace Microsoft.Build.Utilities
     public enum VisualStudioVersion
     {
         /// <summary>
-        /// Visual Studio 2010 and SP1
+        /// Visual Studio 2010 (Dev10) and SP1
         /// </summary>
         Version100,
 
         /// <summary>
-        /// Visual Studio Dev11
+        /// Visual Studio 2012 (Dev11)
         /// </summary>
         Version110,
 
         /// <summary>
-        /// Visual Studio Dev12
+        /// Visual Studio 2013 (Dev12)
         /// </summary>
         Version120,
 
         /// <summary>
-        /// Visual Studio Dev14
+        /// Visual Studio 2015 (Dev14)
         /// </summary>
         Version140,
 
         /// <summary>
-        /// Visual Studio Dev15
+        /// Visual Studio 2017 (Dev15)
         /// </summary>
         Version150,
+
+        /// <summary>
+        /// Visual Studio 2019 (Dev16)
+        /// </summary>
+        Version160,
+
+        /// <summary>
+        /// Visual Studio "Dev17"
+        /// </summary>
+        Version170,
 
         // keep this up-to-date; always point to the last entry.
         /// <summary>
         /// The latest version available at the time of release
         /// </summary>
-        VersionLatest = Version150
+        VersionLatest = Version160
     }
 
     /// <summary>
@@ -2052,26 +2062,22 @@ namespace Microsoft.Build.Utilities
 
         private static Version VisualStudioVersionToSystemVersion(VisualStudioVersion version)
         {
-            switch (version)
+            return version switch
             {
-                case VisualStudioVersion.Version100:
-                    return FrameworkLocationHelper.visualStudioVersion100;
+                VisualStudioVersion.Version100 => FrameworkLocationHelper.visualStudioVersion100,
+                VisualStudioVersion.Version110 => FrameworkLocationHelper.visualStudioVersion110,
+                VisualStudioVersion.Version120 => FrameworkLocationHelper.visualStudioVersion120,
+                VisualStudioVersion.Version140 => FrameworkLocationHelper.visualStudioVersion140,
+                VisualStudioVersion.Version150 => FrameworkLocationHelper.visualStudioVersion150,
+                VisualStudioVersion.Version160 => FrameworkLocationHelper.visualStudioVersion160,
+                VisualStudioVersion.Version170 => FrameworkLocationHelper.visualStudioVersion170,
+                _ => Unsupported()
+            };
 
-                case VisualStudioVersion.Version110:
-                    return FrameworkLocationHelper.visualStudioVersion110;
-
-                case VisualStudioVersion.Version120:
-                    return FrameworkLocationHelper.visualStudioVersion120;
-
-                case VisualStudioVersion.Version140:
-                    return FrameworkLocationHelper.visualStudioVersion140;
-
-                case VisualStudioVersion.Version150:
-                    return FrameworkLocationHelper.visualStudioVersion150;
-
-                default:
-                    ErrorUtilities.ThrowArgument("ToolLocationHelper.UnsupportedVisualStudioVersion", version);
-                    return null;
+            Version Unsupported()
+            {
+                ErrorUtilities.ThrowArgument("ToolLocationHelper.UnsupportedVisualStudioVersion", version);
+                return null;
             }
         }
 
@@ -3250,7 +3256,8 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         /// <param name="fileName">File name to locate in the .NET Framework SDK directory</param>
         /// <returns>Path string.</returns>
-        public static string GetPathToDotNetFrameworkSdkFile(string fileName) => GetPathToDotNetFrameworkSdkFile(fileName, TargetDotNetFrameworkVersion.Latest);
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName)
+            => GetPathToDotNetFrameworkSdkFile(fileName, TargetDotNetFrameworkVersion.Latest);
 
         /// <summary>
         /// Get a fully qualified path to a file in the .NET Framework SDK. Error if the .NET Framework SDK can't be found.
@@ -3261,7 +3268,8 @@ namespace Microsoft.Build.Utilities
         /// <param name="fileName">File name to locate in the .NET Framework SDK directory</param>
         /// <param name="version">Version of the targeted .NET Framework</param>
         /// <returns>Path string.</returns>
-        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version) => GetPathToDotNetFrameworkSdkFile(fileName, version, VisualStudioVersion.VersionLatest);
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version)
+            => GetPathToDotNetFrameworkSdkFile(fileName, version, VisualStudioVersion.VersionLatest);
 
         /// <summary>
         /// Get a fully qualified path to a file in the .NET Framework SDK. Error if the .NET Framework SDK can't be found.
@@ -3276,7 +3284,7 @@ namespace Microsoft.Build.Utilities
                 version,
                 visualStudioVersion,
                 UtilitiesDotNetFrameworkArchitecture.Current,
-                true /* If the file is not found for the current architecture, it's OK to follow fallback mechanisms. */
+                canFallBackIfNecessary: true /* If the file is not found for the current architecture, it's OK to follow fallback mechanisms. */
             );
 
         /// <summary>

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Build.Utilities
         /// breaking change. Use 'Latest' if possible, but note the
         /// compatibility implications.
         /// </summary>
-        VersionLatest = Version48,
+        VersionLatest = Version462,
 
         /// <summary>
         /// Sentinel value for the latest version that this version of MSBuild is aware of. Similar
@@ -168,7 +168,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// The latest version available at the time of release
         /// </summary>
-        VersionLatest = Version160
+        VersionLatest = Version150
     }
 
     /// <summary>


### PR DESCRIPTION
GenerateResource tests were failing when only VS 2019 and 10.0 Windows SDK is installed. I suspect the task itself would also fail if run with ExecuteAsTool.

The problem is that we started look up with .NET 4.6.1 and lower. Start lookup with .NET 4.8 instead and fallback down the chain. This should still find all earlier SDKs too.

Introduce latest versions of Visual Studio too.

Fixes https://github.com/dotnet/msbuild/issues/6266