### PR TITLE
Fix TasksCanAddRecursiveDirBuiltInMetadata()

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -349,8 +349,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.True(result);
 
             // Assuming the current directory of the test .dll has at least one subfolder
-            // such as Roslyn, the log will contain [Roslyn\]
-            logger.AssertLogContains("\\]");
+            // such as Roslyn, the log will contain [Roslyn\] (or [Roslyn/] on Unix)
+            string slashAndBracket = Path.DirectorySeparatorChar.ToString() + "]";
+            logger.AssertLogContains(slashAndBracket);
             logger.AssertLogDoesntContain("MSB4118");
             logger.AssertLogDoesntContain("MSB3031");
         }

--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -19,6 +19,7 @@ using Microsoft.Build.Shared;
 using ElementLocation = Microsoft.Build.Construction.ElementLocation;
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using LegacyThreadingData = Microsoft.Build.Execution.LegacyThreadingData;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -344,9 +344,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 </Project>");
 
             Project project = new Project(XmlReader.Create(new StringReader(projectFileContents)));
-            bool result = project.Build("t", new[] { logger });
-
-            Assert.True(result);
+            project.Build("t", new[] { logger }).ShouldBeTrue();
 
             // Assuming the current directory of the test .dll has at least one subfolder
             // such as Roslyn, the log will contain [Roslyn\] (or [Roslyn/] on Unix)

--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -328,31 +328,29 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// else could let the item get corrupt (inconsistent values for Filename and FullPath, for example)
         /// </summary>
         [Fact]
-        [Trait("Category", "netcore-osx-failing")]
-        [Trait("Category", "netcore-linux-failing")]
-        [Trait("Category", "mono-osx-failing")]
         public void TasksCanAddRecursiveDirBuiltInMetadata()
         {
-            MockLogger logger = new MockLogger();
+            MockLogger logger = new MockLogger(this._testOutput);
 
-            string projectFileContents = ObjectModelHelpers.CleanupFileContents(@"
-<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
+            string projectFileContents = ObjectModelHelpers.CleanupFileContents($@"
+<Project>
 <Target Name='t'>
- <CreateItem Include='$(programfiles)\reference assemblies\**\*.dll;'>
+ <CreateItem Include='{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\**\*.dll'>
    <Output TaskParameter='Include' ItemName='x' />
  </CreateItem>
 <Message Text='@(x)'/>
- <Message Text='[%(x.RecursiveDir)]'/>                    
+ <Message Text='[%(x.RecursiveDir)]'/>
 </Target>
 </Project>");
 
             Project project = new Project(XmlReader.Create(new StringReader(projectFileContents)));
-            List<ILogger> loggers = new List<ILogger>();
-            loggers.Add(logger);
-            bool result = project.Build("t", loggers);
+            bool result = project.Build("t", new[] { logger });
 
             Assert.True(result);
-            logger.AssertLogDoesntContain("[]");
+
+            // Assuming the current directory of the test .dll has at least one subfolder
+            // such as Roslyn, the log will contain [Roslyn\]
+            logger.AssertLogContains("\\]");
             logger.AssertLogDoesntContain("MSB4118");
             logger.AssertLogDoesntContain("MSB3031");
         }


### PR DESCRIPTION
Don't use Program Files\Reference Assemblies as that might not exist for 64-bit.

Pass ITestOutputLogger to MockLogger to get the full log in case of failure.

Search for a log substring that will only be there in case of success. Even successful logs can contain [] when the file is at the root of the directory so RecursiveDir will be empty.

Fixes https://github.com/dotnet/msbuild/issues/6267