### PR TITLE
Allow turning detailed summary off

### DIFF
--- a/src/Build/BackEnd/Components/Scheduler/IScheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/IScheduler.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Build.BackEnd
         void Reset();
 
         /// <summary>
-        /// Writes a detailed summary of the build state which includes informaiton about the scheduling plan.
+        /// Writes a detailed summary of the build state which includes information about the scheduling plan.
         /// </summary>
         void WriteDetailedSummary(int submissionId);
 

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -346,13 +346,22 @@ namespace Microsoft.Build.UnitTests
         [InlineData("detailedsummary")]
         [InlineData("DETAILEDSUMMARY")]
         [InlineData("DetailedSummary")]
-        public void DetailedSummarySwitchIndentificationTests(string detailedsummary)
+        public void DetailedSummarySwitchIdentificationTests(string detailedsummary)
         {
-            CommandLineSwitches.ParameterlessSwitch parameterlessSwitch;
-            string duplicateSwitchErrorMessage;
-            CommandLineSwitches.IsParameterlessSwitch(detailedsummary, out parameterlessSwitch, out duplicateSwitchErrorMessage).ShouldBeTrue();
-            parameterlessSwitch.ShouldBe(CommandLineSwitches.ParameterlessSwitch.DetailedSummary);
+            CommandLineSwitches.IsParameterizedSwitch(
+                detailedsummary,
+                out var parameterizedSwitch,
+                out var duplicateSwitchErrorMessage,
+                out var multipleParametersAllowed,
+                out var missingParametersErrorMessage,
+                out var unquoteParameters,
+                out var emptyParametersAllowed).ShouldBeTrue();
+            parameterizedSwitch.ShouldBe(CommandLineSwitches.ParameterizedSwitch.DetailedSummary);
             duplicateSwitchErrorMessage.ShouldBeNull();
+            multipleParametersAllowed.ShouldBe(false);
+            missingParametersErrorMessage.ShouldBeNull();
+            unquoteParameters.ShouldBe(true);
+            emptyParametersAllowed.ShouldBe(false);
         }
 
         [Theory]

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Build.CommandLine
             OldOM,
 #endif
             DistributedFileLogger,
-            DetailedSummary,
 #if DEBUG
             WaitForDebugger,
 #endif
@@ -104,6 +103,7 @@ namespace Microsoft.Build.CommandLine
             InputResultsCaches,
             OutputResultsCache,
             LowPriority,
+            DetailedSummary,
             NumberOfParameterizedSwitches,
         }
 
@@ -221,7 +221,6 @@ namespace Microsoft.Build.CommandLine
             new ParameterlessSwitchInfo(  new string[] { "oldom" },                         ParameterlessSwitch.OldOM,                 null),
 #endif
             new ParameterlessSwitchInfo(  new string[] { "distributedfilelogger", "dfl" },  ParameterlessSwitch.DistributedFileLogger, null),
-            new ParameterlessSwitchInfo(  new string[] { "detailedsummary", "ds" },         ParameterlessSwitch.DetailedSummary,       null),
 #if DEBUG
             new ParameterlessSwitchInfo(  new string[] { "waitfordebugger", "wfd" },        ParameterlessSwitch.WaitForDebugger,       null),
 #endif
@@ -269,10 +268,11 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "restoreproperty", "rp" },             ParameterizedSwitch.RestoreProperty,            null,                           true,           "MissingRestorePropertyError",         true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "interactive" },                       ParameterizedSwitch.Interactive,                null,                           false,          null,                                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "isolateprojects", "isolate" },        ParameterizedSwitch.IsolateProjects,            null,                           false,          null,                                  true,   false  ),
-            new ParameterizedSwitchInfo(  new string[] { "graphbuild", "graph" },               ParameterizedSwitch.GraphBuild,                 null,                           true,          null,                                  true,   false  ),
+            new ParameterizedSwitchInfo(  new string[] { "graphbuild", "graph" },               ParameterizedSwitch.GraphBuild,                 null,                           true,           null,                                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "inputResultsCaches", "irc" },         ParameterizedSwitch.InputResultsCaches,         null,                           true,           null,                                  true,   true   ),
             new ParameterizedSwitchInfo(  new string[] { "outputResultsCache", "orc" },         ParameterizedSwitch.OutputResultsCache,         "DuplicateOutputResultsCache",  false,          null,                                  true,   true   ),
             new ParameterizedSwitchInfo(  new string[] { "lowpriority", "low" },                ParameterizedSwitch.LowPriority,                null,                           false,          null,                                  true,   false  ),
+            new ParameterizedSwitchInfo(  new string[] { "detailedsummary", "ds" },             ParameterizedSwitch.DetailedSummary,            null,                           false,          null,                                  true,   false  ),
         };
 
         /// <summary>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -601,12 +601,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </value>
   </data>
   <data name="HelpMessage_26_DetailedSummarySwitch">
-    <value>  -detailedSummary
+    <value>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </value>
+    <comment>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </comment>
   </data>
   <data name="HelpMessage_28_WarnAsErrorSwitch" UESanitized="false" Visibility="Public">
     <value>  -warnAsError[:code[;code2]]
@@ -1177,6 +1181,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : error MSB1057: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the -graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </comment>
+  </data>
+  <data name="InvalidDetailedSummaryValue" UESanitized="true" Visibility="Public">
+    <value>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</value>
+    <comment>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </comment>
   </data>

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -939,19 +939,22 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      Při dokončení sestavení zobrazí podrobné informace
                      o sestavených konfiguracích a způsobu jejich
                      naplánování do uzlů.
                      (Krátký tvar: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -960,6 +963,16 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -931,19 +931,22 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      Zeigt am Ende der Erstellung detaillierte Informationen
                      zu den erstellten Konfigurationen an und enthält eine Erläuterung, wie sie
                      in Knoten geplant wurden.
                      (Kurzform: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -952,6 +955,16 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.en.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.en.xlf
@@ -941,19 +941,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="new">  -detailedSummary
+        <target state="new">  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_28_WarnAsErrorSwitch">
         <source>  -warnAsError[:code[;code2]]
@@ -1141,6 +1144,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -940,19 +940,22 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      Muestra información detallada al final de la compilación
                      sobre las configuraciones compiladas y el modo en que
                      se programaron en los nodos.
                      (Forma corta: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -961,6 +964,16 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -932,19 +932,22 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      À la fin de la build, affiche des informations détaillées
                      sur les configurations générées et la façon dont elles
                      étaient planifiées sur les nœuds.
                      (Forme abrégée : -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -953,6 +956,16 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -952,19 +952,22 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      Visualizza informazioni dettagliate al termine della
                      compilazione relative alle configurazioni compilate e alla
                      relativa modalità di pianificazione nei nodi. Forma breve:
                      -ds.
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -973,6 +976,16 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -931,19 +931,22 @@ Copyright (C) Microsoft Corporation.All rights reserved.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                     ビルドの最後に、ビルド構成と、ノードに対して
                     どのようにスケジュールされたかについて、
                     詳細情報が表示されます。
                     (短い形式: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -952,6 +955,16 @@ Copyright (C) Microsoft Corporation.All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -931,19 +931,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      빌드 마지막에 구성 상태 및
                      노드에 대한 해당 구성의 예약 상태와 관련한
                      자세한 정보를 표시합니다.
                      (약식: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -952,6 +955,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -944,19 +944,22 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      Powoduje wyświetlenie na zakończenie kompilacji
                      szczegółowych informacji o utworzonych konfiguracjach
                      i ich planowanym wykorzystaniu węzłów.
                      (Krótka wersja: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -965,6 +968,16 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -932,19 +932,22 @@ isoladamente.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      Mostra informações detalhadas ao final do build
                      sobre as configurações compiladas e o modo como elas foram
                      agendadas para nós. 
                      (Forma abreviada: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -953,6 +956,16 @@ isoladamente.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -931,19 +931,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      Показывает в конце сборки подробные сведения
                      о созданных конфигурациях и графике их передачи
                      на узлы.
                      (Краткая форма: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -952,6 +955,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -935,19 +935,22 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                      Derleme sonunda, derlenen yapılandırmalar ve
                      bu yapılandırmaların düğümlere nasıl zamanlandıkları
                      hakkında ayrıntılı bilgi içerir.
                      (Kısa biçim: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -956,6 +959,16 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -931,19 +931,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedSummary
+        <target state="needs-review-translation">  -detailedSummary
                     在生成的结尾显示有关
                     所生成的配置以及如何向节点安排
                     这些配置的详细信息。
                     (缩写: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -952,6 +955,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -931,19 +931,22 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
         <note />
       </trans-unit>
       <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
-        <source>  -detailedSummary
+        <source>  -detailedSummary[:True|False]
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
                      scheduled to nodes.
                      (Short form: -ds)
     </source>
-        <target state="translated">  -detailedsummary
+        <target state="needs-review-translation">  -detailedsummary
                      在建置結束時顯示詳細資訊，
                      內容為建置的組態，
                      以及將組態排程到節點的方式。
                      (簡短形式: -ds)
     </target>
-        <note />
+        <note>
+      LOCALIZATION: "detailedSummary", "True" and "False" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="InvalidConfigurationFile">
         <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
@@ -952,6 +955,16 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidDetailedSummaryValue">
+        <source>MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1061: Detailed summary value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1061: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -detailedSummary parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidGraphBuildValue">

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2254,8 +2254,6 @@ namespace Microsoft.Build.CommandLine
                         targetsWriter = ProcessTargetsSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Targets]);
                     }
 
-                    detailedSummary = commandLineSwitches.IsParameterlessSwitchSet(CommandLineSwitches.ParameterlessSwitch.DetailedSummary);
-
                     warningsAsErrors = ProcessWarnAsErrorSwitch(commandLineSwitches);
 
                     warningsAsMessages = ProcessWarnAsMessageSwitch(commandLineSwitches);
@@ -2305,13 +2303,21 @@ namespace Microsoft.Build.CommandLine
                         groupedFileLoggerParameters,
                         out distributedLoggerRecords,
                         out verbosity,
-                        ref detailedSummary,
                         cpuCount,
                         out profilerLogger,
                         out enableProfiler
                         );
 
-                    // If we picked up switches from the autoreponse file, let the user know. This could be a useful
+                    if (commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.DetailedSummary))
+                    {
+                        detailedSummary = ProcessBooleanSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.DetailedSummary], defaultValue: true, resourceName: "InvalidDetailedSummaryValue");
+                    }
+                    else if (verbosity == LoggerVerbosity.Diagnostic)
+                    {
+                        detailedSummary = true;
+                    }
+
+                    // If we picked up switches from the autoresponse file, let the user know. This could be a useful
                     // hint to a user that does not know that we are picking up the file automatically.
                     // Since this is going to happen often in normal use, only log it in high verbosity mode.
                     // Also, only log it to the console; logging to loggers would involve increasing the public API of
@@ -3020,7 +3026,6 @@ namespace Microsoft.Build.CommandLine
             string[][] groupedFileLoggerParameters,
             out List<DistributedLoggerRecord> distributedLoggerRecords,
             out LoggerVerbosity verbosity,
-            ref bool detailedSummary,
             int cpuCount,
             out ProfilerLogger profilerLogger,
             out bool enableProfiler
@@ -3049,11 +3054,6 @@ namespace Microsoft.Build.CommandLine
             ProcessBinaryLogger(binaryLoggerParameters, loggers, ref verbosity);
 
             profilerLogger = ProcessProfileEvaluationSwitch(profileEvaluationParameters, loggers, out enableProfiler);
-
-            if (verbosity == LoggerVerbosity.Diagnostic)
-            {
-                detailedSummary = true;
-            }
 
             return loggers.ToArray();
         }


### PR DESCRIPTION
Change the DetailedSummary command-line switch from parameterless to parameterized, allowing the user to have control and explicitly set it to false if needed, overriding the default of true when the verbosity is diagnostic.

This is backwards compatible with the previous behavior, so if /ds is specified, it is equivalent to turning it on.

Fixes https://github.com/dotnet/msbuild/issues/4409