### PR TITLE
Add support for embedding arbitrary files into binlog

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -160,12 +160,21 @@ namespace Microsoft.Build.Logging
             stream = new BufferedStream(stream, bufferSize: 32768);
             binaryWriter = new BinaryWriter(stream);
             eventArgsWriter = new BuildEventArgsWriter(binaryWriter);
+            eventArgsWriter.EmbedFile += EventArgsWriter_EmbedFile;
 
             binaryWriter.Write(FileFormatVersion);
 
             LogInitialInfo();
 
             eventSource.AnyEventRaised += EventSource_AnyEventRaised;
+        }
+
+        private void EventArgsWriter_EmbedFile(string filePath)
+        {
+            if (projectImportsCollector != null)
+            {
+                projectImportsCollector.AddFile(filePath);
+            }
         }
 
         private void LogInitialInfo()

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -160,7 +160,11 @@ namespace Microsoft.Build.Logging
             stream = new BufferedStream(stream, bufferSize: 32768);
             binaryWriter = new BinaryWriter(stream);
             eventArgsWriter = new BuildEventArgsWriter(binaryWriter);
-            eventArgsWriter.EmbedFile += EventArgsWriter_EmbedFile;
+
+            if (projectImportsCollector != null)
+            {
+                eventArgsWriter.EmbedFile += EventArgsWriter_EmbedFile;
+            }
 
             binaryWriter.Write(FileFormatVersion);
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -834,7 +834,9 @@ namespace Microsoft.Build.Logging
 
         private void CheckForFilesToEmbed(string itemType, object itemList)
         {
-            if (!string.Equals(itemType, ItemTypeNames.EmbedInBinlog, StringComparison.OrdinalIgnoreCase) || itemList is not IEnumerable list)
+            if (EmbedFile == null ||
+                !string.Equals(itemType, ItemTypeNames.EmbedInBinlog, StringComparison.OrdinalIgnoreCase) ||
+                itemList is not IEnumerable list)
             {
                 return;
             }
@@ -843,11 +845,11 @@ namespace Microsoft.Build.Logging
             {
                 if (item is ITaskItem taskItem && !string.IsNullOrEmpty(taskItem.ItemSpec))
                 {
-                    EmbedFile?.Invoke(taskItem.ItemSpec);
+                    EmbedFile.Invoke(taskItem.ItemSpec);
                 }
                 else if (item is string itemSpec && !string.IsNullOrEmpty(itemSpec))
                 {
-                    EmbedFile?.Invoke(itemSpec);
+                    EmbedFile.Invoke(itemSpec);
                 }
             }
         }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -832,11 +832,9 @@ namespace Microsoft.Build.Logging
             }
         }
 
-        private const string EmbedInBinlogItemType = "EmbedInBinlog";
-
         private void CheckForFilesToEmbed(string itemType, object itemList)
         {
-            if (!string.Equals(itemType, EmbedInBinlogItemType, StringComparison.OrdinalIgnoreCase) || itemList is not IEnumerable list)
+            if (!string.Equals(itemType, ItemTypeNames.EmbedInBinlog, StringComparison.OrdinalIgnoreCase) || itemList is not IEnumerable list)
             {
                 return;
             }

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -141,6 +141,11 @@ namespace Microsoft.Build.Shared
         /// Declares a project cache plugin and its configuration.
         /// </summary>
         internal const string ProjectCachePlugin = nameof(ProjectCachePlugin);
+
+        /// <summary>
+        /// Embed specified files in the binary log
+        /// </summary>
+        internal const string EmbedInBinlog = nameof(EmbedInBinlog);
     }
 
     /// <summary>


### PR DESCRIPTION
It would be very useful to embed more than just the project files into the binlog. For example, project.assets.json is a common request: https://github.com/dotnet/msbuild/issues/3529. global.json or nuget.config would be other examples. Some users may want to embed all *.cs files as well.

Add a special EmbedInBinlog item type recognized by BuildEventArgsWriter. If after evaluation the items contain EmbedInBinlog, all such items will be logged if the evaluated include points to a full file path that exists on disk. A given file can be mentioned more than once, but will only be embedded once. If a file doesn't exist or is empty, it will not be embedded. If the item is added from a target (after evaluation is done), it will not be embedded.

Checking for EmbedInBinlog is done in BuildEventArgsWriter to reuse the complicated and performance-optimized logic of iterating over all items.

This PR is a prerequisite for https://github.com/dotnet/msbuild/issues/3529