### PR TITLE
Fix project cache plugin exception handling

### DIFF
--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -807,55 +807,157 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
         [Theory]
         [MemberData(nameof(CacheExceptionLocationsTestData))]
-        public void EngineShouldHandleExceptionsFromCachePlugin(ExceptionLocations exceptionLocations)
+        public void EngineShouldHandleExceptionsFromCachePluginViaBuildParameters(ExceptionLocations exceptionLocations)
         {
             _env.DoNotLaunchDebugger();
+
+            SetEnvironmentForExceptionLocations(exceptionLocations);
 
             var project = _env.CreateFile("1.proj", @$"
                     <Project>
                         <Target Name=`Build`>
-                            <Message Text=`Hello EngineShouldHandleExceptionsFromCachePlugin` Importance=`High` />
+                            <Message Text=`Hello World` Importance=`High` />
                         </Target>
                     </Project>".Cleanup());
 
+            Helpers.BuildManagerSession? buildSession = null;
+            MockLogger logger;
+
+            try
+            {
+                buildSession = new Helpers.BuildManagerSession(
+                    _env,
+                    new BuildParameters
+                    {
+                        UseSynchronousLogging = true,
+                        ProjectCacheDescriptor = ProjectCacheDescriptor.FromAssemblyPath(
+                            SamplePluginAssemblyPath.Value,
+                            new[] {new ProjectGraphEntryPoint(project.Path)},
+                            null)
+                    });
+
+                logger = buildSession.Logger;
+                var buildResult = buildSession.BuildProjectFile(project.Path);
+
+                // Plugin construction, initialization, and query all end up throwing in BuildManager.ExecuteSubmission and thus
+                // mark the submission as failed with exception.
+                var exceptionsThatEndUpInBuildResult =
+                    ExceptionLocations.Constructor | ExceptionLocations.BeginBuildAsync | ExceptionLocations.GetCacheResultAsync;
+
+                if ((exceptionsThatEndUpInBuildResult & exceptionLocations) != 0)
+                {
+                    buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
+                    buildResult.Exception.Message.ShouldContain("Cache plugin exception from");
+                }
+
+                // BuildManager.EndBuild calls plugin.EndBuild, so if only plugin.EndBuild fails it means everything else passed,
+                // so the build submission should be successful.
+                if (exceptionLocations == ExceptionLocations.EndBuildAsync)
+                {
+                    buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                }
+            }
+            finally
+            {
+                buildSession.ShouldNotBeNull();
+
+                // These exceptions prevent the creation of a plugin so there's no plugin to shutdown.
+                var exceptionsThatPreventEndBuildFromThrowing = ExceptionLocations.Constructor |
+                                                                ExceptionLocations.BeginBuildAsync;
+
+                if ((exceptionLocations & exceptionsThatPreventEndBuildFromThrowing) != 0 ||
+                    !exceptionLocations.HasFlag(ExceptionLocations.EndBuildAsync))
+                {
+                    Should.NotThrow(() => buildSession.Dispose());
+                }
+                else if (exceptionLocations.HasFlag(ExceptionLocations.EndBuildAsync))
+                {
+                    var e = Should.Throw<Exception>(() => buildSession.Dispose());
+                    e.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            // Plugin query must happen after plugin init. So if plugin init fails, then the plugin should not get queried.
+            var exceptionsThatShouldPreventCacheQueryAndEndBuildAsync = ExceptionLocations.Constructor | ExceptionLocations.BeginBuildAsync;
+
+            if ((exceptionsThatShouldPreventCacheQueryAndEndBuildAsync & exceptionLocations) != 0)
+            {
+                logger.FullLog.ShouldNotContain($"{AssemblyMockCache}: GetCacheResultAsync for");
+                logger.FullLog.ShouldNotContain($"{AssemblyMockCache}: EndBuildAsync");
+            }
+            else
+            {
+                StringShouldContainSubstring(logger.FullLog, $"{AssemblyMockCache}: GetCacheResultAsync for", expectedOccurrences: 1);
+                StringShouldContainSubstring(logger.FullLog, $"{AssemblyMockCache}: EndBuildAsync", expectedOccurrences: 1);
+            }
+
+            // TODO: this ain't right now is it?
+            logger.FullLog.ShouldNotContain("Cache plugin exception");
+
+            // TODO: assert Build Failed event
+        }
+
+        [Theory]
+        [MemberData(nameof(CacheExceptionLocationsTestData))]
+        public void EngineShouldHandleExceptionsFromCachePluginViaGraphBuild(ExceptionLocations exceptionLocations)
+        {
+            _env.DoNotLaunchDebugger();
+
             SetEnvironmentForExceptionLocations(exceptionLocations);
 
-            using var buildSession = new Helpers.BuildManagerSession(
+            var graph = Helpers.CreateProjectGraph(
+                _env,
+                new Dictionary<int, int[]>
+                {
+                    {1, new []{2}}
+                },
+                extraContentPerProjectNumber:null,
+                extraContentForAllNodes:@$"
+<ItemGroup>
+    <{ItemTypeNames.ProjectCachePlugin} Include=`{SamplePluginAssemblyPath.Value}` />
+    <{ItemTypeNames.ProjectReferenceTargets} Include=`Build` Targets=`Build` />
+</ItemGroup>
+<Target Name=`Build`>
+    <Message Text=`Hello World` Importance=`High` />
+</Target>
+"
+                );
+
+            var buildSession = new Helpers.BuildManagerSession(
                 _env,
                 new BuildParameters
                 {
                     UseSynchronousLogging = true,
-                    ProjectCacheDescriptor = ProjectCacheDescriptor.FromAssemblyPath(
-                        SamplePluginAssemblyPath.Value,
-                        new[] {new ProjectGraphEntryPoint(project.Path)},
-                        null)
+                    MaxNodeCount = 1
                 });
 
             var logger = buildSession.Logger;
-            var buildResult = buildSession.BuildProjectFile(project.Path);
 
-            if (exceptionLocations == ExceptionLocations.EndBuildAsync || exceptionLocations == (ExceptionLocations.GetCacheResultAsync
-                                                                                                 | ExceptionLocations.EndBuildAsync))
-            {
-                var e = Should.Throw<Exception>(() => buildSession.Dispose());
-                e.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
-            }
-            else
-            {
-                buildSession.Dispose();
-            }
+            GraphBuildResult? buildResult = null;
 
-            var exceptionsThatEndUpInBuildResult = ExceptionLocations.Constructor | ExceptionLocations.BeginBuildAsync | ExceptionLocations.GetCacheResultAsync;
-
-            if ((exceptionsThatEndUpInBuildResult & exceptionLocations) != 0)
+            try
             {
+                buildResult = buildSession.BuildGraph(graph);
+
+                logger.FullLog.ShouldContain("Loading the following project cache plugin:");
+
+                // Static graph build initializes and tears down the cache plugin so all cache plugin exceptions should end up in the GraphBuildResult
                 buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
                 buildResult.Exception.Message.ShouldContain("Cache plugin exception from");
-            }
 
-            if (exceptionLocations == ExceptionLocations.EndBuildAsync)
+                // TODO: this ain't right now is it?
+                logger.FullLog.ShouldNotContain("Cache plugin exception");
+            }
+            finally
             {
-                buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                // Since all plugin exceptions during a graph build end up in the GraphBuildResult, they should not get rethrown by BM.EndBuild
+                Should.NotThrow(() => buildSession.Dispose());
+
+                // TODO: assert Build Failed event
             }
 
             var exceptionsThatShouldPreventCacheQueryAndEndBuildAsync = ExceptionLocations.Constructor | ExceptionLocations.BeginBuildAsync;
@@ -867,8 +969,14 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             }
             else
             {
-                logger.FullLog.ShouldContain($"{AssemblyMockCache}: GetCacheResultAsync for");
-                logger.FullLog.ShouldContain($"{AssemblyMockCache}: EndBuildAsync");
+                // There's two projects, so there should be two cache queries logged ... unless a cache queries throws an exception. That ends the build.
+                var expectedQueryOccurrences = exceptionLocations.HasFlag(ExceptionLocations.GetCacheResultAsync)
+                    ? 1
+                    : 2;
+
+                StringShouldContainSubstring(logger.FullLog, $"{AssemblyMockCache}: GetCacheResultAsync for", expectedQueryOccurrences);
+
+                StringShouldContainSubstring(logger.FullLog, $"{AssemblyMockCache}: EndBuildAsync", expectedOccurrences: 1);
             }
         }
 
@@ -912,7 +1020,13 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             buildSession.Dispose();
 
-            Regex.Matches(logger.FullLog, $"{nameof(AssemblyMockCache)}: EndBuildAsync").Count.ShouldBe(1);
+            StringShouldContainSubstring(logger.FullLog, $"{nameof(AssemblyMockCache)}: EndBuildAsync", expectedOccurrences: 1);
+        }
+
+        private static void StringShouldContainSubstring(string aString, string substring, int expectedOccurrences)
+        {
+            aString.ShouldContain(substring);
+            Regex.Matches(aString, substring).Count.ShouldBe(expectedOccurrences);
         }
 
         private void SetEnvironmentForExceptionLocations(ExceptionLocations exceptionLocations)

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1736,7 +1736,7 @@ namespace Microsoft.Build.Execution
                     var cacheServiceTask = Task.Run(() => SearchAndInitializeProjectCachePluginFromGraph(projectGraph));
                     var targetListTask = Task.Run(() => projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames));
 
-                    using var cacheService = cacheServiceTask.Result;
+                    using DisposablePluginService cacheService = cacheServiceTask.Result;
 
                     resultsPerNode = BuildGraph(projectGraph, targetListTask.Result, submission.BuildRequestData);
                 }
@@ -1867,14 +1867,14 @@ namespace Microsoft.Build.Execution
             return resultsPerNode;
         }
 
-        private DisposePluginService SearchAndInitializeProjectCachePluginFromGraph(ProjectGraph projectGraph)
+        private DisposablePluginService SearchAndInitializeProjectCachePluginFromGraph(ProjectGraph projectGraph)
         {
             // TODO: Consider allowing parallel graph submissions, each with its own separate cache plugin. Right now the second graph submission with a cache will fail.
 
             if (_buildParameters.ProjectCacheDescriptor != null)
             {
                 // Build parameter specified project cache takes precedence.
-                return new DisposePluginService(null);
+                return new DisposablePluginService(null);
             }
 
             var nodeToCacheItems = projectGraph.ProjectNodes.ToDictionary(
@@ -1899,7 +1899,7 @@ namespace Microsoft.Build.Execution
 
             if (cacheItems.Count == 0)
             {
-                return new DisposePluginService(null);
+                return new DisposablePluginService(null);
             }
 
             ErrorUtilities.VerifyThrowInvalidOperation(
@@ -1930,14 +1930,14 @@ namespace Microsoft.Build.Execution
                     _graphSchedulingCancellationSource.Token);
             }
 
-            return new DisposePluginService(this);
+            return new DisposablePluginService(this);
         }
 
-        private class DisposePluginService : IDisposable
+        private class DisposablePluginService : IDisposable
         {
             private readonly BuildManager _buildManager;
 
-            public DisposePluginService(BuildManager buildManager)
+            public DisposablePluginService(BuildManager buildManager)
             {
                 _buildManager = buildManager;
             }


### PR DESCRIPTION
### Context
The project cache plugin can fail with exceptions from any of its APIs. Currently some exceptions from certain APIs get lost and the build fails with no errors.

This PR ensures that:
- no exceptions get lost
- the build is marked as failed when any plugin API fails

### Changes Made
- `BuildManager.ExecuteSubmission(BuildSubmission)` always completes the build submission with the exception when it detects that it's running in a detached thread.
- `BuildManager.BuildGraph` observes the exceptions captured above and rethrows them to mimic what happens when `ExecuteSubmission(BuildSubmission)` does not run in a detached thread.
- `BuildManager.EndBuild` marks the overall build result as failed if exceptions are thrown in `BM.EndBuild`.

### Testing
Added unit tests to ensure that exceptions thrown from any possible plugin API are observable.

### Notes
This is an intermediary implementation to avoid lost exceptions. A better implementation which I'm working on, builds upon this one and actually logs the plugin exceptions to the `LoggingService` in a similar way to which logger errors get handled.