### PR TITLE
Permit comments and trailing commas in solution filter files

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -152,9 +152,11 @@ namespace Microsoft.Build.UnitTests.Construction
                     @"
                 {
                   ""solution"": {
+                    // I'm a comment
                     ""path"": "".\\SimpleProject\\SimpleProject.sln"",
                     ""projects"": [
-                      ""SimpleProject\\SimpleProject.csproj""
+                    /* ""..\\ClassLibrary\\ClassLibrary\\ClassLibrary.csproj"", */
+                      ""SimpleProject\\SimpleProject.csproj"",
                     ]
                     }
                 }

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -415,7 +415,9 @@ namespace Microsoft.Build.Construction
         {
             try
             {
-                JsonDocument text = JsonDocument.Parse(File.ReadAllText(solutionFilterFile), new JsonDocumentOptions() { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip});
+                // This is to align MSBuild with what VS permits in loading solution filter files. These are not in them by default but can be added manually.
+                JsonDocumentOptions options = new JsonDocumentOptions() { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip };
+                JsonDocument text = JsonDocument.Parse(File.ReadAllText(solutionFilterFile), options);
                 solution = text.RootElement.GetProperty("solution");
                 return FileUtilities.GetFullPath(solution.GetProperty("path").GetString(), Path.GetDirectoryName(solutionFilterFile));
             }

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -415,7 +415,7 @@ namespace Microsoft.Build.Construction
         {
             try
             {
-                JsonDocument text = JsonDocument.Parse(File.ReadAllText(solutionFilterFile));
+                JsonDocument text = JsonDocument.Parse(File.ReadAllText(solutionFilterFile), new JsonDocumentOptions() { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip});
                 solution = text.RootElement.GetProperty("solution");
                 return FileUtilities.GetFullPath(solution.GetProperty("path").GetString(), Path.GetDirectoryName(solutionFilterFile));
             }


### PR DESCRIPTION
Fixes #6317

We previously added support for building solution filter files. With that support, we did not allow them to contain lists of projects with a trailing comma or comments. These are both permitted by VS, so this PR updates our handling of solution filter files to permit building with trailing commas or comments.

Also adds a test.