### PR TITLE
Move to V3 publishing

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -221,6 +221,7 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
+      publishingInfraVersion: 3
       # Symbol validation is not entirely reliable as of yet, so should be turned off until
       # https://github.com/dotnet/arcade/issues/2871 is resolved.
       enableSymbolValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <PropertyGroup>
+        <PublishingVersion>3</PublishingVersion>
+    </PropertyGroup>
+</Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.21160.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.21221.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>670382be6a978ba401c21c57ba44311199d2682a</Sha>
+      <Sha>e304b1672084f2274b5d838893d894fa5cf8abea</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.9.1-rc.8">
       <Uri>https://github.com/nuget/nuget.client</Uri>

--- a/global.json
+++ b/global.json
@@ -12,6 +12,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.21160.3"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.21221.5"
   }
 }


### PR DESCRIPTION
### Context
V3 publishing is much faster and is required for publishing to the "VS 17.0" channel.

### Changes Made
Followed this: https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md#how-to-upgrade-from-v2-to-v3

Add eng\publishing.props with single propertygroup `PublishingVersion` set to 3.
Pass `publishingInfraVersion: 3` to post-build yml.


### Testing
Should launch an exp/ branch to verify this

Added `exp/bevillal/v3-publish-test` as a default channel to "VS 17.0" and kicked off a pipeline build here: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4655204&view=results

- [ ] Remove `exp/bevillal/v3-publish-test` as a default channel from "VS 17.0"