### PR TITLE
GitHub

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -465,6 +465,7 @@ namespace Microsoft.Build.Framework
     public sealed partial class RequiredAttribute : System.Attribute
     {
         public RequiredAttribute() { }
+        public bool AllowEmptyStrings { get { throw null; } set { } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
     public sealed partial class RequiredRuntimeAttribute : System.Attribute

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -464,6 +464,7 @@ namespace Microsoft.Build.Framework
     public sealed partial class RequiredAttribute : System.Attribute
     {
         public RequiredAttribute() { }
+        public bool AllowEmptyStrings { get { throw null; } set { } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
     public sealed partial class RequiredRuntimeAttribute : System.Attribute

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1359,7 +1359,6 @@ namespace Microsoft.Build.Tasks
         public XmlPoke() { }
         public string Namespaces { get { throw null; } set { } }
         public string Query { get { throw null; } set { } }
-        [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem Value { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
         public override bool Execute() { throw null; }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -993,7 +993,6 @@ namespace Microsoft.Build.Tasks
         public XmlPoke() { }
         public string Namespaces { get { throw null; } set { } }
         public string Query { get { throw null; } set { } }
-        [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem Value { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
         public override bool Execute() { throw null; }

--- a/src/Framework/RequiredAttribute.cs
+++ b/src/Framework/RequiredAttribute.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Build.Framework
         public RequiredAttribute()
         {
         }
+
+        public bool AllowEmptyStrings { get; set; }
     }
 }

--- a/src/Tasks/XmlPoke.cs
+++ b/src/Tasks/XmlPoke.cs
@@ -67,8 +67,6 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The value to be inserted into the specified location.
         /// </summary>
-        ///
-
         public ITaskItem Value
         {
             get

--- a/src/Tasks/XmlPoke.cs
+++ b/src/Tasks/XmlPoke.cs
@@ -67,7 +67,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The value to be inserted into the specified location.
         /// </summary>
-        [Required]
+        ///
+
         public ITaskItem Value
         {
             get


### PR DESCRIPTION
Fixes #5814

### Context
Not providing a value to the Value property of the XmlPoke task results in the following error message: error MSB4044: The "XmlPoke" task was not given a value for the required parameter "Value".


### Changes Made
Removed [required] from XmlPoke

### Testing
Tested using the 11 test for Xml

### Notes
