### PR TITLE
Added EnsurePathisSingleQuoted and related unit tests

### DIFF
--- a/src/Deprecated/Engine/Shared/FileUtilities.cs
+++ b/src/Deprecated/Engine/Shared/FileUtilities.cs
@@ -19,6 +19,13 @@ namespace Microsoft.Build.BuildEngine.Shared
     /// <owner>SumedhK</owner>
     static internal class FileUtilities
     {
+        internal static bool EnsurePathIsSingleQuoted(string path)
+        {
+            int endId = path.Length - 1;
+            char singleQuote = '\'';
+
+            return path[0] == singleQuote && path[endId] == singleQuote;
+        }
         #region Item-spec modifiers
 
         /// <summary>

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -27,6 +27,37 @@ namespace Microsoft.Build.UnitTests
             TestGetItemSpecModifier(null);
         }
 
+        [Fact]
+        public void TestEnsurePathIsSingleQuoted()
+        {
+            string currentDirectory = "\'/file/path/hackathon\'";
+            bool isSingleQuoted = FileUtilities.EnsurePathIsSingleQuoted(currentDirectory);
+            Assert.True(isSingleQuoted);
+        }
+
+        [Fact]
+        public void TestEnsurePathIsNotSingleQuoted()
+        {
+            string currentDirectory = "\"/file/path/hackathon\"";
+            bool isSingleQuoted = FileUtilities.EnsurePathIsSingleQuoted(currentDirectory);
+            Assert.False(isSingleQuoted);
+        }
+
+        [Fact]
+        public void TestTrimAndStripAnyQuotes()
+        {
+            string currentDirectory = "\"/file/path/hackathon\"";
+            string isTrimmed = FileUtilities.TrimAndStripAnyQuotes(currentDirectory);
+            Assert.Equal("/file/path/hackathon", isTrimmed);
+        }
+        [Fact]
+        public void TestTrimAndStripSingleQuotes()
+        {
+            string currentDirectory = "\'/file/path/hackathon\'";
+            string isTrimmed = FileUtilities.TrimAndStripAnyQuotes(currentDirectory);
+            Assert.Equal("/file/path/hackathon", isTrimmed);
+        }
+
         private static void TestGetItemSpecModifier(string currentDirectory)
         {
             string cache = null;


### PR DESCRIPTION
Fixes #5884
### Context
Wanted EnsurePathIsSingleQuoted method created to check for single quotes 

### Changes Made
Created EnsurePathIsSingleQuoted method, made changes to TrimAndStripAnyQuotes to incoporporate the new method

### Testing
Added Four unit tests to test for double quotes, test for single quotes and to test that stripping works on both effectively

### Notes
This was part of a hackathon with columbus state community college via Manifest Solutions.  @habibmohammed