### PR TITLE
removed [required] from XmlPoke due to issue #5814

### DIFF
--- a/src/Tasks/XmlPoke.cs
+++ b/src/Tasks/XmlPoke.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The value to be inserted into the specified location.
         /// </summary>
-        [Required]
+
         public ITaskItem Value
         {
             get


### PR DESCRIPTION
Fixes #5814 

### Context
Not providing a value to the Value property of the XmlPoke task results in the following error message:
error MSB4044: The "XmlPoke" task was not given a value for the required parameter "Value".

### Changes Made
removed [required] from line 70

### Testing
passed all 11 unit test

### Notes
