### PR TITLE
Improve plugin error logging

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1476,6 +1476,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
     {
         internal ProjectCacheException() { }
         public string ErrorCode { get { throw null; } }
+        public bool HasBeenLogged { get { throw null; } }
     }
     public abstract partial class ProjectCachePluginBase
     {

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1476,7 +1476,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
     {
         internal ProjectCacheException() { }
         public string ErrorCode { get { throw null; } }
-        public bool HasBeenLogged { get { throw null; } }
+        public bool HasBeenLoggedByProjectCache { get { throw null; } }
     }
     public abstract partial class ProjectCachePluginBase
     {

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1472,6 +1472,11 @@ namespace Microsoft.Build.Experimental.ProjectCache
         public static Microsoft.Build.Experimental.ProjectCache.ProjectCacheDescriptor FromInstance(Microsoft.Build.Experimental.ProjectCache.ProjectCachePluginBase pluginInstance, System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphEntryPoint> entryPoints, Microsoft.Build.Graph.ProjectGraph projectGraph, System.Collections.Generic.IReadOnlyDictionary<string, string> pluginSettings = null) { throw null; }
         public string GetDetailedDescription() { throw null; }
     }
+    public sealed partial class ProjectCacheException : System.Exception
+    {
+        internal ProjectCacheException() { }
+        public string ErrorCode { get { throw null; } }
+    }
     public abstract partial class ProjectCachePluginBase
     {
         protected ProjectCachePluginBase() { }
@@ -1566,8 +1571,8 @@ namespace Microsoft.Build.Graph
         public virtual bool Equals(Microsoft.Build.Graph.GraphBuildOptions other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
-        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
+        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
+        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
         protected virtual bool PrintMembers(System.Text.StringBuilder builder) { throw null; }
         public override string ToString() { throw null; }
         public virtual Microsoft.Build.Graph.GraphBuildOptions <Clone>$() { throw null; }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1466,6 +1466,11 @@ namespace Microsoft.Build.Experimental.ProjectCache
         public static Microsoft.Build.Experimental.ProjectCache.ProjectCacheDescriptor FromInstance(Microsoft.Build.Experimental.ProjectCache.ProjectCachePluginBase pluginInstance, System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphEntryPoint> entryPoints, Microsoft.Build.Graph.ProjectGraph projectGraph, System.Collections.Generic.IReadOnlyDictionary<string, string> pluginSettings = null) { throw null; }
         public string GetDetailedDescription() { throw null; }
     }
+    public sealed partial class ProjectCacheException : System.Exception
+    {
+        internal ProjectCacheException() { }
+        public string ErrorCode { get { throw null; } }
+    }
     public abstract partial class ProjectCachePluginBase
     {
         protected ProjectCachePluginBase() { }
@@ -1560,8 +1565,8 @@ namespace Microsoft.Build.Graph
         public virtual bool Equals(Microsoft.Build.Graph.GraphBuildOptions other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
-        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
+        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
+        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
         protected virtual bool PrintMembers(System.Text.StringBuilder builder) { throw null; }
         public override string ToString() { throw null; }
         public virtual Microsoft.Build.Graph.GraphBuildOptions <Clone>$() { throw null; }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1470,7 +1470,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
     {
         internal ProjectCacheException() { }
         public string ErrorCode { get { throw null; } }
-        public bool HasBeenLogged { get { throw null; } }
+        public bool HasBeenLoggedByProjectCache { get { throw null; } }
     }
     public abstract partial class ProjectCachePluginBase
     {

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1470,6 +1470,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
     {
         internal ProjectCacheException() { }
         public string ErrorCode { get { throw null; } }
+        public bool HasBeenLogged { get { throw null; } }
     }
     public abstract partial class ProjectCachePluginBase
     {

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -200,6 +200,12 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             EndBuildAsync = 1 << 3
         }
 
+        public enum ErrorKind
+        {
+            Exception,
+            LoggedError
+        }
+
         public class InstanceMockCache : ProjectCachePluginBase
         {
             private readonly GraphCacheResponse? _testData;
@@ -791,27 +797,31 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
         {
             get
             {
-                yield return new object[]{ErrorLocations.Constructor};
+                // Plugin constructors cannot log errors, they can only throw exceptions.
+                yield return new object[] { ErrorLocations.Constructor, ErrorKind.Exception };
 
-                yield return new object[]{ErrorLocations.BeginBuildAsync};
-                yield return new object[]{ErrorLocations.BeginBuildAsync | ErrorLocations.GetCacheResultAsync};
-                yield return new object[]{ErrorLocations.BeginBuildAsync | ErrorLocations.GetCacheResultAsync | ErrorLocations.EndBuildAsync};
-                yield return new object[]{ErrorLocations.BeginBuildAsync | ErrorLocations.EndBuildAsync};
+                foreach (var errorKind in new[]{ErrorKind.Exception, ErrorKind.LoggedError})
+                {
+                    yield return new object[] { ErrorLocations.BeginBuildAsync, errorKind };
+                    yield return new object[] { ErrorLocations.BeginBuildAsync | ErrorLocations.GetCacheResultAsync, errorKind };
+                    yield return new object[] { ErrorLocations.BeginBuildAsync | ErrorLocations.GetCacheResultAsync | ErrorLocations.EndBuildAsync, errorKind };
+                    yield return new object[] { ErrorLocations.BeginBuildAsync | ErrorLocations.EndBuildAsync, errorKind };
 
-                yield return new object[]{ErrorLocations.GetCacheResultAsync};
-                yield return new object[]{ErrorLocations.GetCacheResultAsync | ErrorLocations.EndBuildAsync};
+                    yield return new object[] { ErrorLocations.GetCacheResultAsync, errorKind };
+                    yield return new object[] { ErrorLocations.GetCacheResultAsync | ErrorLocations.EndBuildAsync, errorKind };
 
-                yield return new object[]{ErrorLocations.EndBuildAsync};
+                    yield return new object[] { ErrorLocations.EndBuildAsync, errorKind };
+                }
             }
         }
 
         [Theory]
         [MemberData(nameof(CacheExceptionLocationsTestData))]
-        public void EngineShouldHandleExceptionsFromCachePluginViaBuildParameters(ErrorLocations errorLocations)
+        public void EngineShouldHandleExceptionsFromCachePluginViaBuildParameters(ErrorLocations errorLocations, ErrorKind errorKind)
         {
             _env.DoNotLaunchDebugger();
 
-            SetEnvironmentForErrorLocations(errorLocations);
+            SetEnvironmentForErrorLocations(errorLocations, errorKind.ToString());
 
             var project = _env.CreateFile("1.proj", @$"
                     <Project>
@@ -846,10 +856,18 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
                 if ((exceptionsThatEndUpInBuildResult & errorLocations) != 0)
                 {
-                    buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
+                    buildResult.Exception.ShouldNotBeNull();
                     buildResult.Exception.ShouldBeOfType<ProjectCacheException>();
-                    buildResult.Exception.InnerException!.ShouldNotBeNull();
-                    buildResult.Exception.InnerException!.Message.ShouldContain("Cache plugin exception from");
+
+                    if (errorKind == ErrorKind.Exception)
+                    {
+                        buildResult.Exception.InnerException!.ShouldNotBeNull();
+                        buildResult.Exception.InnerException!.Message.ShouldContain("Cache plugin exception from");
+                    }
+                    else
+                    {
+                        buildResult.Exception.InnerException.ShouldBeNull();
+                    }
                 }
 
                 // BuildManager.EndBuild calls plugin.EndBuild, so if only plugin.EndBuild fails it means everything else passed,
@@ -857,6 +875,10 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 if (errorLocations == ErrorLocations.EndBuildAsync)
                 {
                     buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                }
+                else
+                {
+                    buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
                 }
             }
             finally
@@ -873,8 +895,16 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 else if (errorLocations.HasFlag(ErrorLocations.EndBuildAsync))
                 {
                     var e = Should.Throw<ProjectCacheException>(() => buildSession!.Dispose());
-                    e.InnerException!.ShouldNotBeNull();
-                    e.InnerException!.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
+
+                    if (errorKind == ErrorKind.Exception)
+                    {
+                        e.InnerException!.ShouldNotBeNull();
+                        e.InnerException!.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
+                    }
+                    else
+                    {
+                        e.InnerException.ShouldBeNull();
+                    }
                 }
                 else
                 {
@@ -899,15 +929,20 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             }
 
             logger.FullLog.ShouldNotContain("Cache plugin exception from");
+
+            if (errorKind == ErrorKind.LoggedError)
+            {
+                logger.FullLog.ShouldContain("Cache plugin logged error from");
+            }
         }
 
         [Theory]
         [MemberData(nameof(CacheExceptionLocationsTestData))]
-        public void EngineShouldHandleExceptionsFromCachePluginViaGraphBuild(ErrorLocations errorLocations)
+        public void EngineShouldHandleExceptionsFromCachePluginViaGraphBuild(ErrorLocations errorLocations, ErrorKind errorKind)
         {
             _env.DoNotLaunchDebugger();
 
-            SetEnvironmentForErrorLocations(errorLocations);
+            SetEnvironmentForErrorLocations(errorLocations, errorKind.ToString());
 
             var graph = Helpers.CreateProjectGraph(
                 _env,
@@ -947,11 +982,21 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
                 // Static graph build initializes and tears down the cache plugin so all cache plugin exceptions should end up in the GraphBuildResult
                 buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
-                buildResult.Exception.ShouldBeOfType<ProjectCacheException>();
-                buildResult.Exception.InnerException!.ShouldNotBeNull();
-                buildResult.Exception.InnerException!.Message.ShouldContain("Cache plugin exception from");
 
-                logger.FullLog.ShouldNotContain("Cache plugin exception");
+                buildResult.Exception.ShouldBeOfType<ProjectCacheException>();
+
+                if (errorKind == ErrorKind.Exception)
+                {
+                    buildResult.Exception.InnerException!.ShouldNotBeNull();
+                    buildResult.Exception.InnerException!.Message.ShouldContain("Cache plugin exception from");
+                }
+
+                logger.FullLog.ShouldNotContain("Cache plugin exception from");
+
+                if (errorKind == ErrorKind.LoggedError)
+                {
+                    logger.FullLog.ShouldContain("Cache plugin logged error from");
+                }
             }
             finally
             {
@@ -998,7 +1043,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                         </Target>
                     </Project>".Cleanup());
 
-            SetEnvironmentForErrorLocations(ErrorLocations.EndBuildAsync);
+            SetEnvironmentForErrorLocations(ErrorLocations.EndBuildAsync, ErrorKind.Exception.ToString());
 
             using var buildSession = new Helpers.BuildManagerSession(
                 _env,
@@ -1031,7 +1076,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             Regex.Matches(aString, substring).Count.ShouldBe(expectedOccurrences);
         }
 
-        private void SetEnvironmentForErrorLocations(ErrorLocations errorLocations)
+        private void SetEnvironmentForErrorLocations(ErrorLocations errorLocations, string errorKind)
         {
             foreach (var enumValue in Enum.GetValues(typeof(ErrorLocations)))
             {
@@ -1039,7 +1084,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 if (errorLocations.HasFlag(typedValue))
                 {
                     var exceptionLocation = typedValue.ToString();
-                    _env.SetEnvironmentVariable(exceptionLocation, "exception");
+                    _env.SetEnvironmentVariable(exceptionLocation, errorKind);
                     _output.WriteLine($"Set exception location: {exceptionLocation}");
                 }
             }

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -898,7 +898,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 StringShouldContainSubstring(logger.FullLog, $"{AssemblyMockCache}: EndBuildAsync", expectedOccurrences: 1);
             }
 
-            // TODO: this ain't right now is it?
             logger.FullLog.ShouldNotContain("Cache plugin exception");
         }
 
@@ -952,7 +951,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 buildResult.Exception.InnerException!.ShouldNotBeNull();
                 buildResult.Exception.InnerException!.Message.ShouldContain("Cache plugin exception from");
 
-                // TODO: this ain't right now is it?
                 logger.FullLog.ShouldNotContain("Cache plugin exception");
             }
             finally

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -847,7 +847,9 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 if ((exceptionsThatEndUpInBuildResult & exceptionLocations) != 0)
                 {
                     buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
-                    buildResult.Exception.Message.ShouldContain("Cache plugin exception from");
+                    buildResult.Exception.ShouldBeOfType<ProjectCacheException>();
+                    buildResult.Exception.InnerException!.ShouldNotBeNull();
+                    buildResult.Exception.InnerException!.Message.ShouldContain("Cache plugin exception from");
                 }
 
                 // BuildManager.EndBuild calls plugin.EndBuild, so if only plugin.EndBuild fails it means everything else passed,
@@ -870,8 +872,9 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 }
                 else if (exceptionLocations.HasFlag(ExceptionLocations.EndBuildAsync))
                 {
-                    var e = Should.Throw<Exception>(() => buildSession!.Dispose());
-                    e.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
+                    var e = Should.Throw<ProjectCacheException>(() => buildSession!.Dispose());
+                    e.InnerException!.ShouldNotBeNull();
+                    e.InnerException!.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
                 }
                 else
                 {
@@ -945,7 +948,9 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
                 // Static graph build initializes and tears down the cache plugin so all cache plugin exceptions should end up in the GraphBuildResult
                 buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
-                buildResult.Exception.Message.ShouldContain("Cache plugin exception from");
+                buildResult.Exception.ShouldBeOfType<ProjectCacheException>();
+                buildResult.Exception.InnerException!.ShouldNotBeNull();
+                buildResult.Exception.InnerException!.Message.ShouldContain("Cache plugin exception from");
 
                 // TODO: this ain't right now is it?
                 logger.FullLog.ShouldNotContain("Cache plugin exception");
@@ -1014,7 +1019,8 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 });
 
             buildResult!.OverallResult.ShouldBe(BuildResultCode.Failure);
-            buildResult.Exception.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
+            buildResult.Exception.InnerException!.ShouldNotBeNull();
+            buildResult.Exception.InnerException!.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
 
             buildSession.Dispose();
 

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -807,55 +807,157 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
         [Theory]
         [MemberData(nameof(CacheExceptionLocationsTestData))]
-        public void EngineShouldHandleExceptionsFromCachePlugin(ExceptionLocations exceptionLocations)
+        public void EngineShouldHandleExceptionsFromCachePluginViaBuildParameters(ExceptionLocations exceptionLocations)
         {
             _env.DoNotLaunchDebugger();
+
+            SetEnvironmentForExceptionLocations(exceptionLocations);
 
             var project = _env.CreateFile("1.proj", @$"
                     <Project>
                         <Target Name=`Build`>
-                            <Message Text=`Hello EngineShouldHandleExceptionsFromCachePlugin` Importance=`High` />
+                            <Message Text=`Hello World` Importance=`High` />
                         </Target>
                     </Project>".Cleanup());
 
+            Helpers.BuildManagerSession? buildSession = null;
+            MockLogger logger;
+
+            try
+            {
+                buildSession = new Helpers.BuildManagerSession(
+                    _env,
+                    new BuildParameters
+                    {
+                        UseSynchronousLogging = true,
+                        ProjectCacheDescriptor = ProjectCacheDescriptor.FromAssemblyPath(
+                            SamplePluginAssemblyPath.Value,
+                            new[] {new ProjectGraphEntryPoint(project.Path)},
+                            null)
+                    });
+
+                logger = buildSession.Logger;
+                var buildResult = buildSession.BuildProjectFile(project.Path);
+
+                // Plugin construction, initialization, and query all end up throwing in BuildManager.ExecuteSubmission and thus
+                // mark the submission as failed with exception.
+                var exceptionsThatEndUpInBuildResult =
+                    ExceptionLocations.Constructor | ExceptionLocations.BeginBuildAsync | ExceptionLocations.GetCacheResultAsync;
+
+                if ((exceptionsThatEndUpInBuildResult & exceptionLocations) != 0)
+                {
+                    buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
+                    buildResult.Exception.Message.ShouldContain("Cache plugin exception from");
+                }
+
+                // BuildManager.EndBuild calls plugin.EndBuild, so if only plugin.EndBuild fails it means everything else passed,
+                // so the build submission should be successful.
+                if (exceptionLocations == ExceptionLocations.EndBuildAsync)
+                {
+                    buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                }
+            }
+            finally
+            {
+                buildSession.ShouldNotBeNull();
+
+                // These exceptions prevent the creation of a plugin so there's no plugin to shutdown.
+                var exceptionsThatPreventEndBuildFromThrowing = ExceptionLocations.Constructor |
+                                                                ExceptionLocations.BeginBuildAsync;
+
+                if ((exceptionLocations & exceptionsThatPreventEndBuildFromThrowing) != 0 ||
+                    !exceptionLocations.HasFlag(ExceptionLocations.EndBuildAsync))
+                {
+                    Should.NotThrow(() => buildSession.Dispose());
+                }
+                else if (exceptionLocations.HasFlag(ExceptionLocations.EndBuildAsync))
+                {
+                    var e = Should.Throw<Exception>(() => buildSession.Dispose());
+                    e.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            // Plugin query must happen after plugin init. So if plugin init fails, then the plugin should not get queried.
+            var exceptionsThatShouldPreventCacheQueryAndEndBuildAsync = ExceptionLocations.Constructor | ExceptionLocations.BeginBuildAsync;
+
+            if ((exceptionsThatShouldPreventCacheQueryAndEndBuildAsync & exceptionLocations) != 0)
+            {
+                logger.FullLog.ShouldNotContain($"{AssemblyMockCache}: GetCacheResultAsync for");
+                logger.FullLog.ShouldNotContain($"{AssemblyMockCache}: EndBuildAsync");
+            }
+            else
+            {
+                StringShouldContainSubstring(logger.FullLog, $"{AssemblyMockCache}: GetCacheResultAsync for", expectedOccurrences: 1);
+                StringShouldContainSubstring(logger.FullLog, $"{AssemblyMockCache}: EndBuildAsync", expectedOccurrences: 1);
+            }
+
+            // TODO: this ain't right now is it?
+            logger.FullLog.ShouldNotContain("Cache plugin exception");
+
+            // TODO: assert Build Failed event
+        }
+
+        [Theory]
+        [MemberData(nameof(CacheExceptionLocationsTestData))]
+        public void EngineShouldHandleExceptionsFromCachePluginViaGraphBuild(ExceptionLocations exceptionLocations)
+        {
+            _env.DoNotLaunchDebugger();
+
             SetEnvironmentForExceptionLocations(exceptionLocations);
 
-            using var buildSession = new Helpers.BuildManagerSession(
+            var graph = Helpers.CreateProjectGraph(
+                _env,
+                new Dictionary<int, int[]>
+                {
+                    {1, new []{2}}
+                },
+                extraContentPerProjectNumber:null,
+                extraContentForAllNodes:@$"
+<ItemGroup>
+    <{ItemTypeNames.ProjectCachePlugin} Include=`{SamplePluginAssemblyPath.Value}` />
+    <{ItemTypeNames.ProjectReferenceTargets} Include=`Build` Targets=`Build` />
+</ItemGroup>
+<Target Name=`Build`>
+    <Message Text=`Hello World` Importance=`High` />
+</Target>
+"
+                );
+
+            var buildSession = new Helpers.BuildManagerSession(
                 _env,
                 new BuildParameters
                 {
                     UseSynchronousLogging = true,
-                    ProjectCacheDescriptor = ProjectCacheDescriptor.FromAssemblyPath(
-                        SamplePluginAssemblyPath.Value,
-                        new[] {new ProjectGraphEntryPoint(project.Path)},
-                        null)
+                    MaxNodeCount = 1
                 });
 
             var logger = buildSession.Logger;
-            var buildResult = buildSession.BuildProjectFile(project.Path);
 
-            if (exceptionLocations == ExceptionLocations.EndBuildAsync || exceptionLocations == (ExceptionLocations.GetCacheResultAsync
-                                                                                                 | ExceptionLocations.EndBuildAsync))
-            {
-                var e = Should.Throw<Exception>(() => buildSession.Dispose());
-                e.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
-            }
-            else
-            {
-                buildSession.Dispose();
-            }
+            GraphBuildResult? buildResult = null;
 
-            var exceptionsThatEndUpInBuildResult = ExceptionLocations.Constructor | ExceptionLocations.BeginBuildAsync | ExceptionLocations.GetCacheResultAsync;
-
-            if ((exceptionsThatEndUpInBuildResult & exceptionLocations) != 0)
+            try
             {
+                buildResult = buildSession.BuildGraph(graph);
+
+                logger.FullLog.ShouldContain("Loading the following project cache plugin:");
+
+                // Static graph build initializes and tears down the cache plugin so all cache plugin exceptions should end up in the GraphBuildResult
                 buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
                 buildResult.Exception.Message.ShouldContain("Cache plugin exception from");
-            }
 
-            if (exceptionLocations == ExceptionLocations.EndBuildAsync)
+                // TODO: this ain't right now is it?
+                logger.FullLog.ShouldNotContain("Cache plugin exception");
+            }
+            finally
             {
-                buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                // Since all plugin exceptions during a graph build end up in the GraphBuildResult, they should not get rethrown by BM.EndBuild
+                Should.NotThrow(() => buildSession.Dispose());
+
+                // TODO: assert Build Failed event
             }
 
             var exceptionsThatShouldPreventCacheQueryAndEndBuildAsync = ExceptionLocations.Constructor | ExceptionLocations.BeginBuildAsync;
@@ -867,8 +969,14 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             }
             else
             {
-                logger.FullLog.ShouldContain($"{AssemblyMockCache}: GetCacheResultAsync for");
-                logger.FullLog.ShouldContain($"{AssemblyMockCache}: EndBuildAsync");
+                // There's two projects, so there should be two cache queries logged ... unless a cache queries throws an exception. That ends the build.
+                var expectedQueryOccurrences = exceptionLocations.HasFlag(ExceptionLocations.GetCacheResultAsync)
+                    ? 1
+                    : 2;
+
+                StringShouldContainSubstring(logger.FullLog, $"{AssemblyMockCache}: GetCacheResultAsync for", expectedQueryOccurrences);
+
+                StringShouldContainSubstring(logger.FullLog, $"{AssemblyMockCache}: EndBuildAsync", expectedOccurrences: 1);
             }
         }
 
@@ -912,7 +1020,13 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             buildSession.Dispose();
 
-            Regex.Matches(logger.FullLog, $"{nameof(AssemblyMockCache)}: EndBuildAsync").Count.ShouldBe(1);
+            StringShouldContainSubstring(logger.FullLog, $"{nameof(AssemblyMockCache)}: EndBuildAsync", expectedOccurrences: 1);
+        }
+
+        private static void StringShouldContainSubstring(string aString, string substring, int expectedOccurrences)
+        {
+            aString.ShouldContain(substring);
+            Regex.Matches(aString, substring).Count.ShouldBe(expectedOccurrences);
         }
 
         private void SetEnvironmentForExceptionLocations(ExceptionLocations exceptionLocations)

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1736,7 +1736,7 @@ namespace Microsoft.Build.Execution
                     var cacheServiceTask = Task.Run(() => SearchAndInitializeProjectCachePluginFromGraph(projectGraph));
                     var targetListTask = Task.Run(() => projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames));
 
-                    using var cacheService = cacheServiceTask.Result;
+                    using DisposablePluginService cacheService = cacheServiceTask.Result;
 
                     resultsPerNode = BuildGraph(projectGraph, targetListTask.Result, submission.BuildRequestData);
                 }
@@ -1867,14 +1867,14 @@ namespace Microsoft.Build.Execution
             return resultsPerNode;
         }
 
-        private DisposePluginService SearchAndInitializeProjectCachePluginFromGraph(ProjectGraph projectGraph)
+        private DisposablePluginService SearchAndInitializeProjectCachePluginFromGraph(ProjectGraph projectGraph)
         {
             // TODO: Consider allowing parallel graph submissions, each with its own separate cache plugin. Right now the second graph submission with a cache will fail.
 
             if (_buildParameters.ProjectCacheDescriptor != null)
             {
                 // Build parameter specified project cache takes precedence.
-                return new DisposePluginService(null);
+                return new DisposablePluginService(null);
             }
 
             var nodeToCacheItems = projectGraph.ProjectNodes.ToDictionary(
@@ -1899,7 +1899,7 @@ namespace Microsoft.Build.Execution
 
             if (cacheItems.Count == 0)
             {
-                return new DisposePluginService(null);
+                return new DisposablePluginService(null);
             }
 
             ErrorUtilities.VerifyThrowInvalidOperation(
@@ -1930,14 +1930,14 @@ namespace Microsoft.Build.Execution
                     _graphSchedulingCancellationSource.Token);
             }
 
-            return new DisposePluginService(this);
+            return new DisposablePluginService(this);
         }
 
-        private class DisposePluginService : IDisposable
+        private class DisposablePluginService : IDisposable
         {
             private readonly BuildManager _buildManager;
 
-            public DisposePluginService(BuildManager buildManager)
+            public DisposablePluginService(BuildManager buildManager)
             {
                 _buildManager = buildManager;
             }

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheException.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheException.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
         private ProjectCacheException(
             string message,
             Exception innerException,
-            bool hasBeenLogged,
+            bool hasBeenLoggedByProjectCache,
             string errorCode
         )
             : base(message, innerException)
@@ -28,7 +28,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
             ErrorUtilities.VerifyThrow(!string.IsNullOrEmpty(message), "Need error message.");
             ErrorUtilities.VerifyThrow(!string.IsNullOrEmpty(errorCode), "Must specify the error message code.");
 
-            HasBeenLogged = hasBeenLogged;
+            HasBeenLoggedByProjectCache = hasBeenLoggedByProjectCache;
             ErrorCode = errorCode;
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
         /// The project cache has already logged this as an error.
         /// Should not get logged again.
         /// </summary>
-        public bool HasBeenLogged { get; }
+        public bool HasBeenLoggedByProjectCache { get; }
 
         /// <summary>
         /// Gets the error code associated with this exception's message (not the inner exception).
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
             string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out var errorCode, out _, messageResourceName, messageArgs);
 
-            throw new ProjectCacheException(message, innerException, hasBeenLogged: false, errorCode);
+            throw new ProjectCacheException(message, innerException, hasBeenLoggedByProjectCache: false, errorCode);
         }
 
         internal static void ThrowForLoggedError
@@ -68,7 +68,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
             string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out var errorCode, out _, messageResourceName, messageArgs);
 
-            throw new ProjectCacheException(message: message, innerException: null, hasBeenLogged: true, errorCode: errorCode);
+            throw new ProjectCacheException(message: message, innerException: null, hasBeenLoggedByProjectCache: true, errorCode: errorCode);
         }
     }
 }

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheException.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheException.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Experimental.ProjectCache
+{
+    /// <summary>
+    /// This exception is used to wrap an unhandled exception from a project cache plugin. This exception aborts the build, and it can only be
+    /// thrown by the MSBuild engine.
+    /// </summary>
+    public sealed class ProjectCacheException : Exception
+    {
+        private ProjectCacheException()
+        {
+            ErrorUtilities.ThrowInternalErrorUnreachable();
+        }
+
+        private ProjectCacheException(
+            string message,
+            Exception innerException,
+            string errorCode
+        )
+            : base(message, innerException)
+        {
+            ErrorUtilities.VerifyThrow(!string.IsNullOrEmpty(message), "Need error message.");
+            ErrorUtilities.VerifyThrow(!string.IsNullOrEmpty(errorCode), "Must specify the error message code.");
+
+            ErrorCode = errorCode;
+        }
+
+        /// <summary>
+        /// Gets the error code associated with this exception's message (not the inner exception).
+        /// </summary>
+        /// <value>The error code string.</value>
+        public string ErrorCode { get; }
+
+        /// <summary>
+        /// Throws an instance of this exception using rich error information.
+        /// </summary>
+        /// <param name="innerException"></param>
+        /// <param name="messageResourceName"></param>
+        /// <param name="messageArgs"></param>
+        internal static void Throw
+        (
+            Exception innerException,
+            string messageResourceName,
+            params string[] messageArgs
+        )
+        {
+            ErrorUtilities.VerifyThrow(messageResourceName != null, "Need error message.");
+
+            string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out var errorCode, out _, messageResourceName, messageArgs);
+
+            throw new ProjectCacheException(message, innerException, errorCode);
+        }
+    }
+}

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
             if (logger.HasLoggedErrors)
             {
-                ProjectCacheException.Throw(null, "ProjectCacheInitializationFailed");
+                ProjectCacheException.ThrowForLoggedError("ProjectCacheInitializationFailed");
             }
 
             return new ProjectCacheService(plugin, buildManager, logger, pluginDescriptor, cancellationToken);
@@ -114,7 +114,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
             if (type == null)
             {
-                ProjectCacheException.Throw(null, "NoProjectCachePluginFoundInAssembly", pluginAssemblyPath);
+                ProjectCacheException.ThrowAsUnhandledException(null, "NoProjectCachePluginFoundInAssembly", pluginAssemblyPath);
             }
 
             return type!;
@@ -168,7 +168,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
             if (_logger.HasLoggedErrors || cacheResult.ResultType == CacheResultType.None)
             {
-                ProjectCacheException.Throw(null, "ProjectCacheQueryFailed", queryDescription);
+                ProjectCacheException.ThrowForLoggedError("ProjectCacheQueryFailed", queryDescription);
             }
 
             var message = $"Plugin result: {cacheResult.ResultType}.";
@@ -208,7 +208,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
             if (_logger.HasLoggedErrors)
             {
-                ProjectCacheException.Throw(null, "ProjectCacheShutdownFailed");
+                ProjectCacheException.ThrowForLoggedError("ProjectCacheShutdownFailed");
             }
         }
 
@@ -219,7 +219,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 throw e;
             }
 
-            ProjectCacheException.Throw(
+            ProjectCacheException.ThrowAsUnhandledException(
                 e,
                 "ProjectCacheException",
                 apiExceptionWasThrownFrom);

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
     internal class ProjectCacheService
     {
         private readonly BuildManager _buildManager;
-        private readonly PluginLoggerBase _logger;
+        private readonly Func<PluginLoggerBase> _loggerFactory;
         private readonly ProjectCacheDescriptor _projectCacheDescriptor;
         private readonly CancellationToken _cancellationToken;
         private readonly ProjectCachePluginBase _projectCachePlugin;
@@ -28,13 +28,14 @@ namespace Microsoft.Build.Experimental.ProjectCache
         private ProjectCacheService(
             ProjectCachePluginBase projectCachePlugin,
             BuildManager buildManager,
-            PluginLoggerBase logger,
+            Func<PluginLoggerBase> loggerFactory,
             ProjectCacheDescriptor projectCacheDescriptor,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken
+        )
         {
             _projectCachePlugin = projectCachePlugin;
             _buildManager = buildManager;
-            _logger = logger;
+            _loggerFactory = loggerFactory;
             _projectCacheDescriptor = projectCacheDescriptor;
             _cancellationToken = cancellationToken;
         }
@@ -49,7 +50,9 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 .ConfigureAwait(false);
 
             // TODO: Detect and use the highest verbosity from all the user defined loggers. That's tricky because right now we can't discern between user set loggers and msbuild's internally added loggers.
-            var logger = new LoggingServiceToPluginLoggerAdapter(LoggerVerbosity.Normal, loggingService);
+            var loggerFactory = new Func<PluginLoggerBase>(() => new LoggingServiceToPluginLoggerAdapter(LoggerVerbosity.Normal, loggingService));
+
+            var logger = loggerFactory();
 
             try
             {
@@ -73,7 +76,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 ProjectCacheException.ThrowForLoggedError("ProjectCacheInitializationFailed");
             }
 
-            return new ProjectCacheService(plugin, buildManager, logger, pluginDescriptor, cancellationToken);
+            return new ProjectCacheService(plugin, buildManager, loggerFactory, pluginDescriptor, cancellationToken);
         }
 
         private static ProjectCachePluginBase GetPluginInstance(ProjectCacheDescriptor pluginDescriptor)
@@ -152,21 +155,23 @@ namespace Microsoft.Build.Experimental.ProjectCache
                                    $"\n\tTargets:[{string.Join(", ", buildRequest.TargetNames)}]" +
                                    $"\n\tGlobal Properties: {{{string.Join(",", buildRequest.GlobalProperties.Select(kvp => $"{kvp.Name}={kvp.EvaluatedValue}"))}}}";
 
-            _logger.LogMessage(
+            var logger = _loggerFactory();
+
+            logger.LogMessage(
                 "\n====== Querying project cache for project " + queryDescription,
                 MessageImportance.High);
 
             CacheResult cacheResult = null!;
             try
             {
-                cacheResult = await _projectCachePlugin.GetCacheResultAsync(buildRequest, _logger, _cancellationToken);
+                cacheResult = await _projectCachePlugin.GetCacheResultAsync(buildRequest, logger, _cancellationToken);
             }
             catch (Exception e)
             {
                 HandlePluginException(e, nameof(ProjectCachePluginBase.GetCacheResultAsync));
             }
 
-            if (_logger.HasLoggedErrors || cacheResult.ResultType == CacheResultType.None)
+            if (logger.HasLoggedErrors || cacheResult.ResultType == CacheResultType.None)
             {
                 ProjectCacheException.ThrowForLoggedError("ProjectCacheQueryFailed", queryDescription);
             }
@@ -188,7 +193,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                     throw new ArgumentOutOfRangeException();
             }
 
-            _logger.LogMessage(
+            logger.LogMessage(
                 message,
                 MessageImportance.High);
 
@@ -197,16 +202,18 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
         public async Task ShutDown()
         {
+            var logger = _loggerFactory();
+
             try
             {
-                await _projectCachePlugin.EndBuildAsync(_logger, _cancellationToken);
+                await _projectCachePlugin.EndBuildAsync(logger, _cancellationToken);
             }
             catch (Exception e)
             {
                 HandlePluginException(e, nameof(ProjectCachePluginBase.EndBuildAsync));
             }
 
-            if (_logger.HasLoggedErrors)
+            if (logger.HasLoggedErrors)
             {
                 ProjectCacheException.ThrowForLoggedError("ProjectCacheShutdownFailed");
             }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -801,4 +801,10 @@
     <Compile Remove="Collections\RetrievableEntryHashSet\Originals\*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="BackEnd\Components\ProjectCache\ProjectCacheException.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1864,8 +1864,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</value>
   </data>
   <data name="LoadingProjectCachePlugin" xml:space="preserve">
-    <value>"Loading the following project cache plugin:
-    {0}"</value>
+    <value>Loading the following project cache plugin:
+    {0}</value>
   </data>
   <data name="SolutionPathPropertyMustBeSetOnVSSubmissions" xml:space="preserve">
     <value>"MSB4264: Invalid $(SolutionPath) property: {0}"</value>
@@ -1887,6 +1887,9 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   <data name="NoProjectCachePluginFoundInAssembly" xml:space="preserve">
     <value>MSB4270: No project cache plugins found in assembly "{0}". Expected one.</value>
+  </data>
+  <data name="ProjectCacheException" xml:space="preserve">
+    <value>MSB4271: The project cache threw an unhandled exception from the {0} method.</value>
   </data>
   <data name="KillingProcessWithPid" xml:space="preserve">
     <value>Killing process with pid = {0}.</value>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">Načítá se následující modul plug-in mezipaměti projektu:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">Načítá se následující modul plug-in mezipaměti projektu:
     {0}</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: Musí se zadat jeden modul plug-in mezipaměti projektu, ale našlo se jich více: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"Folgendes Projektcache-Plug-In wird geladen:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"Folgendes Projektcache-Plug-In wird geladen:
     {0}"</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: Ein einzelnes Projektcache-Plug-In muss angegeben werden, es wurden jedoch mehrere gefunden: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -138,10 +138,10 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="new">"Loading the following project cache plugin:
-    {0}"</target>
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="new">Loading the following project cache plugin:
+    {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="new">MSB4265: A single project cache plugin must be specified but multiple where found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"Cargando el complemento de caché de proyectos siguiente:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"Cargando el complemento de caché de proyectos siguiente:
     {0} "</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: Debe especificarse un solo complemento de caché de proyectos, pero se encontraron varios: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"Chargement du plug-in de cache de projet suivant :
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"Chargement du plug-in de cache de projet suivant :
     {0}"</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: un seul plug-in de cache de projet doit être spécifié, mais plusieurs plug-ins ont été trouvés : {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"Caricamento del plug-in seguente della cache del progetto:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"Caricamento del plug-in seguente della cache del progetto:
     {0}"</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: è necessario specificare un singolo plug-in della cache del progetto, ma ne sono trovati più di uno: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"次のプロジェクト キャッシュ プラグインを読み込んでいます。
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"次のプロジェクト キャッシュ プラグインを読み込んでいます。
     {0}"</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: 単一のプロジェクト キャッシュ プラグインを指定する必要がありますが、複数指定されています。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"다음 프로젝트 캐시 플러그 인을 로드하는 중:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"다음 프로젝트 캐시 플러그 인을 로드하는 중:
     {0}"</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: 단일 프로젝트 캐시 플러그 인이 지정되어야 하지만, {0}에서 여러 개를 찾았습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">„Ładowanie następującej wtyczki pamięci podręcznej projektu:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">„Ładowanie następującej wtyczki pamięci podręcznej projektu:
     {0}”</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: należy określić jedną wtyczkę pamięci podręcznej projektu, ale znaleziono ich wiele: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"Carregando o seguinte plug-in de cache do projeto:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"Carregando o seguinte plug-in de cache do projeto:
     {0}"</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: é necessário especificar só um plug-in de cache do projeto, mas foram encontrados vários: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"Идет загрузка следующего подключаемого модуля кэша проектов:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"Идет загрузка следующего подключаемого модуля кэша проектов:
     {0}"</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: должен быть указан один подключаемый модуль кэша проектов, но найдено несколько: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"Şu proje önbelleği eklentisi yükleniyor:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"Şu proje önbelleği eklentisi yükleniyor:
     {0}"</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: Tek bir proje önbellek eklentisi belirtilmelidir ancak birden çok eklenti bulundu: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">“正在加载以下项目缓存插件:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">“正在加载以下项目缓存插件:
     {0}”</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: 必须指定单个项目缓存插件，但找到多个位置: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -138,9 +138,9 @@
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
-        <source>"Loading the following project cache plugin:
-    {0}"</source>
-        <target state="translated">"正在載入下列專案快取外掛程式:
+        <source>Loading the following project cache plugin:
+    {0}</source>
+        <target state="needs-review-translation">"正在載入下列專案快取外掛程式:
     {0}"</target>
         <note />
       </trans-unit>
@@ -217,6 +217,11 @@
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
         <target state="translated">MSB4265: 只可指定單一專案快取外掛程式，但發現多個指定項目: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCacheException">
+        <source>MSB4271: The project cache threw an unhandled exception from the {0} method.</source>
+        <target state="new">MSB4271: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -791,12 +791,15 @@ namespace Microsoft.Build.CommandLine
                     exitType = ExitType.InitializationError;
                 }
             }
-            catch (ProjectCacheException e) when (!e.HasBeenLogged)
+            catch (ProjectCacheException e)
             {
                 Console.WriteLine($"MSBUILD : error {e.ErrorCode}: {e.Message}");
 
 #if DEBUG
-                Console.WriteLine("This is an unhandled exception from a project cache -- PLEASE OPEN A BUG AGAINST THE PROJECT CACHE OWNER.");
+                if (!e.HasBeenLoggedByProjectCache)
+                {
+                    Console.WriteLine("This is an unhandled exception from a project cache -- PLEASE OPEN A BUG AGAINST THE PROJECT CACHE OWNER.");
+                }
 #endif
 
                 if (e.InnerException is not null)

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1262,21 +1262,17 @@ namespace Microsoft.Build.CommandLine
                         success = false;
 
                         // InvalidProjectFileExceptions and its aggregates have already been logged.
-                        if (exception.GetType() != typeof(InvalidProjectFileException)
+                        if (exception is not InvalidProjectFileException
                             && !(exception is AggregateException aggregateException && aggregateException.InnerExceptions.All(innerException => innerException is InvalidProjectFileException)))
                         {
-                            if
-                                (
-                                exception.GetType() == typeof(LoggerException) ||
-                                exception.GetType() == typeof(InternalLoggerException)
-                                )
+                            if (exception is LoggerException or InternalLoggerException)
                             {
                                 // We will rethrow this so the outer exception handler can catch it, but we don't
                                 // want to log the outer exception stack here.
                                 throw exception;
                             }
 
-                            if (exception.GetType() == typeof(BuildAbortedException))
+                            if (exception is BuildAbortedException)
                             {
                                 // this is not a bug and should not dump stack. It will already have been logged
                                 // appropriately, there is no need to take any further action with it.

--- a/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
+++ b/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
@@ -14,14 +14,14 @@ namespace MockCacheFromAssembly
     {
         public AssemblyMockCache()
         {
-            ThrowFrom("Constructor");
+            ErrorFrom("Constructor", pluginLoggerBase: null);
         }
 
         public override Task BeginBuildAsync(CacheContext context, PluginLoggerBase logger, CancellationToken cancellationToken)
         {
             logger.LogMessage($"{nameof(AssemblyMockCache)}: BeginBuildAsync", MessageImportance.High);
 
-            ThrowFrom(nameof(BeginBuildAsync));
+            ErrorFrom(nameof(BeginBuildAsync), logger);
 
             return Task.CompletedTask;
         }
@@ -33,7 +33,7 @@ namespace MockCacheFromAssembly
         {
             logger.LogMessage($"{nameof(AssemblyMockCache)}: GetCacheResultAsync for {buildRequest.ProjectFullPath}", MessageImportance.High);
 
-            ThrowFrom(nameof(GetCacheResultAsync));
+            ErrorFrom(nameof(GetCacheResultAsync), logger);
 
             return Task.FromResult(CacheResult.IndicateNonCacheHit(CacheResultType.CacheNotApplicable));
         }
@@ -42,16 +42,22 @@ namespace MockCacheFromAssembly
         {
             logger.LogMessage($"{nameof(AssemblyMockCache)}: EndBuildAsync", MessageImportance.High);
 
-            ThrowFrom(nameof(EndBuildAsync));
+            ErrorFrom(nameof(EndBuildAsync), logger);
 
             return Task.CompletedTask;
         }
 
-        private static void ThrowFrom(string throwFrom)
+        private static void ErrorFrom(string errorLocation, PluginLoggerBase pluginLoggerBase)
         {
-            if (Environment.GetEnvironmentVariable(throwFrom) != null)
+            var errorKind = Environment.GetEnvironmentVariable(errorLocation);
+
+            switch (errorKind)
             {
-                throw new Exception($"Cache plugin exception from {throwFrom}");
+                case "Exception":
+                    throw new Exception($"Cache plugin exception from {errorLocation}");
+                case "LoggedError":
+                    pluginLoggerBase?.LogError($"Cache plugin logged error from {errorLocation}");
+                    break;
             }
         }
     }


### PR DESCRIPTION
Depends on the changes in #6345. Merge that one in first.
These are the isolated diffs for this PR: https://github.com/dotnet/msbuild/pull/6359/files/1472b628aa65b2743b3abf068bcc2e4dc107c9f9..b9e1d9b2e51636d6cf1dae07cc53c119ee090464

### Context
Treat project cache exceptions similar to how MSBuild treats exceptions from `ILogger.Initialize` and `ILogger.Shutdown`. This avoids the "file an issue against the MSBuild team" console messages.
Treat errors logged by the project cache similar to how MSBuild treats errors logged by tasks. Which is to check whether they logged an error and if yes, shut the build down (project cache does not do "continue on error").

### Changes Made
- Adds a `ProjectCacheException` which gets handled similarly to `LoggerException`

### Testing
- Beefed up the existing exception handling tests to also assert what happens when the project cache logs errors instead of throwing exceptions.