### PR TITLE
Remove SolutionFilterName support

### DIFF
--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -190,11 +190,6 @@ namespace Microsoft.Build.Construction
         public IReadOnlyDictionary<string, ProjectInSolution> ProjectsByGuid => new ReadOnlyDictionary<string, ProjectInSolution>(_projects);
 
         /// <summary>
-        /// This is the read accessor for the solution filter file, if present. Set through FullPath.
-        /// </summary>
-        internal string SolutionFilterFilePath { get => _solutionFilterFile; }
-
-        /// <summary>
         /// This is the read/write accessor for the solution file which we will parse.  This
         /// must be set before calling any other methods on this class.
         /// </summary>

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// The set of properties all projects in the solution should be built with
         /// </summary>
-        private const string SolutionProperties = "BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionFilterName=$(SolutionFilterName); SolutionPath=$(SolutionPath)";
+        private const string SolutionProperties = "BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)";
 
         /// <summary>
         /// The set of properties which identify the configuration and platform to build a project with
@@ -94,7 +94,6 @@ namespace Microsoft.Build.Construction
             new Tuple<string, string>("SolutionExt", null),
             new Tuple<string, string>("SolutionFileName", null),
             new Tuple<string, string>("SolutionName", null),
-            new Tuple<string, string>("SolutionFilterName", null),
             new Tuple<string, string>(SolutionPathPropertyName, null)
         };
 
@@ -500,7 +499,7 @@ namespace Microsoft.Build.Construction
 
             string additionalProperties = string.Format(
                 CultureInfo.InvariantCulture,
-                "Configuration={0}; Platform={1}; BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionFilterName=$(SolutionFilterName); SolutionPath=$(SolutionPath)",
+                "Configuration={0}; Platform={1}; BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)",
                 EscapingUtilities.Escape(configurationName),
                 EscapingUtilities.Escape(platformName)
             );
@@ -2292,7 +2291,6 @@ namespace Microsoft.Build.Construction
             globalProperties.AddProperty("SolutionExt", EscapingUtilities.Escape(Path.GetExtension(_solutionFile.FullPath)));
             globalProperties.AddProperty("SolutionFileName", EscapingUtilities.Escape(Path.GetFileName(_solutionFile.FullPath)));
             globalProperties.AddProperty("SolutionName", EscapingUtilities.Escape(Path.GetFileNameWithoutExtension(_solutionFile.FullPath)));
-            globalProperties.AddProperty("SolutionFilterName", EscapingUtilities.Escape(Path.GetFileNameWithoutExtension(_solutionFile.SolutionFilterFilePath ?? string.Empty)));
 
             globalProperties.AddProperty(SolutionPathPropertyName, EscapingUtilities.Escape(Path.Combine(_solutionFile.SolutionFileDirectory, Path.GetFileName(_solutionFile.FullPath))));
 

--- a/src/Deprecated/Engine/Solution/SolutionWrapperProject.cs
+++ b/src/Deprecated/Engine/Solution/SolutionWrapperProject.cs
@@ -1608,7 +1608,7 @@ namespace Microsoft.Build.BuildEngine
                 BuildTask msbuildTask = newTarget.AddNewTask("MSBuild");
                 msbuildTask.Condition = buildItemReference + " != ''";
                 msbuildTask.SetParameterValue("Projects", buildItemReference);
-                msbuildTask.SetParameterValue("Properties", "Configuration=%(Configuration); Platform=%(Platform); BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionFilterName=$(SolutionFilterName); SolutionPath=$(SolutionPath)");
+                msbuildTask.SetParameterValue("Properties", "Configuration=%(Configuration); Platform=%(Platform); BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)");
 
                 if (!string.IsNullOrEmpty(subTargetName))
                 {

--- a/src/Deprecated/Engine/Solution/SolutionWrapperProject.cs
+++ b/src/Deprecated/Engine/Solution/SolutionWrapperProject.cs
@@ -519,7 +519,7 @@ namespace Microsoft.Build.BuildEngine
 
             string additionalProperties = string.Format(
                 CultureInfo.InvariantCulture,
-                "Configuration={0}; Platform={1}; BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionFilterName=$(SolutionFilterName); SolutionPath=$(SolutionPath)",
+                "Configuration={0}; Platform={1}; BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)",
                 EscapingUtilities.Escape(configurationName),
                 EscapingUtilities.Escape(platformName)
             );

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1796,7 +1796,6 @@ elementFormDefault="qualified">
     <xs:element name="SolutionExt" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="SolutionFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="SolutionName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SolutionFilterName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="SolutionPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="StartAction" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="StartArguments" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -346,7 +346,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <DevEnvDir Condition="'$(DevEnvDir)'==''">*Undefined*</DevEnvDir>
     <SolutionName Condition="'$(SolutionName)'==''">*Undefined*</SolutionName>
-    <SolutionFilterName Condition="'$(SolutionFilterName)'==''">*Undefined*</SolutionFilterName>
     <!-- Example, MySolution -->
     <SolutionFileName Condition="'$(SolutionFileName)'==''">*Undefined*</SolutionFileName>
     <!-- Example, MySolution.sln -->


### PR DESCRIPTION
We decided that adding support for a SolutionFilterName property was premature. The point of a solution filter is to permit loading or building only a subset of a more complicated solution file. Of note, however, it is not to permit changing behavior based on which subset is being built—if a full solution is buildable, any associated solution filter file should be as well. Furthermore, if that information is not properly propagated within Visual Studio, it may lead to different behavior when building from the command line versus Visual Studio.