### PR TITLE
Enable FindInvalidProjectReferences for .NET Core

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -290,6 +290,18 @@ namespace Microsoft.Build.Tasks
         public bool MatchFileNameOnly { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    public partial class FindInvalidProjectReferences : Microsoft.Build.Tasks.TaskExtension
+    {
+        public FindInvalidProjectReferences() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] InvalidReferences { get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem[] ProjectReferences { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetPlatformVersion { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
     public partial class FindUnderPath : Microsoft.Build.Tasks.TaskExtension
     {
         public FindUnderPath() { }

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -99,7 +99,6 @@
     <Compile Remove="CSharpTokenizer_Tests.cs" />
     <Compile Remove="DependentAssembly_Tests.cs" />
     <Compile Remove="ErrorWarningMessage_Tests.cs" />
-    <Compile Remove="FindInvalidProjectReferences_Tests.cs" />
     <Compile Remove="ResourceHandling\GenerateResourceOutOfProc_Tests.cs" />
     <Compile Remove="ResourceHandling\ResGen_Tests.cs" />
     <Compile Remove="ResourceHandling\ResGenDependencies_Tests.cs" />

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -387,6 +387,7 @@
     <Compile Include="FindAppConfigFile.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="FindInvalidProjectReferences.cs" />
     <Compile Include="GetFrameworkPath.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -604,7 +605,6 @@
     <Compile Include="ComReferenceWrapperInfo.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="FindInvalidProjectReferences.cs" />
     <Compile Include="GenerateBootstrapper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>


### PR DESCRIPTION
Fixes #6279.

### Context

This task isn't used in the standard .NET SDK build process and was never enabled for the .NET Core/5.0+ flavor of MSBuild.

### Changes Made

Include/stop removing task class from core flavors.

### Testing

Unit tests.
