### PR TITLE
Snapshot Items of TaskParameters from another AppDomain

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Build.BackEnd
             bool logItemMetadata,
             DateTime timestamp)
         {
-            // Only run this method if we use AppDomains and not in the default AppDomain
+            // Only create a snapshot of items if we use AppDomains
 #if FEATURE_APPDOMAIN
             CreateItemsSnapshot(ref items);
 #endif
@@ -287,6 +287,7 @@ namespace Microsoft.Build.BackEnd
             return args;
         }
 
+#if FEATURE_APPDOMAIN
         private static void CreateItemsSnapshot(ref IList items)
         {
             if (items == null)
@@ -294,7 +295,6 @@ namespace Microsoft.Build.BackEnd
                 return;
             }
 
-#if FEATURE_APPDOMAIN
             // If we're in the default AppDomain, but any of the items come from a different AppDomain
             // we need to take a snapshot of the items right now otherwise that AppDomain might get
             // unloaded by the time we want to consume the items.
@@ -320,7 +320,6 @@ namespace Microsoft.Build.BackEnd
                     return;
                 }
             }
-#endif
 
             int count = items.Count;
             var cloned = new object[count];
@@ -340,6 +339,7 @@ namespace Microsoft.Build.BackEnd
 
             items = cloned;
         }
+#endif
 
         internal static string GetTaskParameterText(TaskParameterEventArgs args)
             => GetTaskParameterText(args.Kind, args.ItemType, args.Items, args.LogItemMetadata);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Remoting;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Framework;
@@ -288,10 +289,38 @@ namespace Microsoft.Build.BackEnd
 
         private static void CreateItemsSnapshot(ref IList items)
         {
-            if (items == null || AppDomain.CurrentDomain.IsDefaultAppDomain())
+            if (items == null)
             {
                 return;
             }
+
+#if FEATURE_APPDOMAIN
+            // If we're in the default AppDomain, but any of the items come from a different AppDomain
+            // we need to take a snapshot of the items right now otherwise that AppDomain might get
+            // unloaded by the time we want to consume the items.
+            // If we're not in the default AppDomain, always take the items snapshot.
+            //
+            // It is unfortunate to need to be doing this check, but ResolveComReference and other tasks
+            // still use AppDomains and create a TaskParameterEventArgs in the default AppDomain, but
+            // pass it Items from another AppDomain.
+            if (AppDomain.CurrentDomain.IsDefaultAppDomain())
+            {
+                bool needsSnapshot = false;
+                foreach (var item in items)
+                {
+                    if (RemotingServices.IsTransparentProxy(item))
+                    {
+                        needsSnapshot = true;
+                        break;
+                    }
+                }
+
+                if (!needsSnapshot)
+                {
+                    return;
+                }
+            }
+#endif
 
             int count = items.Count;
             var cloned = new object[count];

--- a/src/Framework/TaskItemData.cs
+++ b/src/Framework/TaskItemData.cs
@@ -25,6 +25,26 @@ namespace Microsoft.Build.Framework
             Metadata = metadata ?? _emptyMetadata;
         }
 
+        /// <summary>
+        /// Clone the task item and all metadata to create a snapshot
+        /// </summary>
+        /// <param name="original">An <see cref="ITaskItem"/> to clone</param>
+        public TaskItemData(ITaskItem original)
+        {
+            ItemSpec = original.ItemSpec;
+            var metadata = original.EnumerateMetadata();
+
+            // Can't preallocate capacity because we don't know how large it will get
+            // without enumerating the enumerable
+            var dictionary = new Dictionary<string, string>();
+            foreach (var item in metadata)
+            {
+                dictionary.Add(item.Key, item.Value);
+            }
+
+            Metadata = dictionary;
+        }
+
         IEnumerable<KeyValuePair<string, string>> IMetadataContainer.EnumerateMetadata() => Metadata;
 
         public int MetadataCount => Metadata.Count;


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6379

We have a situation where we are in a worker node and a task runs in a separate AppDomain and logs a TaskParameterEventArgs. Since logging is asynchronous there's a risk that by the time the node packet translator accesses the TaskParameterEventArgs.Items the AppDomain is already unloaded and we crash when trying to enumerate item metadata.

Detect that we're in another AppDomain and eagerly take a snapshot of task items with all metadata.

I wasn't able to reproduce the issue, but I will ask the customer to validate with the bootstrap MSBuild I built from this PR and see if it goes away.