### PR TITLE
Rar permissions fix

### DIFF
--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (!string.IsNullOrEmpty(stateFile) && FileSystems.Default.FileExists(stateFile))
                 {
-                    using (FileStream s = new FileStream(stateFile, FileMode.Open))
+                    using (FileStream s = File.OpenRead(stateFile))
                     {
                         var formatter = new BinaryFormatter();
                         object deserializedObject = formatter.Deserialize(s);

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (!string.IsNullOrEmpty(stateFile) && FileSystems.Default.FileExists(stateFile))
                 {
-                    using FileStream s = new FileStream(stateFile, FileMode.Open);
+                    using FileStream s = File.OpenRead(stateFile);
                     var translator = BinaryTranslator.GetReadTranslator(s, buffer:null); // TODO: shared buffering?
 
                     // verify file signature


### PR DESCRIPTION
~~Based on #6350 for convenience. That PR centralized the cache deserialization logic for StateFileBase, so it would be easy to accidentally overwrite this change with that one when resolving merge conflicts.~~

### Context
The precomputed cache from https://github.com/dotnet/installer/pull/10037 lives in Program Files after it's installed on a new computer. Program Files can only be accessed with admin privileges, which not all users have and those that have generally wouldn't expect. This permits reading the precomputed cache even without admin rights.

### Changes Made
Switch how the file is read.