### PR TITLE
Remove KeyPair deserialization

### DIFF
--- a/src/Shared/TranslatorHelpers.cs
+++ b/src/Shared/TranslatorHelpers.cs
@@ -261,9 +261,6 @@ namespace Microsoft.Build.BackEnd
                     HashAlgorithm = hashAlgorithm,
                     VersionCompatibility = versionCompatibility,
                     CodeBase = codeBase,
-                    // AssemblyName.KeyPair is not used anywhere, additionally StrongNameKeyPair is not supported in .net core 5-
-                    // and throws platform not supported exception when serialized or deserialized
-                    KeyPair = null,
                 };
 
                 assemblyName.SetPublicKey(publicKey);


### PR DESCRIPTION
Fixes #6389

### Context
Strong Name Key Pairs aren't available on .NET 6+, and although it's fine to serialize null and remember that's what it is, deserializing involves assigning null to something that shouldn't exist, which is throwing an error, invalidating all RAR caches.

This fixes that problem.

### Changes Made
No longer serialize or deserialize a null value for KeyPair.

### Testing
Allowed precomputed cache to function properly. (Local test only)

/cc: @rokonec
