### PR TITLE
Log location of intrinsic tasks

### DIFF
--- a/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 items,
                 logItemMetadata: true,
                 DateTime.MinValue);
+            result.LineNumber = 30000;
+            result.ColumnNumber = 50;
 
             // normalize line endings as we can't rely on the line endings of NodePackets_Tests.cs
             Assert.Equal(@"Task Parameter:
@@ -433,6 +435,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     Assert.Equal(leftTaskParameter.Message, rightTaskParameter.Message);
                     Assert.Equal(leftTaskParameter.BuildEventContext, rightTaskParameter.BuildEventContext);
                     Assert.Equal(leftTaskParameter.Timestamp, rightTaskParameter.Timestamp);
+                    Assert.Equal(leftTaskParameter.LineNumber, rightTaskParameter.LineNumber);
+                    Assert.Equal(leftTaskParameter.ColumnNumber, rightTaskParameter.ColumnNumber);
                     break;
 
                 case LoggingEventType.TaskFinishedEvent:

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -327,11 +327,15 @@ namespace Microsoft.Build.UnitTests
                 new TaskItemData("ItemSpec2", Enumerable.Range(1,3).ToDictionary(i => i.ToString(), i => i.ToString() + "value"))
             };
             var args = new TaskParameterEventArgs(TaskParameterMessageKind.TaskOutput, "ItemName", items, true, DateTime.MinValue);
+            args.LineNumber = 265;
+            args.ColumnNumber = 6;
 
             Roundtrip(args,
                 e => e.Kind.ToString(),
                 e => e.ItemType,
                 e => e.LogItemMetadata.ToString(),
+                e => e.LineNumber.ToString(),
+                e => e.ColumnNumber.ToString(),
                 e => TranslationHelpers.GetItemsString(e.Items));
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -218,7 +218,8 @@ namespace Microsoft.Build.BackEnd
                     TaskParameterMessageKind.AddItem,
                     child.ItemType,
                     itemsToAdd,
-                    logItemMetadata: true);
+                    logItemMetadata: true,
+                    child.Location);
             }
 
             // Now add the items we created to the lookup.
@@ -261,7 +262,8 @@ namespace Microsoft.Build.BackEnd
                         TaskParameterMessageKind.RemoveItem,
                         child.ItemType,
                         itemsToRemove,
-                        logItemMetadata: true);
+                        logItemMetadata: true,
+                        child.Location);
                 }
 
                 bucket.Lookup.RemoveItems(itemsToRemove);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -252,7 +252,8 @@ namespace Microsoft.Build.BackEnd
             TaskParameterMessageKind messageKind,
             string itemType,
             IList items,
-            bool logItemMetadata)
+            bool logItemMetadata,
+            IElementLocation location = null)
         {
             var args = CreateTaskParameterEventArgs(
                 loggingContext.BuildEventContext,
@@ -260,7 +261,10 @@ namespace Microsoft.Build.BackEnd
                 itemType,
                 items,
                 logItemMetadata,
-                DateTime.UtcNow);
+                DateTime.UtcNow,
+                location?.Line ?? 0,
+                location?.Column ?? 0);
+
             loggingContext.LogBuildEvent(args);
         }
 
@@ -270,7 +274,9 @@ namespace Microsoft.Build.BackEnd
             string itemType,
             IList items,
             bool logItemMetadata,
-            DateTime timestamp)
+            DateTime timestamp,
+            int line = 0,
+            int column = 0)
         {
             // Only create a snapshot of items if we use AppDomains
 #if FEATURE_APPDOMAIN
@@ -284,6 +290,8 @@ namespace Microsoft.Build.BackEnd
                 logItemMetadata,
                 timestamp);
             args.BuildEventContext = buildEventContext;
+            args.LineNumber = line;
+            args.ColumnNumber = column;
             return args;
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -658,7 +658,9 @@ namespace Microsoft.Build.Logging
                 itemType,
                 items,
                 logItemMetadata: true,
-                fields.Timestamp);
+                fields.Timestamp,
+                fields.LineNumber,
+                fields.ColumnNumber);
             e.ProjectFile = fields.ProjectFile;
             return e;
         }

--- a/src/Framework/BuildMessageEventArgs.cs
+++ b/src/Framework/BuildMessageEventArgs.cs
@@ -322,12 +322,20 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Line number of interest in associated file. 
         /// </summary>
-        public int LineNumber => lineNumber;
+        public int LineNumber
+        {
+            get => lineNumber;
+            internal set => lineNumber = value;
+        }
 
         /// <summary>
         /// Column number of interest in associated file. 
         /// </summary>
-        public int ColumnNumber => columnNumber;
+        public int ColumnNumber
+        {
+            get => columnNumber;
+            internal set => columnNumber = value;
+        }
 
         /// <summary>
         /// Ending line number of interest in associated file. 

--- a/src/Framework/TaskParameterEventArgs.cs
+++ b/src/Framework/TaskParameterEventArgs.cs
@@ -87,6 +87,8 @@ namespace Microsoft.Build.Framework
             BuildEventContext = reader.ReadOptionalBuildEventContext();
             Kind = (TaskParameterMessageKind)reader.Read7BitEncodedInt();
             ItemType = reader.ReadOptionalString();
+            LineNumber = reader.Read7BitEncodedInt();
+            ColumnNumber = reader.Read7BitEncodedInt();
             Items = ReadItems(reader);
         }
 
@@ -134,6 +136,8 @@ namespace Microsoft.Build.Framework
             writer.WriteOptionalBuildEventContext(BuildEventContext);
             writer.Write7BitEncodedInt((int)Kind);
             writer.WriteOptionalString(ItemType);
+            writer.Write7BitEncodedInt(LineNumber);
+            writer.Write7BitEncodedInt(ColumnNumber);
             WriteItems(writer, Items);
         }
 


### PR DESCRIPTION
Log the Line and Column of add or remove items in ItemGroups inside targets. Previously we could only recover the file from the parent target, but not exactly which line in the file corresponded to the add/remove.

Now we can exactly pinpoint which add/remove is executing. No need to log the file because we can recover this information from the parent target. This saves space.

![IntrinsicTaskLocation2](https://user-images.githubusercontent.com/679326/116765560-a4eea500-a9da-11eb-9307-dcba04461281.gif)

