### PR TITLE
Improve vs debugging

### DIFF
--- a/scripts/Deploy-MSBuild.ps1
+++ b/scripts/Deploy-MSBuild.ps1
@@ -60,6 +60,19 @@ $filesToCopyToBin = @(
     FileToCopy "$bootstrapBinDirectory\Microsoft.Build.Utilities.Core.dll"
     FileToCopy "$bootstrapBinDirectory\Microsoft.NET.StringTools.dll"
 
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Bcl.AsyncInterfaces.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Buffers.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Collections.Immutable.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Memory.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Numerics.Vectors.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Resources.Extensions.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Runtime.CompilerServices.Unsafe.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Text.Encodings.Web.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Text.Json.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Threading.Tasks.Dataflow.dll"
+    FileToCopy "$bootstrapBinDirectory\System.Threading.Tasks.Extensions.dll"
+    FileToCopy "$bootstrapBinDirectory\System.ValueTuple.dll"
+
     FileToCopy "$bootstrapBinDirectory\en\Microsoft.Build.resources.dll" "en"
     FileToCopy "$bootstrapBinDirectory\en\Microsoft.Build.Tasks.Core.resources.dll" "en"
     FileToCopy "$bootstrapBinDirectory\en\Microsoft.Build.Utilities.Core.resources.dll" "en"
@@ -87,6 +100,7 @@ $filesToCopyToBin = @(
 if ($runtime -eq "Desktop") {
     $runtimeSpecificFiles = @(
         FileToCopy "$bootstrapBinDirectory\MSBuild.exe"
+        FileToCopy "$bootstrapBinDirectory\MSBuild.exe.config"
         FileToCopy "artifacts\bin\Microsoft.Build.Conversion\$configuration\$targetFramework\Microsoft.Build.Conversion.Core.dll"
         FileToCopy "artifacts\bin\Microsoft.Build.Engine\$configuration\$targetFramework\Microsoft.Build.Engine.dll"
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -410,6 +410,8 @@ namespace Microsoft.Build.Execution
         {
             lock (_syncLock)
             {
+                AttachDebugger();
+
                 // Check for build in progress.
                 RequireState(BuildManagerState.Idle, "BuildInProgress");
 
@@ -555,6 +557,29 @@ namespace Microsoft.Build.Execution
 
                     _buildParameters.ProjectRootElementCache.DiscardImplicitReferences();
                 }
+            }
+        }
+
+        private void AttachDebugger()
+        {
+            if (Debugger.IsAttached)
+            {
+                return;
+            }
+
+            switch (Environment.GetEnvironmentVariable("MSBuildDebugBuildManagerOnStart"))
+            {
+#if FEATURE_DEBUG_LAUNCH
+                case "1":
+                    Debugger.Launch();
+                    break;
+#endif
+                case "2":
+                    // Sometimes easier to attach rather than deal with JIT prompt
+                    Process currentProcess = Process.GetCurrentProcess();
+                    Console.WriteLine($"Waiting for debugger to attach ({currentProcess.MainModule.FileName} PID {currentProcess.Id}).  Press enter to continue...");
+                    Console.ReadLine();
+                    break;
             }
         }
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -567,6 +567,14 @@ namespace Microsoft.Build.Execution
                 return;
             }
 
+            var processNameToBreakInto = Environment.GetEnvironmentVariable("MSBuildDebugBuildManagerOnStartProcessName");
+            var thisProcessMatchesName = string.IsNullOrWhiteSpace(processNameToBreakInto) || Process.GetCurrentProcess().ProcessName.Contains(processNameToBreakInto);
+
+            if (!thisProcessMatchesName)
+            {
+                return;
+            }
+
             switch (Environment.GetEnvironmentVariable("MSBuildDebugBuildManagerOnStart"))
             {
 #if FEATURE_DEBUG_LAUNCH


### PR DESCRIPTION
### Changes Made
- updated VS deploy script to copy more files needed during runtime
- added option to break into the BuildManager via a new env var. This makes it super easy to debug msbuild running in devenv without having to copy over local bits