### PR TITLE
Log TaskStarted line and column

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -652,6 +652,8 @@ namespace Microsoft.Build.Framework
         protected TaskStartedEventArgs() { }
         public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName) { }
         public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, System.DateTime eventTimestamp) { }
+        public int ColumnNumber { get { throw null; } }
+        public int LineNumber { get { throw null; } }
         public override string Message { get { throw null; } }
         public string ProjectFile { get { throw null; } }
         public string TaskFile { get { throw null; } }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -651,6 +651,8 @@ namespace Microsoft.Build.Framework
         protected TaskStartedEventArgs() { }
         public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName) { }
         public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, System.DateTime eventTimestamp) { }
+        public int ColumnNumber { get { throw null; } }
+        public int LineNumber { get { throw null; } }
         public override string Message { get { throw null; } }
         public string ProjectFile { get { throw null; } }
         public string TaskFile { get { throw null; } }

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -553,7 +553,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <param name="projectFile">The project file</param>
         /// <param name="projectFileOfTaskNode">The project file containing the task node.</param>
         /// <returns>The task logging context</returns>
-        public BuildEventContext LogTaskStarted2(BuildEventContext targetBuildEventContext, string taskName, string projectFile, string projectFileOfTaskNode)
+        public BuildEventContext LogTaskStarted2(BuildEventContext targetBuildEventContext, string taskName, string projectFile, string projectFileOfTaskNode, int line, int column)
         {
             return new BuildEventContext(0, 0, 0, 0);
         }

--- a/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
@@ -195,7 +195,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     new BuildFinishedEventArgs("Message", "Keyword", true),
                     new BuildStartedEventArgs("Message", "Help"),
                     new BuildMessageEventArgs("Message", "help", "sender", MessageImportance.Low),
-                    new TaskStartedEventArgs("message", "help", "projectFile", "taskFile", "taskName"),
+                    new TaskStartedEventArgs("message", "help", "projectFile", "taskFile", "taskName")
+                    {
+                        LineNumber = 345,
+                        ColumnNumber = 123
+                    },
                     new TaskFinishedEventArgs("message", "help", "projectFile", "taskFile", "taskName", true),
                     new TaskCommandLineEventArgs("commandLine", "taskName", MessageImportance.Low),
                     CreateTaskParameter(),
@@ -454,6 +458,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     Assert.Equal(leftTaskStarted.ProjectFile, rightTaskStarted.ProjectFile);
                     Assert.Equal(leftTaskStarted.TaskFile, rightTaskStarted.TaskFile);
                     Assert.Equal(leftTaskStarted.TaskName, rightTaskStarted.TaskName);
+                    Assert.Equal(leftTaskStarted.LineNumber, rightTaskStarted.LineNumber);
+                    Assert.Equal(leftTaskStarted.ColumnNumber, rightTaskStarted.ColumnNumber);
                     break;
 
                 default:

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -160,11 +160,15 @@ namespace Microsoft.Build.UnitTests
                 projectFile: "C:\\project.proj",
                 taskFile: "C:\\common.targets",
                 taskName: "Csc");
+            args.LineNumber = 42;
+            args.ColumnNumber = 999;
 
             Roundtrip(args,
                 e => e.ProjectFile,
                 e => e.TaskFile,
-                e => e.TaskName);
+                e => e.TaskName,
+                e => e.LineNumber.ToString(),
+                e => e.ColumnNumber.ToString());
         }
 
         [Fact]

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -525,8 +525,10 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="taskName">The name of the task</param>
         /// <param name="projectFile">The project file which is being built</param>
         /// <param name="projectFileOfTaskNode">The file in which the task is defined - typically a .targets file</param>
+        /// <param name="line">The line number in the file where the task invocation is located.</param>
+        /// <param name="column">The column number in the file where the task invocation is located.</param>
         /// <returns>The task build event context</returns>
-        BuildEventContext LogTaskStarted2(BuildEventContext targetBuildEventContext, string taskName, string projectFile, string projectFileOfTaskNode);
+        BuildEventContext LogTaskStarted2(BuildEventContext targetBuildEventContext, string taskName, string projectFile, string projectFileOfTaskNode, int line, int column);
 
         /// <summary>
         /// Log that a task has just completed

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -754,9 +754,11 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="taskName">Task Name</param>
         /// <param name="projectFile">Project file being built</param>
         /// <param name="projectFileOfTaskNode">Project file which contains the task</param>
+        /// <param name="line">The line number in the file where the task invocation is located.</param>
+        /// <param name="column">The column number in the file where the task invocation is located.</param>
         /// <returns>The build event context for the task.</returns>
         /// <exception cref="InternalErrorException">BuildEventContext is null</exception>
-        public BuildEventContext LogTaskStarted2(BuildEventContext targetBuildEventContext, string taskName, string projectFile, string projectFileOfTaskNode)
+        public BuildEventContext LogTaskStarted2(BuildEventContext targetBuildEventContext, string taskName, string projectFile, string projectFileOfTaskNode, int line, int column)
         {
             lock (_lockObject)
             {
@@ -782,6 +784,8 @@ namespace Microsoft.Build.BackEnd.Logging
                             taskName
                         );
                     buildEvent.BuildEventContext = taskBuildEventContext;
+                    buildEvent.LineNumber = line;
+                    buildEvent.ColumnNumber = column;
                     ProcessLoggingEvent(buildEvent);
                 }
 

--- a/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
@@ -69,7 +69,9 @@ namespace Microsoft.Build.BackEnd.Logging
                 targetLoggingContext.BuildEventContext,
                 _taskName,
                 projectFullPath,
-                task.Location.File
+                task.Location.File,
+                task.Location.Line,
+                task.Location.Column
                 );
             this.IsValid = true;
         }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -535,6 +535,8 @@ namespace Microsoft.Build.Logging
                 taskFile,
                 taskName,
                 fields.Timestamp);
+            e.LineNumber = fields.LineNumber;
+            e.ColumnNumber = fields.ColumnNumber;
             SetCommonFields(e, fields);
             return e;
         }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -370,7 +370,9 @@ Build
         private void Write(TaskStartedEventArgs e)
         {
             Write(BinaryLogRecordKind.TaskStarted);
-            WriteBuildEventArgsFields(e, writeMessage: false);
+            WriteBuildEventArgsFields(e, writeMessage: false, writeLineAndColumn: true);
+            Write(e.LineNumber);
+            Write(e.ColumnNumber);
             WriteDeduplicatedString(e.TaskName);
             WriteDeduplicatedString(e.ProjectFile);
             WriteDeduplicatedString(e.TaskFile);
@@ -512,9 +514,14 @@ Build
             WriteTaskItemList(e.Items, e.LogItemMetadata);
         }
 
-        private void WriteBuildEventArgsFields(BuildEventArgs e, bool writeMessage = true)
+        private void WriteBuildEventArgsFields(BuildEventArgs e, bool writeMessage = true, bool writeLineAndColumn = false)
         {
             var flags = GetBuildEventArgsFieldFlags(e, writeMessage);
+            if (writeLineAndColumn)
+            {
+                flags |= BuildEventArgsFieldFlags.LineNumber | BuildEventArgsFieldFlags.ColumnNumber;
+            }
+
             Write((int)flags);
             WriteBaseFields(e, flags);
         }

--- a/src/Framework/TaskStartedEventArgs.cs
+++ b/src/Framework/TaskStartedEventArgs.cs
@@ -91,6 +91,8 @@ namespace Microsoft.Build.Framework
             writer.WriteOptionalString(taskName);
             writer.WriteOptionalString(projectFile);
             writer.WriteOptionalString(taskFile);
+            writer.Write7BitEncodedInt(LineNumber);
+            writer.Write7BitEncodedInt(ColumnNumber);
         }
 
         /// <summary>
@@ -105,6 +107,8 @@ namespace Microsoft.Build.Framework
             taskName = reader.ReadByte() == 0 ? null : reader.ReadString();
             projectFile = reader.ReadByte() == 0 ? null : reader.ReadString();
             taskFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+            LineNumber = reader.Read7BitEncodedInt();
+            ColumnNumber = reader.Read7BitEncodedInt();
         }
         #endregion
 
@@ -122,6 +126,16 @@ namespace Microsoft.Build.Framework
         /// MSBuild file where this task was defined.   
         /// </summary>
         public string TaskFile => taskFile;
+
+        /// <summary>
+        /// Line number of the task invocation in the project file
+        /// </summary>
+        public int LineNumber { get; internal set; }
+
+        /// <summary>
+        /// Column number of the task invocation in the project file
+        /// </summary>
+        public int ColumnNumber { get; internal set; }
 
         public override string Message
         {


### PR DESCRIPTION
We currently log the file in which a task is invoked, but we don't log the line and column, so if there are multiple tasks of the same name in a target, there's an ambiguity as to which task it is.

Pass the line and column information to TaskStartedEventArgs.

Fortunately we don't need to increment the binlog file format as we can piggy-back on the existing infrastructure for messages which can already log line and column if present. Reading older binlogs with the new MSBuild will work as the line and column flags won't be set, so no attempt to read anything extra. Reader newer binlogs with old MSBuild (same version but pre-this change) will also work as the line and column fields will be set and the existing infrastructure will read them, but nothing will consume that data.
