### PR TITLE
Scheduler should honor BuildParameters.DisableInprocNode

### DIFF
--- a/src/Build.UnitTests/BackEnd/Scheduler_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/Scheduler_Tests.cs
@@ -498,6 +498,14 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(2, response[1].NumberOfNodesToCreate);
         }
 
+        [Fact]
+        public void SchedulerShouldHonorDisableInprocNode()
+        {
+            var s = new Scheduler();
+            s.InitializeComponent(new MockHost(new BuildParameters {DisableInProcNode = true}));
+            s.ForceAffinityOutOfProc.ShouldBeTrue();
+        }
+
         /// <summary>
         /// Make sure that traversal projects are marked with an affinity of "InProc", which means that
         /// even if multiple are available, we should still only have the single inproc node.

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -439,15 +439,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var graphResult = buildSession.BuildGraph(graph);
 
-            if (buildParameters.DisableInProcNode
-                && testData.NonCacheMissResults.Any(c => c.Value.ProxyTargets is not null))
-            {
-                // TODO: remove this branch when the DisableInProcNode failure is fixed by https://github.com/dotnet/msbuild/pull/6400
-                graphResult.OverallResult.ShouldBe(BuildResultCode.Failure);
-                buildSession.Logger.Errors.First().Code.ShouldBe("MSB4223");
-                return;
-            }
-
             graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
 
             buildSession.Dispose();
@@ -477,16 +468,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             foreach (var node in graph.ProjectNodesTopologicallySorted)
             {
                 var buildResult = buildSession.BuildProjectFile(node.ProjectInstance.FullPath);
-
-                if (buildParameters.DisableInProcNode &&
-                    testData.NonCacheMissResults.TryGetValue(GetProjectNumber(node), out var cacheResult) &&
-                    cacheResult.ProxyTargets is not null)
-                {
-                    // TODO: remove this branch when the DisableInProcNode failure is fixed by https://github.com/dotnet/msbuild/pull/6400
-                    buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
-                    buildSession.Logger.Errors.First().Code.ShouldBe("MSB4223");
-                    return;
-                }
 
                 buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
 
@@ -658,14 +639,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             using var buildSession = new Helpers.BuildManagerSession(_env, buildParameters);
 
             var graphResult = buildSession.BuildGraph(graph);
-
-            if (!disableInprocNodeViaEnvironmentVariable)
-            {
-                // TODO: remove this branch when the DisableInProcNode failure is fixed by https://github.com/dotnet/msbuild/pull/6400
-                graphResult.OverallResult.ShouldBe(BuildResultCode.Failure);
-                buildSession.Logger.Errors.First().Code.ShouldBe("MSB4223");
-                return;
-            }
 
             graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
 
@@ -1268,12 +1241,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
         [InlineData(true, true)]
         public void CacheShouldBeQueriedInParallelDuringGraphBuilds(bool useSynchronousLogging, bool disableInprocNode)
         {
-            if (disableInprocNode)
-            {
-                // TODO: remove this branch when the DisableInProcNode failure is fixed by https://github.com/dotnet/msbuild/pull/6400
-                return;
-            }
-
             var referenceNumbers = new []{2, 3, 4};
 
             var testData = new GraphCacheResponse(
@@ -1354,12 +1321,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
         [InlineData(true, true)]
         public void ParallelStressTest(bool useSynchronousLogging, bool disableInprocNode)
         {
-            if (disableInprocNode)
-            {
-                // TODO: remove this branch when the DisableInProcNode failure is fixed by https://github.com/dotnet/msbuild/pull/6400
-                return;
-            }
-
             var referenceNumbers = Enumerable.Range(2, NativeMethodsShared.GetLogicalCoreCount() * 2).ToArray();
 
             var testData = new GraphCacheResponse(

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -22,6 +22,7 @@ using System.Threading.Tasks;
 using Microsoft.Build.BackEnd.Components.Caching;
 using System.Reflection;
 using Microsoft.Build.Eventing;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -125,8 +126,10 @@ namespace Microsoft.Build.BackEnd
             _targetBuilderCallback = targetBuilderCallback;
             _continueOnError = false;
             _activeProxy = true;
-            _callbackMonitor = new Object();
-            _disableInprocNode = s_disableInprocNodeByEnvironmentVariable || host.BuildParameters.DisableInProcNode;
+            _callbackMonitor = new object();
+            _disableInprocNode = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
+                ? s_disableInprocNodeByEnvironmentVariable || host.BuildParameters.DisableInProcNode
+                : s_disableInprocNodeByEnvironmentVariable;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// True if the "secret" environment variable MSBUILDNOINPROCNODE is set.
         /// </summary>
-        private static bool s_onlyUseOutOfProcNodes = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1";
+        private static bool s_disableInprocNodeByEnvironmentVariable = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1";
 
         /// <summary>
         /// Help diagnose tasks that log after they return.
@@ -104,6 +104,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private int _yieldThreadId = -1;
 
+        private bool _disableInprocNode;
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -124,6 +126,7 @@ namespace Microsoft.Build.BackEnd
             _continueOnError = false;
             _activeProxy = true;
             _callbackMonitor = new Object();
+            _disableInprocNode = s_disableInprocNodeByEnvironmentVariable || host.BuildParameters.DisableInProcNode;
         }
 
         /// <summary>
@@ -137,7 +140,7 @@ namespace Microsoft.Build.BackEnd
             get
             {
                 VerifyActiveProxy();
-                return _host.BuildParameters.MaxNodeCount > 1 || s_onlyUseOutOfProcNodes;
+                return _host.BuildParameters.MaxNodeCount > 1 || _disableInprocNode;
             }
         }
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Flag used for debugging by forcing all scheduling to go out-of-proc.
         /// </summary>
-        private bool _forceAffinityOutOfProc;
+        internal bool ForceAffinityOutOfProc { get; private set; }
 
         /// <summary>
         /// The path into which debug files will be written.
@@ -177,7 +177,6 @@ namespace Microsoft.Build.BackEnd
         public Scheduler()
         {
             _debugDumpState = Environment.GetEnvironmentVariable("MSBUILDDEBUGSCHEDULER") == "1";
-            _forceAffinityOutOfProc = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1";
             _debugDumpPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
             _schedulingUnlimitedVariable = Environment.GetEnvironmentVariable("MSBUILDSCHEDULINGUNLIMITED");
             _nodeLimitOffset = 0;
@@ -616,6 +615,7 @@ namespace Microsoft.Build.BackEnd
             _resultsCache = (IResultsCache)_componentHost.GetComponent(BuildComponentType.ResultsCache);
             _configCache = (IConfigCache)_componentHost.GetComponent(BuildComponentType.ConfigCache);
             _inprocNodeContext =  new NodeLoggingContext(_componentHost.LoggingService, InProcNodeId, true);
+			ForceAffinityOutOfProc = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1" || _componentHost.BuildParameters.DisableInProcNode;
         }
 
         /// <summary>
@@ -1360,7 +1360,7 @@ namespace Microsoft.Build.BackEnd
             // and produce more references (more work to do.)  This just verifies we do not attempt to send a traversal to
             // an out-of-proc node because doing so is inefficient and presently will cause the engine to fail on the remote
             // node because these projects cannot be found.
-            ErrorUtilities.VerifyThrow(nodeId == InProcNodeId || _forceAffinityOutOfProc || !IsTraversalRequest(request.BuildRequest), "Can't assign traversal request to out-of-proc node!");
+            ErrorUtilities.VerifyThrow(nodeId == InProcNodeId || ForceAffinityOutOfProc || !IsTraversalRequest(request.BuildRequest), "Can't assign traversal request to out-of-proc node!");
             request.VerifyState(SchedulableRequestState.Unscheduled);
 
             // Determine if this node has seen our configuration before.  If not, we must send it along with this request.
@@ -2097,7 +2097,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private NodeAffinity GetNodeAffinityForRequest(BuildRequest request)
         {
-            if (_forceAffinityOutOfProc)
+            if (ForceAffinityOutOfProc)
             {
                 return NodeAffinity.OutOfProc;
             }

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -14,7 +14,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Experimental.ProjectCache;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-
+using Microsoft.Build.Utilities;
 using BuildAbortedException = Microsoft.Build.Exceptions.BuildAbortedException;
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using NodeLoggingContext = Microsoft.Build.BackEnd.Logging.NodeLoggingContext;
@@ -615,7 +615,10 @@ namespace Microsoft.Build.BackEnd
             _resultsCache = (IResultsCache)_componentHost.GetComponent(BuildComponentType.ResultsCache);
             _configCache = (IConfigCache)_componentHost.GetComponent(BuildComponentType.ConfigCache);
             _inprocNodeContext =  new NodeLoggingContext(_componentHost.LoggingService, InProcNodeId, true);
-			ForceAffinityOutOfProc = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1" || _componentHost.BuildParameters.DisableInProcNode;
+            var inprocNodeDisabledViaEnvironmentVariable = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1";
+            ForceAffinityOutOfProc = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
+                ? inprocNodeDisabledViaEnvironmentVariable || _componentHost.BuildParameters.DisableInProcNode
+                : inprocNodeDisabledViaEnvironmentVariable;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1358,12 +1358,6 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrowArgumentNull(responses, nameof(responses));
             ErrorUtilities.VerifyThrow(nodeId != InvalidNodeId, "Invalid node id specified.");
 
-            // Currently we cannot move certain kinds of traversals (notably solution metaprojects) to other nodes because 
-            // they only have a ProjectInstance representation, and besides these kinds of projects build very quickly 
-            // and produce more references (more work to do.)  This just verifies we do not attempt to send a traversal to
-            // an out-of-proc node because doing so is inefficient and presently will cause the engine to fail on the remote
-            // node because these projects cannot be found.
-            ErrorUtilities.VerifyThrow(nodeId == InProcNodeId || ForceAffinityOutOfProc || !IsTraversalRequest(request.BuildRequest), "Can't assign traversal request to out-of-proc node!");
             request.VerifyState(SchedulableRequestState.Unscheduled);
 
             // Determine if this node has seen our configuration before.  If not, we must send it along with this request.

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1391,7 +1391,7 @@ namespace Microsoft.Build.BackEnd
                 if (request.IsProxyBuildRequest() && nodeId != InProcNodeId)
                 {
                     ErrorUtilities.VerifyThrow(
-                        _componentHost.BuildParameters.DisableInProcNode || _forceAffinityOutOfProc,
+                        _componentHost.BuildParameters.DisableInProcNode || ForceAffinityOutOfProc,
                         "Proxy requests should only get scheduled to out of proc nodes when the inproc node is disabled");
 
                     var loggedWarnings = Interlocked.CompareExchange(ref _loggedWarningsForProxyBuildsOnOutOfProcNodes, 1, 0);


### PR DESCRIPTION
### Context
There are two ways in MSBuild to disable the inproc node:
- via the environment variable `MSBuildNoInprocNode`
- by setting `BuildParameters.DisableInprocNode`

The implementations of these two, as you'd expect from MSBuild, are totally separate, they have nothing in common. The env var informs the Scheduler to [assign all requests to out of proc nodes](https://github.com/dotnet/msbuild/blob/fa96a2a81e0fb8c028057fa204bbf386bfb36aec/src/Build/BackEnd/Components/Scheduler/Scheduler.cs#L2048-L2053), regardless of their affinities. And the build parameter informs the NodeManager to just [bail out on inproc node creation and return null](https://github.com/dotnet/msbuild/blob/fa96a2a81e0fb8c028057fa204bbf386bfb36aec/src/Build/BackEnd/Components/Communications/NodeManager.cs#L100).

This means that if you set the env var and build a traversal project (dirs.proj, or a solution metaproj file), then all is fine, the scheduler silently redirects them to out of proc nodes. But if you set the build parameter instead of the env var and build the traversal dirs.proj then MSBuild fails with: `MSBUILD : error MSB4223: A node of the required type InProc could not be created.`

This is causing #6386 to fail some unit tests which ensure that the project cache plugin can function with the inproc node disabled: https://dev.azure.com/dnceng/public/_build/results?buildId=1114344&view=ms.vss-test-web.build-test-results-tab&runId=33953534&resultId=101506&paneView=debug

This is a bit inconsistent and I just don't see the reason for having two separate things. So I made BuildParamters.DisableInProcNode also trigger the Scheduler's ForceAffinityOutOfProc. I doubt it would break anybody, and would actually benefit the users that want to both disable the inproc node via the API (like VS does [in certain cases](http://index/?leftProject=Microsoft.Build&leftSymbol=ytxqezflwyea)) and avoid node creation exceptions.

### Changes Made
The scheduler now forces affinity to out of proc when either the env var is set, or the build parameter is set. It will avoid build failures when the build parameter is set.

### Testing
Added / updated unit tests.