### PR TITLE
Add TargetSkipReason and OriginalBuildEventContext to TargetSkippedEventArgs

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Build.Framework
         public override int GetHashCode() { throw null; }
         public static bool operator ==(Microsoft.Build.Framework.BuildEventContext left, Microsoft.Build.Framework.BuildEventContext right) { throw null; }
         public static bool operator !=(Microsoft.Build.Framework.BuildEventContext left, Microsoft.Build.Framework.BuildEventContext right) { throw null; }
+        public override string ToString() { throw null; }
     }
     public partial class BuildFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
@@ -580,10 +581,20 @@ namespace Microsoft.Build.Framework
         public string Condition { get { throw null; } set { } }
         public string EvaluatedCondition { get { throw null; } set { } }
         public override string Message { get { throw null; } }
+        public Microsoft.Build.Framework.BuildEventContext OriginalBuildEventContext { get { throw null; } set { } }
         public bool OriginallySucceeded { get { throw null; } set { } }
         public string ParentTarget { get { throw null; } set { } }
+        public Microsoft.Build.Framework.TargetSkipReason SkipReason { get { throw null; } set { } }
         public string TargetFile { get { throw null; } set { } }
         public string TargetName { get { throw null; } set { } }
+    }
+    public enum TargetSkipReason
+    {
+        None = 0,
+        PreviouslyBuiltSuccessfully = 1,
+        PreviouslyBuiltUnsuccessfully = 2,
+        OutputsUpToDate = 3,
+        ConditionWasFalse = 4,
     }
     public partial class TargetStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Build.Framework
         public override int GetHashCode() { throw null; }
         public static bool operator ==(Microsoft.Build.Framework.BuildEventContext left, Microsoft.Build.Framework.BuildEventContext right) { throw null; }
         public static bool operator !=(Microsoft.Build.Framework.BuildEventContext left, Microsoft.Build.Framework.BuildEventContext right) { throw null; }
+        public override string ToString() { throw null; }
     }
     public partial class BuildFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
@@ -579,10 +580,20 @@ namespace Microsoft.Build.Framework
         public string Condition { get { throw null; } set { } }
         public string EvaluatedCondition { get { throw null; } set { } }
         public override string Message { get { throw null; } }
+        public Microsoft.Build.Framework.BuildEventContext OriginalBuildEventContext { get { throw null; } set { } }
         public bool OriginallySucceeded { get { throw null; } set { } }
         public string ParentTarget { get { throw null; } set { } }
+        public Microsoft.Build.Framework.TargetSkipReason SkipReason { get { throw null; } set { } }
         public string TargetFile { get { throw null; } set { } }
         public string TargetName { get { throw null; } set { } }
+    }
+    public enum TargetSkipReason
+    {
+        None = 0,
+        PreviouslyBuiltSuccessfully = 1,
+        PreviouslyBuiltUnsuccessfully = 2,
+        OutputsUpToDate = 3,
+        ConditionWasFalse = 4,
     }
     public partial class TargetStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {

--- a/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             BuildErrorEventArgs error = new BuildErrorEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender");
             TargetStartedEventArgs targetStarted = new TargetStartedEventArgs("message", "help", "targetName", "ProjectFile", "targetFile");
             TargetFinishedEventArgs targetFinished = new TargetFinishedEventArgs("message", "help", "targetName", "ProjectFile", "targetFile", true);
+            TargetSkippedEventArgs targetSkipped = CreateTargetSkipped();
             ProjectStartedEventArgs projectStarted = new ProjectStartedEventArgs(-1, "message", "help", "ProjectFile", "targetNames", null, null, null);
             ProjectFinishedEventArgs projectFinished = new ProjectFinishedEventArgs("message", "help", "ProjectFile", true);
             ExternalProjectStartedEventArgs externalStartedEvent = new ExternalProjectStartedEventArgs("message", "help", "senderName", "projectFile", "targetNames");
@@ -69,6 +70,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             VerifyLoggingPacket(error, LoggingEventType.BuildErrorEvent);
             VerifyLoggingPacket(targetStarted, LoggingEventType.TargetStartedEvent);
             VerifyLoggingPacket(targetFinished, LoggingEventType.TargetFinishedEvent);
+            VerifyLoggingPacket(targetSkipped, LoggingEventType.TargetSkipped);
             VerifyLoggingPacket(projectStarted, LoggingEventType.ProjectStartedEvent);
             VerifyLoggingPacket(projectFinished, LoggingEventType.ProjectFinishedEvent);
             VerifyLoggingPacket(evaluationStarted, LoggingEventType.ProjectEvaluationStartedEvent);
@@ -174,6 +176,26 @@ namespace Microsoft.Build.UnitTests.BackEnd
             return result;
         }
 
+        private static TargetSkippedEventArgs CreateTargetSkipped()
+        {
+            var result = new TargetSkippedEventArgs(message: null)
+            {
+                BuildReason = TargetBuiltReason.DependsOn,
+                SkipReason = TargetSkipReason.PreviouslyBuiltSuccessfully,
+                BuildEventContext = CreateBuildEventContext(),
+                OriginalBuildEventContext = CreateBuildEventContext(),
+                Condition = "$(Condition) == 'true'",
+                EvaluatedCondition = "'true' == 'true'",
+                Importance = MessageImportance.Normal,
+                OriginallySucceeded = true,
+                ProjectFile = "1.proj",
+                TargetFile = "1.proj",
+                TargetName = "Build",
+                ParentTarget = "ParentTarget"
+            };
+            return result;
+        }
+
         /// <summary>
         /// Tests serialization of LogMessagePacket with each kind of event type.
         /// </summary>
@@ -207,7 +229,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     new ProjectFinishedEventArgs("message", "help", "ProjectFile", true),
                     new ExternalProjectStartedEventArgs("message", "help", "senderName", "projectFile", "targetNames"),
                     CreateProjectEvaluationStarted(),
-                    CreateProjectEvaluationFinished()
+                    CreateProjectEvaluationFinished(),
+                    CreateTargetSkipped()
                 };
 
                 foreach (BuildEventArgs arg in testArgs)
@@ -410,6 +433,23 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     Assert.Equal(leftTargetStarted.ProjectFile, rightTargetStarted.ProjectFile);
                     Assert.Equal(leftTargetStarted.TargetFile, rightTargetStarted.TargetFile);
                     Assert.Equal(leftTargetStarted.TargetName, rightTargetStarted.TargetName);
+                    break;
+
+                case LoggingEventType.TargetSkipped:
+                    TargetSkippedEventArgs leftTargetSkipped = left.NodeBuildEvent.Value.Value as TargetSkippedEventArgs;
+                    TargetSkippedEventArgs rightTargetSkipped = right.NodeBuildEvent.Value.Value as TargetSkippedEventArgs;
+                    Assert.Equal(leftTargetSkipped.BuildReason, rightTargetSkipped.BuildReason);
+                    Assert.Equal(leftTargetSkipped.SkipReason, rightTargetSkipped.SkipReason);
+                    Assert.Equal(leftTargetSkipped.BuildEventContext, rightTargetSkipped.BuildEventContext);
+                    Assert.Equal(leftTargetSkipped.OriginalBuildEventContext, rightTargetSkipped.OriginalBuildEventContext);
+                    Assert.Equal(leftTargetSkipped.Condition, rightTargetSkipped.Condition);
+                    Assert.Equal(leftTargetSkipped.EvaluatedCondition, rightTargetSkipped.EvaluatedCondition);
+                    Assert.Equal(leftTargetSkipped.Importance, rightTargetSkipped.Importance);
+                    Assert.Equal(leftTargetSkipped.OriginallySucceeded, rightTargetSkipped.OriginallySucceeded);
+                    Assert.Equal(leftTargetSkipped.ProjectFile, rightTargetSkipped.ProjectFile);
+                    Assert.Equal(leftTargetSkipped.TargetFile, rightTargetSkipped.TargetFile);
+                    Assert.Equal(leftTargetSkipped.TargetName, rightTargetSkipped.TargetName);
+                    Assert.Equal(leftTargetSkipped.ParentTarget, rightTargetSkipped.ParentTarget);
                     break;
 
                 case LoggingEventType.TaskCommandLineEvent:

--- a/src/Build.UnitTests/BackEnd/TargetResult_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetResult_Tests.cs
@@ -89,8 +89,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             TaskItem item = new TaskItem("foo", "bar.proj");
             item.SetMetadata("a", "b");
+            var buildEventContext = new Framework.BuildEventContext(1, 2, 3, 4, 5, 6, 7);
 
-            TargetResult result = new TargetResult(new TaskItem[] { item }, BuildResultUtilities.GetStopWithErrorResult());
+            TargetResult result = new TargetResult(
+                new TaskItem[] { item },
+                BuildResultUtilities.GetStopWithErrorResult(),
+                buildEventContext);
 
             ((ITranslatable)result).Translate(TranslationHelpers.GetWriteTranslator());
             TargetResult deserializedResult = TargetResult.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -98,6 +102,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(result.ResultCode, deserializedResult.ResultCode);
             Assert.True(TranslationHelpers.CompareCollections(result.Items, deserializedResult.Items, TaskItemComparer.Instance));
             Assert.True(TranslationHelpers.CompareExceptions(result.Exception, deserializedResult.Exception));
+            Assert.Equal(result.OriginalBuildEventContext, deserializedResult.OriginalBuildEventContext);
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -443,20 +443,31 @@ namespace Microsoft.Build.UnitTests
                 ProjectFile = "foo.csproj",
                 TargetName = "target",
                 ParentTarget = "bar",
-                BuildReason = TargetBuiltReason.DependsOn
+                BuildReason = TargetBuiltReason.DependsOn,
+                SkipReason = TargetSkipReason.PreviouslyBuiltSuccessfully,
+                Condition = "$(condition) == true",
+                EvaluatedCondition = "true == true",
+                OriginalBuildEventContext = new BuildEventContext(1, 2, 3, 4, 5, 6, 7),
+                OriginallySucceeded = false,
+                TargetFile = "foo.csproj"
             };
 
             Roundtrip(args,
+                e => e.BuildEventContext.ToString(),
                 e => e.ParentTarget,
                 e => e.Importance.ToString(),
                 e => e.LineNumber.ToString(),
                 e => e.ColumnNumber.ToString(),
-                e => e.LineNumber.ToString(),
                 e => e.Message,
                 e => e.ProjectFile,
                 e => e.TargetFile,
                 e => e.TargetName,
-                e => e.BuildReason.ToString());
+                e => e.BuildReason.ToString(),
+                e => e.SkipReason.ToString(),
+                e => e.Condition,
+                e => e.EvaluatedCondition,
+                e => e.OriginalBuildEventContext.ToString(),
+                e => e.OriginallySucceeded.ToString());
         }
 
         [Fact]

--- a/src/Build/BackEnd/Components/Communications/TranslatorExtensions.cs
+++ b/src/Build/BackEnd/Components/Communications/TranslatorExtensions.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-using System.Reflection;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -102,6 +103,18 @@ namespace Microsoft.Build.BackEnd
             targetInstanceChild.Translate(translator);
 
             return (T) targetInstanceChild;
+        }
+
+        public static void TranslateOptionalBuildEventContext(this ITranslator translator, ref BuildEventContext buildEventContext)
+        {
+            if (translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                buildEventContext = translator.Reader.ReadOptionalBuildEventContext();
+            }
+            else
+            {
+                translator.Writer.WriteOptionalBuildEventContext(buildEventContext);
+            }
         }
     }
 }

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -80,18 +80,26 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ProjectLoggingContext projectLoggingContext = LogProjectStarted(request, configuration);
 
-            // When pulling a request from the cache, we want to make sure we log a task skipped message for any targets which 
-            // were used to build the request including default and inital targets.
+            // When pulling a request from the cache, we want to make sure we log a target skipped event for any targets which
+            // were used to build the request including default and initial targets.
             foreach (string target in configuration.GetTargetsUsedToBuildRequest(request))
             {
-                projectLoggingContext.LogComment
-                    (
-                        MessageImportance.Low,
-                        result[target].ResultCode == TargetResultCode.Failure ? "TargetAlreadyCompleteFailure" : "TargetAlreadyCompleteSuccess",
-                        target
-                    );
+                var targetResult = result[target];
+                bool isFailure = targetResult.ResultCode == TargetResultCode.Failure;
 
-                if (result[target].ResultCode == TargetResultCode.Failure)
+                var skippedTargetEventArgs = new TargetSkippedEventArgs(message: null)
+                {
+                    BuildEventContext = projectLoggingContext.BuildEventContext,
+                    TargetName = target,
+                    BuildReason = TargetBuiltReason.None,
+                    SkipReason = isFailure ? TargetSkipReason.PreviouslyBuiltUnsuccessfully : TargetSkipReason.PreviouslyBuiltSuccessfully,
+                    OriginallySucceeded = !isFailure,
+                    OriginalBuildEventContext = (targetResult as TargetResult)?.OriginalBuildEventContext
+                };
+
+                projectLoggingContext.LogBuildEvent(skippedTargetEventArgs);
+
+                if (targetResult.ResultCode == TargetResultCode.Failure)
                 {
                     break;
                 }

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -564,6 +564,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     // If we've already dealt with this target and it didn't skip, let's log appropriately
                     // Otherwise we don't want anything more to do with it.
+                    bool success = targetResult.ResultCode == TargetResultCode.Success;
                     var skippedTargetEventArgs = new TargetSkippedEventArgs(message: null)
                     {
                         BuildEventContext = _projectLoggingContext.BuildEventContext,
@@ -571,7 +572,9 @@ namespace Microsoft.Build.BackEnd
                         TargetFile = currentTargetEntry.Target.Location.File,
                         ParentTarget = currentTargetEntry.ParentEntry?.Target.Name,
                         BuildReason = currentTargetEntry.BuildReason,
-                        OriginallySucceeded = targetResult.ResultCode == TargetResultCode.Success
+                        OriginallySucceeded = success,
+                        SkipReason = success ? TargetSkipReason.PreviouslyBuiltSuccessfully : TargetSkipReason.PreviouslyBuiltSuccessfully,
+                        OriginalBuildEventContext = targetResult.OriginalBuildEventContext
                     };
 
                     _projectLoggingContext.LogBuildEvent(skippedTargetEventArgs);

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -573,7 +573,7 @@ namespace Microsoft.Build.BackEnd
                         ParentTarget = currentTargetEntry.ParentEntry?.Target.Name,
                         BuildReason = currentTargetEntry.BuildReason,
                         OriginallySucceeded = success,
-                        SkipReason = success ? TargetSkipReason.PreviouslyBuiltSuccessfully : TargetSkipReason.PreviouslyBuiltSuccessfully,
+                        SkipReason = success ? TargetSkipReason.PreviouslyBuiltSuccessfully : TargetSkipReason.PreviouslyBuiltUnsuccessfully,
                         OriginalBuildEventContext = targetResult.OriginalBuildEventContext
                     };
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -354,7 +354,10 @@ namespace Microsoft.Build.BackEnd
 
             if (!condition)
             {
-                _targetResult = new TargetResult(Array.Empty<TaskItem>(), new WorkUnitResult(WorkUnitResultCode.Skipped, WorkUnitActionCode.Continue, null));
+                _targetResult = new TargetResult(
+                    Array.Empty<TaskItem>(),
+                    new WorkUnitResult(WorkUnitResultCode.Skipped, WorkUnitActionCode.Continue, null),
+                    projectLoggingContext.BuildEventContext);
                 _state = TargetEntryState.Completed;
 
                 if (!projectLoggingContext.LoggingService.OnlyLogCriticalEvents)
@@ -640,14 +643,11 @@ namespace Microsoft.Build.BackEnd
                 }
                 finally
                 {
-                       
-                    
-                        // log the last target finished since we now have the target outputs. 
-                        targetLoggingContext?.LogTargetBatchFinished(projectFullPath, targetSuccess, targetOutputItems?.Count > 0 ? targetOutputItems : null);
-                    
+                    // log the last target finished since we now have the target outputs. 
+                    targetLoggingContext?.LogTargetBatchFinished(projectFullPath, targetSuccess, targetOutputItems?.Count > 0 ? targetOutputItems : null);
                 }
 
-                _targetResult = new TargetResult(targetOutputItems.ToArray(), aggregateResult);
+                _targetResult = new TargetResult(targetOutputItems.ToArray(), aggregateResult, targetLoggingContext?.BuildEventContext);
 
                 if (aggregateResult.ResultCode == WorkUnitResultCode.Failed && aggregateResult.ActionCode == WorkUnitActionCode.Stop)
                 {

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -378,6 +378,7 @@ namespace Microsoft.Build.BackEnd
                         TargetFile = _target.Location.File,
                         ParentTarget = ParentEntry?.Target?.Name,
                         BuildReason = BuildReason,
+                        SkipReason = TargetSkipReason.ConditionWasFalse,
                         Condition = _target.Condition,
                         EvaluatedCondition = expanded
                     };

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
@@ -233,9 +233,17 @@ namespace Microsoft.Build.BackEnd
 
                 if (result == DependencyAnalysisResult.SkipUpToDate)
                 {
-                    _loggingService.LogComment(_buildEventContext, MessageImportance.Normal,
-                        "SkipTargetBecauseOutputsUpToDate",
-                        TargetToAnalyze.Name);
+                    var skippedTargetEventArgs = new TargetSkippedEventArgs(message: null)
+                    {
+                        BuildEventContext = _buildEventContext,
+                        TargetName = TargetToAnalyze.Name,
+                        BuildReason = TargetBuiltReason.None,
+                        SkipReason = TargetSkipReason.OutputsUpToDate,
+                        OriginallySucceeded = true,
+                        Importance = MessageImportance.Normal
+                    };
+
+                    _loggingService.LogBuildEvent(skippedTargetEventArgs);
 
                     // Log the target inputs & outputs
                     if (!_loggingService.OnlyLogCriticalEvents)
@@ -337,7 +345,7 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// Extract only the unique inputs and outputs from all the inputs and outputs gathered
-        /// during depedency analysis
+        /// during dependency analysis
         /// </summary>
         private void LogUniqueInputsAndOutputs()
         {

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -45,16 +45,23 @@ namespace Microsoft.Build.Execution
         private CacheInfo _cacheInfo;
 
         /// <summary>
+        /// The (possibly null) <see cref="BuildEventContext"/> from the original target build
+        /// </summary>
+        private BuildEventContext _originalBuildEventContext;
+
+        /// <summary>
         /// Initializes the results with specified items and result.
         /// </summary>
         /// <param name="items">The items produced by the target.</param>
         /// <param name="result">The overall result for the target.</param>
-        internal TargetResult(TaskItem[] items, WorkUnitResult result)
+        /// <param name="originalBuildEventContext">The original build event context from when the target was first built, if available. Can be null.</param>
+        internal TargetResult(TaskItem[] items, WorkUnitResult result, BuildEventContext originalBuildEventContext = null)
         {
             ErrorUtilities.VerifyThrowArgumentNull(items, nameof(items));
             ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
             _items = items;
             _result = result;
+            _originalBuildEventContext = originalBuildEventContext;
         }
 
         /// <summary>
@@ -129,6 +136,11 @@ namespace Microsoft.Build.Execution
             [DebuggerStepThrough]
             get => _result;
         }
+
+        /// <summary>
+        /// The (possibly null) <see cref="BuildEventContext"/> from the original target build
+        /// </summary>
+        internal BuildEventContext OriginalBuildEventContext => _originalBuildEventContext;
 
         /// <summary>
         /// Sets or gets a flag indicating whether or not a failure results should cause the build to fail.
@@ -253,6 +265,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _result, WorkUnitResult.FactoryForDeserialization);
             translator.Translate(ref _targetFailureDoesntCauseBuildFailure);
             translator.Translate(ref _afterTargetsHaveFailed);
+            translator.TranslateOptionalBuildEventContext(ref _originalBuildEventContext);
             TranslateItems(translator);
         }
 

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -54,7 +54,13 @@ namespace Microsoft.Build.Execution
         /// </summary>
         /// <param name="items">The items produced by the target.</param>
         /// <param name="result">The overall result for the target.</param>
-        /// <param name="originalBuildEventContext">The original build event context from when the target was first built, if available. Can be null.</param>
+        /// <param name="originalBuildEventContext">The original build event context from when the target was first built, if available.
+        /// Non-null when creating a <see cref="TargetResult"/> after building the target initially (or skipping due to false condition).
+        /// Null when the <see cref="TargetResult"/> is being created in other scenarios:
+        ///  * Target that never ran because a dependency had an error
+        ///  * in <see cref="ITargetBuilderCallback.LegacyCallTarget"/> when Cancellation was requested
+        ///  * in ProjectCache.CacheResult.ConstructBuildResult
+        /// </param>
         internal TargetResult(TaskItem[] items, WorkUnitResult result, BuildEventContext originalBuildEventContext = null)
         {
             ErrorUtilities.VerifyThrowArgumentNull(items, nameof(items));

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -48,7 +48,10 @@ namespace Microsoft.Build.Logging
         // version 13:
         //   - don't log Message where it can be recovered
         //   - log arguments for LazyFormattedBuildEventArgs
-        internal const int FileFormatVersion = 13;
+        //   - TargetSkippedEventArgs: added OriginallySucceeded, Condition, EvaluatedCondition
+        // version 14:
+        //   - TargetSkippedEventArgs: added SkipReason, OriginalBuildEventContext
+        internal const int FileFormatVersion = 14;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -297,6 +297,8 @@ namespace Microsoft.Build.Logging
             string condition = null;
             string evaluatedCondition = null;
             bool originallySucceeded = false;
+            TargetSkipReason skipReason = TargetSkipReason.None;
+            BuildEventContext originalBuildEventContext = null;
             if (fileFormatVersion >= 13)
             {
                 condition = ReadOptionalString();
@@ -305,6 +307,12 @@ namespace Microsoft.Build.Logging
             }
 
             var buildReason = (TargetBuiltReason)ReadInt32();
+
+            if (fileFormatVersion >= 14)
+            {
+                skipReason = (TargetSkipReason)ReadInt32();
+                originalBuildEventContext = binaryReader.ReadOptionalBuildEventContext();
+            }
 
             var e = new TargetSkippedEventArgs(
                 fields.Message,
@@ -320,6 +328,8 @@ namespace Microsoft.Build.Logging
             e.Condition = condition;
             e.EvaluatedCondition = evaluatedCondition;
             e.OriginallySucceeded = originallySucceeded;
+            e.SkipReason = skipReason;
+            e.OriginalBuildEventContext = originalBuildEventContext;
 
             return e;
         }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -454,6 +454,8 @@ Build
             WriteDeduplicatedString(e.EvaluatedCondition);
             Write(e.OriginallySucceeded);
             Write((int)e.BuildReason);
+            Write((int)e.SkipReason);
+            binaryWriter.WriteOptionalBuildEventContext(e.OriginalBuildEventContext);
         }
 
         private void Write(CriticalBuildMessageEventArgs e)

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -445,6 +445,8 @@ Build
 
         private void Write(TargetSkippedEventArgs e)
         {
+            ErrorUtilities.VerifyThrow(e.SkipReason != TargetSkipReason.None, "TargetSkippedEventArgs.SkipReason needs to be set");
+
             Write(BinaryLogRecordKind.TargetSkipped);
             WriteMessageFields(e, writeMessage: false);
             WriteDeduplicatedString(e.TargetFile);

--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -306,5 +306,9 @@ namespace Microsoft.Build.Framework
         }
         #endregion
 
+        public override string ToString()
+        {
+            return $"Node={NodeId} Submission={SubmissionId} ProjectContext={ProjectContextId} ProjectInstance={ProjectInstanceId} Eval={EvaluationId} Target={TargetId} Task={TaskId}";
+        }
     }
 }

--- a/src/Framework/BuildMessageEventArgs.cs
+++ b/src/Framework/BuildMessageEventArgs.cs
@@ -302,7 +302,11 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Importance of the message
         /// </summary>
-        public MessageImportance Importance => importance;
+        public MessageImportance Importance
+        {
+            get => importance;
+            internal set => importance = value;
+        }
 
         /// <summary>
         /// The custom sub-type of the event.

--- a/src/Shared/BinaryTranslator.cs
+++ b/src/Shared/BinaryTranslator.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Build.BackEnd
                 }
                 else
                 {
-                    byteArray = Array.Empty<byte>();
+                    byteArray = new byte[0];
                 }
             }
 

--- a/src/Shared/BinaryTranslator.cs
+++ b/src/Shared/BinaryTranslator.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Build.BackEnd
                 }
                 else
                 {
-                    byteArray = new byte[0];
+                    byteArray = Array.Empty<byte>();
                 }
             }
 


### PR DESCRIPTION
We weren't logging TargetSkippedEventArgs in two cases: when the target was satisfied from cache (previously built), or when the outputs were up-to-date. We were logging simple messages. Switch to logging TargetSkippedEventArgs in these cases as well.

Add a new TargetSkipReason enum to indicate why the target was skipped. Store and serialize it for node packet translator and binary logger.

When logging a TargetSkippedEventArgs because a target was built previously it is also useful to find the original target invocation (e.g. to see the target outputs). Add OriginalBuildEventContext to TargetResult and ensure it is translated properly. Add OriginalBuildEventContext on TargetSkippedEventArgs and serialize that as well (both node packet translator and binary logger).

Note that if the target didn't build because the Condition was false, the OriginalBuildEventContext will be a project context, not a target context.

We have to increment the binlog file format version to 14 to add the two new fields.

Implement BuildEventContext.ToString() for easier debugging.

Add an internal setter for Importance on BuildMessageEventArgs.

We were missing unit-tests for node packet translation of TargetSkippedEventArgs. Add test.

Fixes https://github.com/dotnet/msbuild/issues/5475