### PR TITLE
Update branding for 16.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ For more information on MSBuild, see the [MSBuild documentation](https://docs.mi
 
 ### Build Status
 
-The current development branch is `main`. Changes in `main` will go into a future update of MSBuild, which will release with Visual Studio 16.10 and a corresponding version of the .NET Core SDK.
+The current development branch is `main`. Changes in `main` will go into a future update of MSBuild, which will release with Visual Studio 17.0 and a corresponding version of the .NET Core SDK.
 
 [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=main)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=main)
 
-We have forked for MSBuild 16.9 in the branch [`vs16.9`](https://github.com/dotnet/msbuild/tree/vs16.9). Changes to that branch need special approval.
+We have forked for MSBuild 16.11 in the branch [`vs16.11`](https://github.com/Microsoft/msbuild/tree/vs16.11). Changes to that branch need special approval.
+
+[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.11)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.11)
+
+MSBuild 16.9 builds from the branch [`vs16.9`](https://github.com/dotnet/msbuild/tree/vs16.9). Only high-priority bugfixes will be considered for servicing 16.9.
 
 [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.9)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.9)
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.10.0</VersionPrefix>
+    <VersionPrefix>16.11.0</VersionPrefix>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -48,8 +48,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.10.0.0" newVersion="16.10.0.0" />
-          <codeBase version="16.10.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.11.0.0" newVersion="16.11.0.0" />
+          <codeBase version="16.11.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Redirects for assemblies redistributed by MSBuild (in the .vsix). -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -113,8 +113,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.10.0.0" newVersion="16.10.0.0" />
-          <codeBase version="16.10.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.11.0.0" newVersion="16.11.0.0" />
+          <codeBase version="16.11.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->


### PR DESCRIPTION
### Context

While mainline development is now focusing on 17.0, we want to have the 16.11 branch ready in case we end up contributing.

### Changes Made

Setting up a branch for MSBuild inserted into Visual Studio 16.11.

### Testing

Grepped the tree for other occurrences of 16.10.

### Notes
