### PR TITLE
Update branding for 17.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.11.0</VersionPrefix>
+    <VersionPrefix>17.0.0</VersionPrefix>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -46,11 +46,6 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
           <codeBase version="15.1.0.0" href="..\Microsoft.Build.Conversion.Core.dll"/>
         </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.11.0.0" newVersion="16.11.0.0" />
-          <codeBase version="16.11.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
-        </dependentAssembly>
 
         <!-- Redirects for assemblies redistributed by MSBuild (in the .vsix). -->
         <dependentAssembly>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -111,11 +111,6 @@
           <bindingRedirect oldVersion="4.0.0.0-16.0.0.0" newVersion="16.0.0.0" />
           <codeBase version="16.0.0.0" href=".\amd64\XamlBuildTask.dll" />
         </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.11.0.0" newVersion="16.11.0.0" />
-          <codeBase version="16.11.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
-        </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
         <dependentAssembly>


### PR DESCRIPTION
### Context

Mainline development is switching to Visual Studio 17.0.

### Changes Made

Merging current `vs17.0` branch into main to pick up branding changes.

### Testing

Grepped the tree for other occurrences of 16.10.

### Notes
