### PR TITLE
Log RAR "size" in ETW

### DIFF
--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -226,9 +226,9 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(28, Keywords = Keywords.All | Keywords.PerformanceLog)]
-        public void RarOverallStop(int resolvedFilesCount, int resolvedDependencyFilesCount, int copyLocalFilesCount)
+        public void RarOverallStop(int assembliesCount, int assemblyFilesCount, int resolvedFilesCount, int resolvedDependencyFilesCount, int copyLocalFilesCount)
         {
-            WriteEvent(28, resolvedFilesCount, resolvedDependencyFilesCount, copyLocalFilesCount);
+            WriteEvent(28, assembliesCount, assemblyFilesCount, resolvedFilesCount, resolvedDependencyFilesCount, copyLocalFilesCount);
         }
 
         /// <summary>

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -220,15 +220,15 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(27, Keywords = Keywords.All | Keywords.PerformanceLog)]
-        public void RarOverallStart()
+        public void RarOverallStart(int assembliesCount, int assemblyFilesCount, bool findDependencies)
         {
-            WriteEvent(27);
+            WriteEvent(27, assembliesCount, assemblyFilesCount, findDependencies);
         }
 
         [Event(28, Keywords = Keywords.All | Keywords.PerformanceLog)]
-        public void RarOverallStop()
+        public void RarOverallStop(int resolvedFilesCount, int resolvedDependencyFilesCount, int copyLocalFilesCount)
         {
-            WriteEvent(28);
+            WriteEvent(28, resolvedFilesCount, resolvedDependencyFilesCount, copyLocalFilesCount);
         }
 
         /// <summary>

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -220,15 +220,15 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(27, Keywords = Keywords.All | Keywords.PerformanceLog)]
-        public void RarOverallStart(int assembliesCount, int assemblyFilesCount, bool findDependencies)
+        public void RarOverallStart()
         {
-            WriteEvent(27, assembliesCount, assemblyFilesCount, findDependencies);
+            WriteEvent(27);
         }
 
         [Event(28, Keywords = Keywords.All | Keywords.PerformanceLog)]
-        public void RarOverallStop(int assembliesCount, int assemblyFilesCount, int resolvedFilesCount, int resolvedDependencyFilesCount, int copyLocalFilesCount)
+        public void RarOverallStop(int assembliesCount, int assemblyFilesCount, int resolvedFilesCount, int resolvedDependencyFilesCount, int copyLocalFilesCount, bool findDependencies)
         {
-            WriteEvent(28, assembliesCount, assemblyFilesCount, resolvedFilesCount, resolvedDependencyFilesCount, copyLocalFilesCount);
+            WriteEvent(28, assembliesCount, assemblyFilesCount, resolvedFilesCount, resolvedDependencyFilesCount, copyLocalFilesCount, findDependencies);
         }
 
         /// <summary>

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2109,7 +2109,7 @@ namespace Microsoft.Build.Tasks
         )
         {
             bool success = true;
-            MSBuildEventSource.Log.RarOverallStart(_assemblyNames.Length, _assemblyFiles.Length, _findDependencies);
+            MSBuildEventSource.Log.RarOverallStart(_assemblyNames?.Length ?? 0, _assemblyFiles?.Length ?? 0, _findDependencies);
             {
                 try
                 {
@@ -2579,7 +2579,7 @@ namespace Microsoft.Build.Tasks
                             }
                         }
                     }
-                    MSBuildEventSource.Log.RarOverallStop(_assemblyNames.Length, _assemblyFiles.Length, _resolvedFiles.Length, _resolvedDependencyFiles.Length, _copyLocalFiles.Length);
+                    MSBuildEventSource.Log.RarOverallStop(_assemblyNames.Length, _assemblyFiles.Length, _resolvedFiles?.Length ?? 0, _resolvedDependencyFiles?.Length ?? 0, _copyLocalFiles?.Length ?? 0);
                     return success && !Log.HasLoggedErrors;
                 }
                 catch (ArgumentException e)
@@ -2596,7 +2596,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            MSBuildEventSource.Log.RarOverallStop(_resolvedFiles.Length, _resolvedDependencyFiles.Length, _copyLocalFiles.Length);
+            MSBuildEventSource.Log.RarOverallStop(_assemblyNames.Length, _assemblyFiles.Length, _resolvedFiles?.Length ?? 0, _resolvedDependencyFiles?.Length ?? 0, _copyLocalFiles?.Length ?? 0);
 
             return success && !Log.HasLoggedErrors;
         }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2579,7 +2579,7 @@ namespace Microsoft.Build.Tasks
                             }
                         }
                     }
-                    MSBuildEventSource.Log.RarOverallStop(_resolvedFiles.Length, _resolvedDependencyFiles.Length, _copyLocalFiles.Length);
+                    MSBuildEventSource.Log.RarOverallStop(_assemblyNames.Length, _assemblyFiles.Length, _resolvedFiles.Length, _resolvedDependencyFiles.Length, _copyLocalFiles.Length);
                     return success && !Log.HasLoggedErrors;
                 }
                 catch (ArgumentException e)

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2579,7 +2579,7 @@ namespace Microsoft.Build.Tasks
                             }
                         }
                     }
-                    MSBuildEventSource.Log.RarOverallStop(_assemblyNames.Length, _assemblyFiles.Length, _resolvedFiles?.Length ?? 0, _resolvedDependencyFiles?.Length ?? 0, _copyLocalFiles?.Length ?? 0);
+                    MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? 0, _assemblyFiles?.Length ?? 0, _resolvedFiles?.Length ?? 0, _resolvedDependencyFiles?.Length ?? 0, _copyLocalFiles?.Length ?? 0);
                     return success && !Log.HasLoggedErrors;
                 }
                 catch (ArgumentException e)
@@ -2596,7 +2596,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            MSBuildEventSource.Log.RarOverallStop(_assemblyNames.Length, _assemblyFiles.Length, _resolvedFiles?.Length ?? 0, _resolvedDependencyFiles?.Length ?? 0, _copyLocalFiles?.Length ?? 0);
+            MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? 0, _assemblyFiles?.Length ?? 0, _resolvedFiles?.Length ?? 0, _resolvedDependencyFiles?.Length ?? 0, _copyLocalFiles?.Length ?? 0);
 
             return success && !Log.HasLoggedErrors;
         }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2109,7 +2109,7 @@ namespace Microsoft.Build.Tasks
         )
         {
             bool success = true;
-            MSBuildEventSource.Log.RarOverallStart();
+            MSBuildEventSource.Log.RarOverallStart(_assemblyNames.Length, _assemblyFiles.Length, _findDependencies);
             {
                 try
                 {
@@ -2579,7 +2579,7 @@ namespace Microsoft.Build.Tasks
                             }
                         }
                     }
-                    MSBuildEventSource.Log.RarOverallStop();
+                    MSBuildEventSource.Log.RarOverallStop(_resolvedFiles.Length, _resolvedDependencyFiles.Length, _copyLocalFiles.Length);
                     return success && !Log.HasLoggedErrors;
                 }
                 catch (ArgumentException e)
@@ -2596,7 +2596,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            MSBuildEventSource.Log.RarOverallStop();
+            MSBuildEventSource.Log.RarOverallStop(_resolvedFiles.Length, _resolvedDependencyFiles.Length, _copyLocalFiles.Length);
 
             return success && !Log.HasLoggedErrors;
         }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2109,7 +2109,7 @@ namespace Microsoft.Build.Tasks
         )
         {
             bool success = true;
-            MSBuildEventSource.Log.RarOverallStart(_assemblyNames?.Length ?? 0, _assemblyFiles?.Length ?? 0, _findDependencies);
+            MSBuildEventSource.Log.RarOverallStart(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _findDependencies);
             {
                 try
                 {
@@ -2579,7 +2579,7 @@ namespace Microsoft.Build.Tasks
                             }
                         }
                     }
-                    MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? 0, _assemblyFiles?.Length ?? 0, _resolvedFiles?.Length ?? 0, _resolvedDependencyFiles?.Length ?? 0, _copyLocalFiles?.Length ?? 0);
+                    MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _resolvedFiles?.Length ?? -1, _resolvedDependencyFiles?.Length ?? -1, _copyLocalFiles?.Length ?? -1);
                     return success && !Log.HasLoggedErrors;
                 }
                 catch (ArgumentException e)
@@ -2596,7 +2596,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? 0, _assemblyFiles?.Length ?? 0, _resolvedFiles?.Length ?? 0, _resolvedDependencyFiles?.Length ?? 0, _copyLocalFiles?.Length ?? 0);
+            MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _resolvedFiles?.Length ?? -1, _resolvedDependencyFiles?.Length ?? -1, _copyLocalFiles?.Length ?? -1);
 
             return success && !Log.HasLoggedErrors;
         }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2109,7 +2109,7 @@ namespace Microsoft.Build.Tasks
         )
         {
             bool success = true;
-            MSBuildEventSource.Log.RarOverallStart(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _findDependencies);
+            MSBuildEventSource.Log.RarOverallStart();
             {
                 try
                 {
@@ -2579,7 +2579,7 @@ namespace Microsoft.Build.Tasks
                             }
                         }
                     }
-                    MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _resolvedFiles?.Length ?? -1, _resolvedDependencyFiles?.Length ?? -1, _copyLocalFiles?.Length ?? -1);
+                    MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _resolvedFiles?.Length ?? -1, _resolvedDependencyFiles?.Length ?? -1, _copyLocalFiles?.Length ?? -1, _findDependencies);
                     return success && !Log.HasLoggedErrors;
                 }
                 catch (ArgumentException e)
@@ -2596,7 +2596,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _resolvedFiles?.Length ?? -1, _resolvedDependencyFiles?.Length ?? -1, _copyLocalFiles?.Length ?? -1);
+            MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _resolvedFiles?.Length ?? -1, _resolvedDependencyFiles?.Length ?? -1, _copyLocalFiles?.Length ?? -1, _findDependencies);
 
             return success && !Log.HasLoggedErrors;
         }


### PR DESCRIPTION
### Context

I'm poking around the question "why do builds using the .NET SDK take longer than older non-SDK builds?" and RAR time is one major factor. It'd be nice to have a complexity estimate in the ETW events: is this RAR instance resolving 3 files, or 300?

### Changes Made

Add lightweight information about the size/complexity of a RAR
invocation by logging counts of the most interesting input/output lists.

### Testing

Collected updated traces manually and confirmed data present.

⚠ Note this is currently targeting 16.11. Open to discussion on pushing it to main/17.0 instead.
