### PR TITLE
Official Builds With Custom OptProf 'Just Work'

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -10,15 +10,28 @@ trigger:
 #   SignType: real
 #   SkipApplyOptimizationData: false
 
+parameters:
+- name: OptProfDropName
+  displayName: Optional OptProfDrop Override
+  type: string
+  default: 'default'
+
 variables:
+  # if OptProfDrop is not set, string '$(OptProfDrop)' will be passed to the build script.
   - name: OptProfDrop
-    value: $(OptProfDropName)
-  - ${{ if eq(variables['Build.OptProfDrop'], '') }}:
+    value: ''
+  - name: SourceBranch
+    value: $(IbcSourceBranchName)
+  # If we're not on a vs* branch, use main as our optprof collection branch
+  - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
     - name: SourceBranch
-      value: $(IbcSourceBranchName)
-    - ${{ if and(ne(variables['Build.SourceBranch'], 'refs/heads/main'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs'))) }}:
-      - name: SourceBranch
-        value: main
+      value: main
+  # if OptProfDropName is set as a parameter, set OptProfDrop to the parameter and unset SourceBranch
+  - ${{ if ne(parameters.OptProfDropName, 'default') }}:
+    - name: OptProfDrop
+      value: ${{parameters.OptProfDropName}}
+    - name: SourceBranch
+      value: ''
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -103,7 +103,7 @@ stages:
                 /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                 /p:TeamName=MSBuild
                 /p:DotNetPublishUsingPipelines=true
-                /p:VisualStudioIbcDrop=$(OptProfDropName)
+                /p:VisualStudioIbcDrop=$(OptProfDrop)
       displayName: Build
       condition: succeeded()
 

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -11,11 +11,14 @@ trigger:
 #   SkipApplyOptimizationData: false
 
 variables:
-  - name: SourceBranch
-    value: $(IbcSourceBranchName)
-  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/') }}:
+  - name: OptProfDrop
+    value: $(OptProfDropName)
+  - ${{ if eq(variables['Build.OptProfDrop'], '') }}:
     - name: SourceBranch
-      value: main
+      value: $(IbcSourceBranchName)
+    - ${{ if and(ne(variables['Build.SourceBranch'], 'refs/heads/main'), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs'))) }}:
+      - name: SourceBranch
+        value: main
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6085

### Context
Fixes two issues:
- If an official build is kicked off that had stale optprof, no optprof, or is a branch that never would have optptrof (think `exp/`), it would fail. We'd then have to re-run using a specific optprofdropname
- When overriding the optprofdropname, we need to delete the IbcSourceBranchName. This is one less thing for the kitten (or any other dev launching pipeline builds of specific branches) to worry about!

### Changes Made
Our official builds now take OptProfDropName as a pipeline parameter. We should leave the default value (which is `default`) if we don't plan to use a custom drop. When we do, paste your optprofdrop there and the script should do the rest.

No more manually clearing the `IbcSourceBranch` pipeline variable!

### Testing
See https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4724888&view=results
I launched a pipeline from branch `bevillal/ci/quality-of-life`.
- I did not clear the IbcSourceBranchName pipeline variable, but did set the OptProfDrop pipeline parameter and it properly cleared `SourceBranch`. This fixes the issue with setting OptProfDrop and needing to clear that field manually.

Now see https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4724898&view=results
I launched a build from the same branch and did NOT set optprofdrop. The build correctly pulls optprof data from `main`.

### Notes
This one was very annoying to figure out.