### PR TITLE
Merge NullReferenceException property function evaluation fix to 16.11

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -2010,13 +2010,16 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void PropertyFunctionNullReturn()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
-            pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
-            string result = expander.ExpandIntoStringLeaveEscaped("$([System.Convert]::ChangeType(,$(SomeStuff.GetType())))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
-
+            // The null-returning function is the only thing in the expression.
+            string result = expander.ExpandIntoStringLeaveEscaped("$([System.Environment]::GetEnvironmentVariable(`_NonExistentVar`))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             Assert.Equal("", result);
+
+            // The result of the null-returning function is concatenated with a non-empty string.
+            result = expander.ExpandIntoStringLeaveEscaped("prefix_$([System.Environment]::GetEnvironmentVariable(`_NonExistentVar`))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+            Assert.Equal("prefix_", result);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1200,19 +1200,22 @@ namespace Microsoft.Build.Evaluation
                             propertyValue = LookupProperty(properties, expression, propertyStartIndex + 2, propertyEndIndex - 1, elementLocation, usedUninitializedProperties);
                         }
 
-                        if (IsTruncationEnabled(options) && propertyValue != null)
+                        if (propertyValue != null)
                         {
-                            var value = propertyValue.ToString();
-                            if (value.Length > CharacterLimitPerExpansion)
+                            if (IsTruncationEnabled(options))
                             {
-                                propertyValue = value.Substring(0, CharacterLimitPerExpansion - 3) + "...";
+                                var value = propertyValue.ToString();
+                                if (value.Length > CharacterLimitPerExpansion)
+                                {
+                                    propertyValue = value.Substring(0, CharacterLimitPerExpansion - 3) + "...";
+                                }
                             }
-                        }
 
-                        // Record our result, and advance
-                        // our sourceIndex pointer to the character just after the closing
-                        // parenthesis.
-                        results.Add(propertyValue);
+                            // Record our result, and advance
+                            // our sourceIndex pointer to the character just after the closing
+                            // parenthesis.
+                            results.Add(propertyValue);
+                        }
                         sourceIndex = propertyEndIndex + 1;
                     }
 


### PR DESCRIPTION
Fixes #6413

### Context

The fix has been merged into 16.10. Automation has opened a PR to merge into main. This PR takes care of porting to 16.11.

### Changes Made

Merged #c040391f9affa509a9a879e17b5d2994ee585a52.

### Testing

Unit tests.

### Notes
