### PR TITLE
Revert Assembly Loading Performance Changes

### DIFF
--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Evaluation
                 BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
             try
             {
-                var NuGetAssembly = Assembly.LoadFrom(Path.Combine(assemblyDirectory, "NuGet.Frameworks.dll"));
+                var NuGetAssembly = Assembly.LoadFile(Path.Combine(assemblyDirectory, "NuGet.Frameworks.dll"));
                 var NuGetFramework = NuGetAssembly.GetType("NuGet.Frameworks.NuGetFramework");
                 var NuGetFrameworkCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.CompatibilityProvider");
                 var NuGetFrameworkDefaultCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.DefaultCompatibilityProvider");

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -32,11 +32,7 @@ namespace Microsoft.Build.Evaluation
                 BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
             try
             {
-#if FEATURE_ASSEMBLYLOADCONTEXT
                 var NuGetAssembly = Assembly.LoadFrom(Path.Combine(assemblyDirectory, "NuGet.Frameworks.dll"));
-#else
-                var NuGetAssembly = Assembly.LoadFile(Path.Combine(assemblyDirectory, "NuGet.Frameworks.dll"));
-#endif
                 var NuGetFramework = NuGetAssembly.GetType("NuGet.Frameworks.NuGetFramework");
                 var NuGetFrameworkCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.CompatibilityProvider");
                 var NuGetFrameworkDefaultCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.DefaultCompatibilityProvider");

--- a/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
+++ b/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
@@ -74,10 +74,4 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <Target Name="CreateTaskDir" AfterTargets="Build" Condition="'$(TargetFrameworkIdentifier)' != ''">
-    <ItemGroup>
-      <OutputAssemblyList Include="$(TargetDir)Microsoft.Build.CommandLine.UnitTests.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(OutputAssemblyList)" DestinationFolder="$(TargetDir)Task" />
-  </Target>
 </Project>

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2383,8 +2383,7 @@ $@"<Project DefaultTargets=""Build"" InitialTargets=""TargetThatComesFromRestore
 
 #if FEATURE_ASSEMBLYLOADCONTEXT
         /// <summary>
-        /// Ensure that tasks get loaded into their own <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
-        /// if they are in a directory other than the MSBuild directory.
+        /// Ensure that tasks get loaded into their own <see cref="System.Runtime.Loader.AssemblyLoadContext"/>.
         /// </summary>
         /// <remarks>
         /// When loading a task from a test assembly in a test within that assembly, the assembly is already loaded
@@ -2394,10 +2393,7 @@ $@"<Project DefaultTargets=""Build"" InitialTargets=""TargetThatComesFromRestore
         [Fact]
         public void TasksGetAssemblyLoadContexts()
         {
-            string customTaskPath = Path.Combine(
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-                "Task",
-                Path.GetFileName(Assembly.GetExecutingAssembly().Location));
+            string customTaskPath = Assembly.GetExecutingAssembly().Location;
 
             string projectContents = $@"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
   <UsingTask TaskName=`ValidateAssemblyLoadContext` AssemblyFile=`{customTaskPath}` />
@@ -2409,6 +2405,7 @@ $@"<Project DefaultTargets=""Build"" InitialTargets=""TargetThatComesFromRestore
 
             ExecuteMSBuildExeExpectSuccess(projectContents);
         }
+
 #endif
 
         private string CopyMSBuild()

--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -23,14 +23,7 @@ namespace Microsoft.Build.Shared
 
         private bool _resolvingHandlerHookedUp = false;
 
-        private static readonly string _msbuildDirPath;
         private static readonly Version _currentAssemblyVersion = new Version(Microsoft.Build.Shared.MSBuildConstants.CurrentAssemblyVersion);
-
-        static CoreClrAssemblyLoader()
-        {
-            _msbuildDirPath = FileUtilities.NormalizePath(typeof(CoreClrAssemblyLoader).Assembly.Location);
-            _msbuildDirPath = Path.GetDirectoryName(_msbuildDirPath);
-        }
 
         public void AddDependencyLocation(string fullPath)
         {
@@ -59,12 +52,7 @@ namespace Microsoft.Build.Shared
             // folders in a NuGet package).
             fullPath = FileUtilities.NormalizePath(fullPath);
 
-            // If the requested load comes from the same directory as MSBuild, assume that
-            // the load is part of the platform, and load it using the Default ALC.
-            string assemblyDir = Path.GetDirectoryName(fullPath);
-
-            if (Traits.Instance.EscapeHatches.UseSingleLoadContext ||
-                FileUtilities.ComparePathsNoThrow(assemblyDir, _msbuildDirPath, string.Empty))
+            if (Traits.Instance.EscapeHatches.UseSingleLoadContext)
             {
                 return LoadUsingLegacyDefaultContext(fullPath);
             }


### PR DESCRIPTION
Fixes # 6377

### Context
When multiple versions of `NuGet.Frameworks.dll` get loaded, the first one wins.  Since MSBuild depends on this DLL, it means that if someone else loads the DLL first and it doesn't match the version that MSBuild carries, then this breaks MSBuild.  The original change was made to improve performance by reducing jitting from the Nuget* DLLs, but it seems that the compatibility tail is too high.

### Changes Made
This change reverts the assembly loading behavior to its previous state.