### PR TITLE
Use packaged C# compiler

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,6 +14,7 @@
   <!-- Repo Toolset Features -->
   <PropertyGroup Condition="'$(MonoBuild)' != 'true'">
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
+    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers><!-- Force a specific compiler version because record changes cause genapi output to flip-flop -->
     <UsingToolVisualStudioIbcTraining>true</UsingToolVisualStudioIbcTraining>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <UsingToolVSSDK>true</UsingToolVSSDK>


### PR DESCRIPTION
This avoids diffs in the genapi-generated public interface that are happening
because of changes in generated code for records in Roslyn 3.10.
