### PR TITLE
Updates to Csc/VB task invocations

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -172,7 +172,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 @(_CoreCompileResourceInputs);
                 $(ApplicationIcon);
                 $(AssemblyOriginatorKeyFile);
-                @(ReferencePath);
+                @(ReferencePathWithRefAssemblies);
                 @(CompiledLicenseFile);
                 @(LinkResource);
                 @(EmbeddedDocumentation);
@@ -181,8 +181,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 @(CustomAdditionalCompileInputs);
                 @(Page);
                 @(ApplicationDefinition);
-                $(ResolvedCodeAnalysisRuleSet)"
-
+                $(ResolvedCodeAnalysisRuleSet);
+                @(AdditionalFiles);
+                @(EmbeddedFiles);
+                @(EditorConfigFiles)"
         Outputs="@(DocFileItem);
                  @(XamlIntermediateAssembly);
                  @(_DebugSymbolsIntermediatePath);
@@ -190,7 +192,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                  @(CustomAdditionalCompileOutputs)"
         Condition="'@(Page)' != '' Or '@(ApplicationDefinition)' != ''"
         Returns=""
-        DependsOnTargets="$(CoreCompileDependsOn)"
+        DependsOnTargets="$(CoreCompileDependsOn);_BeforeVBCSCoreCompile"
     >
        <!-- These two compiler warnings are raised when a reference is bound to a different version
              than specified in the assembly reference version number.  MSBuild raises the same warning in this case,
@@ -201,63 +203,51 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
         <PropertyGroup>
             <!-- To match historical behavior, when inside VS11+ disable the warning from csc.exe indicating that no sources were passed in-->
-            <NoWarn Condition=" '$(BuildingInsideVisualStudio)' == 'true' and '$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' > '10.0' ">$(NoWarn);2008</NoWarn>
+            <NoWarn Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(VisualStudioVersion)' != '' AND '$(VisualStudioVersion)' &gt; '10.0'">$(NoWarn);2008</NoWarn>
         </PropertyGroup>
-
-        <ItemGroup Condition="'$(TargetingClr2Framework)'=='true'">
-            <ReferencePath>
-                <EmbedInteropTypes/>
-            </ReferencePath>
-        </ItemGroup>
 
         <PropertyGroup>
             <!-- If the user has specified AppConfigForCompiler, we'll use it. If they have not, but they set UseAppConfigForCompiler,
                  then we'll use AppConfig -->
-            <AppConfigForCompiler Condition="'$(AppConfigForCompiler)' == '' and '$(UseAppConfigForCompiler)' == 'true'">$(AppConfig)</AppConfigForCompiler>
+            <AppConfigForCompiler Condition="'$(AppConfigForCompiler)' == '' AND '$(UseAppConfigForCompiler)' == 'true'">$(AppConfig)</AppConfigForCompiler>
 
             <!-- If we are targeting winmdobj we want to specifically the pdbFile property since we do not want it to collide with the output of winmdexp-->
-            <PdbFile Condition="'$(PdbFile)' == '' and '$(OutputType)' == 'winmdobj' and '$(_DebugSymbolsProduced)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
-        </PropertyGroup>
-
-        <!-- Prefer32Bit was introduced in .NET 4.5. Set it to false if we are targeting 4.0 -->
-        <PropertyGroup Condition="('$(TargetFrameworkVersion)' == 'v4.0')">
-            <Prefer32Bit>false</Prefer32Bit>
-        </PropertyGroup>
-
-        <ItemGroup Condition="('$(AdditionalFileItemNames)' != '')">
-          <AdditionalFileItems Include="$(AdditionalFileItemNames)" />
-          <AdditionalFiles Include="@(%(AdditionalFileItems.Identity))" />
-        </ItemGroup>
-
-       <PropertyGroup Condition="'$(UseSharedCompilation)' == ''">
-         <UseSharedCompilation>true</UseSharedCompilation>
+            <PdbFile Condition="'$(PdbFile)' == '' AND '$(OutputType)' == 'winmdobj' AND '$(_DebugSymbolsProduced)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
        </PropertyGroup>
 
        <!-- Condition is to filter out the _CoreCompileResourceInputs so that it doesn't pass in culture resources to the compiler -->
-        <Csc  Condition=" '%(_CoreCompileResourceInputs.WithCulture)' != 'true' "
+       <Csc Condition="'%(_CoreCompileResourceInputs.WithCulture)' != 'true'"
               AdditionalLibPaths="$(AdditionalLibPaths)"
               AddModules="@(AddModules)"
               AdditionalFiles="@(AdditionalFiles)"
               AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
+              AnalyzerConfigFiles="@(EditorConfigFiles)"
               Analyzers="@(Analyzer)"
               ApplicationConfiguration="$(AppConfigForCompiler)"
               BaseAddress="$(BaseAddress)"
               CheckForOverflowUnderflow="$(CheckForOverflowUnderflow)"
+              ChecksumAlgorithm="$(ChecksumAlgorithm)"
               CodeAnalysisRuleSet="$(ResolvedCodeAnalysisRuleSet)"
               CodePage="$(CodePage)"
               DebugType="$(DebugType)"
               DefineConstants="$(DefineConstants)"
               DelaySign="$(DelaySign)"
               DisabledWarnings="$(NoWarn)"
+              DisableSdkPath="$(DisableSdkPath)"
               DocumentationFile="@(DocFileItem)"
+              EmbedAllSources="$(EmbedAllSources)"
+              EmbeddedFiles="@(EmbeddedFiles)"
               EmitDebugInformation="$(DebugSymbols)"
               EnvironmentVariables="$(CscEnvironment)"
               ErrorEndLocation="$(ErrorEndLocation)"
               ErrorLog="$(ErrorLog)"
               ErrorReport="$(ErrorReport)"
+              Features="$(Features)"
               FileAlignment="$(FileAlignment)"
+              GeneratedFilesOutputPath="$(CompilerGeneratedFilesOutputPath)"
               GenerateFullPaths="$(GenerateFullPaths)"
               HighEntropyVA="$(HighEntropyVA)"
+              Instrument="$(Instrument)"
               KeyContainer="$(KeyContainerName)"
               KeyFile="$(KeyOriginatorFile)"
               LangVersion="$(LangVersion)"
@@ -270,15 +260,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               NoWin32Manifest="$(NoWin32Manifest)"
               Nullable="$(Nullable)"
               Optimize="$(Optimize)"
+              Deterministic="$(Deterministic)"
+              PublicSign="$(PublicSign)"
               OutputAssembly="@(XamlIntermediateAssembly)"
               PdbFile="$(PdbFile)"
               Platform="$(PlatformTarget)"
               Prefer32Bit="$(Prefer32Bit)"
               PreferredUILang="$(PreferredUILang)"
-              References="@(ReferencePath)"
+              References="@(ReferencePathWithRefAssemblies)"
               ReportAnalyzer="$(ReportAnalyzer)"
               Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
               ResponseFiles="$(CompilerResponseFile)"
+              RuntimeMetadataVersion="$(RuntimeMetadataVersion)"
+              SharedCompilationId="$(SharedCompilationId)"
               SkipAnalyzers="$(_SkipAnalyzers)"
               Sources="@(Compile)"
               SubsystemVersion="$(SubsystemVersion)"
@@ -296,6 +290,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               Win32Icon="$(ApplicationIcon)"
               Win32Manifest="$(Win32Manifest)"
               Win32Resource="$(Win32Resource)"
+              PathMap="$(PathMap)"
+              SourceLink="$(SourceLink)"
               />
 
 <!-- Only Applicable to the regular CoreCompile:

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 ***********************************************************************************************
 Microsoft.VisualBasic.CurrentVersion.targets
 
@@ -175,7 +175,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 @(_CoreCompileResourceInputs);
                 $(ApplicationIcon);
                 $(AssemblyOriginatorKeyFile);
-                @(ReferencePath);
+                @(ReferencePathWithRefAssemblies);
                 @(CompiledLicenseFile);
                 @(LinkResource);
                 @(EmbeddedDocumentation);
@@ -184,70 +184,58 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 @(Page);
                 @(ApplicationDefinition);
                 @(CustomAdditionalCompileInputs);
-                $(ResolvedCodeAnalysisRuleSet)"
+                $(ResolvedCodeAnalysisRuleSet);
+                @(AdditionalFiles);
+                @(EmbeddedFiles);
+                @(EditorConfigFiles)"
         Outputs="@(DocFileItem);
                  @(XamlIntermediateAssembly);
                  @(_DebugSymbolsIntermediatePath);
                  $(NonExistentFile);
                  @(CustomAdditionalCompileOutputs)"
-        Returns=""
-        DependsOnTargets="$(CoreCompileDependsOn)"
+        Returns="@(VbcCommandLineArgs)"
+        DependsOnTargets="$(CoreCompileDependsOn);_BeforeVBCSCoreCompile"
         Condition="'@(Page)' != '' Or '@(ApplicationDefinition)' != ''"
     >
-        <PropertyGroup>
-            <_NoWarnings Condition=" '$(WarningLevel)' == '0' ">true</_NoWarnings>
-            <_NoWarnings Condition=" '$(WarningLevel)' == '1' ">false</_NoWarnings>
-        </PropertyGroup>
+    <PropertyGroup>
+      <_NoWarnings Condition="'$(WarningLevel)' == '0'">true</_NoWarnings>
+      <_NoWarnings Condition="'$(WarningLevel)' == '1'">false</_NoWarnings>
+    </PropertyGroup>
 
-        <PropertyGroup>
-          <!-- If we are targeting winmdobj we want to specifically set the pdbFile property so that it does not collide with the output of winmdexp which we will run subsequently -->
-          <PdbFile Condition="'$(PdbFile)' == '' and '$(OutputType)' == 'winmdobj' and '$(DebugSymbols)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
-        </PropertyGroup>
+    <PropertyGroup>
+      <!-- If we are targeting winmdobj we want to specifically the pdbFile property since we do not want it to collide with the output of winmdexp-->
+      <PdbFile Condition="'$(PdbFile)' == '' AND '$(OutputType)' == 'winmdobj' AND '$(DebugSymbols)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
+    </PropertyGroup>
 
-        <ItemGroup Condition="'$(TargetingClr2Framework)'=='true'">
-            <ReferencePath>
-                <EmbedInteropTypes/>
-            </ReferencePath>
-        </ItemGroup>
-
-        <!-- Prefer32Bit was introduced in .NET 4.5. Set it to false if we are targeting 4.0 -->
-        <PropertyGroup Condition="('$(TargetFrameworkVersion)' == 'v4.0')">
-            <Prefer32Bit>false</Prefer32Bit>
-        </PropertyGroup>
-
-        <ItemGroup Condition="('$(AdditionalFileItemNames)' != '')">
-          <AdditionalFileItems Include="$(AdditionalFileItemNames)" />
-          <AdditionalFiles Include="@(%(AdditionalFileItems.Identity))" />
-        </ItemGroup>
-
-        <!-- Don't run analyzers for Vbc task on XamlPrecompile pass, we only want to run them on core compile. -->
-        <!-- Analyzers="@(Analyzer)" -->
-
-        <PropertyGroup Condition="'$(UseSharedCompilation)' == ''">
-          <UseSharedCompilation>true</UseSharedCompilation>
-        </PropertyGroup>
-
-        <!-- Condition is to filter out the _CoreCompileResourceInputs so that it doesn't pass in culture resources to the compiler -->
-        <Vbc  Condition=" '%(_CoreCompileResourceInputs.WithCulture)' != 'true' "
+    <!-- Condition is to filter out the _CoreCompileResourceInputs so that it doesn't pass in culture resources to the compiler -->
+         <Vbc Condition="'%(_CoreCompileResourceInputs.WithCulture)' != 'true'"
               AdditionalLibPaths="$(AdditionalLibPaths)"
               AddModules="@(AddModules)"
               AdditionalFiles="@(AdditionalFiles)"
+              AnalyzerConfigFiles="@(EditorConfigFiles)"
+              Analyzers="@(Analyzer)"
               BaseAddress="$(BaseAddress)"
+              ChecksumAlgorithm="$(ChecksumAlgorithm)"
               CodeAnalysisRuleSet="$(ResolvedCodeAnalysisRuleSet)"
               CodePage="$(CodePage)"
               DebugType="$(DebugType)"
               DefineConstants="$(FinalDefineConstants)"
               DelaySign="$(DelaySign)"
+              DisableSdkPath="$(DisableSdkPath)"
               DisabledWarnings="$(NoWarn)"
               DocumentationFile="@(DocFileItem)"
+              EmbedAllSources="$(EmbedAllSources)"
+              EmbeddedFiles="@(EmbeddedFiles)"
               EmitDebugInformation="$(DebugSymbols)"
               EnvironmentVariables="$(VbcEnvironment)"
               ErrorLog="$(ErrorLog)"
               ErrorReport="$(ErrorReport)"
+              Features="$(Features)"
               FileAlignment="$(FileAlignment)"
               GenerateDocumentation="$(GenerateDocumentation)"
               HighEntropyVA="$(HighEntropyVA)"
               Imports="@(Import)"
+              Instrument="$(Instrument)"
               KeyContainer="$(KeyContainerName)"
               KeyFile="$(KeyOriginatorFile)"
               LangVersion="$(LangVersion)"
@@ -260,6 +248,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               NoWarnings="$(_NoWarnings)"
               NoWin32Manifest="$(NoWin32Manifest)"
               Optimize="$(Optimize)"
+              Deterministic="$(Deterministic)"
+              PublicSign="$(PublicSign)"
               OptionCompare="$(OptionCompare)"
               OptionExplicit="$(OptionExplicit)"
               OptionInfer="$(OptionInfer)"
@@ -269,14 +259,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               Platform="$(PlatformTarget)"
               Prefer32Bit="$(Prefer32Bit)"
               PreferredUILang="$(PreferredUILang)"
-              References="@(ReferencePath)"
+              References="@(ReferencePathWithRefAssemblies)"
               RemoveIntegerChecks="$(RemoveIntegerChecks)"
               ReportAnalyzer="$(ReportAnalyzer)"
               Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
               ResponseFiles="$(CompilerResponseFile)"
               RootNamespace="$(RootNamespace)"
-              PdbFile="$(PdbFile)"
+              RuntimeMetadataVersion="$(RuntimeMetadataVersion)"
               SdkPath="$(FrameworkPathOverride)"
+              SharedCompilationId="$(SharedCompilationId)"
+              SkipAnalyzers="$(_SkipAnalyzers)"
               Sources="@(Compile)"
               SubsystemVersion="$(SubsystemVersion)"
               TargetCompactFramework="$(TargetCompactFramework)"
@@ -296,14 +288,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               Win32Manifest="$(Win32Manifest)"
               Win32Resource="$(Win32Resource)"
               VBRuntime="$(VBRuntime)"
+              PathMap="$(PathMap)"
+              SourceLink="$(SourceLink)"
               />
 
  <!-- Only Applicable to the regular CoreCompile:
-              <ItemGroup>
-                  <_CoreCompileResourceInputs Remove="@(_CoreCompileResourceInputs)" />
-              </ItemGroup>
+    <ItemGroup>
+      <_CoreCompileResourceInputs Remove="@(_CoreCompileResourceInputs)" />
+    </ItemGroup>
 
-              <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''"/>
+    <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''" />
+  </Target>
  -->
         <OnError Condition="'$(OnXamlPreCompileErrorTarget)' != ''" ExecuteTargets="$(OnXamlPreCompileErrorTarget)" />
     </Target>


### PR DESCRIPTION
From https://github.com/dotnet/roslyn/blob/dec02062738fce323171afb63d9976e6dd75001e/src/Compilers/Core/MSBuildTask/

Changed:

 * IntermediateAssembly -> XamlIntermediateAssembly

 Removed:

 * PdbFile
 * ProvideCommandLineArgs
 * RefOnly
 * SkipCompilerExecution

Fixes #

### Context


### Changes Made


### Testing


### Notes
