### PR TITLE
Query cache in parallel

### DIFF
--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -209,14 +209,19 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
         public class InstanceMockCache : ProjectCachePluginBase
         {
             private readonly GraphCacheResponse? _testData;
-            public ConcurrentQueue<BuildRequestData> Requests { get; } = new ConcurrentQueue<BuildRequestData>();
+            private readonly TimeSpan? _projectQuerySleepTime;
+            public ConcurrentQueue<BuildRequestData> Requests { get; } = new();
 
             public bool BeginBuildCalled { get; set; }
             public bool EndBuildCalled { get; set; }
 
-            public InstanceMockCache(GraphCacheResponse? testData = null)
+            private int _nextId;
+            public ConcurrentQueue<int> QueryStartStops = new();
+
+            public InstanceMockCache(GraphCacheResponse? testData = null, TimeSpan? projectQuerySleepTime = null)
             {
                 _testData = testData;
+                _projectQuerySleepTime = projectQuerySleepTime;
             }
 
             public override Task BeginBuildAsync(CacheContext context, PluginLoggerBase logger, CancellationToken cancellationToken)
@@ -228,18 +233,27 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 return Task.CompletedTask;
             }
 
-            public override Task<CacheResult> GetCacheResultAsync(
+            public override async Task<CacheResult> GetCacheResultAsync(
                 BuildRequestData buildRequest,
                 PluginLoggerBase logger,
                 CancellationToken cancellationToken)
             {
+                var queryId = Interlocked.Increment(ref _nextId);
+
                 Requests.Enqueue(buildRequest);
+                QueryStartStops.Enqueue(queryId);
+
                 logger.LogMessage($"MockCache: GetCacheResultAsync for {buildRequest.ProjectFullPath}", MessageImportance.High);
 
-                return
-                    Task.FromResult(
-                        _testData?.GetExpectedCacheResultForProjectNumber(GetProjectNumber(buildRequest.ProjectFullPath))
-                        ?? CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss));
+                if (_projectQuerySleepTime is not null)
+                {
+                    await Task.Delay(_projectQuerySleepTime.Value);
+                }
+
+                QueryStartStops.Enqueue(queryId);
+
+                return _testData?.GetExpectedCacheResultForProjectNumber(GetProjectNumber(buildRequest.ProjectFullPath))
+                        ?? CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss);
             }
 
             public override Task EndBuildAsync(PluginLoggerBase logger, CancellationToken cancellationToken)
@@ -1068,6 +1082,49 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             buildSession.Dispose();
 
             StringShouldContainSubstring(logger.FullLog, $"{nameof(AssemblyMockCache)}: EndBuildAsync", expectedOccurrences: 1);
+        }
+
+        [Fact]
+        public void CacheShouldBeQueriedInParallelDuringGraphBuilds()
+        {
+            var referenceNumbers = Enumerable.Range(2, NativeMethodsShared.GetLogicalCoreCount() * 2).ToArray();
+
+            var testData = new GraphCacheResponse(
+                new Dictionary<int, int[]>
+                {
+                    {1, referenceNumbers}
+                },
+                referenceNumbers.ToDictionary(k => k, k => GraphCacheResponse.SuccessfulProxyTargetResult())
+            );
+
+            var graph = testData.CreateGraph(_env);
+            var cache = new InstanceMockCache(testData, TimeSpan.FromMilliseconds(50));
+
+            using var buildSession = new Helpers.BuildManagerSession(_env, new BuildParameters()
+            {
+                MaxNodeCount = NativeMethodsShared.GetLogicalCoreCount(),
+                ProjectCacheDescriptor = ProjectCacheDescriptor.FromInstance(
+                    cache,
+                    entryPoints: null,
+                    graph)
+            });
+
+            var graphResult = buildSession.BuildGraph(graph);
+
+            graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            cache.QueryStartStops.Count.ShouldBe(graph.ProjectNodes.Count * 2);
+
+            var cacheCallsAreSerialized = true;
+
+            foreach (var i in Enumerable.Range(0, cache.QueryStartStops.Count).Where(i => i % 2 == 0))
+            {
+                if (cache.QueryStartStops.ElementAt(i) != cache.QueryStartStops.ElementAt(i + 1))
+                {
+                    cacheCallsAreSerialized = false;
+                }
+            }
+
+            cacheCallsAreSerialized.ShouldBeFalse(string.Join(" ", cache.QueryStartStops));
         }
 
         private static void StringShouldContainSubstring(string aString, string substring, int expectedOccurrences)

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -519,6 +519,8 @@ namespace Microsoft.Build.Execution
 
             void InitializeCaches()
             {
+                Debug.Assert(Monitor.IsEntered(_syncLock));
+
                 var usesInputCaches = _buildParameters.UsesInputCaches();
 
                 if (usesInputCaches)
@@ -562,6 +564,8 @@ namespace Microsoft.Build.Execution
             ProjectCacheDescriptor pluginDescriptor,
             CancellationToken cancellationToken)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             if (_projectCacheService != null)
             {
                 ErrorUtilities.ThrowInternalError("Only one project cache plugin may be set on the BuildManager during a begin / end build session");
@@ -1221,6 +1225,7 @@ namespace Microsoft.Build.Execution
                 catch
                 {
                     // Set to null so that EndBuild does not try to shut it down and thus rethrow the exception.
+                    Debug.Assert(Monitor.IsEntered(_syncLock));
                     _projectCacheService = null;
                     throw;
                 }
@@ -1272,6 +1277,8 @@ namespace Microsoft.Build.Execution
             BuildSubmission submission,
             BuildRequestConfiguration config)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             if (BuildEnvironmentHelper.Instance.RunningInVisualStudio &&
                 ProjectCacheItems.Count > 0 &&
                 !_projectCacheServiceInstantiatedByVSWorkaround &&
@@ -1412,6 +1419,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void LoadSolutionIntoConfiguration(BuildRequestConfiguration config, BuildRequest request)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             if (config.IsLoaded)
             {
                 // We've already processed it, nothing to do.
@@ -2029,17 +2038,20 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void ShutdownConnectedNodes(bool abort)
         {
-            _shuttingDown = true;
-
-            // If we are aborting, we will NOT reuse the nodes because their state may be compromised by attempts to shut down while the build is in-progress.
-            _nodeManager.ShutdownConnectedNodes(!abort && _buildParameters.EnableNodeReuse);
-
-            // if we are aborting, the task host will hear about it in time through the task building infrastructure;
-            // so only shut down the task host nodes if we're shutting down tidily (in which case, it is assumed that all
-            // tasks are finished building and thus that there's no risk of a race between the two shutdown pathways).
-            if (!abort)
+            lock (_syncLock)
             {
-                _taskHostNodeManager.ShutdownConnectedNodes(_buildParameters.EnableNodeReuse);
+                _shuttingDown = true;
+
+                // If we are aborting, we will NOT reuse the nodes because their state may be compromised by attempts to shut down while the build is in-progress.
+                _nodeManager.ShutdownConnectedNodes(!abort && _buildParameters.EnableNodeReuse);
+
+                // if we are aborting, the task host will hear about it in time through the task building infrastructure;
+                // so only shut down the task host nodes if we're shutting down tidily (in which case, it is assumed that all
+                // tasks are finished building and thus that there's no risk of a race between the two shutdown pathways).
+                if (!abort)
+                {
+                    _taskHostNodeManager.ShutdownConnectedNodes(_buildParameters.EnableNodeReuse);
+                }
             }
         }
 
@@ -2154,6 +2166,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private BuildRequestConfiguration ResolveConfiguration(BuildRequestConfiguration unresolvedConfiguration, BuildRequestConfiguration matchingConfigurationFromCache, bool replaceProjectInstance)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             BuildRequestConfiguration resolvedConfiguration = matchingConfigurationFromCache ?? _configCache.GetMatchingConfiguration(unresolvedConfiguration);
             if (resolvedConfiguration == null)
             {
@@ -2185,12 +2199,16 @@ namespace Microsoft.Build.Execution
 
         private void ReplaceExistingProjectInstance(BuildRequestConfiguration newConfiguration, BuildRequestConfiguration existingConfiguration)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             existingConfiguration.Project = newConfiguration.Project;
             _resultsCache.ClearResultsForConfiguration(existingConfiguration.ConfigurationId);
         }
 
         private BuildRequestConfiguration AddNewConfiguration(BuildRequestConfiguration unresolvedConfiguration)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             var newConfigurationId = _scheduler.GetConfigurationIdFromPlan(unresolvedConfiguration.ProjectFullPath);
 
             if (_configCache.HasConfiguration(newConfigurationId) || (newConfigurationId == BuildRequestConfiguration.InvalidConfigurationId))
@@ -2245,6 +2263,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void HandleResourceRequest(int node, ResourceRequest request)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             if (request.IsResourceAcquire)
             {
                 // Resource request requires a response and may be blocking. Our continuation is effectively a callback
@@ -2269,6 +2289,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void HandleConfigurationRequest(int node, BuildRequestConfiguration unresolvedConfiguration)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             BuildRequestConfiguration resolvedConfiguration = ResolveConfiguration(unresolvedConfiguration, null, false);
 
             var response = new BuildRequestConfigurationResponse(unresolvedConfiguration.ConfigurationId, resolvedConfiguration.ConfigurationId, resolvedConfiguration.ResultsNodeId);
@@ -2317,6 +2339,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void HandleNodeShutdown(int node, NodeShutdown shutdownPacket)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             _shuttingDown = true;
             ErrorUtilities.VerifyThrow(_activeNodes.Contains(node), "Unexpected shutdown from node {0} which shouldn't exist.", node);
             _activeNodes.Remove(node);
@@ -2379,6 +2403,8 @@ namespace Microsoft.Build.Execution
         /// </remarks>
         private void CheckForActiveNodesAndCleanUpSubmissions()
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             if (_activeNodes.Count == 0)
             {
                 var submissions = new List<BuildSubmission>(_buildSubmissions.Values);
@@ -2429,6 +2455,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void PerformSchedulingActions(IEnumerable<ScheduleResponse> responses)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             foreach (ScheduleResponse response in responses)
             {
                 switch (response.Action)
@@ -2600,6 +2628,8 @@ namespace Microsoft.Build.Execution
 
         private void CheckAllSubmissionsComplete(BuildRequestDataFlags? flags)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             if (_buildSubmissions.Count == 0 && _graphBuildSubmissions.Count == 0)
             {
                 if (flags.HasValue && flags.Value.HasFlag(BuildRequestDataFlags.ClearCachesAfterBuild))
@@ -2624,6 +2654,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private NodeConfiguration GetNodeConfiguration()
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             if (_nodeConfiguration == null)
             {
                 // Get the remote loggers
@@ -2734,9 +2766,12 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void OnProjectStarted(object sender, ProjectStartedEventArgs e)
         {
-            if (!_projectStartedEvents.ContainsKey(e.BuildEventContext.SubmissionId))
+            lock (_syncLock)
             {
-                _projectStartedEvents[e.BuildEventContext.SubmissionId] = e;
+                if (!_projectStartedEvents.ContainsKey(e.BuildEventContext.SubmissionId))
+                {
+                    _projectStartedEvents[e.BuildEventContext.SubmissionId] = e;
+                }
             }
         }
 
@@ -2745,6 +2780,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private ILoggingService CreateLoggingService(IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> forwardingLoggers, ISet<string> warningsAsErrors, ISet<string> warningsAsMessages)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             int cpuCount = _buildParameters.MaxNodeCount;
 
             LoggerMode loggerMode = cpuCount == 1 && _buildParameters.UseSynchronousLogging
@@ -2912,6 +2949,8 @@ namespace Microsoft.Build.Execution
 
         private bool ReuseOldCaches(string[] inputCacheFiles)
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             ErrorUtilities.VerifyThrowInternalNull(inputCacheFiles, nameof(inputCacheFiles));
             ErrorUtilities.VerifyThrow(_configCache == null, "caches must not be set at this point");
             ErrorUtilities.VerifyThrow(_resultsCache == null, "caches must not be set at this point");
@@ -2991,6 +3030,8 @@ namespace Microsoft.Build.Execution
 
         private void CancelAndMarkAsFailure()
         {
+            Debug.Assert(Monitor.IsEntered(_syncLock));
+
             CancelAllSubmissions();
 
             // CancelAllSubmissions also ends up setting _shuttingDown and _overallBuildSuccess but it does so in a separate thread to avoid deadlocks.

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1597,16 +1597,19 @@ namespace Microsoft.Build.Execution
                 }
             }
 
-            // BuildRequest may be null if the submission fails early on.
-            if (submission.BuildRequest != null)
+            lock(_syncLock)
             {
-                var result = new BuildResult(submission.BuildRequest, ex);
-                submission.CompleteResults(result);
-                submission.CompleteLogging(true);
-            }
+                // BuildRequest may be null if the submission fails early on.
+                if (submission.BuildRequest != null)
+                {
+                    var result = new BuildResult(submission.BuildRequest, ex);
+                    submission.CompleteResults(result);
+                    submission.CompleteLogging(true);
+                }
 
-            _overallBuildSuccess = false;
-            CheckSubmissionCompletenessAndRemove(submission);
+                _overallBuildSuccess = false;
+                CheckSubmissionCompletenessAndRemove(submission);
+            }
         }
 
         /// <summary>
@@ -1636,9 +1639,8 @@ namespace Microsoft.Build.Execution
                 }
 
                 _overallBuildSuccess = false;
+                CheckSubmissionCompletenessAndRemove(submission);
             }
-
-            CheckSubmissionCompletenessAndRemove(submission);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -564,20 +564,26 @@ namespace Microsoft.Build.Execution
             ProjectCacheDescriptor pluginDescriptor,
             CancellationToken cancellationToken)
         {
-            Debug.Assert(Monitor.IsEntered(_syncLock));
-
             if (_projectCacheService != null)
             {
                 ErrorUtilities.ThrowInternalError("Only one project cache plugin may be set on the BuildManager during a begin / end build session");
             }
 
-            LogMessage(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("LoadingProjectCachePlugin", pluginDescriptor.GetDetailedDescription()));
+            lock (_syncLock)
+            {
+                if (_projectCacheService != null)
+                {
+                    return;
+                }
 
-            _projectCacheService = ProjectCacheService.FromDescriptorAsync(
-                pluginDescriptor,
-                this,
-                ((IBuildComponentHost) this).LoggingService,
-                cancellationToken);
+                LogMessage(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("LoadingProjectCachePlugin", pluginDescriptor.GetDetailedDescription()));
+
+                _projectCacheService = ProjectCacheService.FromDescriptorAsync(
+                    pluginDescriptor,
+                    this,
+                    ((IBuildComponentHost) this).LoggingService,
+                    cancellationToken);
+            }
         }
 
         /// <summary>
@@ -1073,8 +1079,12 @@ namespace Microsoft.Build.Execution
                     }
 
                     VerifyStateInternal(BuildManagerState.Building);
+                }
 
-                    try
+                try
+                {
+                    BuildRequestConfiguration newConfiguration;
+                    lock (_syncLock)
                     {
                         // If we have an unnamed project, assign it a temporary name.
                         if (string.IsNullOrEmpty(submission.BuildRequestData.ProjectFullPath))
@@ -1099,27 +1109,36 @@ namespace Microsoft.Build.Execution
                         // Create/Retrieve a configuration for each request
                         var buildRequestConfiguration = new BuildRequestConfiguration(submission.BuildRequestData, _buildParameters.DefaultToolsVersion);
                         var matchingConfiguration = _configCache.GetMatchingConfiguration(buildRequestConfiguration);
-                        var newConfiguration = ResolveConfiguration(
+                        newConfiguration = ResolveConfiguration(
                             buildRequestConfiguration,
                             matchingConfiguration,
                             submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.ReplaceExistingProjectInstance));
 
                         newConfiguration.ExplicitlyLoaded = true;
+                    }
 
-                        submission.BuildRequest = CreateRealBuildRequest(submission, newConfiguration.ConfigurationId);
-
+                    CacheResult cacheResult = null;
+                    // Don't lock on _syncLock to avoid calling the cache serially.
+                    // Ideally, we should lock on the <configuration, targets> tuple, but that would make the code even more convoluted
+                    // so lock just on the configuration. Realistically it should not cause overlocking because the cache is only called on
+                    // top level submissions and those tend to be unique.
+                    lock (newConfiguration)
+                    {
                         // TODO: Remove this when VS gets updated to setup project cache plugins.
                         AutomaticallyDetectAndInstantiateProjectCacheServiceForVisualStudio(submission, newConfiguration);
 
-                        CacheResult cacheResult = null;
                         if (_projectCacheService != null)
                         {
                             cacheResult = QueryCache(submission, newConfiguration);
                         }
+                    }
 
+                    lock (_syncLock)
+                    {
                         if (cacheResult == null || cacheResult.ResultType != CacheResultType.CacheHit)
                         {
                             // Issue the real build request.
+                            submission.BuildRequest = CreateRealBuildRequest(submission, newConfiguration.ConfigurationId);
                             SubmitBuildRequest();
                         }
                         else if (cacheResult?.ResultType == CacheResultType.CacheHit && cacheResult.ProxyTargets != null)
@@ -1149,45 +1168,47 @@ namespace Microsoft.Build.Execution
                             ReportResultsToSubmission(result);
                         }
                     }
-                    // This catch should always be the first one because when this method runs in a separate thread
-                    // and throws an exception there is nobody there to observe the exception.
-                    catch (Exception ex) when (thisMethodIsAsync)
-                    {
-                        HandleExecuteSubmissionException(submission, ex);
-                    }
-                    catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
-                    {
-                        HandleExecuteSubmissionException(submission, ex);
-                        throw;
-                    }
-                    void SubmitBuildRequest()
-                    {
-                        if (CheckForShutdown())
-                        {
-                            return;
-                        }
+                }
+                // This catch should always be the first one because when this method runs in a separate thread
+                // and throws an exception there is nobody there to observe the exception.
+                catch (Exception ex) when (thisMethodIsAsync)
+                {
+                    HandleExecuteSubmissionException(submission, ex);
+                }
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                {
+                    HandleExecuteSubmissionException(submission, ex);
+                    throw;
+                }
+                void SubmitBuildRequest()
+                {
+                    Debug.Assert(Monitor.IsEntered(_syncLock));
 
-                        _workQueue.Post(
-                            () =>
-                            {
-                                try
-                                {
-                                    IssueBuildSubmissionToScheduler(submission, allowMainThreadBuild);
-                                }
-                                catch (BuildAbortedException bae)
-                                {
-                                    // We were canceled before we got issued by the work queue.
-                                    var result = new BuildResult(submission.BuildRequest, bae);
-                                    submission.CompleteResults(result);
-                                    submission.CompleteLogging(true);
-                                    CheckSubmissionCompletenessAndRemove(submission);
-                                }
-                                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
-                                {
-                                    HandleExecuteSubmissionException(submission, ex);
-                                }
-                            });
+                    if (CheckForShutdown())
+                    {
+                        return;
                     }
+
+                    _workQueue.Post(
+                        () =>
+                        {
+                            try
+                            {
+                                IssueBuildSubmissionToScheduler(submission, allowMainThreadBuild);
+                            }
+                            catch (BuildAbortedException bae)
+                            {
+                                // We were canceled before we got issued by the work queue.
+                                var result = new BuildResult(submission.BuildRequest, bae);
+                                submission.CompleteResults(result);
+                                submission.CompleteLogging(true);
+                                CheckSubmissionCompletenessAndRemove(submission);
+                            }
+                            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                            {
+                                HandleExecuteSubmissionException(submission, ex);
+                            }
+                        });
                 }
             }
 
@@ -1200,6 +1221,8 @@ namespace Microsoft.Build.Execution
 
             bool CheckForShutdown()
             {
+                Debug.Assert(Monitor.IsEntered(_syncLock));
+
                 if (!_shuttingDown)
                 {
                     return false;
@@ -1224,21 +1247,23 @@ namespace Microsoft.Build.Execution
                 }
                 catch
                 {
-                    // Set to null so that EndBuild does not try to shut it down and thus rethrow the exception.
-                    Debug.Assert(Monitor.IsEntered(_syncLock));
-                    _projectCacheService = null;
-                    throw;
+                    lock (_syncLock)
+                    {
+                        // Set to null so that EndBuild does not try to shut it down and thus rethrow the exception.
+                        _projectCacheService = null;
+                        throw;
+                    }
                 }
 
                 // Project cache plugins require an evaluated project. Evaluate the submission if it's by path.
                 LoadSubmissionProjectIntoConfiguration(buildSubmission, newConfiguration);
 
                 var cacheResult = cacheService.GetCacheResultAsync(
-                        new BuildRequestData(
-                            newConfiguration.Project,
-                            buildSubmission.BuildRequestData.TargetNames.ToArray()))
-                    .GetAwaiter()
-                    .GetResult();
+                    new BuildRequestData(
+                        newConfiguration.Project,
+                        buildSubmission.BuildRequestData.TargetNames.ToArray()))
+                .GetAwaiter()
+                .GetResult();
 
                 return cacheResult;
             }
@@ -1277,15 +1302,21 @@ namespace Microsoft.Build.Execution
             BuildSubmission submission,
             BuildRequestConfiguration config)
         {
-            Debug.Assert(Monitor.IsEntered(_syncLock));
-
             if (BuildEnvironmentHelper.Instance.RunningInVisualStudio &&
                 ProjectCacheItems.Count > 0 &&
                 !_projectCacheServiceInstantiatedByVSWorkaround &&
                 _projectCacheService == null &&
                 _buildParameters.ProjectCacheDescriptor == null)
             {
-                _projectCacheServiceInstantiatedByVSWorkaround = true;
+                lock (_syncLock)
+                {
+                    if (_projectCacheServiceInstantiatedByVSWorkaround)
+                    {
+                        return;
+                    }
+
+                    _projectCacheServiceInstantiatedByVSWorkaround = true;
+                }
 
                 if (ProjectCacheItems.Count != 1)
                 {

--- a/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
+++ b/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
@@ -54,6 +54,7 @@ namespace MockCacheFromAssembly
             switch (errorKind)
             {
                 case "Exception":
+                    pluginLoggerBase?.LogMessage($"{errorLocation} is going to throw an exception", MessageImportance.High);
                     throw new Exception($"Cache plugin exception from {errorLocation}");
                 case "LoggedError":
                     pluginLoggerBase?.LogError($"Cache plugin logged error from {errorLocation}");


### PR DESCRIPTION
Depends on #6412. Merge that one in first (or close it and merge this one).
Make sure to hide white-space in the diffs because there's a lot of indentation changes by moving around locking blocks.

### Context
The project cache was being queried serially. Oops.
This is because the monolithic BuildManager._syncLock was being held during the cache query, thus serializing all access.

### Changes Made
Broke down the monolithic lock in `ExecuteBuildSubmission(BuildSubmission)` in three successive regions:
1. Compute a BuildRequestConfiguration for the given build submission (and various other arbitrary BM state mutations). Protected by _syncLock.
2. If a cache is present, evaluate the build configuration if necessary (non static graph cache scenarios) and query the cache. Protected by locking each BuildRequestConfiguration. This achieves lock striping and enables parallel access to the cache.
3. Respond to cache query result and do arbitrary BM state mutations. Protected by _synclock.

### Testing
Added a parallel stress test. This should be a good test to both ensure the cache is queried in parallel and to stress test the concurrency in the engine.