### PR TITLE
Ensure context is not cached before logging info

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.9.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>16.9.2</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -1,5 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
+
+using Shouldly;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -90,6 +98,49 @@ namespace Microsoft.Build.UnitTests
 </Project>";
 
             ObjectModelHelpers.BuildProjectExpectSuccess(project, binaryLogger);
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/dotnet/msbuild/issues/6323.
+        /// </summary>
+        /// <remarks>
+        /// This isn't strictly a binlog test, but it fits here because
+        /// all log event types will be used when the binlog is attached.
+        /// </remarks>
+        [Fact]
+        public void MessagesCanBeLoggedWhenProjectsAreCached()
+        {
+            using var env = TestEnvironment.Create();
+
+            env.SetEnvironmentVariable("MSBUILDDEBUGFORCECACHING", "1");
+
+            using var buildManager = new BuildManager();
+
+            var binaryLogger = new BinaryLogger
+            {
+                Parameters = $"LogFile={_logFile}"
+            };
+
+            // To trigger #6323, there must be at least two project instances.
+            var referenceProject = _env.CreateTestProjectWithFiles("reference.proj", @"
+         <Project>
+            <Target Name='Target2'>
+               <Exec Command='echo a'/>
+            </Target>
+         </Project>");
+
+            var entryProject = _env.CreateTestProjectWithFiles("entry.proj", $@"
+         <Project>
+            <Target Name='BuildSelf'>
+               <Message Text='MessageOutputText'/>
+               <MSBuild Projects='{referenceProject.ProjectFile}' Targets='Target2' />
+               <MSBuild Projects='{referenceProject.ProjectFile}' Targets='Target2' /><!-- yes, again. That way it's a cached result -->
+            </Target>
+         </Project>");
+
+            buildManager.Build(new BuildParameters() { Loggers = new ILogger[] { binaryLogger } },
+                new BuildRequestData(entryProject.ProjectFile, new Dictionary<string, string>(), null, new string[] { "BuildSelf" }, null))
+                .OverallResult.ShouldBe(BuildResultCode.Success);
         }
 
 

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -69,7 +69,13 @@ namespace Microsoft.Build.BackEnd.Logging
         internal ProjectLoggingContext LogProjectStarted(BuildRequest request, BuildRequestConfiguration configuration)
         {
             ErrorUtilities.VerifyThrow(this.IsValid, "Build not started.");
-            return new ProjectLoggingContext(this, request, configuration.ProjectFullPath, configuration.ToolsVersion, request.ParentBuildEventContext, configuration.Project?.EvaluationId ?? BuildEventContext.InvalidEvaluationId);
+
+            // If we can retrieve the evaluationId from the project, do so. Don't if it's not available or
+            // if we'd have to retrieve it from the cache in order to access it.
+            // Order is important here because the Project getter will throw if IsCached.
+            int evaluationId = (configuration != null && !configuration.IsCached && configuration.Project != null) ? configuration.Project.EvaluationId : BuildEventContext.InvalidEvaluationId;
+
+            return new ProjectLoggingContext(this, request, configuration.ProjectFullPath, configuration.ToolsVersion, request.ParentBuildEventContext, evaluationId);
         }
 
         /// <summary>


### PR DESCRIPTION
Work item (Internal use): [AB#1325685](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1325685)

### Summary

Fixes #6436 which causes this crash in cases where MSBuild's result
caching is turned on (generally this is for large builds in 32-bit
MSBuild).

### Customer Impact

Customers with large builds see MSBuild crashes.

### Regression?

Yes. Worked in 16.8, regressed in 16.9.0 because of #5997

### Testing

Validated minimal repro (using forced caching) passes where it failed on released bits.

### Risk

Low. Additional guarding falling into existing case so log output shouldn't suffer.
