### PR TITLE
Fix generated editor config files for xaml precompile

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -190,7 +190,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                  @(CustomAdditionalCompileOutputs)"
         Condition="'@(Page)' != '' Or '@(ApplicationDefinition)' != ''"
         Returns=""
-        DependsOnTargets="$(CoreCompileDependsOn)"
+        DependsOnTargets="$(CoreCompileDependsOn);GenerateMSBuildEditorConfigFile"
     >
        <!-- These two compiler warnings are raised when a reference is bound to a different version
              than specified in the assembly reference version number.  MSBuild raises the same warning in this case,
@@ -239,6 +239,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               AddModules="@(AddModules)"
               AdditionalFiles="@(AdditionalFiles)"
               AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
+              AnalyzerConfigFiles="@(EditorConfigFiles)"
               Analyzers="@(Analyzer)"
               ApplicationConfiguration="$(AppConfigForCompiler)"
               BaseAddress="$(BaseAddress)"

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -191,7 +191,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                  $(NonExistentFile);
                  @(CustomAdditionalCompileOutputs)"
         Returns=""
-        DependsOnTargets="$(CoreCompileDependsOn)"
+        DependsOnTargets="$(CoreCompileDependsOn);GenerateMSBuildEditorConfigFile"
         Condition="'@(Page)' != '' Or '@(ApplicationDefinition)' != ''"
     >
         <PropertyGroup>
@@ -232,6 +232,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               AdditionalLibPaths="$(AdditionalLibPaths)"
               AddModules="@(AddModules)"
               AdditionalFiles="@(AdditionalFiles)"
+              AnalyzerConfigFiles="@(EditorConfigFiles)"
+              Analyzers="@(Analyzer)"
               BaseAddress="$(BaseAddress)"
               CodeAnalysisRuleSet="$(ResolvedCodeAnalysisRuleSet)"
               CodePage="$(CodePage)"
@@ -277,6 +279,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               RootNamespace="$(RootNamespace)"
               PdbFile="$(PdbFile)"
               SdkPath="$(FrameworkPathOverride)"
+              SkipAnalyzers="$(_SkipAnalyzers)"
               Sources="@(Compile)"
               SubsystemVersion="$(SubsystemVersion)"
               TargetCompactFramework="$(TargetCompactFramework)"


### PR DESCRIPTION
### Summary

The CSC task was not being passing EditorConfig Files when invoked as part of XamlPreCompile. In addition the `GenerateMSBuildEditorConfigFileCore` task needs to have been run to actually generate the required file. Fixes #6323.

### Customer Impact

Source Generators fail in WinUI 3 projects.

### Regression?

Never fully worked. Started passing analyzers to the XamlPreCompile compiler in #6096 (16.9), but didn't pass config files, which are often needed for source generators.

### Testing

@chsienki locally patched and validated against repro provided by partner.

### Risk

Low. Conceivably breaks projects that depend on the current behavior (pass config files that are incorrect for this step) but we know of no such cases.
