### PR TITLE
Update VS version to use in optprof and RPS runs

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -43,7 +43,7 @@ stages:
     - name: VisualStudio.MajorVersion
       value: 16
     - name: VisualStudio.ChannelName
-      value: 'int.main'
+      value: 'int.d16.9'
     - name: VisualStudio.DropName
       value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 


### PR DESCRIPTION
Fixes optprof and RPS runs for vs16.9 branch
