### PR TITLE
Update VS version to use in optprof and RPS runs

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -49,7 +49,7 @@ stages:
     - name: VisualStudio.MajorVersion
       value: 16
     - name: VisualStudio.ChannelName
-      value: 'int.main'
+      value: 'int.d16.11'
     - name: VisualStudio.DropName
       value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 


### PR DESCRIPTION
Merges visual studio version and updates for vs16.11

Is it worth 'merging' the two merge commits into a single commit? That doesn't sound right to me 🤔

In theory replaces https://github.com/dotnet/msbuild/pull/6446