### PR TITLE
Add solution-validation targets as hook points

### DIFF
--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -66,7 +66,11 @@ namespace Microsoft.Build.Construction
             "Build",
             "Clean",
             "Rebuild",
-            "Publish"
+            "Publish",
+            "ValidateSolutionConfiguration",
+            "ValidateToolsVersions",
+            "ValidateProjects",
+            "GetSolutionConfigurationContents"
             );
 
 #if FEATURE_ASPNET_COMPILER


### PR DESCRIPTION
Solution metaprojects are assembled in a confusing way that impacts what
targets can be hooked into via BeforeTargets/AfterTargets. Prior to this
change one couldn't hook before the build would attempt to traverse the
list of projects in the solution.

Extend the "list of targets we know we'll create shortly" list to
include the things that are in the `InitialTargets` list and
`GetSolutionConfigurationContents`.

Fixes #6452.

### Context

See related #4694, #5109.
