### PR TITLE
Fix signing tool lookup for VS64

### DIFF
--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -854,19 +854,20 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
         private static string GetVersionIndependentToolPath(string toolName)
         {
-            RegistryKey localMachineKey = Registry.LocalMachine;
             const string versionIndependentToolKeyName = @"Software\Microsoft\ClickOnce\SignTool";
-
-            using (RegistryKey versionIndependentToolKey = localMachineKey.OpenSubKey(versionIndependentToolKeyName, writable: false))
+            using (RegistryKey localMachineKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
             {
-                string versionIndependentToolPath = null;
-
-                if (versionIndependentToolKey != null)
+                using (RegistryKey versionIndependentToolKey = localMachineKey.OpenSubKey(versionIndependentToolKeyName, writable: false))
                 {
-                    versionIndependentToolPath = versionIndependentToolKey.GetValue("Path") as string;
-                }
+                    string versionIndependentToolPath = null;
 
-                return versionIndependentToolPath != null ? Path.Combine(versionIndependentToolPath, toolName) : null;
+                    if (versionIndependentToolKey != null)
+                    {
+                        versionIndependentToolPath = versionIndependentToolKey.GetValue("Path") as string;
+                    }
+
+                    return versionIndependentToolPath != null ? Path.Combine(versionIndependentToolPath, toolName) : null;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes # DevDiv 1308643

### Context

ClickOnce publishing build task invokes signtool.exe installed by the ClickOnce bootstrapper MSI to sign published files. The MSI writes the signtool.exe path under the HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ClickOnce\SignTool regkey. 

On 64 bit OS, the MSI writes to this regkey under the WoW node. On VS64/msbuild64, the signing task tries to read the regkey from the non-WoW node where it does not exist. This causes ClickOnce Publish in VS64 to fail.

### Changes Made
Fix the signing task to look in the Registry32 view of the registry for the HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ClickOnce\SignTool key.

### Testing
Verified fix on x86 and x64 VS.

### Notes
