### PR TITLE
Make cache queries parallel

### DIFF
--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -484,8 +484,8 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                         currentBuildEnvironment.Mode,
                         currentBuildEnvironment.CurrentMSBuildExePath,
                         currentBuildEnvironment.RunningTests,
-                        true,
-                        currentBuildEnvironment.VisualStudioInstallRootDirectory));
+                        runningInVisualStudio: true,
+                        visualStudioPath: currentBuildEnvironment.VisualStudioInstallRootDirectory));
 
                 BuildManager.ProjectCacheItems.ShouldBeEmpty();
 
@@ -502,12 +502,13 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                         node.ProjectInstance.FullPath,
                         globalProperties:
                             new Dictionary<string, string> {{"SolutionPath", graph.GraphRoots.First().ProjectInstance.FullPath}});
+
                     buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
 
                     nodesToBuildResults[node] = buildResult;
                 }
 
-                buildSession.Logger.FullLog.ShouldContain("Graph entrypoint based");
+                buildSession.Logger.FullLog.ShouldContain("Visual Studio Workaround based");
 
                 AssertCacheBuild(graph, testData, null, buildSession.Logger, nodesToBuildResults);
             }
@@ -746,7 +747,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
 
-            buildSession.Logger.FullLog.ShouldContain("Graph entrypoint based");
+            buildSession.Logger.FullLog.ShouldContain("Explicit entry-point based");
 
             AssertCacheBuild(graph, testData, null, buildSession.Logger, graphResult.ResultsByNode);
         }
@@ -893,7 +894,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 // Plugin constructors cannot log errors, they can only throw exceptions.
                 yield return new object[] { ErrorLocations.Constructor, ErrorKind.Exception };
 
-                foreach (var errorKind in new[]{ErrorKind.Exception, ErrorKind.LoggedError})
+                foreach (var errorKind in new[] { ErrorKind.Exception, ErrorKind.LoggedError })
                 {
                     yield return new object[] { ErrorLocations.BeginBuildAsync, errorKind };
                     yield return new object[] { ErrorLocations.BeginBuildAsync | ErrorLocations.GetCacheResultAsync, errorKind };

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -209,14 +209,19 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
         public class InstanceMockCache : ProjectCachePluginBase
         {
             private readonly GraphCacheResponse? _testData;
-            public ConcurrentQueue<BuildRequestData> Requests { get; } = new ConcurrentQueue<BuildRequestData>();
+            private readonly TimeSpan? _projectQuerySleepTime;
+            public ConcurrentQueue<BuildRequestData> Requests { get; } = new();
 
             public bool BeginBuildCalled { get; set; }
             public bool EndBuildCalled { get; set; }
 
-            public InstanceMockCache(GraphCacheResponse? testData = null)
+            private int _nextId;
+            public ConcurrentQueue<int> QueryStartStops = new();
+
+            public InstanceMockCache(GraphCacheResponse? testData = null, TimeSpan? projectQuerySleepTime = null)
             {
                 _testData = testData;
+                _projectQuerySleepTime = projectQuerySleepTime;
             }
 
             public override Task BeginBuildAsync(CacheContext context, PluginLoggerBase logger, CancellationToken cancellationToken)
@@ -228,18 +233,27 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 return Task.CompletedTask;
             }
 
-            public override Task<CacheResult> GetCacheResultAsync(
+            public override async Task<CacheResult> GetCacheResultAsync(
                 BuildRequestData buildRequest,
                 PluginLoggerBase logger,
                 CancellationToken cancellationToken)
             {
+                var queryId = Interlocked.Increment(ref _nextId);
+
                 Requests.Enqueue(buildRequest);
+                QueryStartStops.Enqueue(queryId);
+
                 logger.LogMessage($"MockCache: GetCacheResultAsync for {buildRequest.ProjectFullPath}", MessageImportance.High);
 
-                return
-                    Task.FromResult(
-                        _testData?.GetExpectedCacheResultForProjectNumber(GetProjectNumber(buildRequest.ProjectFullPath))
-                        ?? CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss));
+                if (_projectQuerySleepTime is not null)
+                {
+                    await Task.Delay(_projectQuerySleepTime.Value);
+                }
+
+                QueryStartStops.Enqueue(queryId);
+
+                return _testData?.GetExpectedCacheResultForProjectNumber(GetProjectNumber(buildRequest.ProjectFullPath))
+                        ?? CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss);
             }
 
             public override Task EndBuildAsync(PluginLoggerBase logger, CancellationToken cancellationToken)
@@ -1147,6 +1161,54 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             buildSession.Dispose();
 
             StringShouldContainSubstring(logger.FullLog, $"{nameof(AssemblyMockCache)}: EndBuildAsync", expectedOccurrences: 1);
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        public void CacheShouldBeQueriedInParallelDuringGraphBuilds(bool useSynchronousLogging, bool disableInprocNode)
+        {
+            var referenceNumbers = Enumerable.Range(2, NativeMethodsShared.GetLogicalCoreCount() * 2).ToArray();
+
+            var testData = new GraphCacheResponse(
+                new Dictionary<int, int[]>
+                {
+                    {1, referenceNumbers}
+                },
+                referenceNumbers.ToDictionary(k => k, k => GraphCacheResponse.SuccessfulProxyTargetResult())
+            );
+
+            var graph = testData.CreateGraph(_env);
+            var cache = new InstanceMockCache(testData, TimeSpan.FromMilliseconds(50));
+
+            using var buildSession = new Helpers.BuildManagerSession(_env, new BuildParameters()
+            {
+                MaxNodeCount = NativeMethodsShared.GetLogicalCoreCount(),
+                ProjectCacheDescriptor = ProjectCacheDescriptor.FromInstance(
+                    cache,
+                    entryPoints: null,
+                    graph),
+                UseSynchronousLogging = useSynchronousLogging,
+                DisableInProcNode = disableInprocNode
+            });
+
+            var graphResult = buildSession.BuildGraph(graph);
+
+            graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            cache.QueryStartStops.Count.ShouldBe(graph.ProjectNodes.Count * 2);
+
+            // Iterate through the ordered list of cache query starts and stops and verify they are out of order.
+            // Out of order means the cache was called in parallel. In order means it was called sequentially.
+            var cacheCallsAreSerialized = true;
+            foreach (var i in Enumerable.Range(0, cache.QueryStartStops.Count).Where(i => i % 2 == 0))
+            {
+                if (cache.QueryStartStops.ElementAt(i) != cache.QueryStartStops.ElementAt(i + 1))
+                {
+                    cacheCallsAreSerialized = false;
+                }
+            }
+
+            cacheCallsAreSerialized.ShouldBeFalse(string.Join(" ", cache.QueryStartStops));
         }
 
         private static void StringShouldContainSubstring(string aString, string substring, int expectedOccurrences)

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -193,6 +193,31 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             }
         }
 
+        public class DelegatingMockCache : ProjectCachePluginBase
+        {
+            private readonly Func<BuildRequestData, PluginLoggerBase, CancellationToken, Task<CacheResult>> _getCacheResultDelegate;
+
+            public DelegatingMockCache(Func<BuildRequestData, PluginLoggerBase, CancellationToken, Task<CacheResult>> getCacheResultDelegate)
+            {
+                _getCacheResultDelegate = getCacheResultDelegate;
+            }
+
+            public override Task BeginBuildAsync(CacheContext context, PluginLoggerBase logger, CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            public override async Task<CacheResult> GetCacheResultAsync(BuildRequestData buildRequest, PluginLoggerBase logger, CancellationToken cancellationToken)
+            {
+                return await _getCacheResultDelegate(buildRequest, logger, cancellationToken);
+            }
+
+            public override Task EndBuildAsync(PluginLoggerBase logger, CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
         [Flags]
         public enum ErrorLocations
         {
@@ -1249,6 +1274,92 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 return;
             }
 
+            var referenceNumbers = new []{2, 3, 4};
+
+            var testData = new GraphCacheResponse(
+                new Dictionary<int, int[]>
+                {
+                    {1, referenceNumbers}
+                },
+                referenceNumbers.ToDictionary(k => k, k => GraphCacheResponse.SuccessfulProxyTargetResult())
+            );
+
+            var graph = testData.CreateGraph(_env);
+
+            var completedCacheRequests = new ConcurrentBag<int>();
+            var task2Completion = new TaskCompletionSource<bool>();
+            task2Completion.Task.IsCompleted.ShouldBeFalse();
+
+            var cache = new DelegatingMockCache(
+                async (buildRequest, _, _) =>
+                {
+                    var projectNumber = GetProjectNumber(buildRequest.ProjectFullPath);
+
+                    try
+                    {
+                        if (projectNumber == 2)
+                        {
+                            await task2Completion.Task;
+                        }
+
+                        return testData.GetExpectedCacheResultForProjectNumber(projectNumber);
+                    }
+                    finally
+                    {
+                        completedCacheRequests.Add(projectNumber);
+                    }
+                });
+
+            using var buildSession = new Helpers.BuildManagerSession(_env, new BuildParameters()
+            {
+                MaxNodeCount = NativeMethodsShared.GetLogicalCoreCount(),
+                ProjectCacheDescriptor = ProjectCacheDescriptor.FromInstance(
+                    cache,
+                    entryPoints: null,
+                    graph),
+                UseSynchronousLogging = useSynchronousLogging,
+                DisableInProcNode = disableInprocNode
+            });
+
+            var task2 = BuildProjectFileAsync(2);
+            var task3 = BuildProjectFileAsync(3);
+            var task4 = BuildProjectFileAsync(4);
+
+            task3.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+            completedCacheRequests.ShouldContain(3);
+            task4.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+            completedCacheRequests.ShouldContain(4);
+
+            // task 2 hasn't been instructed to finish yet
+            task2.IsCompleted.ShouldBeFalse();
+            completedCacheRequests.ShouldNotContain(2);
+
+            task2Completion.SetResult(true);
+
+            task2.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+            completedCacheRequests.ShouldContain(2);
+
+            var task1 = BuildProjectFileAsync(1);
+            task1.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+            completedCacheRequests.ShouldContain(1);
+
+            Task<BuildResult> BuildProjectFileAsync(int projectNumber)
+            {
+                return buildSession.BuildProjectFileAsync(graph.ProjectNodes.First(n => GetProjectNumber(n) == projectNumber).ProjectInstance.FullPath);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        public void ParallelStressTest(bool useSynchronousLogging, bool disableInprocNode)
+        {
+            if (disableInprocNode)
+            {
+                // TODO: remove this branch when the DisableInProcNode failure is fixed by https://github.com/dotnet/msbuild/pull/6400
+                return;
+            }
+
             var referenceNumbers = Enumerable.Range(2, NativeMethodsShared.GetLogicalCoreCount() * 2).ToArray();
 
             var testData = new GraphCacheResponse(
@@ -1277,19 +1388,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
             cache.QueryStartStops.Count.ShouldBe(graph.ProjectNodes.Count * 2);
-
-            // Iterate through the ordered list of cache query starts and stops and verify they are out of order.
-            // Out of order means the cache was called in parallel. In order means it was called sequentially.
-            var cacheCallsAreSerialized = true;
-            foreach (var i in Enumerable.Range(0, cache.QueryStartStops.Count).Where(i => i % 2 == 0))
-            {
-                if (cache.QueryStartStops.ElementAt(i) != cache.QueryStartStops.ElementAt(i + 1))
-                {
-                    cacheCallsAreSerialized = false;
-                }
-            }
-
-            cacheCallsAreSerialized.ShouldBeFalse(string.Join(" ", cache.QueryStartStops));
         }
 
         private static void StringShouldContainSubstring(string aString, string substring, int expectedOccurrences)

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -1243,6 +1243,12 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
         [InlineData(true, true)]
         public void CacheShouldBeQueriedInParallelDuringGraphBuilds(bool useSynchronousLogging, bool disableInprocNode)
         {
+            if (disableInprocNode)
+            {
+                // TODO: remove this branch when the DisableInProcNode failure is fixed by https://github.com/dotnet/msbuild/pull/6400
+                return;
+            }
+
             var referenceNumbers = Enumerable.Range(2, NativeMethodsShared.GetLogicalCoreCount() * 2).ToArray();
 
             var testData = new GraphCacheResponse(

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1081,18 +1081,6 @@ namespace Microsoft.Build.Execution
 
                     newConfiguration.ExplicitlyLoaded = true;
 
-                    // Now create the build request
-                    submission.BuildRequest = new BuildRequest(
-                        submission.SubmissionId,
-                        BackEnd.BuildRequest.InvalidNodeRequestId,
-                        newConfiguration.ConfigurationId,
-                        submission.BuildRequestData.TargetNames,
-                        submission.BuildRequestData.HostServices,
-                        BuildEventContext.Invalid,
-                        null,
-                        submission.BuildRequestData.Flags,
-                        submission.BuildRequestData.RequestedProjectState);
-
                     if (_shuttingDown)
                     {
                         // We were already canceled!
@@ -1103,27 +1091,8 @@ namespace Microsoft.Build.Execution
                         return;
                     }
 
-                    // Submit the build request.
-                    _workQueue.Post(
-                        () =>
-                        {
-                            try
-                            {
-                                IssueBuildSubmissionToScheduler(submission, allowMainThreadBuild);
-                            }
-                            catch (BuildAbortedException bae)
-                            {
-                                // We were canceled before we got issued by the work queue.
-                                var result = new BuildResult(submission.BuildRequest, bae);
-                                submission.CompleteResults(result);
-                                submission.CompleteLogging(true);
-                                CheckSubmissionCompletenessAndRemove(submission);
-                            }
-                            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
-                            {
-                                HandleExecuteSubmissionException(submission, ex);
-                            }
-                        });
+                    AddBuildRequestToSubmission(submission, newConfiguration.ConfigurationId);
+                    IssueBuildSubmissionToScheduler(submission, allowMainThreadBuild);
                 }
                 catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
                 {
@@ -1512,70 +1481,108 @@ namespace Microsoft.Build.Execution
             }
         }
 
+        private static void AddBuildRequestToSubmission(BuildSubmission submission, int configurationId)
+        {
+            submission.BuildRequest = new BuildRequest(
+                submission.SubmissionId,
+                BackEnd.BuildRequest.InvalidNodeRequestId,
+                configurationId,
+                submission.BuildRequestData.TargetNames,
+                submission.BuildRequestData.HostServices,
+                BuildEventContext.Invalid,
+                null,
+                submission.BuildRequestData.Flags,
+                submission.BuildRequestData.RequestedProjectState);
+        }
+
         /// <summary>
         /// The submission is a top level build request entering the BuildManager.
         /// Sends the request to the scheduler with optional legacy threading semantics behavior.
         /// </summary>
-        private void IssueBuildSubmissionToScheduler(BuildSubmission submission, bool allowMainThreadBuild)
+        private void IssueBuildSubmissionToScheduler(BuildSubmission submission, bool allowMainThreadBuild = false)
         {
-            bool resetMainThreadOnFailure = false;
-            try
-            {
-                lock (_syncLock)
+            _workQueue.Post(
+                () =>
                 {
-                    if (_shuttingDown)
+                    try
                     {
-                        throw new BuildAbortedException();
+                        IssueBuildSubmissionToSchedulerImpl(submission, allowMainThreadBuild);
                     }
-
-                    if (allowMainThreadBuild && _buildParameters.LegacyThreadingSemantics)
+                    catch (BuildAbortedException bae)
                     {
-                        if (_legacyThreadingData.MainThreadSubmissionId == -1)
+                        // We were canceled before we got issued by the work queue.
+                        var result = new BuildResult(submission.BuildRequest, bae);
+                        submission.CompleteResults(result);
+                        submission.CompleteLogging(true);
+                        CheckSubmissionCompletenessAndRemove(submission);
+                    }
+                    catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                    {
+                        HandleExecuteSubmissionException(submission, ex);
+                    }
+                });
+
+            void IssueBuildSubmissionToSchedulerImpl(BuildSubmission submission, bool allowMainThreadBuild)
+            {
+                var resetMainThreadOnFailure = false;
+                try
+                {
+                    lock (_syncLock)
+                    {
+                        if (_shuttingDown)
                         {
-                            resetMainThreadOnFailure = true;
-                            _legacyThreadingData.MainThreadSubmissionId = submission.SubmissionId;
+                            throw new BuildAbortedException();
+                        }
+
+                        if (allowMainThreadBuild && _buildParameters.LegacyThreadingSemantics)
+                        {
+                            if (_legacyThreadingData.MainThreadSubmissionId == -1)
+                            {
+                                resetMainThreadOnFailure = true;
+                                _legacyThreadingData.MainThreadSubmissionId = submission.SubmissionId;
+                            }
+                        }
+
+                        BuildRequestBlocker blocker = new BuildRequestBlocker(-1, Array.Empty<string>(), new[] {submission.BuildRequest});
+
+                        HandleNewRequest(Scheduler.VirtualNode, blocker);
+                    }
+                }
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                {
+                    var projectException = ex as InvalidProjectFileException;
+                    if (projectException != null)
+                    {
+                        if (!projectException.HasBeenLogged)
+                        {
+                            BuildEventContext projectBuildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+                            ((IBuildComponentHost)this).LoggingService.LogInvalidProjectFileError(projectBuildEventContext, projectException);
+                            projectException.HasBeenLogged = true;
                         }
                     }
-
-                    BuildRequestBlocker blocker = new BuildRequestBlocker(-1, Array.Empty<string>(), new[] {submission.BuildRequest});
-
-                    HandleNewRequest(Scheduler.VirtualNode, blocker);
-                }
-            }
-            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
-            {
-                InvalidProjectFileException projectException = ex as InvalidProjectFileException;
-                if (projectException != null)
-                {
-                    if (!projectException.HasBeenLogged)
+                    else if ((ex is BuildAbortedException) || ExceptionHandling.NotExpectedException(ex))
                     {
-                        BuildEventContext projectBuildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-                        ((IBuildComponentHost)this).LoggingService.LogInvalidProjectFileError(projectBuildEventContext, projectException);
-                        projectException.HasBeenLogged = true;
-                    }
-                }
-                else if ((ex is BuildAbortedException) || ExceptionHandling.NotExpectedException(ex))
-                {
-                    throw;
-                }
-
-                lock (_syncLock)
-                {
-
-                    if (resetMainThreadOnFailure)
-                    {
-                        _legacyThreadingData.MainThreadSubmissionId = -1;
+                        throw;
                     }
 
-                    if (projectException == null)
+                    lock (_syncLock)
                     {
-                        BuildEventContext buildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-                        ((IBuildComponentHost)this).LoggingService.LogFatalBuildError(buildEventContext, ex, new BuildEventFileInfo(submission.BuildRequestData.ProjectFullPath));
-                    }
 
-                    submission.CompleteLogging(true);
-                    ReportResultsToSubmission(new BuildResult(submission.BuildRequest, ex));
-                    _overallBuildSuccess = false;
+                        if (resetMainThreadOnFailure)
+                        {
+                            _legacyThreadingData.MainThreadSubmissionId = -1;
+                        }
+
+                        if (projectException == null)
+                        {
+                            var buildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+                            ((IBuildComponentHost)this).LoggingService.LogFatalBuildError(buildEventContext, ex, new BuildEventFileInfo(submission.BuildRequestData.ProjectFullPath));
+                        }
+
+                        submission.CompleteLogging(true);
+                        ReportResultsToSubmission(new BuildResult(submission.BuildRequest, ex));
+                        _overallBuildSuccess = false;
+                    }
                 }
             }
         }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1144,6 +1144,9 @@ namespace Microsoft.Build.Execution
             return BuildEnvironmentHelper.Instance.RunningInVisualStudio && ProjectCacheItems.Count > 0;
         }
 
+        // Cache requests on configuration N do not block future build submissions depending on configuration N.
+        // It is assumed that the higher level build orchestrator (static graph scheduler, VS, quickbuild) submits a
+        // project build request only when its references have finished building.
         private void IssueCacheRequestForBuildSubmission(CacheRequest cacheRequest)
         {
             Debug.Assert(Monitor.IsEntered(_syncLock));

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1084,6 +1084,7 @@ namespace Microsoft.Build.Execution
                     if (_shuttingDown)
                     {
                         // We were already canceled!
+                        AddBuildRequestToSubmission(submission, resolvedConfiguration.ConfigurationId);
                         BuildResult result = new BuildResult(submission.BuildRequest, new BuildAbortedException());
                         submission.CompleteResults(result);
                         submission.CompleteLogging(true);

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1022,254 +1022,114 @@ namespace Microsoft.Build.Execution
             ErrorUtilities.VerifyThrowArgumentNull(submission, nameof(submission));
             ErrorUtilities.VerifyThrow(!submission.IsCompleted, "Submission already complete.");
 
-            bool thisMethodIsAsync = false;
-
-            if (ProjectCacheIsPresent())
+            lock (_syncLock)
             {
-                thisMethodIsAsync = true;
-
-                // Potential long running operations:
-                //  - submission may need evaluation
-                //  - project cache may need initializing
-                //  - project cache will be queried
-                // Use separate thread to unblock calling thread.
-                Task.Factory.StartNew(
-                    ExecuteSubmissionImpl,
-                    CancellationToken.None,
-                    TaskCreationOptions.LongRunning,
-                    TaskScheduler.Default
-                );
-            }
-            else
-            {
-                ExecuteSubmissionImpl();
-            }
-
-            void ExecuteSubmissionImpl()
-            {
-                lock (_syncLock)
+                ProjectInstance projectInstance = submission.BuildRequestData.ProjectInstance;
+                if (projectInstance != null)
                 {
-                    ProjectInstance projectInstance = submission.BuildRequestData.ProjectInstance;
-                    if (projectInstance != null)
+                    if (_acquiredProjectRootElementCacheFromProjectInstance)
                     {
-                        if (_acquiredProjectRootElementCacheFromProjectInstance)
-                        {
-                            ErrorUtilities.VerifyThrowArgument(
-                                _buildParameters.ProjectRootElementCache == projectInstance.ProjectRootElementCache,
-                                "OM_BuildSubmissionsMultipleProjectCollections");
-                        }
-                        else
-                        {
-                            _buildParameters.ProjectRootElementCache = projectInstance.ProjectRootElementCache;
-                            _acquiredProjectRootElementCacheFromProjectInstance = true;
-                        }
+                        ErrorUtilities.VerifyThrowArgument(
+                            _buildParameters.ProjectRootElementCache == projectInstance.ProjectRootElementCache,
+                            "OM_BuildSubmissionsMultipleProjectCollections");
                     }
-                    else if (_buildParameters.ProjectRootElementCache == null)
+                    else
                     {
-                        // Create our own cache; if we subsequently get a build submission with a project instance attached,
-                        // we'll dump our cache and use that one.
-                        _buildParameters.ProjectRootElementCache =
-                            new ProjectRootElementCache(false /* do not automatically reload from disk */);
-                    }
-
-                    VerifyStateInternal(BuildManagerState.Building);
-
-                    try
-                    {
-                        // If we have an unnamed project, assign it a temporary name.
-                        if (string.IsNullOrEmpty(submission.BuildRequestData.ProjectFullPath))
-                        {
-                            ErrorUtilities.VerifyThrow(
-                                submission.BuildRequestData.ProjectInstance != null,
-                                "Unexpected null path for a submission with no ProjectInstance.");
-
-                            // If we have already named this instance when it was submitted previously during this build, use the same
-                            // name so that we get the same configuration (and thus don't cause it to rebuild.)
-                            if (!_unnamedProjectInstanceToNames.TryGetValue(submission.BuildRequestData.ProjectInstance, out var tempName))
-                            {
-                                tempName = "Unnamed_" + _nextUnnamedProjectId++;
-                                _unnamedProjectInstanceToNames[submission.BuildRequestData.ProjectInstance] = tempName;
-                            }
-
-                            submission.BuildRequestData.ProjectFullPath = Path.Combine(
-                                submission.BuildRequestData.ProjectInstance.GetProperty(ReservedPropertyNames.projectDirectory).EvaluatedValue,
-                                tempName);
-                        }
-
-                        // Create/Retrieve a configuration for each request
-                        var buildRequestConfiguration = new BuildRequestConfiguration(submission.BuildRequestData, _buildParameters.DefaultToolsVersion);
-                        var matchingConfiguration = _configCache.GetMatchingConfiguration(buildRequestConfiguration);
-                        var newConfiguration = ResolveConfiguration(
-                            buildRequestConfiguration,
-                            matchingConfiguration,
-                            submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.ReplaceExistingProjectInstance));
-
-                        newConfiguration.ExplicitlyLoaded = true;
-
-                        submission.BuildRequest = CreateRealBuildRequest(submission, newConfiguration.ConfigurationId);
-
-                        // TODO: Remove this when VS gets updated to setup project cache plugins.
-                        AutomaticallyDetectAndInstantiateProjectCacheServiceForVisualStudio(submission, newConfiguration);
-
-                        CacheResult cacheResult = null;
-                        if (_projectCacheService != null)
-                        {
-                            cacheResult = QueryCache(submission, newConfiguration);
-                        }
-
-                        if (cacheResult == null || cacheResult.ResultType != CacheResultType.CacheHit)
-                        {
-                            // Issue the real build request.
-                            SubmitBuildRequest();
-                        }
-                        else if (cacheResult?.ResultType == CacheResultType.CacheHit && cacheResult.ProxyTargets != null)
-                        {
-                            // Setup submission.BuildRequest with proxy targets. The proxy request is built on the inproc node (to avoid ProjectInstance serialization).
-                            // The proxy target results are used as results for the real targets.
-
-                            submission.BuildRequest = CreateProxyBuildRequest(
-                                submission,
-                                newConfiguration.ConfigurationId,
-                                cacheResult.ProxyTargets);
-
-                            SubmitBuildRequest();
-                        }
-                        else if (cacheResult?.ResultType == CacheResultType.CacheHit && cacheResult.BuildResult != null)
-                        {
-                            // Mark the build submission as complete with the provided results and return.
-                            var result = new BuildResult(submission.BuildRequest);
-
-                            foreach (var targetResult in cacheResult.BuildResult.ResultsByTarget)
-                            {
-                                result.AddResultsForTarget(targetResult.Key, targetResult.Value);
-                            }
-
-                            _resultsCache.AddResult(result);
-                            submission.CompleteLogging(false);
-                            ReportResultsToSubmission(result);
-                        }
-                    }
-                    // This catch should always be the first one because when this method runs in a separate thread
-                    // and throws an exception there is nobody there to observe the exception.
-                    catch (Exception ex) when (thisMethodIsAsync)
-                    {
-                        HandleExecuteSubmissionException(submission, ex);
-                    }
-                    catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
-                    {
-                        HandleExecuteSubmissionException(submission, ex);
-                        throw;
-                    }
-                    void SubmitBuildRequest()
-                    {
-                        if (CheckForShutdown())
-                        {
-                            return;
-                        }
-
-                        _workQueue.Post(
-                            () =>
-                            {
-                                try
-                                {
-                                    IssueBuildSubmissionToScheduler(submission, allowMainThreadBuild);
-                                }
-                                catch (BuildAbortedException bae)
-                                {
-                                    // We were canceled before we got issued by the work queue.
-                                    var result = new BuildResult(submission.BuildRequest, bae);
-                                    submission.CompleteResults(result);
-                                    submission.CompleteLogging(true);
-                                    CheckSubmissionCompletenessAndRemove(submission);
-                                }
-                                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
-                                {
-                                    HandleExecuteSubmissionException(submission, ex);
-                                }
-                            });
+                        _buildParameters.ProjectRootElementCache = projectInstance.ProjectRootElementCache;
+                        _acquiredProjectRootElementCacheFromProjectInstance = true;
                     }
                 }
-            }
-
-            bool ProjectCacheIsPresent()
-            {
-                return _projectCacheService != null ||
-                       _buildParameters.ProjectCacheDescriptor != null ||
-                       (BuildEnvironmentHelper.Instance.RunningInVisualStudio && ProjectCacheItems.Count > 0);
-            }
-
-            bool CheckForShutdown()
-            {
-                if (!_shuttingDown)
+                else if (_buildParameters.ProjectRootElementCache == null)
                 {
-                    return false;
+                    // Create our own cache; if we subsequently get a build submission with a project instance attached,
+                    // we'll dump our cache and use that one.
+                    _buildParameters.ProjectRootElementCache =
+                        new ProjectRootElementCache(false /* do not automatically reload from disk */);
                 }
 
-                // We were already canceled!
-                var result = new BuildResult(submission.BuildRequest, new BuildAbortedException());
-                submission.CompleteResults(result);
-                submission.CompleteLogging(true);
-                CheckSubmissionCompletenessAndRemove(submission);
-
-                return true;
-            }
-
-            CacheResult QueryCache(BuildSubmission buildSubmission, BuildRequestConfiguration newConfiguration)
-            {
-                ProjectCacheService cacheService = null;
+                VerifyStateInternal(BuildManagerState.Building);
 
                 try
                 {
-                    cacheService = _projectCacheService.Result;
+                    // If we have an unnamed project, assign it a temporary name.
+                    if (string.IsNullOrEmpty(submission.BuildRequestData.ProjectFullPath))
+                    {
+                        ErrorUtilities.VerifyThrow(
+                            submission.BuildRequestData.ProjectInstance != null,
+                            "Unexpected null path for a submission with no ProjectInstance.");
+
+                        // If we have already named this instance when it was submitted previously during this build, use the same
+                        // name so that we get the same configuration (and thus don't cause it to rebuild.)
+                        if (!_unnamedProjectInstanceToNames.TryGetValue(submission.BuildRequestData.ProjectInstance, out var tempName))
+                        {
+                            tempName = "Unnamed_" + _nextUnnamedProjectId++;
+                            _unnamedProjectInstanceToNames[submission.BuildRequestData.ProjectInstance] = tempName;
+                        }
+
+                        submission.BuildRequestData.ProjectFullPath = Path.Combine(
+                            submission.BuildRequestData.ProjectInstance.GetProperty(ReservedPropertyNames.projectDirectory).EvaluatedValue,
+                            tempName);
+                    }
+
+                    // Create/Retrieve a configuration for each request
+                    var buildRequestConfiguration = new BuildRequestConfiguration(submission.BuildRequestData, _buildParameters.DefaultToolsVersion);
+                    var matchingConfiguration = _configCache.GetMatchingConfiguration(buildRequestConfiguration);
+                    var newConfiguration = ResolveConfiguration(
+                        buildRequestConfiguration,
+                        matchingConfiguration,
+                        submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.ReplaceExistingProjectInstance));
+
+                    newConfiguration.ExplicitlyLoaded = true;
+
+                    // Now create the build request
+                    submission.BuildRequest = new BuildRequest(
+                        submission.SubmissionId,
+                        BackEnd.BuildRequest.InvalidNodeRequestId,
+                        newConfiguration.ConfigurationId,
+                        submission.BuildRequestData.TargetNames,
+                        submission.BuildRequestData.HostServices,
+                        BuildEventContext.Invalid,
+                        null,
+                        submission.BuildRequestData.Flags,
+                        submission.BuildRequestData.RequestedProjectState);
+
+                    if (_shuttingDown)
+                    {
+                        // We were already canceled!
+                        BuildResult result = new BuildResult(submission.BuildRequest, new BuildAbortedException());
+                        submission.CompleteResults(result);
+                        submission.CompleteLogging(true);
+                        CheckSubmissionCompletenessAndRemove(submission);
+                        return;
+                    }
+
+                    // Submit the build request.
+                    _workQueue.Post(
+                        () =>
+                        {
+                            try
+                            {
+                                IssueBuildSubmissionToScheduler(submission, allowMainThreadBuild);
+                            }
+                            catch (BuildAbortedException bae)
+                            {
+                                // We were canceled before we got issued by the work queue.
+                                var result = new BuildResult(submission.BuildRequest, bae);
+                                submission.CompleteResults(result);
+                                submission.CompleteLogging(true);
+                                CheckSubmissionCompletenessAndRemove(submission);
+                            }
+                            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                            {
+                                HandleExecuteSubmissionException(submission, ex);
+                            }
+                        });
                 }
-                catch
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
                 {
-                    // Set to null so that EndBuild does not try to shut it down and thus rethrow the exception.
-                    Debug.Assert(Monitor.IsEntered(_syncLock));
-                    _projectCacheService = null;
+                    HandleExecuteSubmissionException(submission, ex);
                     throw;
                 }
-
-                // Project cache plugins require an evaluated project. Evaluate the submission if it's by path.
-                LoadSubmissionProjectIntoConfiguration(buildSubmission, newConfiguration);
-
-                var cacheResult = cacheService.GetCacheResultAsync(
-                        new BuildRequestData(
-                            newConfiguration.Project,
-                            buildSubmission.BuildRequestData.TargetNames.ToArray()))
-                    .GetAwaiter()
-                    .GetResult();
-
-                return cacheResult;
-            }
-
-            static BuildRequest CreateRealBuildRequest(BuildSubmission submission, int configurationId)
-            {
-                return new BuildRequest(
-                    submission.SubmissionId,
-                    BackEnd.BuildRequest.InvalidNodeRequestId,
-                    configurationId,
-                    submission.BuildRequestData.TargetNames,
-                    submission.BuildRequestData.HostServices,
-                    BuildEventContext.Invalid,
-                    null,
-                    submission.BuildRequestData.Flags,
-                    submission.BuildRequestData.RequestedProjectState);
-            }
-
-            static BuildRequest CreateProxyBuildRequest(
-                BuildSubmission submission,
-                int configurationId,
-                ProxyTargets proxyTargets)
-            {
-                return new BuildRequest(
-                    submission.SubmissionId,
-                    BackEnd.BuildRequest.InvalidNodeRequestId,
-                    configurationId,
-                    proxyTargets,
-                    submission.BuildRequestData.HostServices,
-                    submission.BuildRequestData.Flags,
-                    submission.BuildRequestData.RequestedProjectState);
             }
         }
 
@@ -1293,7 +1153,7 @@ namespace Microsoft.Build.Execution
                         "OnlyOneCachePluginMustBeSpecified",
                         string.Join("; ", ProjectCacheItems.Values.Select(c => c.PluginPath)));
                 }
-                
+
                 // Plugin needs the graph root (aka top BuildSubmission path, aka the solution path when in VS) which, under VS, is accessible
                 // only by evaluating the submission and retrieving the 'SolutionPath' property set by VS. This is also the reason why
                 // this method cannot be called from BeginBuild, because no build submissions are available there to extract the solution path from.

--- a/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.BackEnd;
@@ -46,6 +47,8 @@ namespace Microsoft.Build.Experimental.ProjectCache
     /// </summary>
     public class CacheResult
     {
+        public Exception Exception { get; }
+
         private CacheResult(
             CacheResultType resultType,
             BuildResult? buildResult = null,
@@ -61,6 +64,12 @@ namespace Microsoft.Build.Experimental.ProjectCache
             ResultType = resultType;
             BuildResult = buildResult;
             ProxyTargets = proxyTargets;
+        }
+
+        private CacheResult(Exception exception)
+        {
+            ResultType = CacheResultType.None;
+            Exception = exception;
         }
 
         public CacheResultType ResultType { get; }
@@ -88,6 +97,11 @@ namespace Microsoft.Build.Experimental.ProjectCache
         {
             ErrorUtilities.VerifyThrowInvalidOperation(resultType != CacheResultType.CacheHit, "CantBeCacheHit");
             return new CacheResult(resultType);
+        }
+
+        internal static CacheResult IndicateException(Exception e)
+        {
+            return new CacheResult(e);
         }
 
         private static BuildResult ConstructBuildResult(IReadOnlyCollection<PluginTargetResult> targetResults)

--- a/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
@@ -47,7 +47,10 @@ namespace Microsoft.Build.Experimental.ProjectCache
     /// </summary>
     public class CacheResult
     {
-        public Exception Exception { get; }
+        public CacheResultType ResultType { get; }
+        public BuildResult? BuildResult { get; }
+        public ProxyTargets? ProxyTargets { get; }
+        internal Exception? Exception { get; }
 
         private CacheResult(
             CacheResultType resultType,
@@ -71,10 +74,6 @@ namespace Microsoft.Build.Experimental.ProjectCache
             ResultType = CacheResultType.None;
             Exception = exception;
         }
-
-        public CacheResultType ResultType { get; }
-        public BuildResult? BuildResult { get; }
-        public ProxyTargets? ProxyTargets { get; }
 
         public static CacheResult IndicateCacheHit(BuildResult buildResult)
         {

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -8,15 +8,25 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
 using Microsoft.Build.FileSystem;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Graph;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Experimental.ProjectCache
 {
+    internal record CacheRequest(BuildSubmission Submission, BuildRequestConfiguration Configuration);
+
+    internal record VolatileNullableBool(bool Value)
+    {
+        public static implicit operator bool(VolatileNullableBool? d) => d is not null && d.Value;
+    }
+
     internal class ProjectCacheService
     {
         private readonly BuildManager _buildManager;
@@ -24,6 +34,13 @@ namespace Microsoft.Build.Experimental.ProjectCache
         private readonly ProjectCacheDescriptor _projectCacheDescriptor;
         private readonly CancellationToken _cancellationToken;
         private readonly ProjectCachePluginBase _projectCachePlugin;
+
+        // Volatile because one thread writes it, another reads it.
+        // The BuildManager thread reads this to cheaply back off when the cache is disabled.
+        // It is written to only once by a ThreadPool thread.
+        // null means no decision has been made yet. bool? cannot be marked volatile so use a class wrapper instead.
+        // TODO: remove after we change VS to set the cache descriptor via build parameters.
+        public volatile VolatileNullableBool? DesignTimeBuildsDetected;
 
         private ProjectCacheService(
             ProjectCachePluginBase projectCachePlugin,
@@ -49,9 +66,30 @@ namespace Microsoft.Build.Experimental.ProjectCache
             var plugin = await Task.Run(() => GetPluginInstance(pluginDescriptor), cancellationToken)
                 .ConfigureAwait(false);
 
-            // TODO: Detect and use the highest verbosity from all the user defined loggers. That's tricky because right now we can't discern between user set loggers and msbuild's internally added loggers.
+            // TODO: Detect and use the highest verbosity from all the user defined loggers. That's tricky because right now we can't query loggers about
+            // their verbosity levels.
             var loggerFactory = new Func<PluginLoggerBase>(() => new LoggingServiceToPluginLoggerAdapter(LoggerVerbosity.Normal, loggingService));
 
+            // TODO: remove after we change VS to set the cache descriptor via build parameters.
+            if (pluginDescriptor.VsWorkaround)
+            {
+                // When running under VS we can't initialize the plugin until we evaluate a project (any project) and extract
+                // further information (set by VS) from it required by the plugin.
+                return new ProjectCacheService(plugin, buildManager, loggerFactory, pluginDescriptor, cancellationToken);
+            }
+
+            await InitializePlugin(pluginDescriptor, cancellationToken, loggerFactory, plugin);
+
+            return new ProjectCacheService(plugin, buildManager, loggerFactory, pluginDescriptor, cancellationToken);
+        }
+
+        private static async Task InitializePlugin(
+            ProjectCacheDescriptor pluginDescriptor,
+            CancellationToken cancellationToken,
+            Func<PluginLoggerBase> loggerFactory,
+            ProjectCachePluginBase plugin
+        )
+        {
             var logger = loggerFactory();
 
             try
@@ -75,8 +113,6 @@ namespace Microsoft.Build.Experimental.ProjectCache
             {
                 ProjectCacheException.ThrowForErrorLoggedInsideTheProjectCache("ProjectCacheInitializationFailed");
             }
-
-            return new ProjectCacheService(plugin, buildManager, loggerFactory, pluginDescriptor, cancellationToken);
         }
 
         private static ProjectCachePluginBase GetPluginInstance(ProjectCacheDescriptor pluginDescriptor)
@@ -148,9 +184,112 @@ namespace Microsoft.Build.Experimental.ProjectCache
         private static readonly CoreClrAssemblyLoader _loader = new CoreClrAssemblyLoader();
 #endif
 
-        public async Task<CacheResult> GetCacheResultAsync(BuildRequestData buildRequest)
+        public void PostCacheRequest(CacheRequest cacheRequest)
         {
-            // TODO: Parent these logs under the project build event so they appear nested under the project in the binlog viewer.
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var cacheResult = await ProcessCacheRequest(cacheRequest);
+                    _buildManager.PostCacheResult(cacheRequest, cacheResult);
+                }
+                catch (Exception e)
+                {
+                    _buildManager.PostCacheResult(cacheRequest, CacheResult.IndicateException(e));
+                }
+            }, _cancellationToken);
+
+            async Task<CacheResult> ProcessCacheRequest(CacheRequest request)
+            {
+                EvaluateProjectIfNecessary(request);
+                if (DesignTimeBuildsDetected)
+                {
+                    throw new NotImplementedException();
+                    // The BuildManager should disable the cache after the first query that finds
+                    // a design time build.
+                    return CacheResult.IndicateNonCacheHit(CacheResultType.CacheNotApplicable);
+                }
+
+                if (_projectCacheDescriptor.VsWorkaround)
+                {
+                    // TODO: remove after we change VS to set the cache descriptor via build parameters.
+                    await LateInitializePluginForVsWorkaround(request);
+                }
+
+                return await GetCacheResultAsync(cacheRequest.Submission.BuildRequestData);
+            }
+
+            void EvaluateProjectIfNecessary(CacheRequest request)
+            {
+                // TODO: only do this if the project cache requests evaluation. QB needs evaluations, but the Anybuild implementation
+                // TODO: might not need them, so no point evaluating if it's not necessary. As a caveat, evaluations would still be optimal
+                // TODO: when proxy builds are issued by the plugin ( scheduled on the inproc node, no point re-evaluating on out-of-proc nodes).
+                lock (request.Configuration)
+                {
+                    if (!request.Configuration.IsLoaded)
+                    {
+                        request.Configuration.LoadProjectIntoConfiguration(
+                            _buildManager,
+                            request.Submission.BuildRequestData.Flags,
+                            request.Submission.SubmissionId,
+                            Scheduler.InProcNodeId
+                        );
+
+                        // If we're taking the time to evaluate, avoid having other nodes to repeat the same evaluation.
+                        // Based on the assumption that ProjectInstance serialization is faster than evaluating from scratch.
+                        request.Configuration.Project.TranslateEntireState = true;
+                    }
+                }
+
+                // Attribute is volatile and reference writes are atomic.
+                // Assume that if one request is a design time build, all of them are.
+                DesignTimeBuildsDetected ??= new VolatileNullableBool(IsDesignTimeBuild(request.Configuration.Project));
+            }
+
+            static bool IsDesignTimeBuild(ProjectInstance project)
+            {
+                var designTimeBuild = project.GetPropertyValue(DesignTimeProperties.DesignTimeBuild);
+                var buildingProject = project.GlobalPropertiesDictionary[DesignTimeProperties.BuildingProject]?.EvaluatedValue;
+
+                return MSBuildStringIsTrue(designTimeBuild) ||
+                       buildingProject != null && !MSBuildStringIsTrue(buildingProject);
+            }
+
+            async Task LateInitializePluginForVsWorkaround(CacheRequest request)
+            {
+                var (_, configuration) = request;
+                var solutionPath = configuration.Project.GetPropertyValue(SolutionProjectGenerator.SolutionPathPropertyName);
+
+                ErrorUtilities.VerifyThrow(
+                    solutionPath != null && !string.IsNullOrWhiteSpace(solutionPath) && solutionPath != "*Undefined*",
+                    $"Expected VS to set a valid SolutionPath property but got: {solutionPath}");
+
+                ErrorUtilities.VerifyThrow(
+                    FileSystems.Default.FileExists(solutionPath),
+                    $"Solution file does not exist: {solutionPath}");
+
+                await InitializePlugin(
+                    ProjectCacheDescriptor.FromAssemblyPath(
+                        _projectCacheDescriptor.PluginAssemblyPath,
+                        new[]
+                        {
+                            new ProjectGraphEntryPoint(
+                                solutionPath,
+                                configuration.Project.GlobalProperties)
+                        },
+                        projectGraph: null,
+                        _projectCacheDescriptor.PluginSettings),
+                    _cancellationToken,
+                    _loggerFactory,
+                    _projectCachePlugin);
+            }
+
+            static bool MSBuildStringIsTrue(string msbuildString) =>
+                ConversionUtilities.ConvertStringToBool(msbuildString, nullOrWhitespaceIsFalse: true);
+        }
+
+        private async Task<CacheResult> GetCacheResultAsync(BuildRequestData buildRequest)
+        {
             var queryDescription = $"{buildRequest.ProjectFullPath}" +
                                    $"\n\tTargets:[{string.Join(", ", buildRequest.TargetNames)}]" +
                                    $"\n\tGlobal Properties: {{{string.Join(",", buildRequest.GlobalProperties.Select(kvp => $"{kvp.Name}={kvp.EvaluatedValue}"))}}}";
@@ -176,7 +315,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 ProjectCacheException.ThrowForErrorLoggedInsideTheProjectCache("ProjectCacheQueryFailed", queryDescription);
             }
 
-            var message = $"Plugin result: {cacheResult.ResultType}.";
+            var message = $"------  Plugin result: {cacheResult.ResultType}.";
 
             switch (cacheResult.ResultType)
             {


### PR DESCRIPTION
Can review the commits individually.  Ignore whitespace helps.

### Context
The project cache was being queried serially. Oops.
This is because the monolithic BuildManager._syncLock was being held during the cache query, thus serializing all access.

### Changes Made
Implements the 2nd option from the design doc: https://gist.github.com/cdmihai/0955cb217b2cbd66e18c89b20bf68319#2-reuse-how-the-buildmanager-offloads-parallel-work-to-build-nodes

- Reverted code of ExecuteSubmission to what it was before project cache plugins.
- Changed ExecuteSubmission to either issue a cache request or a build request (until now it only issues build requests)
- The cache request is sent to the ProjectCacheService which submits it to the thread pool. This achieves parallelization of cache requests
- Each cache request, on its own thread:
  - evaluates the project if necessary
  - does the cache query
- When a cache request finishes in the ProjectCacheService it is posted back on the BuildManager work queue thread and is handled by either skipping the build or doing a real build.

Design time builds were a pain to get right this time. Previously design time builds were easy to deal with because the BuildManager detected them early enough. Now they get detected later in the project cache service. The build manager detects this and shuts the cache service off when design time builds are detected.

### Testing
Added a parallel stress test. This should be a good test to both ensure the cache is queried in parallel and to stress test the concurrency in the engine.

### Risk assessment
This should make the non project cache logic less risky than it was before, since I took the project cache logic out of BuildManager and moved it to the ProjectCacheService.