### PR TITLE
Stop MSBuildTaskHost importing Microsoft.VisualStudio.Setup.Configuration.Interop

### DIFF
--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -99,7 +99,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_DEBUGGER</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_WORKINGSET</DefineConstants>
-    <DefineConstants Condition="'$(MonoBuild)' != 'true' and '$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>
+    <DefineConstants Condition="'$(MonoBuild)' != 'true' and '$(MachineIndependentBuild)' != 'true' and '$(TargetFrameworkVersion)' != 'v3.5'">$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MSCOREE</DefineConstants>
   </PropertyGroup>
 

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -204,7 +204,6 @@
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <!-- Disabled PdbGit because of warnings; it could/should be brought back.
     <PackageReference Include="PdbGit" /> -->
     <PackageReference Include="SourceLink.Create.CommandLine" />


### PR DESCRIPTION
Fixes [AB#1329223](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1329223)

### Context
We're hitting issues with MSBuildTaskHost importing the Microsoft.VisualStudio.Setup.Configuration.Interop assembly, which is not being ngen'd properly. Turns out we don't need to import this package at all, so I've removed the packagereference along with un-defining constants when on net3.5 to prevent compilation errors.

### Testing
Tested a successful build with msbuildtaskhost.csproj

### Notes
Also don't define FEATURE_VISUALSTUDIOSETUP for MSBuildTaskHost.csproj[automated] Merge branch 'vs16.11' => 'main'
