### PR TITLE
UnGAC System.Memory 4.0.1.1

### DIFF
--- a/src/Package/Microsoft.Build.UnGAC/Program.cs
+++ b/src/Package/Microsoft.Build.UnGAC/Program.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Build.UnGAC
                     "Microsoft.Build.Framework, Version=15.1.0.0",
                     "Microsoft.Build.Tasks.Core, Version=15.1.0.0",
                     "Microsoft.Build.Utilities.Core, Version=15.1.0.0",
-                    "Microsoft.Build.Conversion.Core, Version=15.1.0.0"
+                    "Microsoft.Build.Conversion.Core, Version=15.1.0.0",
+                    "System.Memory, Version=4.0.1.1"
                 };
 
                 uint hresult = NativeMethods.CreateAssemblyCache(out IAssemblyCache assemblyCache, 0);


### PR DESCRIPTION
Fixes #5955 

I thought we had done something like this previously, but I don't see that we did. If this is bad, we can just close this.

### Context
System.Memory 4.5.3 and System.Memory 4.5.4 both correspond to 4-part version 4.0.1.1, which is problematic when it comes to the GAC that receives a request for System.Memory 4.0.1.1 and may return the wrong one. These two versions have different dependencies as well, which can result in FileNotFoundExceptions. This may affect non-MSBuild applications, so it may be a bad idea, but it may also resolve issues like https://dev.azure.com/devdiv/DevDiv/_queries/edit/1250432/?triage=true that refer to missing files.