### PR TITLE
Add github action to start closing stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,10 +12,7 @@ jobs:
           stale-issue-message: |
             This issue is marked as stale due to requiring feedback for 30 days. Please respond within 5 days or this issue will be closed due to inactivity.
           close-issue-message: |
-            This issue was closed due to inactivity. If you can still reproduce this bug, please comment with the following information:
-            1. Full output of running `msbuild --version` and `dotnet --version` (if applicable) on a developer command prompt.
-            2. Steps to reproduce your scenario.
-            3. Any other notes that might help in the investigation.
+            This issue was closed due to inactivity. If you can still reproduce this bug, please comment with the requested information, detailed steps to reproduce the problem, or any other notes that might help in the investigation.
           days-before-stale: 30
           days-before-close: 14
           stale-issue-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,12 +10,15 @@ jobs:
       - uses: actions/stale@v3
         with:
           stale-issue-message: |
-            This issue is marked as stale because author feedback has been requested for 30 days with no response. Please respond within 14 days or this issue will be closed due to inactivity.
+            This issue is marked as stale because feedback has been requested for 30 days with no response. Please respond within 14 days or this issue will be closed due to inactivity.
           close-issue-message: |
             This issue was closed due to inactivity. If you can still reproduce this bug, please comment with the requested information, detailed steps to reproduce the problem, or any other notes that might help in the investigation.
           start-date: '2021-01-06T00:00:00Z'
           days-before-stale: 30
           days-before-close: 14
           stale-issue-label: stale
-          any-of-labels: 'Needs: Author Feedback'
-          exempt-milestones: 'Backlog'
+          any-of-labels: 'needs-more-info'
+          exempt-milestones: 'Backlog,Discussion'
+          exempt-issue-labels: 'bot-exclude,needs-triage'
+          labels-to-remove-when-unstale: 'needs-more-info'
+          labels-to-add-when-unstale: 'needs-attention'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '00 19 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: |
+            This issue is marked as stale due to requiring feedback for 30 days. Please respond within 5 days or this issue will be closed due to inactivity.
+          close-issue-message: |
+            This issue was closed due to inactivity. If you can still reproduce this bug, please comment with the following information:
+            1. Full output of running `msbuild --version` and `dotnet --version` (if applicable) on a developer command prompt.
+            2. Steps to reproduce your scenario.
+            3. Any other notes that might help in the investigation.
+          days-before-stale: 30
+          days-before-close: 14
+          stale-issue-label: stale
+          any-of-labels: 'Needs: Author Feedback'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,9 @@ jobs:
             This issue is marked as stale because author feedback has been requested for 30 days with no response. Please respond within 14 days or this issue will be closed due to inactivity.
           close-issue-message: |
             This issue was closed due to inactivity. If you can still reproduce this bug, please comment with the requested information, detailed steps to reproduce the problem, or any other notes that might help in the investigation.
+          start-date: '2021-01-06T00:00:00Z'
           days-before-stale: 30
           days-before-close: 14
           stale-issue-label: stale
           any-of-labels: 'Needs: Author Feedback'
+          exempt-milestones: 'Backlog'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v3
         with:
           stale-issue-message: |
-            This issue is marked as stale due to requiring feedback for 30 days. Please respond within 5 days or this issue will be closed due to inactivity.
+            This issue is marked as stale because author feedback has been requested for 30 days with no response. Please respond within 14 days or this issue will be closed due to inactivity.
           close-issue-message: |
             This issue was closed due to inactivity. If you can still reproduce this bug, please comment with the requested information, detailed steps to reproduce the problem, or any other notes that might help in the investigation.
           days-before-stale: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
             This issue is marked as stale because feedback has been requested for 30 days with no response. Please respond within 14 days or this issue will be closed due to inactivity.
           close-issue-message: |
             This issue was closed due to inactivity. If you can still reproduce this bug, please comment with the requested information, detailed steps to reproduce the problem, or any other notes that might help in the investigation.
-          start-date: '2021-01-06T00:00:00Z'
+          start-date: '2021-06-01'
           days-before-stale: 1
           days-before-close: 1
           stale-issue-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,11 +14,11 @@ jobs:
           close-issue-message: |
             This issue was closed due to inactivity. If you can still reproduce this bug, please comment with the requested information, detailed steps to reproduce the problem, or any other notes that might help in the investigation.
           start-date: '2021-01-06T00:00:00Z'
-          days-before-stale: 30
-          days-before-close: 14
+          days-before-stale: 1
+          days-before-close: 1
           stale-issue-label: stale
-          any-of-labels: 'needs-more-info'
+          any-of-labels: 'bot-test'
           exempt-milestones: 'Backlog,Discussion'
           exempt-issue-labels: 'bot-exclude,needs-triage'
-          labels-to-remove-when-unstale: 'needs-more-info'
+          labels-to-remove-when-unstale: 'bot-test'
           labels-to-add-when-unstale: 'needs-attention'


### PR DESCRIPTION
Part 1/x to fix https://github.com/dotnet/msbuild/issues/6472

Let's reduce the energy required to keep up with some of the issues we get in this repo.

### Context
We should be strict when it comes to cutting out issues that don't get responses from customers. This change closes out issues after ~1.5 months of inactivity that require the author of an issue to respond.

### Changes Made
Created a github action to:
1. Mark issues stale after 30 days of inactivity
2. Close them two weeks after they've been marked stale
3. To start, **this will only affect issues marked as "Needs: Author Feedback"**

### For the dev team
When you respond to github issues and need authors to respond, please apply "Needs: Author Feedback". We can figure out how to scale this over time, but starting with a small subset of issues is the right move.

To avoid a situation where customers are forced to ["bump" their issues](https://github.com/actions/stale/issues/288), remove "Needs: Author Feedback" from the issue.