### PR TITLE
Use new variable for the AL tool path

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3772,7 +3772,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Title="$(Satellite_Title)"
         ToolPath="$(AlToolPath)"
         ToolExe ="$(AlToolExe)"
-        SdkToolsPath="$(SdkToolsPathMaybeWithx64Architecture)"
+        SdkToolsPath="$(_ALExeToolPath)"
         Trademark="$(Satellite_Trademark)"
         Version="$(Satellite_Version)"
         Win32Icon="$(Satellite_Win32Icon)"


### PR DESCRIPTION
Fixes # https://github.com/dotnet/msbuild/issues/5981

### Summary
MSBuild didn't support customers using the x64 AL.exe tool by default when their projects targeted x64. https://github.com/dotnet/msbuild/pull/6207 implemented a fix to include `x64` in the path when relevant, but [this commit](https://github.com/dotnet/msbuild/pull/6207/commits/ca5012a3532a86cb9cfe841d431453cb3b0db250) mistakenly forgot to update one property name which results in an empty parameter being passed. This results in the x86 version of AL.exe being the default choice.

This fix changes the name of the property to the correct one that is set just before AL is called.

### Customer Impact
Customer's that want to compile .resx files using 64-bit AL.exe require a workaround to do so. This change will allow this workaround to become default behavior.

### Testing
Customer did a manual fix [here](https://github.com/dotnet/msbuild/issues/5981#issuecomment-848309143) that manually set  `SdkToolsPathMaybeWithx64Architecture` to the value that `_ALExeToolPath` would be and their build succeeded.

### Risk
Low. The previous value is preserved when not on x64, and only appends the platform to the path to AL.exe when targeting x64.

### Code Reviewers


### Description of fix
Rename property passed into AL from `SdkToolsPathMaybeWithx64Architecture` to `_ALExeToolPath`, which is set a few lines above the AL call.

--------

### Context
https://github.com/dotnet/msbuild/pull/6207 introduced logic to fix the above issue. Unfortunately we need to update one location (the one that matters) to use that newly created variable. I missed this during the refactor in [this commit](https://github.com/dotnet/msbuild/pull/6207/commits/ca5012a3532a86cb9cfe841d431453cb3b0db250)

### Changes Made
Update the variable used for SdkToolsPath when calling AL.

### Testing
See the linked issue. The customer passing `/p:SdkToolsPathMaybeWithx64Architecture="C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\"` (the value that _ALExeToolPath has) fixed their issue.

### Notes
_ALExeToolPath is defined just above the AL call that this PR modifies, if you're wondering where it came from.