### PR TITLE
Add [Serializable] to PortableLibraryFiles and other similar classes

### DIFF
--- a/src/Tasks/AssemblyRegistrationCache.cs
+++ b/src/Tasks/AssemblyRegistrationCache.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Build.Tasks
     /// <remarks>
     /// This class is a caching mechanism for the Register/UnregisterAssembly task to keep track of registered assemblies to clean up
     /// </remarks>
+    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
     [Serializable]
     internal sealed class AssemblyRegistrationCache : StateFileBase, ITranslatable
     {

--- a/src/Tasks/AssemblyRegistrationCache.cs
+++ b/src/Tasks/AssemblyRegistrationCache.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Shared;
@@ -10,6 +11,7 @@ namespace Microsoft.Build.Tasks
     /// <remarks>
     /// This class is a caching mechanism for the Register/UnregisterAssembly task to keep track of registered assemblies to clean up
     /// </remarks>
+    [Serializable]
     internal sealed class AssemblyRegistrationCache : StateFileBase, ITranslatable
     {
         /// <summary>

--- a/src/Tasks/DependencyFile.cs
+++ b/src/Tasks/DependencyFile.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Build.Tasks
     /// Represents a single input to a compilation-style task.
     /// Keeps track of timestamp for later comparison.
     /// </remarks>
+    [Serializable]
     internal class DependencyFile
     {
         // Filename

--- a/src/Tasks/DependencyFile.cs
+++ b/src/Tasks/DependencyFile.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Build.Tasks
     /// Represents a single input to a compilation-style task.
     /// Keeps track of timestamp for later comparison.
     /// </remarks>
+    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
     [Serializable]
     internal class DependencyFile
     {

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -317,6 +317,7 @@ namespace Microsoft.Build.Tasks
         /// 
         /// This is an on-disk serialization format, don't change field names or types or use readonly.
         /// </remarks>
+        [Serializable]
         internal sealed class PortableLibraryFile : DependencyFile, ITranslatable
         {
             internal string[] outputFiles;

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Build.Tasks
     /// 
     /// This is an on-disk serialization format, don't change field names or types or use readonly.
     /// </remarks>
+    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
     [Serializable]
     internal sealed class ResGenDependencies : StateFileBase, ITranslatable
     {
@@ -214,6 +215,7 @@ namespace Microsoft.Build.Tasks
         /// 
         /// This is an on-disk serialization format, don't change field names or types or use readonly.
         /// </remarks>
+        /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
         [Serializable]
         internal sealed class ResXFile : DependencyFile, ITranslatable
         {
@@ -319,6 +321,7 @@ namespace Microsoft.Build.Tasks
         /// 
         /// This is an on-disk serialization format, don't change field names or types or use readonly.
         /// </remarks>
+        /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
         [Serializable]
         internal sealed class PortableLibraryFile : DependencyFile, ITranslatable
         {

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Build.Tasks
     /// 
     /// This is an on-disk serialization format, don't change field names or types or use readonly.
     /// </remarks>
+    [Serializable]
     internal sealed class ResGenDependencies : StateFileBase, ITranslatable
     {
         /// <summary>
@@ -213,6 +214,7 @@ namespace Microsoft.Build.Tasks
         /// 
         /// This is an on-disk serialization format, don't change field names or types or use readonly.
         /// </remarks>
+        [Serializable]
         internal sealed class ResXFile : DependencyFile, ITranslatable
         {
             // Files contained within this resx file.

--- a/src/Tasks/ResolveComReferenceCache.cs
+++ b/src/Tasks/ResolveComReferenceCache.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Build.Tasks
     /// 
     /// This is an on-disk serialization format, don't change field names or types or use readonly.
     /// </remarks>
+    [Serializable]
     internal sealed class ResolveComReferenceCache : StateFileBase, ITranslatable
     {
         /// <summary>

--- a/src/Tasks/ResolveComReferenceCache.cs
+++ b/src/Tasks/ResolveComReferenceCache.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Build.Tasks
     /// 
     /// This is an on-disk serialization format, don't change field names or types or use readonly.
     /// </remarks>
+    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
     [Serializable]
     internal sealed class ResolveComReferenceCache : StateFileBase, ITranslatable
     {

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Build.Tasks
     /// <remarks>
     /// Base class for task state files.
     /// </remarks>
+    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
     [Serializable]
     internal abstract class StateFileBase
     {

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Build.Tasks
     /// <remarks>
     /// Base class for task state files.
     /// </remarks>
+    [Serializable]
     internal abstract class StateFileBase
     {
         // Current version for serialization. This should be changed when breaking changes

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Class is used to cache system state.
     /// </summary>
+    [Serializable]
     internal sealed class SystemState : StateFileBase, ITranslatable
     {
         /// <summary>
@@ -102,6 +103,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Class that holds the current file state.
         /// </summary>
+        [Serializable]
         internal sealed class FileState : ITranslatable
         {
             /// <summary>

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Class is used to cache system state.
     /// </summary>
+    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
     [Serializable]
     internal sealed class SystemState : StateFileBase, ITranslatable
     {


### PR DESCRIPTION
This broke an internal test (see https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/326484).

I tested reverting the PR that removed the [Serializable] attributes as well as just adding them back in parallel. Both PRs worked:
https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/327003
https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/327004

So I would suggest just taking the smaller change to unblock master without creating unnecessary future changes.

/cc: @rainersigwald @BenVillalobos 