### PR TITLE
Add common properties to XSD

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1724,6 +1724,7 @@ elementFormDefault="qualified">
         <xs:documentation><!-- _locID_text="PreserveCompilationContext" _locComment="" -->Value indicating whether reference assemblies can be used in dynamic compilation</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="ProduceReferenceAssemblies" type="msb:boolean" substitutionGroup="msb:Property" />
     <xs:element name="ProductName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="ProductVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="ProjectGuid" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
@@ -1868,6 +1869,8 @@ elementFormDefault="qualified">
     <xs:element name="UseApplicationTrust" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="UseOfMfc" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="UseOfAtl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="UseWindowsForms" type="msb:boolean" substitutionGroup="msb:Property" />
+    <xs:element name="UseWPF" type="msb:boolean" substitutionGroup="msb:Property" />
     <xs:element name="UseVSHostingProcess" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="UTF8OutPut" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="VCTargetsPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>


### PR DESCRIPTION
Adding these allows them to be provided in Visual Studio's completion.

- ProduceReferenceAssemblies
- UseWindowsForms
- UseWPF
