### PR TITLE
Move RichCodeNav to its own job

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -103,12 +103,6 @@ jobs:
     inputs:
       filename: 'eng/cibuild.cmd'
       arguments: '-configuration Release -test'
-  - task: RichCodeNavIndexer@0
-    displayName: RichCodeNav Upload
-    inputs:
-      languages: 'csharp'
-    continueOnError: true
-    condition: succeeded()
   - task: PublishTestResults@2
     displayName: Publish .NET Framework Test Results
     inputs:
@@ -143,6 +137,22 @@ jobs:
       ArtifactName: 'FullOnWindows Release test logs'
     continueOnError: true
     condition: always()
+
+- job: RichCodeNavIndex
+  displayName: "Windows Code Indexing"
+  pool:
+    vmImage: 'windows-latest'
+  steps:
+  - task: BatchScript@1
+    displayName: build.cmd
+    inputs:
+      filename: 'build.cmd'
+  - task: RichCodeNavIndexer@0
+    displayName: RichCodeNav Upload
+    inputs:
+      languages: 'csharp'
+    continueOnError: true
+    condition: succeeded()
 
 - job: CoreBootstrappedOnLinux
   displayName: "Linux Core"


### PR DESCRIPTION
It's taking longer than we initially hoped so moving it to get it off the critical path.
