### PR TITLE
Add SourceBuildManagedOnly to SourceBuild.props

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <GitHubRepositoryName>msbuild</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
 
   <Target Name="ConfigureInnerBuildArgs" BeforeTargets="GetSourceBuildCommandConfiguration">


### PR DESCRIPTION
Fixes dotnet/source-build#2068

### Context
This was something I discovered while trying to consume the Source-Build intermediate package produced by the first ArPow changes made in #6387

### Changes Made

Set the `SourceBuildManagedOnly` property correctly.

### How Tested

Verified the resulting `Microsoft.SourceBuild.Intermediate.msbuild` package is not named rid specific.
