### PR TITLE
Enable SignFile on .NET Core/5+

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -875,6 +875,18 @@ namespace Microsoft.Build.Tasks
         public override bool Execute() { throw null; }
         protected override string GenerateFullPathToTool() { throw null; }
     }
+    public sealed partial class SignFile : Microsoft.Build.Utilities.Task
+    {
+        public SignFile() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string CertificateThumbprint { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem SigningTarget { get { throw null; } set { } }
+        public string TargetFrameworkIdentifier { get { throw null; } set { } }
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+        public string TimestampUrl { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
     public abstract partial class TaskExtension : Microsoft.Build.Utilities.Task
     {
         internal TaskExtension() { }

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -521,6 +521,9 @@
     <Compile Include="SGen.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="SignFile.cs" Condition="'$(MonoBuild)' != 'true'">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="System.Design.cs" />
     <Compile Include="system.design\stronglytypedresourcebuilder.cs" />
     <Compile Include="TaskExtension.cs">
@@ -644,9 +647,6 @@
     <Compile Include="ResolveSDKReference.cs" />
     <Compile Include="SdkToolsPathUtility.cs" />
     <Compile Include="RequiresFramework35SP1Assembly.cs" Condition="'$(MonoBuild)' != 'true'">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="SignFile.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="StrongNameException.cs">


### PR DESCRIPTION
Fixes #6098

### Context

The `SignFile` task is referenced by the SDK for both .NET Framework and Core/5+, but not actually included in the non-framework assemblies.

### Changes Made

Include `SignFile.cs` in the non-framework compilation.

### Testing

A simple test, applying `SignFile` to one of the DLLs in artifacts using a self-signed certificate, succeeded.