### PR TITLE
Do not expect PDB files for a refonly build

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -179,6 +179,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DebugSymbolsProduced Condition="'$(DebugType)'=='full'">true</_DebugSymbolsProduced>
     <_DebugSymbolsProduced Condition="'$(DebugType)'=='portable'">true</_DebugSymbolsProduced>
     <_DebugSymbolsProduced Condition="'$(DebugType)'=='embedded'">false</_DebugSymbolsProduced>
+    <_DebugSymbolsProduced Condition="'$(ProduceOnlyReferenceAssembly)'=='true'">false</_DebugSymbolsProduced>
 
     <!-- Whether or not a .xml file is produced. -->
     <_DocumentationFileProduced>true</_DocumentationFileProduced>


### PR DESCRIPTION
Fixes #6510

### Context

MSBuild currently incorrectly expects PDB files to be produced by a refonly compile.

### Changes Made

This defaults both `ProduceReferenceAssembly` and `ProduceOnlyReferenceAssembly` (slightly earlier than before).

When `ProduceOnlyReferenceAssembly` is set to `true`, don't expect symbols to be produced.
