### PR TITLE
Ignore the order of the items when computing the hash inside the _GenerateCompileDependencyCache target.

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -745,6 +745,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public string HashResult { get { throw null; } set { } }
         public bool IgnoreCase { get { throw null; } set { } }
+        public bool IgnoreOrder { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ItemsToHash { get { throw null; } set { } }
         public override bool Execute() { throw null; }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -577,6 +577,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public string HashResult { get { throw null; } set { } }
         public bool IgnoreCase { get { throw null; } set { } }
+        public bool IgnoreOrder { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ItemsToHash { get { throw null; } set { } }
         public override bool Execute() { throw null; }

--- a/src/Tasks.UnitTests/Hash_Tests.cs
+++ b/src/Tasks.UnitTests/Hash_Tests.cs
@@ -44,6 +44,113 @@ namespace Microsoft.Build.Tasks.UnitTests
         }
 
         [Fact]
+        public void HashTaskIgnoreOrderTest()
+        {
+            var variant1 =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("item1"),
+                        new TaskItem("item2"),
+                        new TaskItem("item3")
+                    },
+                    ignoreOrder: true);
+            var variant2 =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("item2"),
+                        new TaskItem("item1"),
+                        new TaskItem("item3")
+                    },
+                    ignoreOrder: true);
+            var variant3 =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("item1"),
+                        new TaskItem("item3"),
+                        new TaskItem("item2")
+                    },
+                    ignoreOrder: true);
+            Assert.Equal(variant1, variant3);
+            Assert.Equal(variant1, variant2);
+            Assert.Equal(variant2, variant3);
+        }
+
+        [Fact]
+        public void HashTaskIgnoreOrderNegativeTest()
+        {
+            var variant1 =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("item1"),
+                        new TaskItem("item2"),
+                        new TaskItem("item3")
+                    });
+            var variant2 =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("item2"),
+                        new TaskItem("item1"),
+                        new TaskItem("item3")
+                    });
+            Assert.NotEqual(variant1, variant2);
+        }
+
+        [Fact]
+        public void HashTaskIgnoreCaseNegativeTest()
+        {
+            var uppercaseHash =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("ITEM1"),
+                        new TaskItem("ITEM2"),
+                        new TaskItem("ITEM3")
+                    });
+            var mixedcaseHash =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("Item1"),
+                        new TaskItem("iTEm2"),
+                        new TaskItem("iteM3")
+                    });
+            Assert.NotEqual(uppercaseHash, mixedcaseHash);
+        }
+
+        [Fact]
+        public void HashTaskIgnoreOrderIgnoreCaseTest()
+        {
+            var variant1 =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("ITEM1"),
+                        new TaskItem("ITEM2"),
+                        new TaskItem("ITEM3")
+                    },
+                    ignoreCase: true,
+                    ignoreOrder: true);
+            var variant2 =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("iTEm2"),
+                        new TaskItem("Item1"),
+                        new TaskItem("iteM3")
+                    },
+                    ignoreCase: true,
+                    ignoreOrder: true);
+            var variant3 =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("item1"),
+                        new TaskItem("item3"),
+                        new TaskItem("item2")
+                    },
+                    ignoreCase: true,
+                    ignoreOrder: true);
+            Assert.Equal(variant1, variant3);
+            Assert.Equal(variant1, variant2);
+            Assert.Equal(variant2, variant3);
+        }
+
+        [Fact]
         public void HashTaskIgnoreCaseTest()
         {
             var uppercaseHash =
@@ -53,7 +160,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                         new TaskItem("ITEM2"),
                         new TaskItem("ITEM3")
                     },
-                    true);
+                    ignoreCase: true);
             var mixedcaseHash =
                 ExecuteHashTask(new ITaskItem[]
                     {
@@ -61,7 +168,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                         new TaskItem("iTEm2"),
                         new TaskItem("iteM3")
                     },
-                    true);
+                    ignoreCase: true);
             var lowercaseHash =
                 ExecuteHashTask(new ITaskItem[]
                     {
@@ -69,19 +176,20 @@ namespace Microsoft.Build.Tasks.UnitTests
                         new TaskItem("item2"),
                         new TaskItem("item3")
                     },
-                    true);
+                    ignoreCase: true);
             Assert.Equal(uppercaseHash, lowercaseHash);
             Assert.Equal(uppercaseHash, mixedcaseHash);
             Assert.Equal(mixedcaseHash, lowercaseHash);
         }
 
-        private string ExecuteHashTask(ITaskItem[] items, bool ignoreCase = false)
+        private string ExecuteHashTask(ITaskItem[] items, bool ignoreCase = false, bool ignoreOrder = false)
         {
             var hashTask = new Hash
             {
                 BuildEngine = new MockEngine(),
                 ItemsToHash = items,
-                IgnoreCase = ignoreCase
+                IgnoreCase = ignoreCase,
+                IgnoreOrder = ignoreOrder
             };
 
             Assert.True(hashTask.Execute());

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Build.Framework;
@@ -32,6 +34,14 @@ namespace Microsoft.Build.Tasks
         public bool IgnoreCase { get; set; }
 
         /// <summary>
+        /// When true, will generate a hash that does not depend on the order of the items.
+        /// </summary>
+        /// <remarks>
+        /// When true, the items are sorted first using their Identity
+        /// </remarks>
+        public bool IgnoreOrder { get; set; }
+
+        /// <summary>
         /// Hash of the ItemsToHash ItemSpec.
         /// </summary>
         [Output]
@@ -52,7 +62,12 @@ namespace Microsoft.Build.Tasks
 
                     using (var stringBuilder = new ReuseableStringBuilder(Math.Max(concatenatedItemStringSize, hashStringSize)))
                     {
-                        foreach (var item in ItemsToHash)
+                        IEnumerable<ITaskItem> items = ItemsToHash;
+                        if (IgnoreOrder)
+                        {
+                            items = items.OrderBy(o => o.ItemSpec, IgnoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+                        }
+                        foreach (var item in items)
                         {
                             string itemSpec = item.ItemSpec;
                             stringBuilder.Append(IgnoreCase ? itemSpec.ToUpperInvariant() : itemSpec);

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3537,6 +3537,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <Hash
       ItemsToHash="@(CoreCompileCache)"
+      IgnoreOrder="$([MSBuild]::ValueOrDefault(`$(CoreCompileCacheIgnoreOrder)`, `false`))"
       IgnoreCase="$([MSBuild]::ValueOrDefault(`$(CoreCompileCacheIgnoreCase)`, `true`))">
       <Output TaskParameter="HashResult" PropertyName="CoreCompileDependencyHash" />
     </Hash>


### PR DESCRIPTION
Fixes #6401 
