### PR TITLE
Minor perf fixes for LazyItemEvaluator

### DIFF
--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.Evaluation
         /// where metadata key is like "itemname.metadataname" or "metadataname".
         /// PERF: Tables are null if there are no entries, because this is quite a common case.
         /// </summary>
-        internal static ItemsAndMetadataPair GetReferencedItemNamesAndMetadata(List<string> expressions)
+        internal static ItemsAndMetadataPair GetReferencedItemNamesAndMetadata(IEnumerable<string> expressions)
         {
             ItemsAndMetadataPair pair = new ItemsAndMetadataPair(null, null);
 

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -230,7 +230,6 @@ namespace Microsoft.Build.Evaluation
                         // End of legal area for metadata expressions.
                         _expander.Metadata = null;
                     }
-
                     // End of pseudo batching
                     ////////////////////////////////////////////////////
                     // Start of old code
@@ -283,17 +282,18 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            protected bool NeedToExpandMetadataForEachItem(ImmutableList<ProjectMetadataElement> metadata, out ItemsAndMetadataPair itemsAndMetadataFound)
+            private static IEnumerable<string> GetMetadataValuesAndConditions(ImmutableList<ProjectMetadataElement> metadata)
             {
-                List<string> values = new List<string>(metadata.Count * 2);
-
                 foreach (var metadataElement in metadata)
                 {
-                    values.Add(metadataElement.Value);
-                    values.Add(metadataElement.Condition);
+                    yield return metadataElement.Value;
+                    yield return metadataElement.Condition;
                 }
+            }
 
-                itemsAndMetadataFound = ExpressionShredder.GetReferencedItemNamesAndMetadata(values);
+            protected bool NeedToExpandMetadataForEachItem(ImmutableList<ProjectMetadataElement> metadata, out ItemsAndMetadataPair itemsAndMetadataFound)
+            {
+                itemsAndMetadataFound = ExpressionShredder.GetReferencedItemNamesAndMetadata(GetMetadataValuesAndConditions(metadata));
 
                 bool needToExpandMetadataForEachItem = false;
 


### PR DESCRIPTION
Fixes #6062

### Context
Minor fixes for the LazyItemEvaluator: unnecessary memory allocations were removed.

### Testing
Manual testing.