### PR TITLE
Fix *.* wildcard glob matching regression

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1574,8 +1574,8 @@ namespace Microsoft.Build.Graph
         public virtual bool Equals(Microsoft.Build.Graph.GraphBuildOptions other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
-        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
+        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
+        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
         protected virtual bool PrintMembers(System.Text.StringBuilder builder) { throw null; }
         public override string ToString() { throw null; }
         public virtual Microsoft.Build.Graph.GraphBuildOptions <Clone>$() { throw null; }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1568,8 +1568,8 @@ namespace Microsoft.Build.Graph
         public virtual bool Equals(Microsoft.Build.Graph.GraphBuildOptions other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
-        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
+        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
+        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
         protected virtual bool PrintMembers(System.Text.StringBuilder builder) { throw null; }
         public override string ToString() { throw null; }
         public virtual Microsoft.Build.Graph.GraphBuildOptions <Clone>$() { throw null; }

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Build.Shared
                                     "*",
                                     directory,
                                     false));
-                        IEnumerable<string> filteredEntriesForPath = (pattern != null && pattern != "*" && pattern != "*.*")
+                        IEnumerable<string> filteredEntriesForPath = (pattern != null && !IsAllFilesWildcard(pattern))
                             ? allEntriesForPath.Where(o => IsMatch(Path.GetFileName(o), pattern))
                             : allEntriesForPath;
                         return stripProjectDirectory
@@ -886,7 +886,7 @@ namespace Microsoft.Build.Shared
                         //  The wildcard path portion of the excluded search matches the include search
                         searchToExclude.RemainingWildcardDirectory == recursionState.RemainingWildcardDirectory &&
                         //  The exclude search will match ALL filenames OR
-                        (searchToExclude.SearchData.Filespec == "*" || searchToExclude.SearchData.Filespec == "*.*" ||
+                        (IsAllFilesWildcard(searchToExclude.SearchData.Filespec) ||
                             //  The exclude search filename pattern matches the include search's pattern
                             searchToExclude.SearchData.Filespec == recursionState.SearchData.Filespec))
                     {
@@ -1091,7 +1091,11 @@ namespace Microsoft.Build.Shared
 
         private static bool MatchFileRecursionStep(RecursionState recursionState, string file)
         {
-            if (recursionState.SearchData.Filespec != null)
+            if (IsAllFilesWildcard(recursionState.SearchData.Filespec))
+            {
+                return true;
+            }
+            else if (recursionState.SearchData.Filespec != null)
             {
                 return IsMatch(Path.GetFileName(file), recursionState.SearchData.Filespec);
             }
@@ -2563,6 +2567,17 @@ namespace Microsoft.Build.Shared
             int index = directoryPath.LastIndexOfAny(FileUtilities.Slashes);
             return (index != -1 && IsMatch(directoryPath.Substring(index + 1), pattern));
         }
+
+        /// <summary>
+        /// Returns true if <paramref name="pattern"/> is <code>*</code> or <code>*.*</code>.
+        /// </summary>
+        /// <param name="pattern">The filename pattern to check.</param>
+        private static bool IsAllFilesWildcard(string pattern) => pattern?.Length switch
+        {
+            1 => pattern[0] == '*',
+            3 => pattern[0] == '*' && pattern[1] == '.' && pattern[2] == '*',
+            _ => false
+        };
 
         internal static bool IsRecursiveDirectoryMatch(string path) => path.TrimTrailingSlashes() == recursiveDirectoryMatch;
     }

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -154,6 +154,7 @@ namespace Microsoft.Build.UnitTests
                 @"src\bar.cs",
                 @"src\baz.cs",
                 @"src\foo\foo.cs",
+                @"src\foo\licence",
                 @"src\bar\bar.cs",
                 @"src\baz\baz.cs",
                 @"src\foo\inner\foo.cs",
@@ -368,7 +369,8 @@ namespace Microsoft.Build.UnitTests
                         ExpectedMatches = new[]
                         {
                             @"readme.txt",
-                            @"licence"
+                            @"licence",
+                            @"src\foo\licence",
                         }
                     }
                 };
@@ -417,6 +419,30 @@ namespace Microsoft.Build.UnitTests
                         ExpectedMatches = new[]
                         {
                             @"subdirectory\subdirectory.cs",
+                        },
+                        ExpectNoMatches = NativeMethodsShared.IsLinux,
+                    }
+                };
+
+                // Regression test for https://github.com/Microsoft/msbuild/issues/6502
+                yield return new object[]
+                {
+                    new GetFilesComplexGlobbingMatchingInfo
+                    {
+                        Include = @"src\**",
+                        Excludes = new[]
+                        {
+                            @"**\foo\**",
+                        },
+                        ExpectedMatches = new[]
+                        {
+                            @"src\foo.cs",
+                            @"src\bar.cs",
+                            @"src\baz.cs",
+                            @"src\bar\bar.cs",
+                            @"src\baz\baz.cs",
+                            @"src\bar\inner\baz.cs",
+                            @"src\bar\inner\baz\baz.cs",
                         },
                         ExpectNoMatches = NativeMethodsShared.IsLinux,
                     }


### PR DESCRIPTION
Fixes #6502

### Summary

This change fixes a regression in glob matching where files without extension are erroneously not matched when taking a specific globbing code path.

### Customer impact

Any customer who uses a glob pattern susceptible to the bug and has files without extensions in their source tree is affected. The bug was reported by external customers.

### Regression?

Yes, caused by #6151 where glob matching was optimized which internally made it take a different code path.

### Changes Made

Fixes the regression by properly handling `*.*` to mean all files, not just files with a dot in the name. This convention is used in .NET APIs on all platforms and matches the pre-regression behavior.

### Testing

Added unit test coverage. Also verified locally with the repro provided by the original bug reporter.

### Risk

Low. The star patterns are special-cased to mean all files, other patterns are unaffected.