### PR TITLE
Normalize RAR output paths

### DIFF
--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -516,6 +516,8 @@ namespace Microsoft.Build.Tasks
         internal void NormalizeFullPath()
         {
             _fullPath = FileUtilities.NormalizePath(_fullPath);
+            _fullPathWithoutExtension = null;
+            _directoryName = null;
         }
 
         /// <summary>

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -513,6 +513,11 @@ namespace Microsoft.Build.Tasks
             }
         }
 
+        internal void NormalizeFullPath()
+        {
+            _fullPath = FileUtilities.NormalizePath(_fullPath);
+        }
+
         /// <summary>
         /// The directory that this assembly lives in.
         /// </summary>

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -407,7 +407,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
+            if (reference.FullPath.Length > 0 && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
             {
                 // Saves effort and makes deduplication possible downstream
                 reference.FullPath = FileUtilities.NormalizePath(reference.FullPath);
@@ -1343,7 +1343,11 @@ namespace Microsoft.Build.Tasks
             // If the path was resolved, then specify the full path on the reference.
             if (resolvedPath != null)
             {
-                if (!Path.IsPathRooted(resolvedPath))
+                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
+                {
+                    resolvedPath = FileUtilities.NormalizePath(resolvedPath);
+                }
+                else if (!Path.IsPathRooted(resolvedPath))
                 {
                     resolvedPath = Path.GetFullPath(resolvedPath);
                 }

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -407,7 +407,12 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            reference.FullPath = FileUtilities.NormalizePath(reference.FullPath);
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
+            {
+                // Saves effort and makes deduplication possible downstream
+                reference.FullPath = FileUtilities.NormalizePath(reference.FullPath);
+            }
+
             References[assemblyName] = reference;
         }
 

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Build.Tasks
             if (reference.FullPath.Length > 0 && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
             {
                 // Saves effort and makes deduplication possible downstream
-                reference.FullPath = FileUtilities.NormalizePath(reference.FullPath);
+                reference.NormalizeFullPath();
             }
 
             References[assemblyName] = reference;

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -407,6 +407,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
+            reference.FullPath = FileUtilities.NormalizePath(reference.FullPath);
             References[assemblyName] = reference;
         }
 


### PR DESCRIPTION
Fixes #6501

### Context
RAR can output paths not in their canonical forms. This allows for there to be multiple identical paths, only distinguished by extra directory separator characters, for example, which can lead to duplicate work or failing to find paths in a cache.

### Changes Made
This normalizes all paths output by RAR, ensuring any given path is in its canonical form.

### Testing
To follow.

### Notes
