### PR TITLE
Add reserved properties MSBuildFileVersion and MSBuildSemanticVersion

### DIFF
--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -2587,6 +2587,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Project project = new Project(xml);
 
             string msbuildVersionProperty = project.GetPropertyValue("MSBuildVersion");
+            string msbuildFileVersionProperty = project.GetPropertyValue("MSBuildFileVersion");
+            string msbuildSemanticVersionProperty = project.GetPropertyValue("MSBuildSemanticVersion");
 
             Version.TryParse(msbuildVersionProperty, out Version msbuildVersionAsVersion).ShouldBeTrue();
 
@@ -2596,9 +2598,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
             // Version parses missing elements into -1, and this property should be Major.Minor.Patch only
             msbuildVersionAsVersion.Revision.ShouldBe(-1);
 
+            msbuildFileVersionProperty.ShouldBe(ProjectCollection.Version.ToString());
             ProjectCollection.Version.ToString().ShouldStartWith(msbuildVersionProperty,
                 "ProjectCollection.Version should match the property MSBuildVersion, but can contain another version part");
 
+            msbuildSemanticVersionProperty.ShouldBe(ProjectCollection.DisplayVersion);
             ProjectCollection.DisplayVersion.ShouldStartWith(msbuildVersionProperty,
                 "DisplayVersion is semver2 while MSBuildVersion is Major.Minor.Build but should be a prefix match");
         }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1106,6 +1106,8 @@ namespace Microsoft.Build.Evaluation
             SetBuiltInProperty(ReservedPropertyNames.programFiles32, FrameworkLocationHelper.programFiles32);
             SetBuiltInProperty(ReservedPropertyNames.assemblyVersion, Constants.AssemblyVersion);
             SetBuiltInProperty(ReservedPropertyNames.version, MSBuildAssemblyFileVersion.Instance.MajorMinorBuild);
+            SetBuiltInProperty(ReservedPropertyNames.fileVersion, ProjectCollection.Version.ToString());
+            SetBuiltInProperty(ReservedPropertyNames.semanticVersion, ProjectCollection.DisplayVersion);
 
             ValidateChangeWaveState();
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1091,6 +1091,8 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
+        private static readonly string CachedFileVersion = ProjectCollection.Version.ToString();
+
         /// <summary>
         /// Set the built-in properties, most of which are read-only
         /// </summary>
@@ -1106,7 +1108,7 @@ namespace Microsoft.Build.Evaluation
             SetBuiltInProperty(ReservedPropertyNames.programFiles32, FrameworkLocationHelper.programFiles32);
             SetBuiltInProperty(ReservedPropertyNames.assemblyVersion, Constants.AssemblyVersion);
             SetBuiltInProperty(ReservedPropertyNames.version, MSBuildAssemblyFileVersion.Instance.MajorMinorBuild);
-            SetBuiltInProperty(ReservedPropertyNames.fileVersion, ProjectCollection.Version.ToString());
+            SetBuiltInProperty(ReservedPropertyNames.fileVersion, CachedFileVersion);
             SetBuiltInProperty(ReservedPropertyNames.semanticVersion, ProjectCollection.DisplayVersion);
 
             ValidateChangeWaveState();

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Build.Internal
         internal const string programFiles32 = "MSBuildProgramFiles32";
         internal const string localAppData = "LocalAppData";
         internal const string assemblyVersion = "MSBuildAssemblyVersion";
+        internal const string fileVersion = "MSBuildFileVersion";
+        internal const string semanticVersion = "MSBuildSemanticVersion";
         internal const string version = "MSBuildVersion";
         internal const string osName = "OS";
         internal const string frameworkToolsRoot = "MSBuildFrameworkToolsRoot";


### PR DESCRIPTION
### Context
There's no easy way to get all of MSBuild's version numbers at evaluation time or build time.

### Changes Made
Added `MSBuildFileVersion` and `MSBuildSemanticVersion`. With these two, users should have all the information they require to mix and match all the version components they want: 

![image](https://user-images.githubusercontent.com/2255729/121096959-0ce99580-c7a8-11eb-8b71-19e73e1132fb.png)

### Testing
Updated version test.

### Note
Targeting 16.11 as it only adds new stuff that should not break. Caveat is if users define the new built-in properties. We'll break those users. Though I think those users don't exist :)