### PR TITLE
Update NETCOREAPP2_1 ifdefs

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -394,7 +394,7 @@ namespace Microsoft.Build.BackEnd
 
                 CommunicationsUtilities.Trace("Reading handshake from pipe {0}", pipeName);
 
-#if NETCOREAPP2_1 || MONO
+#if NETCOREAPP2_1_OR_GREATER || MONO
                 nodeStream.ReadEndOfHandshakeSignal(true, timeout);
 #else
                 nodeStream.ReadEndOfHandshakeSignal(true);

--- a/src/MSBuild.UnitTests/ValidateAssemblyLoadContext.cs
+++ b/src/MSBuild.UnitTests/ValidateAssemblyLoadContext.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Build.UnitTests
             // This probably doesn't need to be how it is forever: https://github.com/microsoft/msbuild/issues/5041
             if (thisLoadContext.GetType().FullName == typeof(MSBuildLoadContext).FullName)
             {
-#if NETCOREAPP && !NETCOREAPP2_1 // TODO: enable this functionality when targeting .NET Core 3.0+
                 if (!thisLoadContext.Name.EndsWith(typeof(ValidateAssemblyLoadContext).Assembly.GetName().Name + ".dll"))
                 {
                     Log.LogError($"Unexpected AssemblyLoadContext name: \"{thisLoadContext.Name}\", but the current executing assembly was {typeof(ValidateAssemblyLoadContext).Assembly.GetName().Name}");
@@ -32,7 +31,6 @@ namespace Microsoft.Build.UnitTests
                 {
                     Log.LogMessage(MessageImportance.High, $"Task {nameof(ValidateAssemblyLoadContext)} loaded in AssemblyLoadContext named {thisLoadContext.Name}");
                 }
-#endif
             }
             else
             {

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -332,14 +332,14 @@ namespace Microsoft.Build.Internal
         }
 
         internal static void ReadEndOfHandshakeSignal(this PipeStream stream, bool isProvider
-#if NETCOREAPP2_1 || MONO
+#if NETCOREAPP2_1_OR_GREATER || MONO
             , int timeout
 #endif
             )
         {
             // Accept only the first byte of the EndOfHandshakeSignal
             int valueRead = stream.ReadIntForHandshake(null
-#if NETCOREAPP2_1 || MONO
+#if NETCOREAPP2_1_OR_GREATER || MONO
             , timeout
 #endif
                 );
@@ -363,14 +363,14 @@ namespace Microsoft.Build.Internal
         /// If specified, leading byte matches one in the supplied array if any, returns rejection byte and throws IOException.
         /// </summary>
         internal static int ReadIntForHandshake(this PipeStream stream, byte? byteToAccept
-#if NETCOREAPP2_1 || MONO
+#if NETCOREAPP2_1_OR_GREATER || MONO
             , int timeout
 #endif
             )
         {
             byte[] bytes = new byte[4];
 
-#if NETCOREAPP2_1 || MONO
+#if NETCOREAPP2_1_OR_GREATER || MONO
             if (!NativeMethodsShared.IsWindows)
             {
                 // Enforce a minimum timeout because the Windows code can pass

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.BackEnd
     {
 #region Private Data
 
-#if NETCOREAPP2_1 || MONO
+#if NETCOREAPP2_1_OR_GREATER || MONO
         /// <summary>
         /// The amount of time to wait for the client to connect to the host.
         /// </summary>
@@ -386,7 +386,7 @@ namespace Microsoft.Build.BackEnd
                         for (int i = 0; i < handshakeComponents.Length; i++)
                         {
                             int handshakePart = _pipeServer.ReadIntForHandshake(i == 0 ? (byte?)CommunicationsUtilities.handshakeVersion : null /* this will disconnect a < 16.8 host; it expects leading 00 or F5 or 06. 0x00 is a wildcard */
-#if NETCOREAPP2_1 || MONO
+#if NETCOREAPP2_1_OR_GREATER || MONO
                             , ClientConnectTimeout /* wait a long time for the handshake from this side */
 #endif
                             );
@@ -403,7 +403,7 @@ namespace Microsoft.Build.BackEnd
                         if (gotValidConnection)
                         {
                             // To ensure that our handshake and theirs have the same number of bytes, receive and send a magic number indicating EOS.
-#if NETCOREAPP2_1 || MONO
+#if NETCOREAPP2_1_OR_GREATER || MONO
                             _pipeServer.ReadEndOfHandshakeSignal(false, ClientConnectTimeout); /* wait a long time for the handshake from this side */
 #else
                             _pipeServer.ReadEndOfHandshakeSignal(false);


### PR DESCRIPTION
We actually meant 'or higher' and now that's expressible, so doing so.

Should fix the hang that held up https://github.com/dotnet/installer/pull/10804.

Note: 16.11, since this just restores the previously compiled behavior before we updated to net5.0.
