### PR TITLE
Update 17.0-preview1 with 16.10 servicing fixes

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1574,8 +1574,8 @@ namespace Microsoft.Build.Graph
         public virtual bool Equals(Microsoft.Build.Graph.GraphBuildOptions other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
-        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
+        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
+        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
         protected virtual bool PrintMembers(System.Text.StringBuilder builder) { throw null; }
         public override string ToString() { throw null; }
         public virtual Microsoft.Build.Graph.GraphBuildOptions <Clone>$() { throw null; }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1568,8 +1568,8 @@ namespace Microsoft.Build.Graph
         public virtual bool Equals(Microsoft.Build.Graph.GraphBuildOptions other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
-        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions r1, Microsoft.Build.Graph.GraphBuildOptions r2) { throw null; }
+        public static bool operator ==(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
+        public static bool operator !=(Microsoft.Build.Graph.GraphBuildOptions left, Microsoft.Build.Graph.GraphBuildOptions right) { throw null; }
         protected virtual bool PrintMembers(System.Text.StringBuilder builder) { throw null; }
         public override string ToString() { throw null; }
         public virtual Microsoft.Build.Graph.GraphBuildOptions <Clone>$() { throw null; }

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -514,7 +514,18 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         public bool IncludeEvaluationPropertiesAndItems
         {
-            get => _includeEvaluationPropertiesAndItems ??= _eventSinkDictionary.Values.OfType<EventSourceSink>().Any(sink => sink.IncludeEvaluationPropertiesAndItems);
+            get
+            {
+                if (_includeEvaluationPropertiesAndItems == null)
+                {
+                    var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>();
+                    // .All() on an empty list defaults to true, we want to default to false
+                    _includeEvaluationPropertiesAndItems = sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
+                }
+
+                return _includeEvaluationPropertiesAndItems ?? false;
+            }
+
             set => _includeEvaluationPropertiesAndItems = value;
         }
 

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Build.Shared
                                     "*",
                                     directory,
                                     false));
-                        IEnumerable<string> filteredEntriesForPath = (pattern != null && pattern != "*" && pattern != "*.*")
+                        IEnumerable<string> filteredEntriesForPath = (pattern != null && !IsAllFilesWildcard(pattern))
                             ? allEntriesForPath.Where(o => IsMatch(Path.GetFileName(o), pattern))
                             : allEntriesForPath;
                         return stripProjectDirectory
@@ -886,7 +886,7 @@ namespace Microsoft.Build.Shared
                         //  The wildcard path portion of the excluded search matches the include search
                         searchToExclude.RemainingWildcardDirectory == recursionState.RemainingWildcardDirectory &&
                         //  The exclude search will match ALL filenames OR
-                        (searchToExclude.SearchData.Filespec == "*" || searchToExclude.SearchData.Filespec == "*.*" ||
+                        (IsAllFilesWildcard(searchToExclude.SearchData.Filespec) ||
                             //  The exclude search filename pattern matches the include search's pattern
                             searchToExclude.SearchData.Filespec == recursionState.SearchData.Filespec))
                     {
@@ -1091,7 +1091,11 @@ namespace Microsoft.Build.Shared
 
         private static bool MatchFileRecursionStep(RecursionState recursionState, string file)
         {
-            if (recursionState.SearchData.Filespec != null)
+            if (IsAllFilesWildcard(recursionState.SearchData.Filespec))
+            {
+                return true;
+            }
+            else if (recursionState.SearchData.Filespec != null)
             {
                 return IsMatch(Path.GetFileName(file), recursionState.SearchData.Filespec);
             }
@@ -2563,6 +2567,17 @@ namespace Microsoft.Build.Shared
             int index = directoryPath.LastIndexOfAny(FileUtilities.Slashes);
             return (index != -1 && IsMatch(directoryPath.Substring(index + 1), pattern));
         }
+
+        /// <summary>
+        /// Returns true if <paramref name="pattern"/> is <code>*</code> or <code>*.*</code>.
+        /// </summary>
+        /// <param name="pattern">The filename pattern to check.</param>
+        private static bool IsAllFilesWildcard(string pattern) => pattern?.Length switch
+        {
+            1 => pattern[0] == '*',
+            3 => pattern[0] == '*' && pattern[1] == '.' && pattern[2] == '*',
+            _ => false
+        };
 
         internal static bool IsRecursiveDirectoryMatch(string path) => path.TrimTrailingSlashes() == recursiveDirectoryMatch;
     }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1078,7 +1078,12 @@ namespace Microsoft.Build.Shared
             {
                 sb.Append(splitPath[i]).Append(Path.DirectorySeparatorChar);
             }
-            sb.Length--;
+
+            if (fullPath[fullPath.Length - 1] != Path.DirectorySeparatorChar)
+            {
+                sb.Length--;
+            }
+
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -154,6 +154,7 @@ namespace Microsoft.Build.UnitTests
                 @"src\bar.cs",
                 @"src\baz.cs",
                 @"src\foo\foo.cs",
+                @"src\foo\licence",
                 @"src\bar\bar.cs",
                 @"src\baz\baz.cs",
                 @"src\foo\inner\foo.cs",
@@ -368,7 +369,8 @@ namespace Microsoft.Build.UnitTests
                         ExpectedMatches = new[]
                         {
                             @"readme.txt",
-                            @"licence"
+                            @"licence",
+                            @"src\foo\licence",
                         }
                     }
                 };
@@ -417,6 +419,30 @@ namespace Microsoft.Build.UnitTests
                         ExpectedMatches = new[]
                         {
                             @"subdirectory\subdirectory.cs",
+                        },
+                        ExpectNoMatches = NativeMethodsShared.IsLinux,
+                    }
+                };
+
+                // Regression test for https://github.com/Microsoft/msbuild/issues/6502
+                yield return new object[]
+                {
+                    new GetFilesComplexGlobbingMatchingInfo
+                    {
+                        Include = @"src\**",
+                        Excludes = new[]
+                        {
+                            @"**\foo\**",
+                        },
+                        ExpectedMatches = new[]
+                        {
+                            @"src\foo.cs",
+                            @"src\bar.cs",
+                            @"src\baz.cs",
+                            @"src\bar\bar.cs",
+                            @"src\baz\baz.cs",
+                            @"src\bar\inner\baz.cs",
+                            @"src\bar\inner\baz\baz.cs",
                         },
                         ExpectNoMatches = NativeMethodsShared.IsLinux,
                     }

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -97,6 +97,24 @@ namespace Microsoft.Build.UnitTests
                 Assert.Equal(@"\\host\path\file", FileUtilities.MakeRelative(@"c:\abc\def", @"\\host\path\file"));
                 Assert.Equal(@"\\host\d$\file", FileUtilities.MakeRelative(@"c:\abc\def", @"\\host\d$\file"));
                 Assert.Equal(@"..\fff\ggg.hh", FileUtilities.MakeRelative(@"c:\foo\bar\..\abc\cde", @"c:\foo\bar\..\abc\fff\ggg.hh"));
+
+                /* Directories */
+                Assert.Equal(@"def\", FileUtilities.MakeRelative(@"c:\abc\", @"c:\abc\def\"));
+                Assert.Equal(@"..\", FileUtilities.MakeRelative(@"c:\abc\def\xyz\", @"c:\abc\def\"));
+                Assert.Equal(@"..\ttt\", FileUtilities.MakeRelative(@"c:\abc\def\xyz\", @"c:\abc\def\ttt\"));
+                Assert.Equal(@".", FileUtilities.MakeRelative(@"c:\abc\def\", @"c:\abc\def\"));
+
+                /* Directory + File */
+                Assert.Equal(@"def", FileUtilities.MakeRelative(@"c:\abc\", @"c:\abc\def"));
+                Assert.Equal(@"..\..\ghi", FileUtilities.MakeRelative(@"c:\abc\def\xyz\", @"c:\abc\ghi"));
+                Assert.Equal(@"..\ghi", FileUtilities.MakeRelative(@"c:\abc\def\xyz\", @"c:\abc\def\ghi"));
+                Assert.Equal(@"..\ghi", FileUtilities.MakeRelative(@"c:\abc\def\", @"c:\abc\ghi"));
+
+                /* File + Directory */
+                Assert.Equal(@"def\", FileUtilities.MakeRelative(@"c:\abc", @"c:\abc\def\"));
+                Assert.Equal(@"..\", FileUtilities.MakeRelative(@"c:\abc\def\xyz", @"c:\abc\def\"));
+                Assert.Equal(@"..\ghi\", FileUtilities.MakeRelative(@"c:\abc\def\xyz", @"c:\abc\def\ghi\"));
+                Assert.Equal(@".", FileUtilities.MakeRelative(@"c:\abc\def", @"c:\abc\def\"));
             }
             else
             {
@@ -106,6 +124,25 @@ namespace Microsoft.Build.UnitTests
                 Assert.Equal(@"../ttt/foo.cpp", FileUtilities.MakeRelative(@"/abc/def/xyz/", @"/abc/def/ttt/foo.cpp"));
                 Assert.Equal(@"foo.cpp", FileUtilities.MakeRelative(@"/abc/def", @"foo.cpp"));
                 Assert.Equal(@"../fff/ggg.hh", FileUtilities.MakeRelative(@"/foo/bar/../abc/cde", @"/foo/bar/../abc/fff/ggg.hh"));
+
+                /* Directories */
+                Assert.Equal(@"def/", FileUtilities.MakeRelative(@"/abc/", @"/abc/def/"));
+                Assert.Equal(@"../", FileUtilities.MakeRelative(@"/abc/def/xyz/", @"/abc/def/"));
+                Assert.Equal(@"../ttt/", FileUtilities.MakeRelative(@"/abc/def/xyz/", @"/abc/def/ttt/"));
+                Assert.Equal(@".", FileUtilities.MakeRelative(@"/abc/def/", @"/abc/def/"));
+
+                /* Directory + File */
+                Assert.Equal(@"def", FileUtilities.MakeRelative(@"/abc/", @"/abc/def"));
+                Assert.Equal(@"../../ghi", FileUtilities.MakeRelative(@"/abc/def/xyz/", @"/abc/ghi"));
+                Assert.Equal(@"../ghi", FileUtilities.MakeRelative(@"/abc/def/xyz/", @"/abc/def/ghi"));
+                Assert.Equal(@"../ghi", FileUtilities.MakeRelative(@"/abc/def/", @"/abc/ghi"));
+
+                /* File + Directory */
+                Assert.Equal(@"def/", FileUtilities.MakeRelative(@"/abc", @"/abc/def/"));
+                Assert.Equal(@"../", FileUtilities.MakeRelative(@"/abc/def/xyz", @"/abc/def/"));
+                Assert.Equal(@"../ghi/", FileUtilities.MakeRelative(@"/abc/def/xyz", @"/abc/def/ghi/"));
+                Assert.Equal(@".", FileUtilities.MakeRelative(@"/abc/def", @"/abc/def/"));
+
             }
         }
 


### PR DESCRIPTION
- Fix MakeRelative regression in v16.10
- Pulled in some external changes to Microsoft.Build.cs
- Don't move Properties and Items to ProjectEvaluationFinished if legacy loggers present
- Introduce IsAllFilesWildcard() and call it from MatchFileRecursionStep
