### PR TITLE
Bind to 17.0 version of Workflow build tasks for Dev17

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -110,11 +110,11 @@
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="17.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0-16.0.0.0" newVersion="16.0.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0-17.0.0.0" newVersion="17.0.0.0" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -103,13 +103,13 @@
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
-          <codeBase version="16.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="17.0.0.0" />
+          <codeBase version="17.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0-16.0.0.0" newVersion="16.0.0.0" />
-          <codeBase version="16.0.0.0" href=".\amd64\XamlBuildTask.dll" />
+          <bindingRedirect oldVersion="4.0.0.0-17.0.0.0" newVersion="17.0.0.0" />
+          <codeBase version="17.0.0.0" href=".\amd64\XamlBuildTask.dll" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1340776

### Context

The Workflow Foundation build tasks are built by VS and installed to the MSBuild bin folder (see src\SetupPackages\Workflow\Workflowv2\core\files.swr in the VS repo).  These assemblies have been bumped to 17.0 as part of the Dev17 product cycle, but the msbuild bindings were still looking for 16.0.  This led to the following build error for Workflow projects:

>C:\WINDOWS\Microsoft.NET\Framework\v4.0.30319\Microsoft.WorkflowBuildExtensions.targets(110,5): error MSB4062: The "ReportDeferredValidationErrorsTask" task could not be loaded from the assembly Microsoft.Activities.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35. Could not load file or assembly 'Microsoft.Activities.Build, Version=16.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040) Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.

### Changes Made

Updated binding redirects to 17.0.

### Testing

Applied fix locally and verified WF projects could build.

### Notes
