### PR TITLE
Catch ArgumentException as well as BadImageFormatException when failing because of libraries without resources

### DIFF
--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -3153,7 +3153,7 @@ namespace Microsoft.Build.Tasks
             }
             catch (ArgumentException e) when (e.InnerException is BadImageFormatException)
             {
-                // BadImageFormatExceptions can be wrapped in ArgumentExceptions, so catch those, too.
+                // BadImageFormatExceptions can be wrapped in ArgumentExceptions, so catch those, too. See https://referencesource.microsoft.com/#mscorlib/system/reflection/module.cs,857
                 return;
             }
             catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -3151,7 +3151,7 @@ namespace Microsoft.Build.Tasks
                 // We can't easily filter those.  We can simply skip them.
                 return;
             }
-            catch (ArgumentException)
+            catch (ArgumentException e) when (e.InnerException is BadImageFormatException)
             {
                 // BadImageFormatExceptions can be wrapped in ArgumentExceptions, so catch those, too.
                 return;

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -3151,10 +3151,13 @@ namespace Microsoft.Build.Tasks
                 // We can't easily filter those.  We can simply skip them.
                 return;
             }
-            catch (Exception e)
+            catch (ArgumentException)
             {
-                if (ExceptionHandling.IsCriticalException(e))
-                    throw;
+                // BadImageFormatExceptions can be wrapped in ArgumentExceptions, so catch those, too.
+                return;
+            }
+            catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
+            {
                 _logger.LogErrorWithCodeFromResources("GenerateResource.CannotLoadAssemblyLoadFromFailed", name, e);
             }
 


### PR DESCRIPTION
This was a heinous bug to repro.

Using VS 17.0.0+, create a blank UWP app with target platform version 16299 or 17134. Build Debug/x86.
If that doesn't work, clean and build again.
If that doesn't work, clean and build again.

It should work every time, but from my testing, every other clean-build cycle succeeds even following identical steps. Every other build clean-build cycle fails with a message saying an attempt was made to load a file with incorrect format. This is normally a BadImageFormatException and caught (see comment above), but it seems that with dev 17, that is sometimes (always?) wrapped in an ArgumentException and not caught. This fixes that problem by catching both.

Maybe we should verify that the ArgumentException mentions BadImageFormatException before just continuing?

Testing: Several attempted repros in a row succeeded. It had been pretty reliably failing every other time, so that was a shift.