### PR TITLE
Simplify reference to Microsoft.Extensions.DependencyModel

### DIFF
--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -190,6 +190,11 @@
     <Copy SourceFiles="@(InstalledSdks)"
           DestinationFiles="@(InstalledSdks -> '$(BootstrapDestination)Sdks\%(RecursiveDir)%(Filename)%(Extension)')" />
 
+    <!-- The .NET SDK has a dependency on DependencyModel, but relies on having it "next to MSBuild" in the final
+         layout. Copy it from there to our little weirdo bootstrap layout. -->
+    <Copy SourceFiles="$(DOTNET_INSTALL_DIR)\sdk\$(DotNetCliVersion)\Microsoft.Extensions.DependencyModel.dll"
+          DestinationFolder="$(BootstrapDestination)" />
+
     <Copy SourceFiles="@(InstalledExtensions)"
           DestinationFolder="$(BootstrapDestination)Current\%(RecursiveDir)" />
 

--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -190,8 +190,11 @@
     <Copy SourceFiles="@(InstalledSdks)"
           DestinationFiles="@(InstalledSdks -> '$(BootstrapDestination)Sdks\%(RecursiveDir)%(Filename)%(Extension)')" />
 
-    <!-- The .NET SDK has a dependency on DependencyModel, but relies on having it "next to MSBuild" in the final
-         layout. Copy it from there to our little weirdo bootstrap layout next to the SDK tasks. -->
+    <!-- The .NET SDK has a dependency on DependencyModel, but relies on having it in the final
+         MSBuild.deps.json, which differs from ours because it's generated in the SDK repo.
+
+         Copy it from "next to MSBuild" in the pre-bootstrap SDK to our little weirdo bootstrap
+         layout next to the SDK tasks, so it can get loaded by the SDK tasks that need it. -->
     <Copy SourceFiles="$(DOTNET_INSTALL_DIR)\sdk\$(DotNetCliVersion)\Microsoft.Extensions.DependencyModel.dll"
           DestinationFolder="$(BootstrapDestination)Sdks\Microsoft.NET.Sdk\tools\net6.0" />
 

--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -154,7 +154,7 @@
     <!-- Copy our binaries to the x64 location. -->
      <Copy SourceFiles="@(FreshlyBuiltBinariesx64)"
           DestinationFiles="@(FreshlyBuiltBinariesx64 -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\amd64\%(RecursiveDir)%(Filename)%(Extension)')" />
-    
+
     <!-- Copy our freshly-built props and targets, overwriting anything we copied from the machine -->
     <Copy SourceFiles="@(FreshlyBuiltRootProjects)"
           DestinationFiles="@(FreshlyBuiltRootProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\%(Filename)%(Extension)')" />
@@ -191,9 +191,9 @@
           DestinationFiles="@(InstalledSdks -> '$(BootstrapDestination)Sdks\%(RecursiveDir)%(Filename)%(Extension)')" />
 
     <!-- The .NET SDK has a dependency on DependencyModel, but relies on having it "next to MSBuild" in the final
-         layout. Copy it from there to our little weirdo bootstrap layout. -->
+         layout. Copy it from there to our little weirdo bootstrap layout next to the SDK tasks. -->
     <Copy SourceFiles="$(DOTNET_INSTALL_DIR)\sdk\$(DotNetCliVersion)\Microsoft.Extensions.DependencyModel.dll"
-          DestinationFolder="$(BootstrapDestination)" />
+          DestinationFolder="$(BootstrapDestination)Sdks\Microsoft.NET.Sdk\tools\net6.0" />
 
     <Copy SourceFiles="@(InstalledExtensions)"
           DestinationFolder="$(BootstrapDestination)Current\%(RecursiveDir)" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -10,7 +10,6 @@
     <PackageReference Update="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetBuildTasksVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="$(MicrosoftNetCompilersToolsetVersion)" />
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="2.1.0-prerelease-02404-02" />
-    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" />
     <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
@@ -37,10 +36,6 @@
     <PackageReference Update="xunit.assert" Version="$(XUnitVersion)" />
     <PackageReference Update="xunit.console" Version="$(XUnitVersion)" />
     <PackageReference Update="xunit.core" Version="$(XUnitVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(MonoBuild)' == 'true' or $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp2.1'))">
-    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,10 +10,6 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>e84a10e4b0e6bccce7421af020728d9bbc3e64e0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.2.21154.6">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha />
-    </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-1.21304.5">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>b6a9f8c39f7a71b02b9a8b929f002777e4efd6f1</Sha>

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MSBuild\MSBuild.csproj" />
-    
+
     <!-- Direct project references needed here to avoid NuGet version conflict errors -->
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
     <ProjectReference Include="..\Tasks\Microsoft.Build.Tasks.csproj" />
@@ -37,11 +37,6 @@
     <Content Include="$(MSBuildExtensionsPath)\**\*" LinkBase="Extensions" CopyToOutputDirectory="PreserveNewest" />
 
     <Content Include="$(RepoRoot).dotnet\sdk\$(DotNetCliVersion)\RuntimeIdentifierGraph.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(MonoBuild)' != 'true'">
-    <!-- Include DependencyModel libraries. -->
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
   </ItemGroup>
 
   <!-- Use deps file from this project with additional dependencies listed instead of the one generated in the MSBuild project -->


### PR DESCRIPTION
Looks like this was useless but cost time doing darc update flow. Pulling it from the pre-bootstrap SDK directly.