### PR TITLE
Make InterningBinaryReader pool buffers

### DIFF
--- a/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
@@ -25,15 +25,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void TestSerializationMode()
         {
             MemoryStream stream = new MemoryStream();
-            using (ITranslator translator = BinaryTranslator.GetReadTranslator(stream, null))
-            {
-                Assert.Equal(TranslationDirection.ReadFromStream, translator.Mode);
-            }
+            using ITranslator readTranslator = BinaryTranslator.GetReadTranslator(stream, null);
+            Assert.Equal(TranslationDirection.ReadFromStream, readTranslator.Mode);
 
-            using (ITranslator translator = BinaryTranslator.GetWriteTranslator(stream))
-            {
-                Assert.Equal(TranslationDirection.WriteToStream, translator.Mode);
-            }
+            using ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(stream);
+            Assert.Equal(TranslationDirection.WriteToStream, writeTranslator.Mode);
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
@@ -25,11 +25,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void TestSerializationMode()
         {
             MemoryStream stream = new MemoryStream();
-            ITranslator translator = BinaryTranslator.GetReadTranslator(stream, null);
-            Assert.Equal(TranslationDirection.ReadFromStream, translator.Mode);
+            using (ITranslator translator = BinaryTranslator.GetReadTranslator(stream, null))
+            {
+                Assert.Equal(TranslationDirection.ReadFromStream, translator.Mode);
+            }
 
-            translator = BinaryTranslator.GetWriteTranslator(stream);
-            Assert.Equal(TranslationDirection.WriteToStream, translator.Mode);
+            using (ITranslator translator = BinaryTranslator.GetWriteTranslator(stream))
+            {
+                Assert.Equal(TranslationDirection.WriteToStream, translator.Mode);
+            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/CacheSerialization.cs
+++ b/src/Build/BackEnd/BuildManager/CacheSerialization.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Execution
 
                 using (var fileStream = File.OpenRead(inputCacheFile))
                 {
-                    var translator = BinaryTranslator.GetReadTranslator(fileStream, null);
+                    using var translator = BinaryTranslator.GetReadTranslator(fileStream, null);
 
                     translator.Translate(ref configCache);
                     translator.Translate(ref resultsCache);

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -671,19 +671,12 @@ namespace Microsoft.Build.BackEnd
                 {
                     if (IsCacheable)
                     {
-                        ITranslator translator = GetConfigurationTranslator(TranslationDirection.WriteToStream);
+                        using ITranslator translator = GetConfigurationTranslator(TranslationDirection.WriteToStream);
 
-                        try
-                        {
-                            _project.Cache(translator);
-                            _baseLookup = null;
+                        _project.Cache(translator);
+                        _baseLookup = null;
 
-                            IsCached = true;
-                        }
-                        finally
-                        {
-                            translator.Writer.BaseStream.Dispose();
-                        }
+                        IsCached = true;
                     }
                 }
             }
@@ -706,7 +699,7 @@ namespace Microsoft.Build.BackEnd
                     return;
                 }
 
-                ITranslator translator = GetConfigurationTranslator(TranslationDirection.ReadFromStream);
+                using ITranslator translator = GetConfigurationTranslator(TranslationDirection.ReadFromStream);
                 try
                 {
                     _project.RetrieveFromCache(translator);

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -700,16 +700,10 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 using ITranslator translator = GetConfigurationTranslator(TranslationDirection.ReadFromStream);
-                try
-                {
-                    _project.RetrieveFromCache(translator);
 
-                    IsCached = false;
-                }
-                finally
-                {
-                    translator.Reader.BaseStream.Dispose();
-                }
+                _project.RetrieveFromCache(translator);
+
+                IsCached = false;
             }
         }
 

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -243,22 +243,15 @@ namespace Microsoft.Build.Execution
                     return;
                 }
 
-                ITranslator translator = GetResultsCacheTranslator(configId, targetName, TranslationDirection.WriteToStream);
+                using ITranslator translator = GetResultsCacheTranslator(configId, targetName, TranslationDirection.WriteToStream);
 
                 // If the translator is null, it means these results were cached once before.  Since target results are immutable once they
                 // have been created, there is no point in writing them again.
                 if (translator != null)
                 {
-                    try
-                    {
-                        TranslateItems(translator);
-                        _items = null;
-                        _cacheInfo = new CacheInfo(configId, targetName);
-                    }
-                    finally
-                    {
-                        translator.Writer.BaseStream.Dispose();
-                    }
+                    TranslateItems(translator);
+                    _items = null;
+                    _cacheInfo = new CacheInfo(configId, targetName);
                 }
             }
         }
@@ -284,7 +277,7 @@ namespace Microsoft.Build.Execution
             {
                 if (_items == null)
                 {
-                    ITranslator translator = GetResultsCacheTranslator(_cacheInfo.ConfigId, _cacheInfo.TargetName, TranslationDirection.ReadFromStream);
+                    using ITranslator translator = GetResultsCacheTranslator(_cacheInfo.ConfigId, _cacheInfo.TargetName, TranslationDirection.ReadFromStream);
 
                     try
                     {
@@ -339,7 +332,7 @@ namespace Microsoft.Build.Execution
                 ErrorUtilities.VerifyThrow(buffer != null, "Unexpected null items buffer during translation.");
 
                 using MemoryStream itemsStream = new MemoryStream(buffer, 0, buffer.Length, writable: false, publiclyVisible: true);
-                var itemTranslator = BinaryTranslator.GetReadTranslator(itemsStream, null);
+                using var itemTranslator = BinaryTranslator.GetReadTranslator(itemsStream, null);
                 _items = new TaskItem[itemsCount];
                 for (int i = 0; i < _items.Length; i++)
                 {

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -279,15 +279,8 @@ namespace Microsoft.Build.Execution
                 {
                     using ITranslator translator = GetResultsCacheTranslator(_cacheInfo.ConfigId, _cacheInfo.TargetName, TranslationDirection.ReadFromStream);
 
-                    try
-                    {
-                        TranslateItems(translator);
-                        _cacheInfo = new CacheInfo();
-                    }
-                    finally
-                    {
-                        translator.Reader.BaseStream.Dispose();
-                    }
+                    TranslateItems(translator);
+                    _cacheInfo = new CacheInfo();
                 }
             }
         }

--- a/src/Shared/BinaryTranslator.cs
+++ b/src/Shared/BinaryTranslator.cs
@@ -65,6 +65,14 @@ namespace Microsoft.Build.BackEnd
             }
 
             /// <summary>
+            /// Delegates the Dispose call the to the underlying BinaryReader.
+            /// </summary>
+            public void Dispose()
+            {
+                _reader.Close();
+            }
+
+            /// <summary>
             /// Gets the reader, if any.
             /// </summary>
             public BinaryReader Reader
@@ -714,6 +722,14 @@ namespace Microsoft.Build.BackEnd
             {
                 _packetStream = packetStream;
                 _writer = new BinaryWriter(packetStream);
+            }
+
+            /// <summary>
+            /// Delegates the Dispose call the to the underlying BinaryWriter.
+            /// </summary>
+            public void Dispose()
+            {
+                _writer.Close();
             }
 
             /// <summary>

--- a/src/Shared/ITranslator.cs
+++ b/src/Shared/ITranslator.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Build.BackEnd
     ///    that by ensuring a single Translate method on a given object can handle both reads and
     ///    writes without referencing any field more than once.
     /// </remarks>
-    internal interface ITranslator
+    internal interface ITranslator : IDisposable
     {
         /// <summary>
         /// Returns the current serialization mode.

--- a/src/Shared/InterningBinaryReader.cs
+++ b/src/Shared/InterningBinaryReader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using System.IO;
 using System.Diagnostics;
+using System.Threading;
 
 using ErrorUtilities = Microsoft.Build.Shared.ErrorUtilities;
 
@@ -27,9 +28,21 @@ namespace Microsoft.Build
 #endif
 
         /// <summary>
+        /// A cache of recently used buffers. This is a pool of size 1 to avoid allocating moderately sized
+        /// <see cref="Buffer"/> objects repeatedly. Used in scenarios that don't have a good context to attach
+        /// a shared buffer to.
+        /// </summary>
+        private static Buffer s_bufferPool;
+
+        /// <summary>
         /// Shared buffer saves allocating these arrays many times.
         /// </summary>
         private Buffer _buffer;
+
+        /// <summary>
+        /// True if <see cref="_buffer"/> is owned by this instance, false if it was passed by the caller.
+        /// </summary>
+        private bool _isPrivateBuffer;
 
         /// <summary>
         /// The decoder used to translate from UTF8 (or whatever).
@@ -39,7 +52,7 @@ namespace Microsoft.Build
         /// <summary>
         /// Comment about constructing.
         /// </summary>
-        private InterningBinaryReader(Stream input, Buffer buffer)
+        private InterningBinaryReader(Stream input, Buffer buffer, bool isPrivateBuffer)
             : base(input, Encoding.UTF8)
         {
             if (input == null)
@@ -48,6 +61,7 @@ namespace Microsoft.Build
             }
 
             _buffer = buffer;
+            _isPrivateBuffer = isPrivateBuffer;
             _decoder = Encoding.UTF8.GetDecoder();
         }
 
@@ -152,10 +166,45 @@ namespace Microsoft.Build
         /// <summary>
         /// A shared buffer to avoid extra allocations in InterningBinaryReader.
         /// </summary>
+        /// <remarks>
+        /// The caller is responsible for managing the lifetime of the returned buffer and for passing it to <see cref="Create"/>.
+        /// </remarks>
         internal static SharedReadBuffer CreateSharedBuffer()
         {
             return new Buffer();
         }
+
+        /// <summary>
+        /// Gets a buffer from the pool or creates a new one.
+        /// </summary>
+        /// <returns>The <see cref="Buffer"/>. Should be returned to the pool after we're done with it.</returns>
+        private static Buffer GetPooledBuffer()
+        {
+            Buffer buffer = Interlocked.Exchange(ref s_bufferPool, null);
+            if (buffer != null)
+            {
+                return buffer;
+            }
+            return new Buffer();
+        }
+
+        #region IDisposable pattern
+
+        /// <summary>
+        /// Returns our buffer to the pool if we were not passed one by the caller.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (_isPrivateBuffer)
+            {
+                // If we created this buffer then try to return it to the pool. If s_bufferPool is non-null we leave it alone,
+                // the idea being that it's more likely to have lived longer than our buffer.
+                Interlocked.CompareExchange(ref s_bufferPool, _buffer, null);
+            }
+            base.Dispose(disposing);
+        }
+
+        #endregion
 
         /// <summary>
         /// Create a BinaryReader. It will either be an interning reader or standard binary reader
@@ -164,13 +213,11 @@ namespace Microsoft.Build
         internal static BinaryReader Create(Stream stream, SharedReadBuffer sharedBuffer)
         {
             Buffer buffer = (Buffer)sharedBuffer;
-
-            if (buffer == null)
+            if (buffer != null)
             {
-                buffer = new Buffer();
+                return new InterningBinaryReader(stream, buffer, false);
             }
-
-            return new InterningBinaryReader(stream, buffer);
+            return new InterningBinaryReader(stream, GetPooledBuffer(), true);
         }
 
         /// <summary>
@@ -178,13 +225,14 @@ namespace Microsoft.Build
         /// </summary>
         private class Buffer : SharedReadBuffer
         {
+            private char[] _charBuffer;
+            private byte[] _byteBuffer;
+
             /// <summary>
             /// Yes, we are constructing.
             /// </summary>
             internal Buffer()
             {
-                this.CharBuffer = new char[MaxCharsBuffer];
-                this.ByteBuffer = new byte[Encoding.UTF8.GetMaxByteCount(MaxCharsBuffer)];
             }
 
             /// <summary>
@@ -192,8 +240,11 @@ namespace Microsoft.Build
             /// </summary>
             internal char[] CharBuffer
             {
-                get;
-                private set;
+                get
+                {
+                    _charBuffer ??= new char[MaxCharsBuffer];
+                    return _charBuffer;
+                }
             }
 
             /// <summary>
@@ -201,8 +252,11 @@ namespace Microsoft.Build
             /// </summary>
             internal byte[] ByteBuffer
             {
-                get;
-                private set;
+                get
+                {
+                    _byteBuffer ??= new byte[Encoding.UTF8.GetMaxByteCount(MaxCharsBuffer)];
+                    return _byteBuffer;
+                }
             }
         }
     }

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -928,7 +928,7 @@ namespace Microsoft.Build.Tasks
                     if (!string.IsNullOrEmpty(cacheFile))
                     {
                         using FileStream fs = new FileStream(cacheFile, FileMode.Open);
-                        var translator = BinaryTranslator.GetReadTranslator(fs, buffer: null);
+                        using var translator = BinaryTranslator.GetReadTranslator(fs, buffer: null);
                         SDKInfo sdkInfo = new SDKInfo();
                         sdkInfo.Translate(translator);
                         return sdkInfo;

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Tasks
                 {
                     using (FileStream s = File.OpenRead(stateFile))
                     {
-                        var translator = BinaryTranslator.GetReadTranslator(s, buffer: null);
+                        using var translator = BinaryTranslator.GetReadTranslator(s, buffer: null);
                         byte version = 0;
                         translator.Translate(ref version);
                         var constructors = requiredReturnType.GetConstructors();


### PR DESCRIPTION
Fixes #3954

### Context

The `Buffer` class is 100 kB (40 for characters and 60 for the byte array) and it is being allocated a lot, easily in the order of tens of thousands of instances per build. OOM crashes are often blamed on such allocations.

### Changes Made

1. Made the byte array allocation lazy since in many scenarios it ends up not being used.
2. Implemented a trivial `Buffer` pooling which eliminates >97% of allocations.

### Testing

- [x] Existing unit tests.
- [x] Experimental VS insertion.

### Notes

Opted for a 1-element static cache to keep the last used `Buffer` around. This works very well given MSBuild's single-threadedness and keeps the code simple and policy-free.