### PR TITLE
Issue templates apply needs-triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bugreport.md
+++ b/.github/ISSUE_TEMPLATE/01_bugreport.md
@@ -2,7 +2,7 @@
 name: 🐞 Bug Report
 about: Report a bug to help us improve MSBuild.
 title: ''
-labels: bug, untriaged
+labels: bug, needs-triage
 ---
 
 <!-- This is a template that helps us provide quicker feedback. Please use any relevant sections and delete anything you don't need. -->

--- a/.github/ISSUE_TEMPLATE/02_performanceissue.md
+++ b/.github/ISSUE_TEMPLATE/02_performanceissue.md
@@ -2,7 +2,7 @@
 name: 📉 Performance Issue
 about: Report a performance issue or regression.
 title: ''
-labels: performance, untriaged
+labels: performance, needs-triage
 ---
 
 <!-- This is a template that helps us provide quicker feedback. Please use any relevant sections and delete anything you don't need. -->

--- a/.github/ISSUE_TEMPLATE/03_mybuildisbroken.md
+++ b/.github/ISSUE_TEMPLATE/03_mybuildisbroken.md
@@ -2,7 +2,7 @@
 name: 😵 My Build is Broken
 about: Use this template for helping figure out what's wrong with your build.
 title: ''
-labels: untriaged
+labels: needs-triage
 ---
 
 <!-- NOTE: The MSBuild team receives a lot of issues and we need to prioritize them accordingly. Please understand that we may not get to your issue for some time. -->

--- a/.github/ISSUE_TEMPLATE/04_blankissue.md
+++ b/.github/ISSUE_TEMPLATE/04_blankissue.md
@@ -2,5 +2,5 @@
 name: 📄 Blank Issue
 about: Doesn't fit the other categories? File a blank ticket here.
 title: ''
-labels: untriaged
+labels: needs-triage
 ---


### PR DESCRIPTION
### Context
Updating untriaged to needs-triage was done for consistency (needs-attention/design/more-info), ease of search/use (no spaces, all lowercase). Not to mention `untriaged` eventually meant some combination of "find a bucket this fits in" and "this needs attention".

However updating the label requires an update to our bug templates that apply those labels.

These bugs should have gotten `needs-triage` labels applied but the bug templates still try to apply `untriaged`.

https://github.com/dotnet/msbuild/issues/6553
https://github.com/dotnet/msbuild/issues/6551