### PR TITLE
Use extension in Next-to-MSBuild fallback

### DIFF
--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Build.Shared
             //   into the default ALC (so it's shared with other uses).
 
             var assemblyNameInExecutableDirectory = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory,
-                assemblyName.Name!);
+                $"{assemblyName.Name}.dll");
 
             if (FileSystems.Default.FileExists(assemblyNameInExecutableDirectory))
             {


### PR DESCRIPTION
The idea behind the fallback was that we'd load an assembly
that matched (by simple name) from the MSBuild directory if
there wasn't a match in the task/plugin folder. But
assemblies aren't in the MSBuild folder (or anywhere on disk)
by simple name: they have an extension. So this was never
working.

That was mostly irrelevant, because the assemblies that are
'next to MSBuild' in the .NET SDK are in MSBuild.deps.json
as assembled in the SDK repo. But in our own bootstrap build,
that's not the case and the normal fallback matters.
