### PR TITLE
Revert "Add more params to the evaluation pass stops"

### DIFF
--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -627,7 +627,7 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 _data.InitialTargets = initialTargets;
-                MSBuildEventSource.Log.EvaluatePass1Stop(projectFile, _projectRootElement.Properties.Count, _projectRootElement.Imports.Count);
+                MSBuildEventSource.Log.EvaluatePass1Stop(projectFile);
                 // Pass2: evaluate item definitions
                 // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
                 MSBuildEventSource.Log.EvaluatePass2Start(projectFile);
@@ -641,7 +641,7 @@ namespace Microsoft.Build.Evaluation
                         }
                     }
                 }
-                MSBuildEventSource.Log.EvaluatePass2Stop(projectFile, _itemDefinitionGroupElements.Count);
+                MSBuildEventSource.Log.EvaluatePass2Stop(projectFile);
                 LazyItemEvaluator<P, I, M, D> lazyEvaluator = null;
                 using (_evaluationProfiler.TrackPass(EvaluationPass.Items))
                 {
@@ -684,7 +684,7 @@ namespace Microsoft.Build.Evaluation
                     lazyEvaluator = null;
                 }
 
-                MSBuildEventSource.Log.EvaluatePass3Stop(projectFile, _itemGroupElements.Count);
+                MSBuildEventSource.Log.EvaluatePass3Stop(projectFile);
 
                 // Pass4: evaluate using-tasks
                 MSBuildEventSource.Log.EvaluatePass4Start(projectFile);
@@ -714,7 +714,7 @@ namespace Microsoft.Build.Evaluation
                 Dictionary<string, List<TargetSpecification>> targetsWhichRunAfterByTarget = new Dictionary<string, List<TargetSpecification>>(StringComparer.OrdinalIgnoreCase);
                 LinkedList<ProjectTargetElement> activeTargetsByEvaluationOrder = new LinkedList<ProjectTargetElement>();
                 Dictionary<string, LinkedListNode<ProjectTargetElement>> activeTargets = new Dictionary<string, LinkedListNode<ProjectTargetElement>>(StringComparer.OrdinalIgnoreCase);
-                MSBuildEventSource.Log.EvaluatePass4Stop(projectFile, _usingTaskElements.Count);
+                MSBuildEventSource.Log.EvaluatePass4Stop(projectFile);
 
                 using (_evaluationProfiler.TrackPass(EvaluationPass.Targets))
                 {
@@ -773,7 +773,7 @@ namespace Microsoft.Build.Evaluation
                     }
 
                     _data.FinishEvaluation();
-                    MSBuildEventSource.Log.EvaluatePass5Stop(projectFile, targetElementsCount);
+                    MSBuildEventSource.Log.EvaluatePass5Stop(projectFile);
                 }
             }
 

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -132,12 +132,10 @@ namespace Microsoft.Build.Eventing
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
-        /// <param name="numberOfProperties">Number of Properties getting evaluated.</param>
-        /// <param name="numberOfImports">Number of Imports getting evaluated.</param>
         [Event(15, Keywords = Keywords.All)]
-        public void EvaluatePass1Stop(string projectFile, int numberOfProperties, int numberOfImports)
+        public void EvaluatePass1Stop(string projectFile)
         {
-            WriteEvent(15, projectFile, numberOfProperties, numberOfImports);
+            WriteEvent(15, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
@@ -148,11 +146,10 @@ namespace Microsoft.Build.Eventing
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
-        /// <param name="numberOfItemDefinitionGroupElements">Number of ItemDefinitionGroupElements getting evaluated.</param>
         [Event(17, Keywords = Keywords.All)]
-        public void EvaluatePass2Stop(string projectFile, int numberOfItemDefinitionGroupElements)
+        public void EvaluatePass2Stop(string projectFile)
         {
-            WriteEvent(17, projectFile, numberOfItemDefinitionGroupElements);
+            WriteEvent(17, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
@@ -163,11 +160,10 @@ namespace Microsoft.Build.Eventing
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
-        /// <param name="numberOfItemGroupElements">Number of project items evaluated.</param>
         [Event(19, Keywords = Keywords.All)]
-        public void EvaluatePass3Stop(string projectFile, int numberOfItemGroupElements)
+        public void EvaluatePass3Stop(string projectFile)
         {
-            WriteEvent(19, projectFile, numberOfItemGroupElements);
+            WriteEvent(19, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
@@ -178,11 +174,10 @@ namespace Microsoft.Build.Eventing
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
-        /// <param name="numberOfUsingTaskElements">Number of using tasks elements evaluated.</param>
         [Event(21, Keywords = Keywords.All)]
-        public void EvaluatePass4Stop(string projectFile, int numberOfUsingTaskElements)
+        public void EvaluatePass4Stop(string projectFile)
         {
-            WriteEvent(21, projectFile, numberOfUsingTaskElements);
+            WriteEvent(21, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
@@ -193,11 +188,10 @@ namespace Microsoft.Build.Eventing
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
-        /// <param name="targetElementsCount">Number of targets read.</param>
         [Event(23, Keywords = Keywords.All)]
-        public void EvaluatePass5Stop(string projectFile, int targetElementsCount)
+        public void EvaluatePass5Stop(string projectFile)
         {
-            WriteEvent(23, projectFile, targetElementsCount);
+            WriteEvent(23, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>


### PR DESCRIPTION
This reverts commit e9946d0e7aec542587cc2f374abcf544e85d5e47.

Fixes #
https://github.com/dotnet/msbuild/issues/6039

