### PR TITLE
Properly condition onelocbuild template

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -26,7 +26,7 @@ stages:
   displayName: Build
 
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         LclSource: lclFilesfromPackage

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -26,7 +26,7 @@ stages:
   displayName: Build
 
   jobs:
-  - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         LclSource: lclFilesfromPackage

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -73,14 +73,14 @@ stages:
         signType: $(SignType)
         zipSources: false
       condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
-
+      
     - task: MicroBuildOptProfPlugin@6
       inputs:
         ProfilingInputsDropName: '$(VisualStudio.DropName)'
         ShouldSkipOptimize: true
         AccessToken: '$(System.AccessToken)'
         feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-      displayName: 'Install OptProf Plugin'
+      displayName: 'Install OptProf Plugin'      
 
     # Required by MicroBuildBuildVSBootstrapper
     - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -26,13 +26,12 @@ stages:
   displayName: Build
 
   jobs:
-  - {{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
-        CreatePr: false
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
-        MirrorRepo: {{msbuild}}
+        MirrorRepo: 'msbuild'
 
   - job: Windows_NT
     pool:

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -26,7 +26,7 @@ stages:
   displayName: Build
 
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/vs16.11') }}: # should track next-release's active dev branch
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         LclSource: lclFilesfromPackage
@@ -73,14 +73,14 @@ stages:
         signType: $(SignType)
         zipSources: false
       condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
-      
+
     - task: MicroBuildOptProfPlugin@6
       inputs:
         ProfilingInputsDropName: '$(VisualStudio.DropName)'
         ShouldSkipOptimize: true
         AccessToken: '$(System.AccessToken)'
         feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-      displayName: 'Install OptProf Plugin'      
+      displayName: 'Install OptProf Plugin'
 
     # Required by MicroBuildBuildVSBootstrapper
     - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -26,11 +26,13 @@ stages:
   displayName: Build
 
   jobs:
-  - template: /eng/common/templates/job/onelocbuild.yml
-    parameters:
-      CreatePr: false
-      LclSource: lclFilesfromPackage
-      LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
+  - {{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+    - template: /eng/common/templates/job/onelocbuild.yml
+      parameters:
+        CreatePr: false
+        LclSource: lclFilesfromPackage
+        LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
+        MirrorRepo: {{msbuild}}
 
   - job: Windows_NT
     pool:


### PR DESCRIPTION
### Context
Migrates us "fully" onto the OneLocBuild.yml template. We were missing a condition and parameter in the template import.

Thought: This doesn't need to be backported to <=`vs16.11` right? Those builds should be having the onelocbuild template imported regardless. On second thought, they may need the `MirrorRepo` parameter.

### Changes Made
Add `MirrorRepo` parameter
Add condition on importing the template.

### Testing
Will create `exp/` branch to test this.

### Notes
