### PR TITLE
Opt into quirks in amd64 MSBuild explicitly

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -10,7 +10,7 @@
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
-      <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
+      <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false;Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -10,7 +10,10 @@
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
-      <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false;Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+      <!-- Manually expanded list of quirks applied to a .NET 4.7.2 application, to work around CLR bug that doesn't apply them correctly
+           https://referencesource.microsoft.com/#mscorlib/system/AppContext/AppContextDefaultValues.Defaults.cs,37
+           Framework bug: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1148752 -->
+      <AppContextSwitchOverrides value="Switch.System.Globalization.NoAsyncCurrentCulture=false;Switch.System.Threading.ThrowExceptionIfDisposedCancellationTokenSource=false;Switch.System.Security.ClaimsIdentity.SetActorAsReferenceWhenCopyingClaimsIdentity=false;Switch.System.Security.Cryptography.DoNotAddrOfCspParentWindowHandle=false;Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false;Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false;Switch.System.Security.Cryptography.UseLegacyFipsThrow=false;" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />


### PR DESCRIPTION
Fixes #5331 by explicitly specifying all quirks that the runtime should specify for us because we target .NET 4.7.2.

Obnoxiously, amd64 MSBuild was fixed for long paths for exactly one release, 16.7. 16.8 broke it again.
