### PR TITLE
Fix missing project instance in project cache requests

### DIFF
--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -1351,6 +1351,86 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
         [Theory]
         [InlineData(false, false)]
+        // TODO: Reenable when this gets into the main branch.
+        //[InlineData(true, true)]
+        public void ParallelStressTestForVsWorkaround(bool useSynchronousLogging, bool disableInprocNode)
+        {
+            var currentBuildEnvironment = BuildEnvironmentHelper.Instance;
+
+            try
+            {
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(
+                    new BuildEnvironment(
+                        currentBuildEnvironment.Mode,
+                        currentBuildEnvironment.CurrentMSBuildExePath,
+                        currentBuildEnvironment.RunningTests,
+                        runningInVisualStudio: true,
+                        visualStudioPath: currentBuildEnvironment.VisualStudioInstallRootDirectory));
+
+                BuildManager.ProjectCacheItems.ShouldBeEmpty();
+
+                var referenceNumbers = Enumerable.Range(2, NativeMethodsShared.GetLogicalCoreCount() * 2).ToArray();
+
+                var testData = new GraphCacheResponse(
+                    new Dictionary<int, int[]>
+                    {
+                        {1, referenceNumbers}
+                    },
+                    referenceNumbers.ToDictionary(k => k, k => GraphCacheResponse.SuccessfulProxyTargetResult())
+                );
+
+                var graph = testData.CreateGraph(_env);
+
+                // Even though the assembly cache is discovered, we'll be overriding it with a descriptor based cache.
+                BuildManager.ProjectCacheItems.ShouldHaveSingleItem();
+
+                var cache = new InstanceMockCache(testData, TimeSpan.FromMilliseconds(50));
+
+                using var buildSession = new Helpers.BuildManagerSession(_env, new BuildParameters
+                {
+                    MaxNodeCount = NativeMethodsShared.GetLogicalCoreCount(),
+                    ProjectCacheDescriptor = ProjectCacheDescriptor.FromInstance(
+                        cache,
+                        entryPoints: null,
+                        graph),
+                    UseSynchronousLogging = useSynchronousLogging,
+                    DisableInProcNode = disableInprocNode
+                });
+
+                var buildResultTasks = new List<Task<BuildResult>>();
+
+                foreach (var node in graph.ProjectNodes.Where(n => referenceNumbers.Contains(GetProjectNumber(n))))
+                {
+                    var buildResultTask = buildSession.BuildProjectFileAsync(
+                        node.ProjectInstance.FullPath,
+                        globalProperties:
+                        new Dictionary<string, string> { { "SolutionPath", graph.GraphRoots.First().ProjectInstance.FullPath } });
+
+                    buildResultTasks.Add(buildResultTask);
+                }
+
+                foreach (var buildResultTask in buildResultTasks)
+                {
+                    buildResultTask.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+                }
+
+                buildSession.BuildProjectFile(
+                        graph.GraphRoots.First().ProjectInstance.FullPath,
+                        globalProperties:
+                        new Dictionary<string, string> {{"SolutionPath", graph.GraphRoots.First().ProjectInstance.FullPath}})
+                    .OverallResult.ShouldBe(BuildResultCode.Success);
+
+                cache.QueryStartStops.Count.ShouldBe(graph.ProjectNodes.Count * 2);
+            }
+            finally
+            {
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(currentBuildEnvironment);
+                BuildManager.ProjectCacheItems.Clear();
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
         [InlineData(true, true)]
         public void ParallelStressTest(bool useSynchronousLogging, bool disableInprocNode)
         {

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -272,6 +272,8 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
                 logger.LogMessage($"MockCache: GetCacheResultAsync for {buildRequest.ProjectFullPath}", MessageImportance.High);
 
+                buildRequest.ProjectInstance.ShouldNotBeNull("The cache plugin expects evaluated projects.");
+
                 if (_projectQuerySleepTime is not null)
                 {
                     await Task.Delay(_projectQuerySleepTime.Value);

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -230,7 +230,10 @@ namespace Microsoft.Build.Experimental.ProjectCache
                     await LateInitializePluginForVsWorkaround(request);
                 }
 
-                return await GetCacheResultAsync(cacheRequest.Submission.BuildRequestData);
+                return await GetCacheResultAsync(
+                    new BuildRequestData(
+                        request.Configuration.Project,
+                        request.Submission.BuildRequestData.TargetNames.ToArray()));
             }
 
             static bool IsDesignTimeBuild(ProjectInstance project)

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -303,6 +303,8 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
         private async Task<CacheResult> GetCacheResultAsync(BuildRequestData buildRequest)
         {
+            ErrorUtilities.VerifyThrowInternalNull(buildRequest.ProjectInstance, nameof(buildRequest.ProjectInstance));
+
             var queryDescription = $"{buildRequest.ProjectFullPath}" +
                                    $"\n\tTargets:[{string.Join(", ", buildRequest.TargetNames)}]" +
                                    $"\n\tGlobal Properties: {{{string.Join(",", buildRequest.GlobalProperties.Select(kvp => $"{kvp.Name}={kvp.EvaluatedValue}"))}}}";

--- a/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
+++ b/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Experimental.ProjectCache;
 using Microsoft.Build.Framework;
+using Shouldly;
 
 namespace MockCacheFromAssembly
 {
@@ -32,6 +34,8 @@ namespace MockCacheFromAssembly
             CancellationToken cancellationToken)
         {
             logger.LogMessage($"{nameof(AssemblyMockCache)}: GetCacheResultAsync for {buildRequest.ProjectFullPath}", MessageImportance.High);
+
+            buildRequest.ProjectInstance.ShouldNotBeNull("The cache plugin expects evaluated projects.");
 
             ErrorFrom(nameof(GetCacheResultAsync), logger);
 

--- a/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
+++ b/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
@@ -12,4 +12,7 @@
     <ProjectReference Include="..\..\Build\Microsoft.Build.csproj" />
     <ProjectReference Include="..\..\Framework\Microsoft.Build.Framework.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Context
Non static graph builds using the project cache didn't set the ProjectInstance on the cache request, leading to crashes in the cache.

### Changes Made
Recreate the BuildRequestData for the cache request after the cache service evaluates projects. I was initially using the original BuildSubmission.BuildRequestData which does not contain the project instance.

### Testing
Unit tests

### Notes
This does not affect non project cache code paths so it shouldn't be a risk for 16.11.