### PR TITLE
Ensure project cache initialization happens only once

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public BuildRequestConfiguration_Tests(ITestOutputHelper testOutput)
         {
             _env = TestEnvironment.Create(testOutput);
-            _env.DoNotLaunchDebugger();
         }
 
         public void Dispose()

--- a/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
+++ b/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
@@ -125,8 +125,6 @@ namespace Microsoft.Build.UnitTests.Definition
         [Fact]
         public void IsolatedContextShouldNotSupportBeingPassedAFileSystem()
         {
-            _env.DoNotLaunchDebugger();
-
             var fileSystem = new Helpers.LoggingFileSystem();
             Should.Throw<ArgumentException>(() => EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated, fileSystem));
         }

--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Build.Graph.UnitTests
         [InlineData("1.sln", "2.proj")]
         public void ASolutionShouldBeTheSingleEntryPoint(params string[] files)
         {
-            _env.DoNotLaunchDebugger();
-
             for (var i = 0; i < files.Length; i++)
             {
                 files[i] = _env.CreateFile(files[i], string.Empty).Path;
@@ -52,8 +50,6 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void GraphConstructionFailsOnNonExistentSolution()
         {
-            _env.DoNotLaunchDebugger();
-
             var exception = Should.Throw<InvalidProjectFileException>(
                 () =>
                 {
@@ -79,8 +75,6 @@ namespace Microsoft.Build.Graph.UnitTests
                 projectReferenceTargets: null,
                 defaultTargets: null,
                 extraContent: referenceToSolution);
-
-            _env.DoNotLaunchDebugger();
 
             var exception = Should.Throw<InvalidOperationException>(
                 () =>
@@ -621,8 +615,6 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void GraphConstructionShouldThrowOnMissingSolutionDependencies()
         {
-            _env.DoNotLaunchDebugger();
-
             var solutionContents = SolutionFileBuilder.FromGraphEdges(
                 _env,
                 new Dictionary<int, int[]> {{1, null}, {2, null}},

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -106,7 +106,6 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void ProjectGraphNodeConstructorNoNullArguments()
         {
-            _env.DoNotLaunchDebugger();
             Assert.Throws<InternalErrorException>(() => new ProjectGraphNode(null));
         }
 

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
         {
             _output = output;
             _env = TestEnvironment.Create(output);
-            _env.DoNotLaunchDebugger();
 
             BuildManager.ProjectCacheItems.ShouldBeEmpty();
             _env.WithInvariant(new CustomConditionInvariant(() => BuildManager.ProjectCacheItems.Count == 0));

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Copy constructor
         /// </summary>
-        private BuildParameters(BuildParameters other)
+        internal BuildParameters(BuildParameters other, bool resetEnvironment = false)
         {
             ErrorUtilities.VerifyThrowInternalNull(other, nameof(other));
 
@@ -261,7 +261,11 @@ namespace Microsoft.Build.Execution
             _culture = other._culture;
             _defaultToolsVersion = other._defaultToolsVersion;
             _enableNodeReuse = other._enableNodeReuse;
-            _buildProcessEnvironment = other._buildProcessEnvironment != null ? new Dictionary<string, string>(other._buildProcessEnvironment) : null;
+            _buildProcessEnvironment = resetEnvironment
+                ? CommunicationsUtilities.GetEnvironmentVariables()
+                : other._buildProcessEnvironment != null
+                    ? new Dictionary<string, string>(other._buildProcessEnvironment)
+                    : null;
             _environmentProperties = other._environmentProperties != null ? new PropertyDictionary<ProjectPropertyInstance>(other._environmentProperties) : null;
             _forwardingLoggers = other._forwardingLoggers != null ? new List<ForwardingLoggerRecord>(other._forwardingLoggers) : null;
             _globalProperties = other._globalProperties != null ? new PropertyDictionary<ProjectPropertyInstance>(other._globalProperties) : null;

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
         // Volatile because it is read by the BuildManager thread and written by one project cache service thread pool thread.
         // TODO: remove after we change VS to set the cache descriptor via build parameters.
         public volatile NullableBool? DesignTimeBuildsDetected;
+        private TaskCompletionSource<bool>? LateInitializationForVSWorkaroundCompleted;
 
         private ProjectCacheService(
             ProjectCachePluginBase projectCachePlugin,
@@ -225,12 +226,19 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
                 EvaluateProjectIfNecessary(request);
 
+                // Detect design time builds.
                 if (_projectCacheDescriptor.VsWorkaround)
                 {
-                    Interlocked.CompareExchange(
+                    var isDesignTimeBuild = IsDesignTimeBuild(request.Configuration.Project);
+
+                    var previousValue = Interlocked.CompareExchange(
                         ref DesignTimeBuildsDetected,
-                        new NullableBool(IsDesignTimeBuild(request.Configuration.Project)),
+                        new NullableBool(isDesignTimeBuild),
                         null);
+
+                    ErrorUtilities.VerifyThrowInternalError(
+                        previousValue is null || previousValue == false || isDesignTimeBuild,
+                        "Either all builds in a build session or design time builds, or none");
 
                     // No point progressing with expensive plugin initialization or cache query if design time build detected.
                     if (DesignTimeBuildsDetected)
@@ -240,11 +248,28 @@ namespace Microsoft.Build.Experimental.ProjectCache
                     }
                 }
 
-                if (_projectCacheDescriptor.VsWorkaround)
-                {
                 // TODO: remove after we change VS to set the cache descriptor via build parameters.
+                // VS workaround needs to wait until the first project is evaluated to extract enough information to initialize the plugin.
+                // No cache request can progress until late initialization is complete.
+                if (_projectCacheDescriptor.VsWorkaround &&
+                    Interlocked.CompareExchange(
+                        ref LateInitializationForVSWorkaroundCompleted,
+                        new TaskCompletionSource<bool>(),
+                        null) is null)
+                {
                     await LateInitializePluginForVsWorkaround(request);
+                    LateInitializationForVSWorkaroundCompleted.SetResult(true);
                 }
+                else if (_projectCacheDescriptor.VsWorkaround)
+                {
+                    // Can't be null. If the thread got here it means another thread initialized the completion source.
+                    await LateInitializationForVSWorkaroundCompleted!.Task;
+                }
+
+                ErrorUtilities.VerifyThrowInternalError(
+                    LateInitializationForVSWorkaroundCompleted is null ||
+                    _projectCacheDescriptor.VsWorkaround && LateInitializationForVSWorkaroundCompleted.Task.IsCompleted,
+                    "Completion source should be null when this is not the VS workaround");
 
                 return await GetCacheResultAsync(
                     new BuildRequestData(

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -251,19 +251,21 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 // TODO: remove after we change VS to set the cache descriptor via build parameters.
                 // VS workaround needs to wait until the first project is evaluated to extract enough information to initialize the plugin.
                 // No cache request can progress until late initialization is complete.
-                if (_projectCacheDescriptor.VsWorkaround &&
-                    Interlocked.CompareExchange(
-                        ref LateInitializationForVSWorkaroundCompleted,
-                        new TaskCompletionSource<bool>(),
-                        null) is null)
+                if (_projectCacheDescriptor.VsWorkaround)
                 {
-                    await LateInitializePluginForVsWorkaround(request);
-                    LateInitializationForVSWorkaroundCompleted.SetResult(true);
-                }
-                else if (_projectCacheDescriptor.VsWorkaround)
-                {
-                    // Can't be null. If the thread got here it means another thread initialized the completion source.
-                    await LateInitializationForVSWorkaroundCompleted!.Task;
+                    if (Interlocked.CompareExchange(
+                            ref LateInitializationForVSWorkaroundCompleted,
+                            new TaskCompletionSource<bool>(),
+                            null) is null)
+                    {
+                        await LateInitializePluginForVsWorkaround(request);
+                        LateInitializationForVSWorkaroundCompleted.SetResult(true);
+                    }
+                    else
+                    {
+                        // Can't be null. If the thread got here it means another thread initialized the completion source.
+                        await LateInitializationForVSWorkaroundCompleted!.Task;
+                    }
                 }
 
                 ErrorUtilities.VerifyThrowInternalError(

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -69,39 +69,43 @@ namespace Microsoft.Build.Experimental.ProjectCache
             // their verbosity levels.
             var loggerFactory = new Func<PluginLoggerBase>(() => new LoggingServiceToPluginLoggerAdapter(LoggerVerbosity.Normal, loggingService));
 
-            // TODO: remove after we change VS to set the cache descriptor via build parameters.
-            if (pluginDescriptor.VsWorkaround)
-            {
+            var service = new ProjectCacheService(plugin, buildManager, loggerFactory, pluginDescriptor, cancellationToken);
+
+            // TODO: remove the if after we change VS to set the cache descriptor via build parameters and always call BeginBuildAsync in FromDescriptorAsync.
                 // When running under VS we can't initialize the plugin until we evaluate a project (any project) and extract
                 // further information (set by VS) from it required by the plugin.
-                return new ProjectCacheService(plugin, buildManager, loggerFactory, pluginDescriptor, cancellationToken);
+            if (!pluginDescriptor.VsWorkaround)
+            {
+                await service.BeginBuildAsync();
             }
 
-            await InitializePlugin(pluginDescriptor, cancellationToken, loggerFactory, plugin);
-
-            return new ProjectCacheService(plugin, buildManager, loggerFactory, pluginDescriptor, cancellationToken);
+            return service;
         }
 
-        private static async Task InitializePlugin(
-            ProjectCacheDescriptor pluginDescriptor,
-            CancellationToken cancellationToken,
-            Func<PluginLoggerBase> loggerFactory,
-            ProjectCachePluginBase plugin
-        )
+        // TODO: remove vsWorkaroundOverrideDescriptor after we change VS to set the cache descriptor via build parameters.
+        private async Task BeginBuildAsync(ProjectCacheDescriptor? vsWorkaroundOverrideDescriptor = null)
         {
-            var logger = loggerFactory();
+            var logger = _loggerFactory();
 
             try
             {
-                await plugin.BeginBuildAsync(
+
+                if (_projectCacheDescriptor.VsWorkaround)
+                {
+                    logger.LogMessage("Running project cache with Visual Studio workaround");
+                }
+
+                var projectDescriptor = vsWorkaroundOverrideDescriptor ?? _projectCacheDescriptor;
+                await _projectCachePlugin.BeginBuildAsync(
                     new CacheContext(
-                        pluginDescriptor.PluginSettings,
+                        projectDescriptor.PluginSettings,
                         new IFileSystemAdapter(FileSystems.Default),
-                        pluginDescriptor.ProjectGraph,
-                        pluginDescriptor.EntryPoints),
+                        projectDescriptor.ProjectGraph,
+                        projectDescriptor.EntryPoints),
                     // TODO: Detect verbosity from logging service.
                     logger,
-                    cancellationToken);
+                    _cancellationToken);
+
             }
             catch (Exception e)
             {
@@ -281,7 +285,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                     FileSystems.Default.FileExists(solutionPath),
                     $"Solution file does not exist: {solutionPath}");
 
-                await InitializePlugin(
+                await BeginBuildAsync(
                     ProjectCacheDescriptor.FromAssemblyPath(
                         _projectCacheDescriptor.PluginAssemblyPath!,
                         new[]
@@ -291,10 +295,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                                 configuration.Project.GlobalProperties)
                         },
                         projectGraph: null,
-                        _projectCacheDescriptor.PluginSettings),
-                    _cancellationToken,
-                    _loggerFactory,
-                    _projectCachePlugin);
+                        _projectCacheDescriptor.PluginSettings));
             }
 
             static bool MSBuildStringIsTrue(string msbuildString) =>

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -47,6 +47,14 @@ namespace Microsoft.Build.Shared
 #if !BUILDINGAPPXTASKS
         #region VerifyThrow -- for internal errors
 
+        internal static void VerifyThrowInternalError(bool condition, string message, params object[] args)
+        {
+            if (s_throwExceptions && !condition)
+            {
+                throw new InternalErrorException(ResourceUtilities.FormatString(message, args));
+            }
+        }
+
         /// <summary>
         /// Throws InternalErrorException. 
         /// This is only for situations that would mean that there is a bug in MSBuild itself.

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -35,6 +35,8 @@ public class MSBuildTestAssemblyFixture : IDisposable
 
         _testEnvironment = TestEnvironment.Create();
 
+        _testEnvironment.DoNotLaunchDebugger();
+
         //  Reset the VisualStudioVersion environment variable.  This will be set if tests are run from a VS command prompt.  However,
         //  if the environment variable is set, it will interfere with tests which set the SubToolsetVersion
         //  (VerifySubToolsetVersionSetByConstructorOverridable), as the environment variable would take precedence.


### PR DESCRIPTION
Based on #6568. Review that one first. First commit of this PR is [Don't launch debugger window for all tests](https://github.com/dotnet/msbuild/commit/529e2ae13d060adb50f7cf5304e6f781d8666941).

### Context
Turns out the VS workaround was initializing the plugin on every project query, thus crashing the cache.

### Changes Made
Initialization is happening only once now.
`ProjectCacheService` is now asserting that it's always in expected states.

### Testing
Unit tests.

### Notes
Does not affect non project cache code paths so should be no risk for 16.11.