### PR TITLE
Set branch for loc PRs

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -32,6 +32,7 @@ stages:
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
         MirrorRepo: 'msbuild'
+        MirrorBranch: 'vs16.11' # should match condition above
 
   - job: Windows_NT
     pool:


### PR DESCRIPTION
See https://github.com/dotnet/msbuild/pull/6561#issuecomment-862627551.

Because we're getting updated localization from 16.11, we need to tell the automation to send the PRs to the 16.11 branch.