### PR TITLE
Backport Ubuntu update to 16.11

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -153,7 +153,7 @@ jobs:
 - job: CoreBootstrappedOnLinux
   displayName: "Linux Core"
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build


### PR DESCRIPTION
I'm tired of seeing warnings all the time and the lifetime of 16.11 will very likely exceed the lifetime of the 16.04 image so backporting #6488.