### PR TITLE
Infer target skip reason from older binlogs

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Build.Logging
 
                 // Attempt to infer skip reason from the data we have
                 skipReason = condition != null ?
-                    TargetSkipReason.ConditionWasFalse
+                    TargetSkipReason.ConditionWasFalse // condition expression only stored when false
                     : originallySucceeded ?
                         TargetSkipReason.PreviouslyBuiltSuccessfully
                         : TargetSkipReason.PreviouslyBuiltUnsuccessfully;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -304,6 +304,13 @@ namespace Microsoft.Build.Logging
                 condition = ReadOptionalString();
                 evaluatedCondition = ReadOptionalString();
                 originallySucceeded = ReadBoolean();
+
+                // Attempt to infer skip reason from the data we have
+                skipReason = condition != null ?
+                    TargetSkipReason.ConditionWasFalse
+                    : originallySucceeded ?
+                        TargetSkipReason.PreviouslyBuiltSuccessfully
+                        : TargetSkipReason.PreviouslyBuiltUnsuccessfully;
             }
 
             var buildReason = (TargetBuiltReason)ReadInt32();

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -447,8 +447,6 @@ Build
 
         private void Write(TargetSkippedEventArgs e)
         {
-            ErrorUtilities.VerifyThrow(e.SkipReason != TargetSkipReason.None, "TargetSkippedEventArgs.SkipReason needs to be set");
-
             Write(BinaryLogRecordKind.TargetSkipped);
             WriteMessageFields(e, writeMessage: false);
             WriteDeduplicatedString(e.TargetFile);


### PR DESCRIPTION
Remove an assert that is too aggressive. When reading old binlogs the TargetSkipReason is not known, so TargetSkipReason.None is a valid state.

We can do a best effort and infer the skip reason for format version 13.

Fixes #6563
