### PR TITLE
Publish FileAssociation Icons correctly in Single-File ClickOnce publish

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4232,6 +4232,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup Condition="'$(PublishSingleFile)' == 'true'">
       <_ClickOnceFiles Include="$(PublishedSingleFilePath)"/>
       <_ClickOnceFiles Include="@(_FilesExcludedFromBundle)"/>
+
+      <!-- Include file association icons from Content as loose files -->
+      <_FileAssociationIcons Include="%(FileAssociation.DefaultIcon)"/>
+      <_ClickOnceFiles Include="@(ContentWithTargetPath)" Condition="'%(Identity)'=='@(_FileAssociationIcons)'"/>
     </ItemGroup>
 
     <!-- For single file publish in .net core app, sign the SF EXE if signing is enabled -->


### PR DESCRIPTION
Ensure file association icons files get published as loose files in Single-File publish for ClickOnce

Fixes #1340931

### Context
ClickOnce applications can associate file extension and icons with the application. In this scenario, the icon files should be published. When published in Single-File mode, we fail to publish the icon files.

### Changes Made
In Single-File publishing, ClickOnce only publishes the SF Exe and any uncompressed file that cannot go into the bundle. The ico files get ignored. The fix made now ensure that ico files in FileAssociation item list are also published as uncompressed file. These file need be be outside of the bundle so that the ClickOnce installer and runtime can see them.

### Testing
CTI tested all configurations (Portable/x64/x86 across FDD/SCD and SF modes).

### Notes
