### PR TITLE
Use List<string> for excludes

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Evaluation
             
             readonly string _rootDirectory;
 
-            readonly ImmutableList<string> _excludes;
+            readonly ImmutableArray<string> _excludes;
 
             readonly ImmutableList<ProjectMetadataElement> _metadata;
 
@@ -167,7 +167,7 @@ namespace Microsoft.Build.Evaluation
             public int ElementOrder { get; set; }
             public string RootDirectory { get; set; }
 
-            public ImmutableList<string>.Builder Excludes { get; } = ImmutableList.CreateBuilder<string>();
+            public ImmutableArray<string>.Builder Excludes { get; } = ImmutableArray.CreateBuilder<string>();
 
             public IncludeOperationBuilder(ProjectItemElement itemElement, bool conditionResult) : base(itemElement, conditionResult)
             {

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Build.Evaluation
             
             readonly string _rootDirectory;
 
-            readonly ImmutableArray<string> _excludes;
+            // TODO: Convert this to ImmutableSegmentedList<T> once available.
+            // https://github.com/dotnet/msbuild/issues/6601
+            readonly List<string> _excludes;
 
             readonly ImmutableList<ProjectMetadataElement> _metadata;
 
@@ -31,7 +33,7 @@ namespace Microsoft.Build.Evaluation
                 _elementOrder = builder.ElementOrder;
                 _rootDirectory = builder.RootDirectory;
 
-                _excludes = builder.Excludes.ToImmutable();
+                _excludes = builder.Excludes;
                 _metadata = builder.Metadata.ToImmutable();
             }
 
@@ -167,7 +169,9 @@ namespace Microsoft.Build.Evaluation
             public int ElementOrder { get; set; }
             public string RootDirectory { get; set; }
 
-            public ImmutableArray<string>.Builder Excludes { get; } = ImmutableArray.CreateBuilder<string>();
+            // TODO: Convert this to ImmutableSegmentedList<T>.Builder once available.
+            // https://github.com/dotnet/msbuild/issues/6601
+            public List<string> Excludes { get; } = new();
 
             public IncludeOperationBuilder(ProjectItemElement itemElement, bool conditionResult) : base(itemElement, conditionResult)
             {


### PR DESCRIPTION
My preference is to use `ImmutableSegmentedList<string>` for this (avoids the Large Object Heap and avoids the array copy in `ToImmutable()`), but I haven't finished implementing it yet in Microsoft.CodeAnalysis.Collections. In the mean time, I've corrected an acute performance problem by using ~`ImmutableArray<string>`~ `List<string>` instead of `ImmutableList<string>`.

Fixes [AB#1344683](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1344683)
