### PR TITLE
Default to transitively copying content items

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -29,5 +29,6 @@ The opt-out comes in the form of setting the environment variable `MSBuildDisabl
 - [Allow users that have certain special characters in their username to build successfully when using exec](https://github.com/dotnet/msbuild/pull/6223)
 - [Fail restore operations when an SDK is unresolveable](https://github.com/dotnet/msbuild/pull/6430)
 ### 17.0
+- [Default to transitively copying content items](https://github.com/dotnet/msbuild/pull/6622)
 
 ## Change Waves No Longer In Rotation

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4737,7 +4737,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       This target enforces the dependency.
     -->
 
-    <MSBuildCopyContentTransitively Condition="$([MSBuild]::AreFeaturesEnabled('17.0'))">true</MSBuildCopyContentTransitively>
+    <MSBuildCopyContentTransitively Condition=" '$(MSBuildCopyContentTransitively)' == '' and $([MSBuild]::AreFeaturesEnabled('17.0'))">true</MSBuildCopyContentTransitively>
 
     <_TargetsThatPrepareProjectReferences Condition=" '$(MSBuildCopyContentTransitively)' == 'true' ">
       AssignProjectConfiguration;

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4735,9 +4735,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       GetCopyToOutputDirectoryItems depends on an unspecified dependency _SplitProjectReferencesByFileExistence -> AssignProjectConfiguration (https://github.com/microsoft/msbuild/issues/4677).
       When the unspecified dependency does not happen by accident, content copying is only 1 level deep instead of transitive.
       This target enforces the dependency.
-
-      TODO: make transitive content copying the default when the breaking change is acceptable.
     -->
+
+    <MSBuildCopyContentTransitively Condition="$([MSBuild]::AreFeaturesEnabled('17.0'))">true</MSBuildCopyContentTransitively>
+
     <_TargetsThatPrepareProjectReferences Condition=" '$(MSBuildCopyContentTransitively)' == 'true' ">
       AssignProjectConfiguration;
       _SplitProjectReferencesByFileExistence


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/1054

### Context
IncrementalClean has the behavior of deleting content items from transitive references on rebuild of the main project. With the move to 17.0, we want to default to copying all transitive content items into the main output folder to avoid this behavior.

### Changes Made
Under change wave 17.0, default `MSBuildCopyContentTransitively` to true.

### Testing
Tested locally on https://github.com/rainersigwald/IncrementalCleanDemo

### Notes
