### PR TITLE
Don't compile globbing regexes on .NET Framework

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -29,5 +29,7 @@ The opt-out comes in the form of setting the environment variable `MSBuildDisabl
 - [Allow users that have certain special characters in their username to build successfully when using exec](https://github.com/dotnet/msbuild/pull/6223)
 - [Fail restore operations when an SDK is unresolveable](https://github.com/dotnet/msbuild/pull/6430)
 ### 17.0
+- [Scheduler should honor BuildParameters.DisableInprocNode](https://github.com/dotnet/msbuild/pull/6400)
+- [Don't compile globbing regexes on .NET Framework](https://github.com/dotnet/msbuild/pull/6632)
 
 ## Change Waves No Longer In Rotation

--- a/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
                 return path.Replace(Path.DirectorySeparatorChar == '/' ? '\\' : '/', Path.DirectorySeparatorChar);
             }
 
-            Assert.Equal(NormalizeSlashes(Path.Combine(Path.GetFullPath(globRoot), fixedDirectoryPart)), result.FixedDirectoryPartMatchGroup);
+            Assert.Equal(NormalizeSlashes(Path.GetFullPath(Path.Combine(globRoot, fixedDirectoryPart))), result.FixedDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(wildcardDirectoryPart), result.WildcardDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(filenamePart), result.FilenamePartMatchGroup);
         }

--- a/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
@@ -350,11 +350,13 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
 
             string NormalizeSlashes(string path)
             {
-                string normalized = path.Replace(Path.DirectorySeparatorChar == '/' ? '\\' : '/', Path.DirectorySeparatorChar);
-                return NativeMethodsShared.IsWindows ? normalized.Replace("\\\\", "\\") : normalized;
+                string normalizedPath = path.Replace(Path.DirectorySeparatorChar == '/' ? '\\' : '/', Path.DirectorySeparatorChar);
+                return NativeMethodsShared.IsWindows ? normalizedPath.Replace("\\\\", "\\") : normalizedPath;
             }
 
-            Assert.Equal(NormalizeSlashes(Path.Combine(FileUtilities.NormalizePath(globRoot), fixedDirectoryPart)), result.FixedDirectoryPartMatchGroup);
+            var rootedFixedDirectoryPart = Path.Combine(FileUtilities.NormalizePath(globRoot), fixedDirectoryPart);
+
+            Assert.Equal(FileUtilities.GetFullPathNoThrow(rootedFixedDirectoryPart), result.FixedDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(wildcardDirectoryPart), result.WildcardDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(filenamePart), result.FilenamePartMatchGroup);
         }

--- a/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
                 return NativeMethodsShared.IsWindows ? normalized.Replace("\\\\", "\\") : normalized;
             }
 
-            Assert.Equal(NormalizeSlashes(Path.Combine(FileUtilities.NormalizePath(globRoot), fixedDirectoryPart)), result.FixedDirectoryPartMatchGroup);
+            Assert.Equal(NormalizeSlashes(Path.Combine(globRoot, fixedDirectoryPart)), result.FixedDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(wildcardDirectoryPart), result.WildcardDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(filenamePart), result.FilenamePartMatchGroup);
         }

--- a/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
             @"a/b/\c",
             @"d/e\/*b*/\*.cs",
             @"d\e\\abc/\a.cs",
-            @"d\e\", @"abc\", @"a.cs")]
+            @"d\e\\", @"abc\\", @"a.cs")]
         public void GlobMatchingIgnoresSlashOrientationAndRepetitions(string globRoot, string fileSpec, string stringToMatch,
             string fixedDirectoryPart, string wildcardDirectoryPart, string filenamePart)
         {
@@ -350,10 +350,11 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
 
             string NormalizeSlashes(string path)
             {
-                return path.Replace(Path.DirectorySeparatorChar == '/' ? '\\' : '/', Path.DirectorySeparatorChar);
+                string normalized = path.Replace(Path.DirectorySeparatorChar == '/' ? '\\' : '/', Path.DirectorySeparatorChar);
+                return NativeMethodsShared.IsWindows ? normalized.Replace("\\\\", "\\") : normalized;
             }
 
-            Assert.Equal(NormalizeSlashes(Path.GetFullPath(Path.Combine(globRoot, fixedDirectoryPart))), result.FixedDirectoryPartMatchGroup);
+            Assert.Equal(NormalizeSlashes(Path.Combine(FileUtilities.NormalizePath(globRoot), fixedDirectoryPart)), result.FixedDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(wildcardDirectoryPart), result.WildcardDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(filenamePart), result.FilenamePartMatchGroup);
         }

--- a/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
                 return NativeMethodsShared.IsWindows ? normalized.Replace("\\\\", "\\") : normalized;
             }
 
-            Assert.Equal(NormalizeSlashes(Path.Combine(globRoot, fixedDirectoryPart)), result.FixedDirectoryPartMatchGroup);
+            Assert.Equal(NormalizeSlashes(Path.Combine(FileUtilities.NormalizePath(globRoot), fixedDirectoryPart)), result.FixedDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(wildcardDirectoryPart), result.WildcardDirectoryPartMatchGroup);
             Assert.Equal(NormalizeSlashes(filenamePart), result.FilenamePartMatchGroup);
         }

--- a/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
@@ -326,20 +326,36 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
         [InlineData(
             @"a/b\c",
             @"d/e\f/**\a.cs",
-            @"d\e/f\g/h\i/a.cs")]
+            @"d\e/f\g/h\i/a.cs",
+            @"d\e/f\", @"g/h\i/", @"a.cs")]
         [InlineData(
             @"a/b\c",
             @"d/e\f/*b*\*.cs",
-            @"d\e/f\abc/a.cs")]
+            @"d\e/f\abc/a.cs",
+            @"d\e/f\", @"abc/", @"a.cs")]
         [InlineData(
             @"a/b/\c",
             @"d/e\/*b*/\*.cs",
-            @"d\e\\abc/\a.cs")]
-        public void GlobMatchingIgnoresSlashOrientationAndRepetitions(string globRoot, string fileSpec, string stringToMatch)
+            @"d\e\\abc/\a.cs",
+            @"d\e\", @"abc\", @"a.cs")]
+        public void GlobMatchingIgnoresSlashOrientationAndRepetitions(string globRoot, string fileSpec, string stringToMatch,
+            string fixedDirectoryPart, string wildcardDirectoryPart, string filenamePart)
         {
             var glob = MSBuildGlob.Parse(globRoot, fileSpec);
 
             Assert.True(glob.IsMatch(stringToMatch));
+
+            MSBuildGlob.MatchInfoResult result = glob.MatchInfo(stringToMatch);
+            Assert.True(result.IsMatch);
+
+            string NormalizeSlashes(string path)
+            {
+                return path.Replace(Path.DirectorySeparatorChar == '/' ? '\\' : '/', Path.DirectorySeparatorChar);
+            }
+
+            Assert.Equal(NormalizeSlashes(Path.Combine(Path.GetFullPath(globRoot), fixedDirectoryPart)), result.FixedDirectoryPartMatchGroup);
+            Assert.Equal(NormalizeSlashes(wildcardDirectoryPart), result.WildcardDirectoryPartMatchGroup);
+            Assert.Equal(NormalizeSlashes(filenamePart), result.FilenamePartMatchGroup);
         }
     }
 }

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Build.Shared
                 else
                 {
                     // Relative
-                    pathRoot = String.Empty;
+                    pathRoot = string.Empty;
                     startingElement = 0;
                 }
             }
@@ -516,7 +516,7 @@ namespace Microsoft.Build.Shared
                 // If there is a zero-length part, then that means there was an extra slash.
                 if (parts[i].Length == 0)
                 {
-                    longParts[i - startingElement] = String.Empty;
+                    longParts[i - startingElement] = string.Empty;
                 }
                 else
                 {
@@ -556,7 +556,7 @@ namespace Microsoft.Build.Shared
                 }
             }
 
-            return pathRoot + String.Join(s_directorySeparator, longParts);
+            return pathRoot + string.Join(s_directorySeparator, longParts);
         }
 
         /// <summary>
@@ -630,8 +630,8 @@ namespace Microsoft.Build.Shared
                  * 
                  *     **
                  */
-                fixedDirectoryPart = String.Empty;
-                wildcardDirectoryPart = String.Empty;
+                fixedDirectoryPart = string.Empty;
+                wildcardDirectoryPart = string.Empty;
                 filenamePart = filespec;
                 return;
             }
@@ -661,7 +661,7 @@ namespace Microsoft.Build.Shared
 
                 // We know the fixed director part now.
                 fixedDirectoryPart = filespec.Substring(0, indexOfLastDirectorySeparator + 1);
-                wildcardDirectoryPart = String.Empty;
+                wildcardDirectoryPart = string.Empty;
                 filenamePart = filespec.Substring(indexOfLastDirectorySeparator + 1);
                 return;
             }
@@ -682,7 +682,7 @@ namespace Microsoft.Build.Shared
                  * 
                  *      dir?\**
                  */
-                fixedDirectoryPart = String.Empty;
+                fixedDirectoryPart = string.Empty;
                 wildcardDirectoryPart = filespec.Substring(0, indexOfLastDirectorySeparator + 1);
                 filenamePart = filespec.Substring(indexOfLastDirectorySeparator + 1);
                 return;
@@ -1567,9 +1567,9 @@ namespace Microsoft.Build.Shared
             FixupParts fixupParts = null)
         {
             needsRecursion = false;
-            fixedDirectoryPart = String.Empty;
-            wildcardDirectoryPart = String.Empty;
-            filenamePart = String.Empty;
+            fixedDirectoryPart = string.Empty;
+            wildcardDirectoryPart = string.Empty;
+            filenamePart = string.Empty;
 
             if (!RawFileSpecIsValid(filespec))
             {
@@ -1661,7 +1661,7 @@ namespace Microsoft.Build.Shared
             internal bool isLegalFileSpec; // initially false
             internal bool isMatch; // initially false
             internal bool isFileSpecRecursive; // initially false
-            internal string wildcardDirectoryPart = String.Empty;
+            internal string wildcardDirectoryPart = string.Empty;
         }
 
         /// <summary>
@@ -1870,8 +1870,8 @@ namespace Microsoft.Build.Shared
             Match match = fileSpecRegex.Match(fileToMatch);
 
             isMatch = match.Success;
-            wildcardDirectoryPart = String.Empty;
-            filenamePart = String.Empty;
+            wildcardDirectoryPart = string.Empty;
+            filenamePart = string.Empty;
 
             if (isMatch)
             {
@@ -2085,7 +2085,7 @@ namespace Microsoft.Build.Shared
                         return SearchAction.ReturnEmptyList;
                     }
 
-                    stripProjectDirectory = !String.Equals(fixedDirectoryPart, oldFixedDirectoryPart, StringComparison.OrdinalIgnoreCase);
+                    stripProjectDirectory = !string.Equals(fixedDirectoryPart, oldFixedDirectoryPart, StringComparison.OrdinalIgnoreCase);
                 }
                 else
                 {

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -1653,7 +1653,7 @@ namespace Microsoft.Build.UnitTests
             "",
             "",
             "",
-            "^(?<FIXEDDIR>)(?<WILDCARDDIR>)(?<FILENAME>)$",
+            "^(?<WILDCARDDIR>)(?<FILENAME>)$",
             false,
             true
         )]
@@ -1723,7 +1723,7 @@ namespace Microsoft.Build.UnitTests
             "",
             @"*fo?ba?\",
             "*fo?ba?",
-            @"^(?<FIXEDDIR>)(?<WILDCARDDIR>[^/\\]*fo.ba.[/\\]+)(?<FILENAME>[^/\\]*fo.ba.)$",
+            @"^(?<WILDCARDDIR>[^/\\]*fo.ba.[/\\]+)(?<FILENAME>[^/\\]*fo.ba.)$",
             true,
             true
         )]
@@ -1733,7 +1733,7 @@ namespace Microsoft.Build.UnitTests
             "",
             "",
             "?oo*.",
-            @"^(?<FIXEDDIR>)(?<WILDCARDDIR>)(?<FILENAME>[^\.].oo[^\.]*)$",
+            @"^(?<WILDCARDDIR>)(?<FILENAME>[^\.].oo[^\.]*)$",
             false,
             true
         )]
@@ -1743,7 +1743,7 @@ namespace Microsoft.Build.UnitTests
             "",
             "",
             "*.*foo*.*",
-            @"^(?<FIXEDDIR>)(?<WILDCARDDIR>)(?<FILENAME>[^/\\]*foo[^/\\]*)$",
+            @"^(?<WILDCARDDIR>)(?<FILENAME>[^/\\]*foo[^/\\]*)$",
             false,
             true
         )]
@@ -1753,7 +1753,7 @@ namespace Microsoft.Build.UnitTests
             @"\foo///bar\\\",
             @"?foo///bar\\\",
             "foo",
-            @"^(?<FIXEDDIR>[/\\]+foo[/\\]+bar[/\\]+)(?<WILDCARDDIR>.foo[/\\]+bar[/\\]+)(?<FILENAME>foo)$",
+            @"^[/\\]+foo[/\\]+bar[/\\]+(?<WILDCARDDIR>.foo[/\\]+bar[/\\]+)(?<FILENAME>foo)$",
             true,
             true
         )]
@@ -1763,7 +1763,7 @@ namespace Microsoft.Build.UnitTests
             @"\./.\foo/.\./bar\./.\",
             @"?foo/.\./bar\./.\",
             "foo",
-            @"^(?<FIXEDDIR>[/\\]+foo[/\\]+bar[/\\]+)(?<WILDCARDDIR>.foo[/\\]+bar[/\\]+)(?<FILENAME>foo)$",
+            @"^[/\\]+foo[/\\]+bar[/\\]+(?<WILDCARDDIR>.foo[/\\]+bar[/\\]+)(?<FILENAME>foo)$",
             true,
             true
         )]
@@ -1773,7 +1773,7 @@ namespace Microsoft.Build.UnitTests
             @"foo\",
             @"**/**\bar/**\**/foo\**/**\",
             "bar",
-            @"^(?<FIXEDDIR>foo[/\\]+)(?<WILDCARDDIR>((.*/)|(.*\\)|())bar((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/))foo((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/)))(?<FILENAME>bar)$",
+            @"^foo[/\\]+(?<WILDCARDDIR>((.*/)|(.*\\)|())bar((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/))foo((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/)))(?<FILENAME>bar)$",
             true,
             true
         )]
@@ -1783,7 +1783,7 @@ namespace Microsoft.Build.UnitTests
             @"foo\\\.///",
             @"**\\\.///**\\\.///bar\\\.///**\\\.///**\\\.///foo\\\.///**\\\.///**\\\.///",
             "bar",
-            @"^(?<FIXEDDIR>foo[/\\]+)(?<WILDCARDDIR>((.*/)|(.*\\)|())bar((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/))foo((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/)))(?<FILENAME>bar)$",
+            @"^foo[/\\]+(?<WILDCARDDIR>((.*/)|(.*\\)|())bar((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/))foo((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/)))(?<FILENAME>bar)$",
             true,
             true
         )]
@@ -1821,7 +1821,7 @@ namespace Microsoft.Build.UnitTests
             @"$()+.[^{\",
             @"?$()+.[^{\",
             "$()+.[^{",
-            @"^(?<FIXEDDIR>\$\(\)\+\.\[\^\{[/\\]+)(?<WILDCARDDIR>.\$\(\)\+\.\[\^\{[/\\]+)(?<FILENAME>\$\(\)\+\.\[\^\{)$",
+            @"^\$\(\)\+\.\[\^\{[/\\]+(?<WILDCARDDIR>.\$\(\)\+\.\[\^\{[/\\]+)(?<FILENAME>\$\(\)\+\.\[\^\{)$",
             true,
             true
         )]
@@ -1831,7 +1831,7 @@ namespace Microsoft.Build.UnitTests
             @"\\\.\foo/",
             "",
             "bar",
-            @"^(?<FIXEDDIR>\\\\foo[/\\]+)(?<WILDCARDDIR>)(?<FILENAME>bar)$",
+            @"^\\\\foo[/\\]+(?<WILDCARDDIR>)(?<FILENAME>bar)$",
             false,
             true
         )]
@@ -1864,7 +1864,7 @@ namespace Microsoft.Build.UnitTests
             @"$()+.[^{|/",
             @"?$()+.[^{|/",
             "$()+.[^{|",
-            @"^(?<FIXEDDIR>\$\(\)\+\.\[\^\{\|[/\\]+)(?<WILDCARDDIR>.\$\(\)\+\.\[\^\{\|[/\\]+)(?<FILENAME>\$\(\)\+\.\[\^\{\|)$",
+            @"^\$\(\)\+\.\[\^\{\|[/\\]+(?<WILDCARDDIR>.\$\(\)\+\.\[\^\{\|[/\\]+)(?<FILENAME>\$\(\)\+\.\[\^\{\|)$",
             true,
             true
         )]
@@ -1874,7 +1874,7 @@ namespace Microsoft.Build.UnitTests
             @"///./foo/",
             "",
             "bar",
-            @"^(?<FIXEDDIR>[/\\]+foo[/\\]+)(?<WILDCARDDIR>)(?<FILENAME>bar)$",
+            @"^[/\\]+foo[/\\]+(?<WILDCARDDIR>)(?<FILENAME>bar)$",
             false,
             true
         )]


### PR DESCRIPTION
Fixes #6599

### Context

Compiled regular expressions have a high first-call cost on .NET Framework, especially when running in a 64-bit process. At best, they need to be used thousands of times to make up for the compilation cost. In some cases compiled regexes are even slower than interpreted ones.

### Changes Made

Switched regexes used in `MSBuildGlob` to interpreted on .NET Framework. Also optimized capture groups as suggested by @ToddGrun and removed a couple of unused fields.

### Testing

- Existing unit tests with added coverage for `MSBuildGlob.MatchInfoResult`.
- Experimental insertion to confirm the CPU time win.