### PR TITLE
Improve debugging experience: add global switch MSBuildDebugEngine; Inject binary logger from BuildManager; print static graph as .dot file

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -32,6 +32,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Don't compile globbing regexes on .NET Framework](https://github.com/dotnet/msbuild/pull/6632)
 - [Default to transitively copying content items](https://github.com/dotnet/msbuild/pull/6622)
 - [Reference assemblies are now no longer placed in the `bin` directory by default](https://github.com/dotnet/msbuild/pull/6560)
+- [Improve debugging experience: add global switch MSBuildDebugEngine; Inject binary logger from BuildManager; print static graph as .dot file](https://github.com/dotnet/msbuild/pull/6639)
 
 ## Change Waves No Longer In Rotation
 ### 16.8

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -1477,12 +1477,21 @@ $@"
             var graph = Helpers.CreateProjectGraph(
                 _env,
                 edges,
-                new Dictionary<string, string> {{"a", "b"}});
+                globalProperties: new Dictionary<string, string> {{"a", "b"}},
+                createProjectFile: (env, projectId, references, _, _, _) => Helpers.CreateProjectFile(
+                    env,
+                    projectId,
+                    references,
+                    projectReferenceTargets: new Dictionary<string, string[]>
+                    {
+                        {"Build", new[] {$"TargetFrom{projectId}", "Build"}}
+                    }));
 
+            var targetsPerNode = graph.GetTargetLists(new []{ "Build" });
 
             Func<ProjectGraphNode, string> nodeIdProvider = GetProjectFileName;
 
-            var dot = graph.ToDot(nodeIdProvider);
+            var dot = graph.ToDot(nodeIdProvider, targetsPerNode);
 
             var edgeCount = 0;
 
@@ -1490,9 +1499,12 @@ $@"
             {
                 var nodeId = nodeIdProvider(node);
 
+                var targets = string.Join(".*", targetsPerNode[node]);
+                targets.ShouldNotBeNullOrEmpty();
+
                 foreach (var globalProperty in node.ProjectInstance.GlobalProperties)
                 {
-                    dot.ShouldMatch($@"{nodeId}\s*\[.*{globalProperty.Key}.*{globalProperty.Value}.*\]");
+                    dot.ShouldMatch($@"{nodeId}\s*\[.*{targets}.*{globalProperty.Key}.*{globalProperty.Value}.*\]");
                 }
 
                 foreach (var reference in node.ProjectReferences)

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -488,7 +488,7 @@ namespace Microsoft.Build.Execution
             ILoggingService InitializeLoggingService()
             {
                 ILoggingService loggingService = CreateLoggingService(
-                    (_buildParameters.Loggers ?? Enumerable.Empty<ILogger>()).Concat(GetDebuggingLoggers()),
+                    AppendDebuggingLoggers(_buildParameters.Loggers),
                     _buildParameters.ForwardingLoggers,
                     _buildParameters.WarningsAsErrors,
                     _buildParameters.WarningsAsMessages);
@@ -521,19 +521,19 @@ namespace Microsoft.Build.Execution
             }
 
             // VS builds discard many msbuild events so attach a binlogger to capture them all.
-            IEnumerable<ILogger> GetDebuggingLoggers()
+            IEnumerable<ILogger> AppendDebuggingLoggers(IEnumerable<ILogger> loggers)
             {
                 if (CurrentProcessMatchesDebugName() is false ||
                     Traits.Instance.DebugEngine is false)
                 {
-                    return Enumerable.Empty<ILogger>();
+                    return loggers;
                 }
 
-                var binlogPath = DebugUtils.FindNextAvailableDebugFilePath($"{DebugUtils.ProcessInfoString}_BuildManager_{_hostName}_{GetHashCode()}.binlog");
+                var binlogPath = DebugUtils.FindNextAvailableDebugFilePath($"{DebugUtils.ProcessInfoString}_BuildManager_{_hostName}.binlog");
 
                 var logger = new BinaryLogger { Parameters = binlogPath };
 
-                return new []{ logger };
+                return (loggers ?? Enumerable.Empty<ILogger>()).Concat(new[] { logger });
             }
 
             void InitializeCaches()

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Build.Execution
             // VS builds discard many msbuild events so attach a binlogger to capture them all.
             IEnumerable<ILogger> AppendDebuggingLoggers(IEnumerable<ILogger> loggers)
             {
-                if (CurrentProcessMatchesDebugName() is false ||
+                if (DebugUtils.ShouldDebugCurrentProcess is false ||
                     Traits.Instance.DebugEngine is false)
                 {
                     return loggers;
@@ -586,7 +586,7 @@ namespace Microsoft.Build.Execution
                 return;
             }
 
-            if (!CurrentProcessMatchesDebugName())
+            if (!DebugUtils.ShouldDebugCurrentProcess)
             {
                 return;
             }
@@ -605,15 +605,6 @@ namespace Microsoft.Build.Execution
                     Console.ReadLine();
                     break;
             }
-        }
-
-        private static bool CurrentProcessMatchesDebugName()
-        {
-            var processNameToBreakInto = Environment.GetEnvironmentVariable("MSBuildDebugBuildManagerOnStartProcessName");
-            var thisProcessMatchesName = string.IsNullOrWhiteSpace(processNameToBreakInto) ||
-                                         Process.GetCurrentProcess().ProcessName.Contains(processNameToBreakInto);
-
-            return thisProcessMatchesName;
         }
 
         private void InitializeProjectCacheService(

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -12,6 +12,8 @@ using System.Threading.Tasks.Dataflow;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.Debugging;
+using Microsoft.Build.Utilities;
 using BuildAbortedException = Microsoft.Build.Exceptions.BuildAbortedException;
 
 namespace Microsoft.Build.BackEnd
@@ -115,8 +117,10 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal BuildRequestEngine()
         {
-            _debugDumpState = Environment.GetEnvironmentVariable("MSBUILDDEBUGSCHEDULER") == "1";
-            _debugDumpPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+            _debugDumpState = Traits.Instance.DebugScheduler;
+            _debugDumpPath = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
+                ? DebugUtils.DebugDumpPath()
+                : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
             _debugForceCaching = Environment.GetEnvironmentVariable("MSBUILDDEBUGFORCECACHING") == "1";
 
             if (String.IsNullOrEmpty(_debugDumpPath))

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Build.BackEnd
         {
             _debugDumpState = Traits.Instance.DebugScheduler;
             _debugDumpPath = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
-                ? DebugUtils.DebugDumpPath()
+                ? DebugUtils.DebugPath
                 : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
             _debugForceCaching = Environment.GetEnvironmentVariable("MSBUILDDEBUGFORCECACHING") == "1";
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -14,6 +14,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Experimental.ProjectCache;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.Debugging;
 using Microsoft.Build.Utilities;
 using BuildAbortedException = Microsoft.Build.Exceptions.BuildAbortedException;
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
@@ -176,8 +177,10 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public Scheduler()
         {
-            _debugDumpState = Environment.GetEnvironmentVariable("MSBUILDDEBUGSCHEDULER") == "1";
-            _debugDumpPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+            _debugDumpState = Traits.Instance.DebugScheduler;
+            _debugDumpPath = Traits.Instance.DebugEngine
+                ? DebugUtils.DebugDumpPath()
+                : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
             _schedulingUnlimitedVariable = Environment.GetEnvironmentVariable("MSBUILDSCHEDULINGUNLIMITED");
             _nodeLimitOffset = 0;
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Build.BackEnd
         public Scheduler()
         {
             _debugDumpState = Traits.Instance.DebugScheduler;
-            _debugDumpPath = Traits.Instance.DebugEngine
+            _debugDumpPath = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
                 ? DebugUtils.DebugDumpPath()
                 : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
             _schedulingUnlimitedVariable = Environment.GetEnvironmentVariable("MSBUILDSCHEDULINGUNLIMITED");

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Build.BackEnd
         {
             _debugDumpState = Traits.Instance.DebugScheduler;
             _debugDumpPath = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
-                ? DebugUtils.DebugDumpPath()
+                ? DebugUtils.DebugPath
                 : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
             _schedulingUnlimitedVariable = Environment.GetEnvironmentVariable("MSBUILDSCHEDULINGUNLIMITED");
             _nodeLimitOffset = 0;

--- a/src/Build/BackEnd/Components/Scheduler/SchedulingPlan.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulingPlan.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -316,7 +317,7 @@ namespace Microsoft.Build.BackEnd
         private void AnalyzeData()
         {
             DoRecursiveAnalysis();
-            if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDEBUGSCHEDULER")))
+            if (Traits.Instance.DebugScheduler)
             {
                 DetermineExpensiveConfigs();
                 DetermineConfigsByNumberOfOccurrences();

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -119,11 +119,6 @@ namespace Microsoft.Build.Execution
         private Exception _shutdownException;
 
         /// <summary>
-        /// Flag indicating if we should debug communications or not.
-        /// </summary>
-        private readonly bool _debugCommunications;
-
-        /// <summary>
         /// Data for the use of LegacyThreading semantics.
         /// </summary>
         private readonly LegacyThreadingData _legacyThreadingData;
@@ -139,8 +134,6 @@ namespace Microsoft.Build.Execution
         public OutOfProcNode()
         {
             s_isOutOfProcNode = true;
-
-            _debugCommunications = (Environment.GetEnvironmentVariable("MSBUILDDEBUGCOMM") == "1");
 
             _receivedPackets = new ConcurrentQueue<INodePacket>();
             _packetReceivedEvent = new AutoResetEvent(false);

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -843,7 +843,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void GetCommandLineQuotedExeOnPath()
         {
-            string output = null;
+            string output;
             string current = Directory.GetCurrentDirectory();
 
             try
@@ -1270,10 +1270,10 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestProcessProjectSwitchOneProjNotFoundExtension()
         {
-            string[] projects = new[] { "my.proj" };
-            string[] extensionsToIgnore = new[] { ".phantomextension" };
+            string[] projects = { "my.proj" };
+            string[] extensionsToIgnore = { ".phantomextension" };
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
         }
 
         /// <summary>
@@ -1282,10 +1282,10 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestTwoIdenticalExtensionsToIgnore()
         {
-            string[] projects = new[] { "my.proj" };
-            string[] extensionsToIgnore = new[] { ".phantomextension", ".phantomextension" };
+            string[] projects = { "my.proj" };
+            string[] extensionsToIgnore = { ".phantomextension", ".phantomextension" };
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
         }
 
         /// <summary>
@@ -1294,13 +1294,13 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestProcessProjectSwitchNullandEmptyProjectsToIgnore()
         {
-            string[] projects = new[] { "my.proj" };
+            string[] projects = { "my.proj" };
             string[] extensionsToIgnore = null;
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
 
             extensionsToIgnore = new string[] { };
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
         }
 
         /// <summary>
@@ -1311,10 +1311,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "my.proj" };
-                string[] extensionsToIgnore = new[] { ".phantomextension", null };
+                string[] projects = { "my.proj" };
+                string[] extensionsToIgnore = { ".phantomextension", null };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
             }
            );
         }
@@ -1327,10 +1327,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "my.proj" };
-                string[] extensionsToIgnore = new[] { ".phantomextension", string.Empty };
+                string[] projects = { "my.proj" };
+                string[] extensionsToIgnore = { ".phantomextension", string.Empty };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
             }
            );
         }
@@ -1342,10 +1342,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "my.proj" };
-                string[] extensionsToIgnore = new[] { "phantomextension" };
+                string[] projects = { "my.proj" };
+                string[] extensionsToIgnore = { "phantomextension" };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase);
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase);
             }
            );
         }
@@ -1357,10 +1357,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "my.proj" };
-                string[] extensionsToIgnore = new[] { ".C:\\boocatmoo.a" };
+                string[] projects = { "my.proj" };
+                string[] extensionsToIgnore = { ".C:\\boocatmoo.a" };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
             }
            );
         }
@@ -1372,65 +1372,65 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "my.proj" };
-                string[] extensionsToIgnore = new[] { ".proj*", ".nativeproj?" };
+                string[] projects = { "my.proj" };
+                string[] extensionsToIgnore = { ".proj*", ".nativeproj?" };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
            );
         }
         [Fact]
         public void TestProcessProjectSwitch()
         {
-            string[] projects = new[] { "test.nativeproj", "test.vcproj" };
-            string[] extensionsToIgnore = new[] { ".phantomextension", ".vcproj" };
+            string[] projects = { "test.nativeproj", "test.vcproj" };
+            string[] extensionsToIgnore = { ".phantomextension", ".vcproj" };
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.nativeproj", StringCompareShould.IgnoreCase); // "Expected test.nativeproj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.nativeproj", StringCompareShould.IgnoreCase); // "Expected test.nativeproj to be only project found"
 
             projects = new[] { "test.nativeproj", "test.vcproj", "test.proj" };
             extensionsToIgnore = new[] { ".phantomextension", ".vcproj" };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj", StringCompareShould.IgnoreCase); // "Expected test.proj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj", StringCompareShould.IgnoreCase); // "Expected test.proj to be only project found"
 
             projects = new[] { "test.nativeproj", "test.vcproj" };
             extensionsToIgnore = new[] { ".vcproj" };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.nativeproj", StringCompareShould.IgnoreCase); // "Expected test.nativeproj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.nativeproj", StringCompareShould.IgnoreCase); // "Expected test.nativeproj to be only project found"
 
             projects = new[] { "test.proj", "test.sln" };
             extensionsToIgnore = new[] { ".vcproj" };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
 
             projects = new[] { "test.proj", "test.sln", "test.proj~", "test.sln~" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
 
             projects = new[] { "test.proj" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj", StringCompareShould.IgnoreCase); // "Expected test.proj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj", StringCompareShould.IgnoreCase); // "Expected test.proj to be only project found"
 
             projects = new[] { "test.proj", "test.proj~" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj", StringCompareShould.IgnoreCase); // "Expected test.proj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj", StringCompareShould.IgnoreCase); // "Expected test.proj to be only project found"
 
             projects = new[] { "test.sln" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
 
             projects = new[] { "test.sln", "test.sln~" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
 
             projects = new[] { "test.sln~", "test.sln" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
         }
 
         /// <summary>
@@ -1439,10 +1439,10 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestProcessProjectSwitchReplicateBuildingDFLKG()
         {
-            string[] projects = new[] { "test.proj", "test.sln", "Foo.vcproj" };
+            string[] projects = { "test.proj", "test.sln", "Foo.vcproj" };
             string[] extensionsToIgnore = { ".sln", ".vcproj" };
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-            MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj"); // "Expected test.proj to be only project found"
+            MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj"); // "Expected test.proj to be only project found"
         }
 
         /// <summary>
@@ -1453,12 +1453,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects;
-                string[] extensionsToIgnore = null;
-                projects = new[] { "test.nativeproj", "test.vcproj" };
-                extensionsToIgnore = new[] { ".nativeproj", ".vcproj" };
+                var projects = new[] { "test.nativeproj", "test.vcproj" };
+                var extensionsToIgnore = new[] { ".nativeproj", ".vcproj" };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
            );
         }
@@ -1470,10 +1468,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "test.proj", "Different.sln" };
+                string[] projects = { "test.proj", "Different.sln" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
            );
         }
@@ -1485,10 +1483,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "test.proj", "Different.proj" };
+                string[] projects = { "test.proj", "Different.proj" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
            );
         }
@@ -1500,10 +1498,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "test.nativeproj", "Different.nativeproj" };
+                string[] projects = { "test.nativeproj", "Different.nativeproj" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
            );
         }
@@ -1515,10 +1513,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "test.sln", "Different.sln" };
+                string[] projects = { "test.sln", "Different.sln" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
            );
         }
@@ -1530,10 +1528,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new[] { "test.nativeproj", "Different.csproj", "Another.proj" };
+                string[] projects = { "test.nativeproj", "Different.csproj", "Another.proj" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
            );
         }
@@ -1545,10 +1543,10 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { };
+                string[] projects = { };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
-                MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
+                MSBuildApp.ProcessProjectSwitch(new string[] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
            );
         }
@@ -1557,7 +1555,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         internal class IgnoreProjectExtensionsHelper
         {
-            private List<string> _directoryFileNameList;
+            private readonly List<string> _directoryFileNameList;
 
             /// <summary>
             /// Takes in a list of file names to simulate as being in a directory
@@ -1725,7 +1723,7 @@ namespace Microsoft.Build.UnitTests
             distributedLoggerRecords = new List<DistributedLoggerRecord>();
 
             loggers = new List<ILogger>();
-            fileLoggerParameters = new string[1] { "Parameter" };
+            fileLoggerParameters = new[] { "Parameter" };
             MSBuildApp.ProcessDistributedFileLogger
                        (
                            distributedFileLogger,
@@ -1740,7 +1738,7 @@ namespace Microsoft.Build.UnitTests
             distributedLoggerRecords = new List<DistributedLoggerRecord>();
 
             loggers = new List<ILogger>();
-            fileLoggerParameters = new string[2] { "Parameter1", "Parameter" };
+            fileLoggerParameters = new[] { "Parameter1", "Parameter" };
             MSBuildApp.ProcessDistributedFileLogger
                        (
                            distributedFileLogger,
@@ -1780,7 +1778,7 @@ namespace Microsoft.Build.UnitTests
             distributedLoggerRecords = new List<DistributedLoggerRecord>();
 
             loggers = new List<ILogger>();
-            fileLoggerParameters = new string[1] { "verbosity=Normal;" };
+            fileLoggerParameters = new[] { "verbosity=Normal;" };
             MSBuildApp.ProcessDistributedFileLogger
                        (
                            distributedFileLogger,
@@ -1797,7 +1795,7 @@ namespace Microsoft.Build.UnitTests
             distributedLoggerRecords = new List<DistributedLoggerRecord>();
 
             loggers = new List<ILogger>();
-            fileLoggerParameters = new string[2] { "verbosity=Normal", "" };
+            fileLoggerParameters = new[] { "verbosity=Normal", "" };
             MSBuildApp.ProcessDistributedFileLogger
                        (
                            distributedFileLogger,
@@ -1814,7 +1812,7 @@ namespace Microsoft.Build.UnitTests
             distributedLoggerRecords = new List<DistributedLoggerRecord>();
 
             loggers = new List<ILogger>();
-            fileLoggerParameters = new string[2] { "", "Parameter1" };
+            fileLoggerParameters = new[] { "", "Parameter1" };
             MSBuildApp.ProcessDistributedFileLogger
                        (
                            distributedFileLogger,
@@ -1831,7 +1829,7 @@ namespace Microsoft.Build.UnitTests
             distributedLoggerRecords = new List<DistributedLoggerRecord>();
 
             loggers = new List<ILogger>();
-            fileLoggerParameters = new string[2] { "Parameter1", "verbosity=Normal;logfile=" + (NativeMethodsShared.IsWindows ? "c:\\temp\\cat.log" : "/tmp/cat.log") };
+            fileLoggerParameters = new[] { "Parameter1", "verbosity=Normal;logfile=" + (NativeMethodsShared.IsWindows ? "c:\\temp\\cat.log" : "/tmp/cat.log") };
             MSBuildApp.ProcessDistributedFileLogger
                        (
                            distributedFileLogger,
@@ -1846,7 +1844,7 @@ namespace Microsoft.Build.UnitTests
 
             distributedLoggerRecords = new List<DistributedLoggerRecord>();
             loggers = new List<ILogger>();
-            fileLoggerParameters = new string[2] { "Parameter1", "verbosity=Normal;logfile=" + Path.Combine("..", "cat.log") + ";Parameter1" };
+            fileLoggerParameters = new[] { "Parameter1", "verbosity=Normal;logfile=" + Path.Combine("..", "cat.log") + ";Parameter1" };
             MSBuildApp.ProcessDistributedFileLogger
                        (
                            distributedFileLogger,
@@ -1861,7 +1859,7 @@ namespace Microsoft.Build.UnitTests
 
             loggers = new List<ILogger>();
             distributedLoggerRecords = new List<DistributedLoggerRecord>();
-            fileLoggerParameters = new string[6] { "Parameter1", ";Parameter;", "", ";", ";Parameter", "Parameter;" };
+            fileLoggerParameters = new[] { "Parameter1", ";Parameter;", "", ";", ";Parameter", "Parameter;" };
             MSBuildApp.ProcessDistributedFileLogger
                        (
                            distributedFileLogger,
@@ -1904,7 +1902,7 @@ namespace Microsoft.Build.UnitTests
             var loggers = new List<ILogger>();
             LoggerVerbosity verbosity = LoggerVerbosity.Normal;
             List<DistributedLoggerRecord> distributedLoggerRecords = new List<DistributedLoggerRecord>();
-            string[] consoleLoggerParameters = new string[6] { "Parameter1", ";Parameter;", "", ";", ";Parameter", "Parameter;" };
+            string[] consoleLoggerParameters = { "Parameter1", ";Parameter;", "", ";", ";Parameter", "Parameter;" };
 
             MSBuildApp.ProcessConsoleLoggerSwitch
                        (

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -139,11 +139,8 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void SplitUnquotedTest()
         {
-            List<string> sa;
-            int emptySplits;
-
             // nothing quoted
-            sa = QuotingUtilities.SplitUnquoted("abcdxyz");
+            var sa = QuotingUtilities.SplitUnquoted("abcdxyz");
             sa.Count.ShouldBe(1);
             sa[0].ShouldBe("abcdxyz");
 
@@ -167,7 +164,7 @@ namespace Microsoft.Build.UnitTests
             sa[2].ShouldBe("dxyz");
 
             // nothing quoted
-            sa = QuotingUtilities.SplitUnquoted("abc,c;dxyz", 2, false, false, out emptySplits, ';', ',');
+            sa = QuotingUtilities.SplitUnquoted("abc,c;dxyz", 2, false, false, out var emptySplits, ';', ',');
             emptySplits.ShouldBe(0);
             sa.Count.ShouldBe(2);
             sa[0].ShouldBe("abc");
@@ -332,10 +329,8 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void UnquoteTest()
         {
-            int doubleQuotesRemoved;
-
             // "cde" is quoted
-            QuotingUtilities.Unquote("abc\"cde\"xyz", out doubleQuotesRemoved).ShouldBe("abccdexyz");
+            QuotingUtilities.Unquote("abc\"cde\"xyz", out var doubleQuotesRemoved).ShouldBe("abccdexyz");
             doubleQuotesRemoved.ShouldBe(2);
 
             // "xyz" is quoted (the terminal double-quote is assumed)
@@ -395,8 +390,7 @@ namespace Microsoft.Build.UnitTests
         public void ExtractSwitchParametersTest()
         {
             string commandLineArg = "\"/p:foo=\"bar";
-            int doubleQuotesRemovedFromArg;
-            string unquotedCommandLineArg = QuotingUtilities.Unquote(commandLineArg, out doubleQuotesRemovedFromArg);
+            string unquotedCommandLineArg = QuotingUtilities.Unquote(commandLineArg, out var doubleQuotesRemovedFromArg);
             MSBuildApp.ExtractSwitchParameters(commandLineArg, unquotedCommandLineArg, doubleQuotesRemovedFromArg, "p", unquotedCommandLineArg.IndexOf(':')).ShouldBe(":\"foo=\"bar");
             doubleQuotesRemovedFromArg.ShouldBe(2);
 
@@ -649,8 +643,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + pathToProjectFile + "\"";
 
-                bool successfulExit;
-                output = RunnerUtilities.ExecMSBuild(newPathToMSBuildExe, msbuildParameters, out successfulExit);
+                output = RunnerUtilities.ExecMSBuild(newPathToMSBuildExe, msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeFalse();
             }
             catch (Exception ex)
@@ -815,8 +808,7 @@ namespace Microsoft.Build.UnitTests
             var msbuildParameters = "\"" + _pathToArbitraryBogusFile + "\"" + (NativeMethodsShared.IsWindows ? " /v:diag" : " -v:diag");
             File.Exists(_pathToArbitraryBogusFile).ShouldBeTrue();
 
-            bool successfulExit;
-            string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out successfulExit);
+            string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
             successfulExit.ShouldBeFalse();
 
             output.ShouldContain(RunnerUtilities.PathToCurrentlyRunningMsBuildExe + (NativeMethodsShared.IsWindows ? " /v:diag " : " -v:diag ") + _pathToArbitraryBogusFile, Case.Insensitive);
@@ -831,7 +823,6 @@ namespace Microsoft.Build.UnitTests
             var msbuildParameters = "\"" + _pathToArbitraryBogusFile + "\"" + (NativeMethodsShared.IsWindows ? " /v:diag" : " -v:diag");
             File.Exists(_pathToArbitraryBogusFile).ShouldBeTrue();
 
-            bool successfulExit;
             string pathToMSBuildExe = RunnerUtilities.PathToCurrentlyRunningMsBuildExe;
             // This @pathToMSBuildExe is used directly with Process, so don't quote it on
             // Unix
@@ -840,7 +831,7 @@ namespace Microsoft.Build.UnitTests
                 pathToMSBuildExe = "\"" + pathToMSBuildExe + "\"";
             }
 
-            string output = RunnerUtilities.ExecMSBuild(pathToMSBuildExe, msbuildParameters, out successfulExit);
+            string output = RunnerUtilities.ExecMSBuild(pathToMSBuildExe, msbuildParameters, out var successfulExit);
             successfulExit.ShouldBeFalse();
 
             output.ShouldContain(RunnerUtilities.PathToCurrentlyRunningMsBuildExe + (NativeMethodsShared.IsWindows ? " /v:diag " : " -v:diag ") + _pathToArbitraryBogusFile, Case.Insensitive);
@@ -861,8 +852,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + _pathToArbitraryBogusFile + "\"" + (NativeMethodsShared.IsWindows ? " /v:diag" : " -v:diag");
 
-                bool successfulExit;
-                output = RunnerUtilities.ExecMSBuild(msbuildParameters, out successfulExit);
+                output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeFalse();
             }
             finally
@@ -922,8 +912,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + projectPath + "\"";
 
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out successfulExit);
+                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeTrue();
 
                 output.ShouldContain("[A=1]");
@@ -958,8 +947,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + projectPath + "\"";
 
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out successfulExit);
+                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeTrue();
 
                 output.ShouldContain("[A=]");
@@ -995,8 +983,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + projectPath + "\"" + " /p:A=2";
 
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out successfulExit);
+                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeTrue();
 
                 output.ShouldContain("[A=2]");
@@ -1041,8 +1028,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + projectPath + "\"";
 
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(exePath, msbuildParameters, out successfulExit);
+                string output = RunnerUtilities.ExecMSBuild(exePath, msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeTrue();
 
                 output.ShouldContain("[A=1]");
@@ -1077,8 +1063,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + projectPath + "\"";
 
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(exePath, msbuildParameters, out successfulExit);
+                string output = RunnerUtilities.ExecMSBuild(exePath, msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeTrue();
 
                 output.ShouldContain("[A=1]");
@@ -1111,8 +1096,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + projectPath + "\"";
 
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out successfulExit);
+                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeFalse();
 
                 output.ShouldContain("MSB1027"); // msbuild.rsp cannot have /noautoresponse in it
@@ -1147,8 +1131,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + projectPath + "\" /noautoresponse";
 
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out successfulExit);
+                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeTrue();
 
                 output.ShouldContain("[A=]");
@@ -1180,8 +1163,7 @@ namespace Microsoft.Build.UnitTests
 
                 var msbuildParameters = "\"" + projectPath + "\"";
 
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out successfulExit);
+                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
                 successfulExit.ShouldBeTrue();
 
                 output.ShouldContain("[A=]");
@@ -2407,9 +2389,7 @@ EndGlobal
                 }
             }
 
-            bool success;
-
-            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" {String.Join(" ", arguments)}", out success, _output);
+            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" {String.Join(" ", arguments)}", out var success, _output);
 
             return (success, output);
         }

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -22,7 +22,7 @@ using System.Reflection;
 
 namespace Microsoft.Build.UnitTests
 {
-    public class XMakeAppTests
+    public class XMakeAppTests : IDisposable
     {
 #if USE_MSBUILD_DLL_EXTN
         private const string MSBuildExeName = "MSBuild.dll";
@@ -31,10 +31,12 @@ namespace Microsoft.Build.UnitTests
 #endif
 
         private readonly ITestOutputHelper _output;
+        private readonly TestEnvironment _env;
 
         public XMakeAppTests(ITestOutputHelper output)
         {
             _output = output;
+            _env = UnitTests.TestEnvironment.Create(_output);
         }
 
         private const string AutoResponseFileName = "MSBuild.rsp";
@@ -878,38 +880,23 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ResponseFileInProjectDirectoryFoundImplicitly()
         {
-            string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            string directory = _env.DefaultTestDirectory.Path;
             string projectPath = Path.Combine(directory, "my.proj");
             string rspPath = Path.Combine(directory, AutoResponseFileName);
 
-            string currentDirectory = Directory.GetCurrentDirectory();
+            string content = ObjectModelHelpers.CleanupFileContents("<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'><Target Name='t'><Warning Text='[A=$(A)]'/></Target></Project>");
+            File.WriteAllText(projectPath, content);
 
-            try
-            {
-                Directory.CreateDirectory(directory);
+            string rspContent = "/p:A=1";
+            File.WriteAllText(rspPath, rspContent);
 
-                string content = ObjectModelHelpers.CleanupFileContents("<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'><Target Name='t'><Warning Text='[A=$(A)]'/></Target></Project>");
-                File.WriteAllText(projectPath, content);
+            // Find the project in the current directory
+            _env.SetCurrentDirectory(directory);
 
-                string rspContent = "/p:A=1";
-                File.WriteAllText(rspPath, rspContent);
+            string output = RunnerUtilities.ExecMSBuild(String.Empty, out var successfulExit);
+            successfulExit.ShouldBeTrue();
 
-                // Find the project in the current directory
-                Directory.SetCurrentDirectory(directory);
-
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(String.Empty, out successfulExit);
-                successfulExit.ShouldBeTrue();
-
-                output.ShouldContain("[A=1]");
-            }
-            finally
-            {
-                Directory.SetCurrentDirectory(currentDirectory);
-                File.Delete(projectPath);
-                File.Delete(rspPath);
-                FileUtilities.DeleteWithoutTrailingBackslash(directory);
-            }
+            output.ShouldContain("[A=1]");
         }
 
         /// <summary>
@@ -2443,6 +2430,11 @@ EndGlobal
 
                 return (success, output);
             }
+        }
+
+        public void Dispose()
+        {
+            _env.Dispose();
         }
     }
 }

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1200,22 +1200,19 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ResponseFileSupportsThisFileDirectory()
         {
-            using (var env = UnitTests.TestEnvironment.Create())
-            {
-                var content = ObjectModelHelpers.CleanupFileContents(
-                    "<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'><Target Name='t'><Warning Text='[A=$(A)]'/></Target></Project>");
+            var content = ObjectModelHelpers.CleanupFileContents(
+                "<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'><Target Name='t'><Warning Text='[A=$(A)]'/></Target></Project>");
 
-                var directory = env.CreateFolder();
-                directory.CreateFile("Directory.Build.rsp", "/p:A=%MSBuildThisFileDirectory%");
-                var projectPath = directory.CreateFile("my.proj", content).Path;
+            var directory = _env.CreateFolder();
+            directory.CreateFile("Directory.Build.rsp", "/p:A=%MSBuildThisFileDirectory%");
+            var projectPath = directory.CreateFile("my.proj", content).Path;
 
-                var msbuildParameters = "\"" + projectPath + "\"";
+            var msbuildParameters = "\"" + projectPath + "\"";
 
-                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
-                successfulExit.ShouldBeTrue();
+            string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
+            successfulExit.ShouldBeTrue();
 
-                output.ShouldContain($"[A={directory.Path}{Path.DirectorySeparatorChar}]");
-            }
+            output.ShouldContain($"[A={directory.Path}{Path.DirectorySeparatorChar}]");
         }
 
         /// <summary>
@@ -2173,18 +2170,15 @@ $@"<Project>
                 "<Project>" +
                 "<Target Name=\"t\"><Message Text=\"Hello\"/></Target>" +
                 "</Project>";
-            using (var env = UnitTests.TestEnvironment.Create())
-            {
-                var tempDir = env.CreateFolder();
-                var projectFile = tempDir.CreateFile("missingloggertest.proj", projectString);
+            var tempDir = _env.CreateFolder();
+            var projectFile = tempDir.CreateFile("missingloggertest.proj", projectString);
 
-                var parametersLoggerOptional = $"{logger} -verbosity:diagnostic \"{projectFile.Path}\"";
+            var parametersLoggerOptional = $"{logger} -verbosity:diagnostic \"{projectFile.Path}\"";
 
-                var output = RunnerUtilities.ExecMSBuild(parametersLoggerOptional, out bool successfulExit, _output);
-                successfulExit.ShouldBe(true);
-                output.ShouldContain("Hello", output);
-                output.ShouldContain("The specified logger could not be created and will not be used.", output);
-            }
+            var output = RunnerUtilities.ExecMSBuild(parametersLoggerOptional, out bool successfulExit, _output);
+            successfulExit.ShouldBe(true);
+            output.ShouldContain("Hello", output);
+            output.ShouldContain("The specified logger could not be created and will not be used.", output);
         }
 
         [Theory]
@@ -2212,45 +2206,40 @@ $@"<Project>
         [Fact]
         public void BinaryLogContainsImportedFiles()
         {
-            using (TestEnvironment testEnvironment = UnitTests.TestEnvironment.Create())
+            var testProject = _env.CreateFile("Importer.proj", ObjectModelHelpers.CleanupFileContents(@"
+            <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Import Project=""TestProject.proj"" />
+
+                <Target Name=""Build"">
+                </Target>
+
+            </Project>"));
+
+            _env.CreateFile("TestProject.proj", @"
+            <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+              <Target Name=""Build"">
+                <Message Text=""Hello from TestProject!"" />
+              </Target>
+            </Project>
+            ");
+
+            string binLogLocation = _env.DefaultTestDirectory.Path;
+
+            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.Path}\" \"/bl:{binLogLocation}/output.binlog\"", out var success, _output);
+
+            success.ShouldBeTrue(output);
+
+            RunnerUtilities.ExecMSBuild($"\"{binLogLocation}/output.binlog\" \"/bl:{binLogLocation}/replay.binlog;ProjectImports=ZipFile\"", out success, _output);
+
+            using (ZipArchive archive = ZipFile.OpenRead($"{binLogLocation}/replay.ProjectImports.zip"))
             {
-                var testProject = testEnvironment.CreateFile("Importer.proj", ObjectModelHelpers.CleanupFileContents(@"
-                <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-                    <Import Project=""TestProject.proj"" />
-
-                    <Target Name=""Build"">
-                    </Target>
-
-                </Project>"));
-
-                testEnvironment.CreateFile("TestProject.proj", @"
-                <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-                  <Target Name=""Build"">
-                    <Message Text=""Hello from TestProject!"" />
-                  </Target>
-                </Project>
-                ");
-
-                string binLogLocation = testEnvironment.DefaultTestDirectory.Path;
-
-                string output = RunnerUtilities.ExecMSBuild($"\"{testProject.Path}\" \"/bl:{binLogLocation}/output.binlog\"", out var success, _output);
-
-                success.ShouldBeTrue(output);
-
-                RunnerUtilities.ExecMSBuild($"\"{binLogLocation}/output.binlog\" \"/bl:{binLogLocation}/replay.binlog;ProjectImports=ZipFile\"", out success, _output);
-
-                using (ZipArchive archive = ZipFile.OpenRead($"{binLogLocation}/replay.ProjectImports.zip"))
-                {
-                     archive.Entries.ShouldContain(e => e.FullName.EndsWith(".proj", StringComparison.OrdinalIgnoreCase), 2);
-                }
+                 archive.Entries.ShouldContain(e => e.FullName.EndsWith(".proj", StringComparison.OrdinalIgnoreCase), 2);
             }
         }
 
         [Fact]
         public void EndToEndWarnAsErrors()
         {
-            using TestEnvironment testEnvironment = UnitTests.TestEnvironment.Create();
-
             string projectContents = ObjectModelHelpers.CleanupFileContents(@"<Project>
 
   <Target Name=""IssueWarning"">
@@ -2259,7 +2248,7 @@ $@"<Project>
 
 </Project>");
 
-            TransientTestProjectWithFiles testProject = testEnvironment.CreateTestProjectWithFiles(projectContents);
+            TransientTestProjectWithFiles testProject = _env.CreateTestProjectWithFiles(projectContents);
 
             RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" -warnaserror", out bool success, _output);
 
@@ -2271,44 +2260,40 @@ $@"<Project>
         [Fact]
         public void BuildSlnOutOfProc()
         {
-            using (TestEnvironment testEnvironment = UnitTests.TestEnvironment.Create())
-            {
-                string solutionFileContents =
-                    @"
-Microsoft Visual Studio Solution File, Format Version 12.00
+            string solutionFileContents =
+@"Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'TestProject', 'TestProject.proj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
 EndProject
 Global
-    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-        Debug|Mixed Platforms = Debug|Mixed Platforms
-        Release|Any CPU = Release|Any CPU
-    EndGlobalSection
-    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.ActiveCfg = CSConfig1|Any CPU
-        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.Build.0 = CSConfig1|Any CPU
-    EndGlobalSection
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+    Debug|Mixed Platforms = Debug|Mixed Platforms
+    Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+    {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.ActiveCfg = CSConfig1|Any CPU
+    {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.Build.0 = CSConfig1|Any CPU
+EndGlobalSection
 EndGlobal
-                    ".Replace("'", "\"");
+                ".Replace("'", "\"");
 
-                var testSolution = testEnvironment.CreateFile("TestSolution.sln", ObjectModelHelpers.CleanupFileContents(solutionFileContents));
+            var testSolution = _env.CreateFile("TestSolution.sln", ObjectModelHelpers.CleanupFileContents(solutionFileContents));
 
-                string testMessage = "Hello from TestProject!";
-                testEnvironment.CreateFile("TestProject.proj", @$"
-                <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-                  <Target Name=""Build"">
-                    <Message Text=""{testMessage}"" />
-                  </Target>
-                </Project>
-                ");
+            string testMessage = "Hello from TestProject!";
+            _env.CreateFile("TestProject.proj", @$"
+            <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+              <Target Name=""Build"">
+                <Message Text=""{testMessage}"" />
+              </Target>
+            </Project>
+            ");
 
-                testEnvironment.SetEnvironmentVariable("MSBUILDNOINPROCNODE", "1");
+            _env.SetEnvironmentVariable("MSBUILDNOINPROCNODE", "1");
 
-                string output = RunnerUtilities.ExecMSBuild($"\"{testSolution.Path}\" /p:Configuration=Debug", out var success, _output);
+            string output = RunnerUtilities.ExecMSBuild($"\"{testSolution.Path}\" /p:Configuration=Debug", out var success, _output);
 
-                success.ShouldBeTrue(output);
-                output.ShouldContain(testMessage);
-            }
+            success.ShouldBeTrue(output);
+            output.ShouldContain(testMessage);
         }
 
 #if FEATURE_ASSEMBLYLOADCONTEXT
@@ -2404,32 +2389,29 @@ EndGlobal
 
         private (bool result, string output) ExecuteMSBuildExe(string projectContents, IDictionary<string, string> filesToCreate = null, IDictionary<string, string> envsToCreate = null, params string[] arguments)
         {
-            using (TestEnvironment testEnvironment = UnitTests.TestEnvironment.Create())
+            TransientTestProjectWithFiles testProject = _env.CreateTestProjectWithFiles(projectContents, new string[0]);
+
+            if (filesToCreate != null)
             {
-                TransientTestProjectWithFiles testProject = testEnvironment.CreateTestProjectWithFiles(projectContents, new string[0]);
-
-                if (filesToCreate != null)
+                foreach (var item in filesToCreate)
                 {
-                    foreach (var item in filesToCreate)
-                    {
-                        File.WriteAllText(Path.Combine(testProject.TestRoot, item.Key), item.Value);
-                    }
+                    File.WriteAllText(Path.Combine(testProject.TestRoot, item.Key), item.Value);
                 }
-
-                if (envsToCreate != null)
-                {
-                    foreach (var env in envsToCreate)
-                    {
-                        testEnvironment.SetEnvironmentVariable(env.Key, env.Value);
-                    }
-                }
-
-                bool success;
-
-                string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" {String.Join(" ", arguments)}", out success, _output);
-
-                return (success, output);
             }
+
+            if (envsToCreate != null)
+            {
+                foreach (var env in envsToCreate)
+                {
+                    _env.SetEnvironmentVariable(env.Key, env.Value);
+                }
+            }
+
+            bool success;
+
+            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" {String.Join(" ", arguments)}", out success, _output);
+
+            return (success, output);
         }
 
         public void Dispose()

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -182,8 +182,8 @@ namespace Microsoft.Build.UnitTests
             emptySplits.ShouldBe(0);
             sa.Count.ShouldBe(4);
             sa[0].ShouldBe("abc");
-            sa[1].ShouldBe(String.Empty);
-            sa[2].ShouldBe(String.Empty);
+            sa[1].ShouldBe(string.Empty);
+            sa[2].ShouldBe(string.Empty);
             sa[3].ShouldBe("dxyz");
 
             // "c d" is quoted
@@ -582,7 +582,7 @@ namespace Microsoft.Build.UnitTests
             MSBuildApp.SetConsoleUI();
 
             // Make sure this doesn't throw an exception.
-            string bar = String.Format(CultureInfo.CurrentUICulture, "{0}", 1);
+            string bar = string.Format(CultureInfo.CurrentUICulture, "{0}", 1);
 
             // Restore the current UI culture back to the way it was at the beginning of this unit test.
             thisThread.CurrentUICulture = originalUICulture;
@@ -883,7 +883,7 @@ namespace Microsoft.Build.UnitTests
             // Find the project in the current directory
             _env.SetCurrentDirectory(directory);
 
-            string output = RunnerUtilities.ExecMSBuild(String.Empty, out var successfulExit);
+            string output = RunnerUtilities.ExecMSBuild(string.Empty, out var successfulExit);
             successfulExit.ShouldBeTrue();
 
             output.ShouldContain("[A=1]");
@@ -1584,14 +1584,14 @@ namespace Microsoft.Build.UnitTests
                 List<string> fileNamesToReturn = new List<string>();
                 foreach (string file in _directoryFileNameList)
                 {
-                    if (String.Equals(searchPattern, "*.sln", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(searchPattern, "*.sln", StringComparison.OrdinalIgnoreCase))
                     {
                         if (FileUtilities.IsSolutionFilename(file))
                         {
                             fileNamesToReturn.Add(file);
                         }
                     }
-                    else if (String.Equals(searchPattern, "*.*proj", StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals(searchPattern, "*.*proj", StringComparison.OrdinalIgnoreCase))
                     {
                         if (Path.GetExtension(file).Contains("proj"))
                         {
@@ -2389,7 +2389,7 @@ EndGlobal
                 }
             }
 
-            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" {String.Join(" ", arguments)}", out var success, _output);
+            string output = RunnerUtilities.ExecMSBuild($"\"{testProject.ProjectFile}\" {string.Join(" ", arguments)}", out var success, _output);
 
             return (success, output);
         }

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.UnitTests
             CommandLineSwitches switches = new CommandLineSwitches();
 
             var arguments = new List<string>();
-            arguments.AddRange(new string[] { "/p:a=b", "/p:c=d" });
+            arguments.AddRange(new[] { "/p:a=b", "/p:c=d" });
 
             MSBuildApp.GatherCommandLineSwitches(arguments, switches);
 
@@ -62,7 +62,7 @@ namespace Microsoft.Build.UnitTests
             CommandLineSwitches switches = new CommandLineSwitches();
 
             var arguments = new List<string>();
-            arguments.AddRange(new string[] { "/m:2" });
+            arguments.AddRange(new[] { "/m:2" });
 
             MSBuildApp.GatherCommandLineSwitches(arguments, switches);
 
@@ -79,7 +79,7 @@ namespace Microsoft.Build.UnitTests
             CommandLineSwitches switches = new CommandLineSwitches();
 
             var arguments = new List<string>();
-            arguments.AddRange(new string[] { "/m:3", "/m" });
+            arguments.AddRange(new[] { "/m:3", "/m" });
 
             MSBuildApp.GatherCommandLineSwitches(arguments, switches);
 
@@ -99,7 +99,7 @@ namespace Microsoft.Build.UnitTests
             CommandLineSwitches switches = new CommandLineSwitches();
 
             var arguments = new List<string>();
-            arguments.AddRange(new string[] { "/m:" });
+            arguments.AddRange(new[] { "/m:" });
 
             MSBuildApp.GatherCommandLineSwitches(arguments, switches);
 
@@ -515,15 +515,15 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ValidMaxCPUCountSwitch()
         {
-            MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "1" }).ShouldBe(1);
-            MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "2" }).ShouldBe(2);
-            MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "3" }).ShouldBe(3);
-            MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "4" }).ShouldBe(4);
-            MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "8" }).ShouldBe(8);
-            MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "63" }).ShouldBe(63);
+            MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "1" }).ShouldBe(1);
+            MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "2" }).ShouldBe(2);
+            MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "3" }).ShouldBe(3);
+            MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "4" }).ShouldBe(4);
+            MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "8" }).ShouldBe(8);
+            MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "63" }).ShouldBe(63);
 
             // Should pick last value
-            MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "8", "4" }).ShouldBe(4);
+            MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "8", "4" }).ShouldBe(4);
         }
 
         [Fact]
@@ -531,7 +531,7 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<CommandLineSwitchException>(() =>
             {
-                MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "-1" });
+                MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "-1" });
             }
            );
         }
@@ -541,7 +541,7 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<CommandLineSwitchException>(() =>
             {
-                MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "0" });
+                MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "0" });
             }
            );
         }
@@ -552,7 +552,7 @@ namespace Microsoft.Build.UnitTests
             Should.Throw<CommandLineSwitchException>(() =>
             {
                 // Too big
-                MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "foo" });
+                MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "foo" });
             }
            );
         }
@@ -562,7 +562,7 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<CommandLineSwitchException>(() =>
             {
-                MSBuildApp.ProcessMaxCPUCountSwitch(new string[] { "1025" });
+                MSBuildApp.ProcessMaxCPUCountSwitch(new[] { "1025" });
             }
            );
         }
@@ -1238,7 +1238,7 @@ namespace Microsoft.Build.UnitTests
 
         private void RunPriorityBuildTest(ProcessPriorityClass expectedPrority, params string[] arguments)
         {
-            string[] aggregateArguments = arguments.Union(new string[] { " /nr:false /v:diag "}).ToArray();
+            string[] aggregateArguments = arguments.Union(new[] { " /nr:false /v:diag "}).ToArray();
 
             string contents = ObjectModelHelpers.CleanupFileContents(@"
 <Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
@@ -1267,11 +1267,11 @@ namespace Microsoft.Build.UnitTests
         /// Test the default file to build in cases involving at least one solution filter file.
         /// </summary>
         [Theory]
-        [InlineData(new string[] { "my.proj", "my.sln", "my.slnf" }, "my.sln")]
-        [InlineData(new string[] { "abc.proj", "bcd.csproj", "slnf.slnf", "other.slnf" }, "abc.proj")]
-        [InlineData(new string[] { "abc.sln", "slnf.slnf", "abc.slnf" }, "abc.sln")]
-        [InlineData(new string[] { "abc.csproj", "abc.slnf", "not.slnf" }, "abc.csproj")]
-        [InlineData(new string[] { "abc.slnf" }, "abc.slnf")]
+        [InlineData(new[] { "my.proj", "my.sln", "my.slnf" }, "my.sln")]
+        [InlineData(new[] { "abc.proj", "bcd.csproj", "slnf.slnf", "other.slnf" }, "abc.proj")]
+        [InlineData(new[] { "abc.sln", "slnf.slnf", "abc.slnf" }, "abc.sln")]
+        [InlineData(new[] { "abc.csproj", "abc.slnf", "not.slnf" }, "abc.csproj")]
+        [InlineData(new[] { "abc.slnf" }, "abc.slnf")]
         public void TestDefaultBuildWithSolutionFilter(string[] projects, string answer)
         {
             string[] extensionsToIgnore = Array.Empty<string>();
@@ -1288,8 +1288,8 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestProcessProjectSwitchOneProjNotFoundExtension()
         {
-            string[] projects = new string[] { "my.proj" };
-            string[] extensionsToIgnore = new string[] { ".phantomextension" };
+            string[] projects = new[] { "my.proj" };
+            string[] extensionsToIgnore = new[] { ".phantomextension" };
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
         }
@@ -1300,8 +1300,8 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestTwoIdenticalExtensionsToIgnore()
         {
-            string[] projects = new string[] { "my.proj" };
-            string[] extensionsToIgnore = new string[] { ".phantomextension", ".phantomextension" };
+            string[] projects = new[] { "my.proj" };
+            string[] extensionsToIgnore = new[] { ".phantomextension", ".phantomextension" };
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
         }
@@ -1312,7 +1312,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestProcessProjectSwitchNullandEmptyProjectsToIgnore()
         {
-            string[] projects = new string[] { "my.proj" };
+            string[] projects = new[] { "my.proj" };
             string[] extensionsToIgnore = null;
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
@@ -1329,8 +1329,8 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "my.proj" };
-                string[] extensionsToIgnore = new string[] { ".phantomextension", null };
+                string[] projects = new[] { "my.proj" };
+                string[] extensionsToIgnore = new[] { ".phantomextension", null };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
             }
@@ -1345,8 +1345,8 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "my.proj" };
-                string[] extensionsToIgnore = new string[] { ".phantomextension", string.Empty };
+                string[] projects = new[] { "my.proj" };
+                string[] extensionsToIgnore = new[] { ".phantomextension", string.Empty };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
             }
@@ -1360,8 +1360,8 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "my.proj" };
-                string[] extensionsToIgnore = new string[] { "phantomextension" };
+                string[] projects = new[] { "my.proj" };
+                string[] extensionsToIgnore = new[] { "phantomextension" };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase);
             }
@@ -1375,8 +1375,8 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "my.proj" };
-                string[] extensionsToIgnore = new string[] { ".C:\\boocatmoo.a" };
+                string[] projects = new[] { "my.proj" };
+                string[] extensionsToIgnore = new[] { ".C:\\boocatmoo.a" };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("my.proj", StringCompareShould.IgnoreCase); // "Expected my.proj to be only project found"
             }
@@ -1390,8 +1390,8 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "my.proj" };
-                string[] extensionsToIgnore = new string[] { ".proj*", ".nativeproj?" };
+                string[] projects = new[] { "my.proj" };
+                string[] extensionsToIgnore = new[] { ".proj*", ".nativeproj?" };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
@@ -1400,52 +1400,52 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestProcessProjectSwitch()
         {
-            string[] projects = new string[] { "test.nativeproj", "test.vcproj" };
-            string[] extensionsToIgnore = new string[] { ".phantomextension", ".vcproj" };
+            string[] projects = new[] { "test.nativeproj", "test.vcproj" };
+            string[] extensionsToIgnore = new[] { ".phantomextension", ".vcproj" };
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.nativeproj", StringCompareShould.IgnoreCase); // "Expected test.nativeproj to be only project found"
 
-            projects = new string[] { "test.nativeproj", "test.vcproj", "test.proj" };
-            extensionsToIgnore = new string[] { ".phantomextension", ".vcproj" };
+            projects = new[] { "test.nativeproj", "test.vcproj", "test.proj" };
+            extensionsToIgnore = new[] { ".phantomextension", ".vcproj" };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj", StringCompareShould.IgnoreCase); // "Expected test.proj to be only project found"
 
-            projects = new string[] { "test.nativeproj", "test.vcproj" };
-            extensionsToIgnore = new string[] { ".vcproj" };
+            projects = new[] { "test.nativeproj", "test.vcproj" };
+            extensionsToIgnore = new[] { ".vcproj" };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.nativeproj", StringCompareShould.IgnoreCase); // "Expected test.nativeproj to be only project found"
 
-            projects = new string[] { "test.proj", "test.sln" };
-            extensionsToIgnore = new string[] { ".vcproj" };
+            projects = new[] { "test.proj", "test.sln" };
+            extensionsToIgnore = new[] { ".vcproj" };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
 
-            projects = new string[] { "test.proj", "test.sln", "test.proj~", "test.sln~" };
+            projects = new[] { "test.proj", "test.sln", "test.proj~", "test.sln~" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
 
-            projects = new string[] { "test.proj" };
+            projects = new[] { "test.proj" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj", StringCompareShould.IgnoreCase); // "Expected test.proj to be only project found"
 
-            projects = new string[] { "test.proj", "test.proj~" };
+            projects = new[] { "test.proj", "test.proj~" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj", StringCompareShould.IgnoreCase); // "Expected test.proj to be only project found"
 
-            projects = new string[] { "test.sln" };
+            projects = new[] { "test.sln" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
 
-            projects = new string[] { "test.sln", "test.sln~" };
+            projects = new[] { "test.sln", "test.sln~" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
 
-            projects = new string[] { "test.sln~", "test.sln" };
+            projects = new[] { "test.sln~", "test.sln" };
             extensionsToIgnore = new string[] { };
             projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.sln", StringCompareShould.IgnoreCase); // "Expected test.sln to be only solution found"
@@ -1457,7 +1457,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestProcessProjectSwitchReplicateBuildingDFLKG()
         {
-            string[] projects = new string[] { "test.proj", "test.sln", "Foo.vcproj" };
+            string[] projects = new[] { "test.proj", "test.sln", "Foo.vcproj" };
             string[] extensionsToIgnore = { ".sln", ".vcproj" };
             IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
             MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles).ShouldBe("test.proj"); // "Expected test.proj to be only project found"
@@ -1473,8 +1473,8 @@ namespace Microsoft.Build.UnitTests
             {
                 string[] projects;
                 string[] extensionsToIgnore = null;
-                projects = new string[] { "test.nativeproj", "test.vcproj" };
-                extensionsToIgnore = new string[] { ".nativeproj", ".vcproj" };
+                projects = new[] { "test.nativeproj", "test.vcproj" };
+                extensionsToIgnore = new[] { ".nativeproj", ".vcproj" };
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
             }
@@ -1488,7 +1488,7 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "test.proj", "Different.sln" };
+                string[] projects = new[] { "test.proj", "Different.sln" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
@@ -1503,7 +1503,7 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "test.proj", "Different.proj" };
+                string[] projects = new[] { "test.proj", "Different.proj" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
@@ -1518,7 +1518,7 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "test.nativeproj", "Different.nativeproj" };
+                string[] projects = new[] { "test.nativeproj", "Different.nativeproj" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
@@ -1533,7 +1533,7 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "test.sln", "Different.sln" };
+                string[] projects = new[] { "test.sln", "Different.sln" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);
@@ -1548,7 +1548,7 @@ namespace Microsoft.Build.UnitTests
         {
             Should.Throw<InitializationException>(() =>
             {
-                string[] projects = new string[] { "test.nativeproj", "Different.csproj", "Another.proj" };
+                string[] projects = new[] { "test.nativeproj", "Different.csproj", "Another.proj" };
                 string[] extensionsToIgnore = null;
                 IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(projects);
                 MSBuildApp.ProcessProjectSwitch(new string[0] { }, extensionsToIgnore, projectHelper.GetFiles);

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -648,14 +648,14 @@ namespace Microsoft.Build.UnitTests
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.ToString());
+                _output.WriteLine(ex.ToString());
                 throw;
             }
             finally
             {
                 if (output != null)
                 {
-                    Console.WriteLine(output);
+                    _output.WriteLine(output);
                 }
 
                 try
@@ -795,7 +795,7 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        private string _pathToArbitraryBogusFile = NativeMethodsShared.IsWindows // OK on 64 bit as well
+        private readonly string _pathToArbitraryBogusFile = NativeMethodsShared.IsWindows // OK on 64 bit as well
                                                         ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "notepad.exe")
                                                         : "/bin/cat";
 
@@ -1241,7 +1241,7 @@ namespace Microsoft.Build.UnitTests
 
             string logContents = ExecuteMSBuildExeExpectSuccess(contents, envsToCreate: environmentVars, arguments: aggregateArguments);
 
-            string expected = string.Format(@"Task priority is '{0}'", expectedPrority);
+            string expected = $@"Task priority is '{expectedPrority}'";
             logContents.ShouldContain(expected, () => logContents);
         }
 
@@ -2211,10 +2211,8 @@ $@"<Project>
 
             RunnerUtilities.ExecMSBuild($"\"{binLogLocation}/output.binlog\" \"/bl:{binLogLocation}/replay.binlog;ProjectImports=ZipFile\"", out success, _output);
 
-            using (ZipArchive archive = ZipFile.OpenRead($"{binLogLocation}/replay.ProjectImports.zip"))
-            {
-                 archive.Entries.ShouldContain(e => e.FullName.EndsWith(".proj", StringComparison.OrdinalIgnoreCase), 2);
-            }
+            using ZipArchive archive = ZipFile.OpenRead($"{binLogLocation}/replay.ProjectImports.zip");
+            archive.Entries.ShouldContain(e => e.FullName.EndsWith(".proj", StringComparison.OrdinalIgnoreCase), 2);
         }
 
         [Fact]

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Build.CommandLine
             // We don't know what the current build thinks this variable should be until RunTask(), but as a fallback in case there are
             // communications before we get the configuration set up, just go with what was already in the environment from when this node
             // was initially launched.
-            _debugCommunications = (Environment.GetEnvironmentVariable("MSBUILDDEBUGCOMM") == "1");
+            _debugCommunications = Traits.Instance.DebugNodeCommunication;
 
             _receivedPackets = new Queue<INodePacket>();
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -560,7 +560,7 @@ namespace Microsoft.Build.Internal
 #if CLR2COMPATIBILITY
                         Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #else
-                        Traits.Instance.DebugEngine
+                        ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
                             ? DebugUtils.DebugDumpPath()
                             : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #endif

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -13,7 +13,11 @@ using System.Threading;
 
 using Microsoft.Build.Shared;
 using System.Reflection;
+using Microsoft.Build.Utilities;
 
+#if !CLR2COMPATIBILITY
+using Microsoft.Build.Shared.Debugging;
+#endif
 #if !FEATURE_APM
 using System.Threading.Tasks;
 #endif
@@ -131,7 +135,7 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// Whether to trace communications
         /// </summary>
-        private static bool s_trace = String.Equals(Environment.GetEnvironmentVariable("MSBUILDDEBUGCOMM"), "1", StringComparison.Ordinal);
+        private static bool s_trace = Traits.Instance.DebugNodeCommunication;
 
         /// <summary>
         /// Place to dump trace
@@ -552,7 +556,14 @@ namespace Microsoft.Build.Internal
             {
                 if (s_debugDumpPath == null)
                 {
-                    s_debugDumpPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+                    s_debugDumpPath =
+#if CLR2COMPATIBILITY
+                        Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+#else
+                        Traits.Instance.DebugEngine
+                            ? DebugUtils.DebugDumpPath()
+                            : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+#endif
 
                     if (String.IsNullOrEmpty(s_debugDumpPath))
                     {

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -179,6 +179,13 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static Dictionary<string, string> GetEnvironmentVariables()
         {
+#if !CLR2COMPATIBILITY
+            // The DebugUtils static constructor can set the MSBUILDDEBUGPATH environment variable to propagate the debug path to out of proc nodes.
+            // Need to ensure that constructor is called before this method returns in order to capture its env var write.
+            // Otherwise the env var is not captured and thus gets deleted when RequiestBuilder resets the environment based on the cached results of this method.
+            ErrorUtilities.VerifyThrowInternalNull(DebugUtils.DebugPath, nameof(DebugUtils.DebugPath));
+#endif
+
             Dictionary<string, string> table = new Dictionary<string, string>(200, StringComparer.OrdinalIgnoreCase); // Razzle has 150 environment variables
 
             if (NativeMethodsShared.IsWindows)
@@ -561,7 +568,7 @@ namespace Microsoft.Build.Internal
                         Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #else
                         ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
-                            ? DebugUtils.DebugDumpPath()
+                            ? DebugUtils.DebugPath
                             : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #endif
 

--- a/src/Shared/Debugging/DebugUtils.cs
+++ b/src/Shared/Debugging/DebugUtils.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Build.Shared.Debugging
+{
+    internal static class DebugUtils
+    {
+        private enum NodeMode
+        {
+            CentralNode,
+            OutOfProcNode,
+            OutOfProcTaskHostNode
+        }
+
+        private static readonly Lazy<NodeMode> ProcessNodeMode = new(
+        () =>
+        {
+            return ScanNodeMode(Environment.CommandLine);
+
+            NodeMode ScanNodeMode(string input)
+            {
+                var match = Regex.Match(input, @"/nodemode:(?<nodemode>[12\s])(\s|$)", RegexOptions.IgnoreCase);
+
+                if (!match.Success)
+                {
+                    return NodeMode.CentralNode;
+                }
+                var nodeMode = match.Groups["nodemode"].Value;
+
+                Trace.Assert(!string.IsNullOrEmpty(nodeMode));
+
+                return nodeMode switch
+                {
+                    "1" => NodeMode.OutOfProcNode,
+                    "2" => NodeMode.OutOfProcTaskHostNode,
+                    _ => throw new NotImplementedException(),
+                };
+            }
+        });
+
+        public static string ProcessInfoString =
+            $"{ProcessNodeMode.Value}_{Process.GetCurrentProcess().ProcessName}_PID={Process.GetCurrentProcess().Id}_x{(Environment.Is64BitProcess ? "64" : "86")}";
+
+        public static string DebugDumpPath()
+        {
+            var debugDirectory = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH") ?? Path.Combine(Directory.GetCurrentDirectory(), "MSBuild_Logs");
+            FileUtilities.EnsureDirectoryExists(debugDirectory);
+
+            return debugDirectory;
+        }
+
+        public static string FindNextAvailableDebugFilePath(string fileName)
+        {
+            fileName = Path.Combine(DebugDumpPath(), fileName);
+
+            var counter = 0;
+            while (File.Exists(fileName))
+            {
+                fileName = $"{counter++}_{fileName}";
+            }
+
+            return fileName;
+        }
+    }
+}

--- a/src/Shared/Debugging/DebugUtils.cs
+++ b/src/Shared/Debugging/DebugUtils.cs
@@ -43,8 +43,19 @@ namespace Microsoft.Build.Shared.Debugging
             }
         });
 
-        public static string ProcessInfoString =
+        private static bool CurrentProcessMatchesDebugName()
+        {
+            var processNameToBreakInto = Environment.GetEnvironmentVariable("MSBuildDebugProcessName");
+            var thisProcessMatchesName = string.IsNullOrWhiteSpace(processNameToBreakInto) ||
+                                         Process.GetCurrentProcess().ProcessName.Contains(processNameToBreakInto);
+
+            return thisProcessMatchesName;
+        }
+
+        public static readonly string ProcessInfoString =
             $"{ProcessNodeMode.Value}_{Process.GetCurrentProcess().ProcessName}_PID={Process.GetCurrentProcess().Id}_x{(Environment.Is64BitProcess ? "64" : "86")}";
+
+        public static readonly bool ShouldDebugCurrentProcess = CurrentProcessMatchesDebugName();
 
         public static string DebugDumpPath()
         {

--- a/src/Shared/Debugging/DebugUtils.cs
+++ b/src/Shared/Debugging/DebugUtils.cs
@@ -56,15 +56,20 @@ namespace Microsoft.Build.Shared.Debugging
 
         public static string FindNextAvailableDebugFilePath(string fileName)
         {
-            fileName = Path.Combine(DebugDumpPath(), fileName);
+            var extension = Path.GetExtension(fileName);
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+
+            var debugRoot = DebugDumpPath();
+            var fullPath = Path.Combine(debugRoot, fileName);
 
             var counter = 0;
-            while (File.Exists(fileName))
+            while (File.Exists(fullPath))
             {
-                fileName = $"{counter++}_{fileName}";
+                fileName = $"{fileNameWithoutExtension}_{counter++}{extension}";
+                fullPath = Path.Combine(debugRoot, fileName);
             }
 
-            return fileName;
+            return fullPath;
         }
     }
 }

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -19,6 +19,10 @@ using System.Xml;
 using Microsoft.Build.Shared.FileSystem;
 using System.Xml.Schema;
 using System.Runtime.Serialization;
+#if !CLR2COMPATIBILITY
+using Microsoft.Build.Shared.Debugging;
+#endif
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Shared
 #endif
@@ -41,7 +45,15 @@ namespace Microsoft.Build.Shared
         /// <returns></returns>
         private static string GetDebugDumpPath()
         {
-            string debugPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+            string debugPath =
+#if CLR2COMPATIBILITY || MICROSOFT_BUILD_ENGINE_OM_UNITTESTS
+                        Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+#else
+                ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
+                    ? DebugUtils.DebugDumpPath()
+                    : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+#endif
+
             return !string.IsNullOrEmpty(debugPath)
                     ? debugPath
                     : Path.GetTempPath();

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Build.Shared
                         Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #else
                 ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
-                    ? DebugUtils.DebugDumpPath()
+                    ? DebugUtils.DebugPath
                     : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #endif
 

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Build.Shared
         private static string GetDebugDumpPath()
         {
             string debugPath =
+// Cannot access change wave logic from these assemblies (https://github.com/dotnet/msbuild/issues/6707)
 #if CLR2COMPATIBILITY || MICROSOFT_BUILD_ENGINE_OM_UNITTESTS
                         Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #else

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -44,11 +44,6 @@ namespace Microsoft.Build.BackEnd
         private const int PipeBufferSize = 131072;
 
         /// <summary>
-        /// Flag indicating if we should debug communications or not.
-        /// </summary>
-        private bool _debugCommunications = false;
-
-        /// <summary>
         /// The current communication status of the node.
         /// </summary>
         private LinkStatus _status;
@@ -192,8 +187,6 @@ namespace Microsoft.Build.BackEnd
         internal void InternalConstruct(string pipeName)
         {
             ErrorUtilities.VerifyThrowArgumentLength(pipeName, nameof(pipeName));
-
-            _debugCommunications = (Environment.GetEnvironmentVariable("MSBUILDDEBUGCOMM") == "1");
 
             _status = LinkStatus.Inactive;
             _asyncDataMonitor = new object();

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Build.Utilities
         public Traits()
         {
             EscapeHatches = new EscapeHatches();
+
+            DebugScheduler = DebugEngine || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDEBUGSCHEDULER"));
+            DebugNodeCommunication = DebugEngine || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDEBUGCOMM"));
         }
 
         public EscapeHatches EscapeHatches { get; }
@@ -85,6 +88,10 @@ namespace Microsoft.Build.Utilities
         /// Log property tracking information.
         /// </summary>
         public readonly int LogPropertyTracking = ParseIntFromEnvironmentVariableOrDefault("MsBuildLogPropertyTracking", 0); // Default to logging nothing via the property tracker.
+
+        public readonly bool DebugEngine = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBuildDebugEngine"));
+        public readonly bool DebugScheduler;
+        public readonly bool DebugNodeCommunication;
 
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {


### PR DESCRIPTION
### Context
There's still a bit of friction when debugging MSBuild, especially under VS. You have to set multiple env vars, or search through temp, find all the obscure env var names, etc

### Changes Made
- add one env var, `MSBuildDebugEngine` to turn everything on and also automatically pick `./MSBuild_Logs` as the debug log path for everything that spews out log files.
- in addition, when `MSBuildDebugEngine`: 
  - inject a binary logger directly from the build manager. This is super useful when running MSBuild in VS, as the build logging that VS gives is kind of lacking
  - dump a `.dot` representation of the static graph, when one is available

This is how `MSBuild_Logs` looks like after doing a build (both VS and cmdline should produce this):
![image](https://user-images.githubusercontent.com/2255729/123869003-4b74fa80-d8e5-11eb-8fef-bd0bea421411.png)
