### PR TITLE
Add ETW trace for PerformDependencyAnalysis

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Eventing;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -465,7 +466,9 @@ namespace Microsoft.Build.BackEnd
 
                         // UNDONE: (Refactor) Refactor TargetUpToDateChecker to take a logging context, not a logging service.
                         TargetUpToDateChecker dependencyAnalyzer = new TargetUpToDateChecker(requestEntry.RequestConfiguration.Project, _target, targetLoggingContext.LoggingService, targetLoggingContext.BuildEventContext);
+                        MSBuildEventSource.Log.PerformDependencyAnalysisStart();
                         DependencyAnalysisResult dependencyResult = dependencyAnalyzer.PerformDependencyAnalysis(bucket, out changedTargetInputs, out upToDateTargetInputs);
+                        MSBuildEventSource.Log.PerformDependencyAnalysisStop();
 
                         switch (dependencyResult)
                         {

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -465,10 +465,10 @@ namespace Microsoft.Build.BackEnd
                         Lookup lookupForExecution;
 
                         // UNDONE: (Refactor) Refactor TargetUpToDateChecker to take a logging context, not a logging service.
+                        MSBuildEventSource.Log.TargetUpToDateStart();
                         TargetUpToDateChecker dependencyAnalyzer = new TargetUpToDateChecker(requestEntry.RequestConfiguration.Project, _target, targetLoggingContext.LoggingService, targetLoggingContext.BuildEventContext);
-                        MSBuildEventSource.Log.PerformDependencyAnalysisStart();
                         DependencyAnalysisResult dependencyResult = dependencyAnalyzer.PerformDependencyAnalysis(bucket, out changedTargetInputs, out upToDateTargetInputs);
-                        MSBuildEventSource.Log.PerformDependencyAnalysisStop();
+                        MSBuildEventSource.Log.TargetUpToDateStop((int)dependencyResult);
 
                         switch (dependencyResult)
                         {

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -423,6 +423,18 @@ namespace Microsoft.Build.Eventing
         {
             WriteEvent(55, size);
         }
+
+        [Event(56, Keywords = Keywords.All)]
+        public void PerformDependencyAnalysisStart()
+        {
+            WriteEvent(56);
+        }
+
+        [Event(57, Keywords = Keywords.All)]
+        public void PerformDependencyAnalysisStop()
+        {
+            WriteEvent(57);
+        }
         #endregion
     }
 }

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -425,15 +425,27 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(56, Keywords = Keywords.All)]
-        public void PerformDependencyAnalysisStart()
+        public void TargetUpToDateStart()
         {
             WriteEvent(56);
         }
 
         [Event(57, Keywords = Keywords.All)]
-        public void PerformDependencyAnalysisStop()
+        public void TargetUpToDateStop(int result)
         {
-            WriteEvent(57);
+            WriteEvent(57, result);
+        }
+
+        [Event(58, Keywords = Keywords.All)]
+        public void CopyStart(bool singleThreaded)
+        {
+            WriteEvent(58, singleThreaded);
+        }
+
+        [Event(59, Keywords = Keywords.All)]
+        public void CopyStop(bool singleThreaded)
+        {
+            WriteEvent(59, singleThreaded);
         }
         #endregion
     }

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -435,18 +435,6 @@ namespace Microsoft.Build.Eventing
         {
             WriteEvent(57, result);
         }
-
-        [Event(58, Keywords = Keywords.All)]
-        public void CopyStart(bool singleThreaded)
-        {
-            WriteEvent(58, singleThreaded);
-        }
-
-        [Event(59, Keywords = Keywords.All)]
-        public void CopyStop(bool singleThreaded)
-        {
-            WriteEvent(59, singleThreaded);
-        }
         #endregion
     }
 }

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -12,6 +12,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.Eventing;
 
 namespace Microsoft.Build.Tasks
 {
@@ -426,6 +427,8 @@ namespace Microsoft.Build.Tasks
                 DestinationFiles.Length, // Set length to common case of 1:1 source->dest.
                 StringComparer.OrdinalIgnoreCase);
 
+            MSBuildEventSource.Log.CopyStart(true);
+
             // Now that we have a list of destinationFolder files, copy from source to destinationFolder.
             for (int i = 0; i < SourceFiles.Length && !_cancellationTokenSource.IsCancellationRequested; ++i)
             {
@@ -459,6 +462,8 @@ namespace Microsoft.Build.Tasks
                     destinationFilesSuccessfullyCopied.Add(DestinationFiles[i]);
                 }
             }
+
+            MSBuildEventSource.Log.CopyStop(true);
 
             return success;
         }
@@ -499,6 +504,8 @@ namespace Microsoft.Build.Tasks
             var partitionsByDestination = new Dictionary<string, List<int>>(
                 DestinationFiles.Length, // Set length to common case of 1:1 source->dest.
                 StringComparer.OrdinalIgnoreCase);
+
+            MSBuildEventSource.Log.CopyStart(false);
 
             for (int i = 0; i < SourceFiles.Length && !_cancellationTokenSource.IsCancellationRequested; ++i)
             {
@@ -588,6 +595,8 @@ namespace Microsoft.Build.Tasks
                     destinationFilesSuccessfullyCopied.Add(DestinationFiles[i]);
                 }
             }
+
+            MSBuildEventSource.Log.CopyStop(false);
 
             return success;
         }

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -12,7 +12,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
-using Microsoft.Build.Eventing;
 
 namespace Microsoft.Build.Tasks
 {
@@ -427,8 +426,6 @@ namespace Microsoft.Build.Tasks
                 DestinationFiles.Length, // Set length to common case of 1:1 source->dest.
                 StringComparer.OrdinalIgnoreCase);
 
-            MSBuildEventSource.Log.CopyStart(true);
-
             // Now that we have a list of destinationFolder files, copy from source to destinationFolder.
             for (int i = 0; i < SourceFiles.Length && !_cancellationTokenSource.IsCancellationRequested; ++i)
             {
@@ -462,8 +459,6 @@ namespace Microsoft.Build.Tasks
                     destinationFilesSuccessfullyCopied.Add(DestinationFiles[i]);
                 }
             }
-
-            MSBuildEventSource.Log.CopyStop(true);
 
             return success;
         }
@@ -504,8 +499,6 @@ namespace Microsoft.Build.Tasks
             var partitionsByDestination = new Dictionary<string, List<int>>(
                 DestinationFiles.Length, // Set length to common case of 1:1 source->dest.
                 StringComparer.OrdinalIgnoreCase);
-
-            MSBuildEventSource.Log.CopyStart(false);
 
             for (int i = 0; i < SourceFiles.Length && !_cancellationTokenSource.IsCancellationRequested; ++i)
             {
@@ -595,8 +588,6 @@ namespace Microsoft.Build.Tasks
                     destinationFilesSuccessfullyCopied.Add(DestinationFiles[i]);
                 }
             }
-
-            MSBuildEventSource.Log.CopyStop(false);
 
             return success;
         }


### PR DESCRIPTION
I was considering adding bucket.bucketSequenceNumber, but I don't think that's too important. Complicated information can't be easily ( / efficiently) attached to ETW traces

Fixes #6616

I should make sure they appear in PerfView before merging.