### PR TITLE
Stop checking .ni.dll/exe on Core

### DIFF
--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -153,26 +153,23 @@ namespace Microsoft.Build.Shared
             {
                 foreach (var searchPath in searchPaths)
                 {
-                    foreach (var extension in MSBuildLoadContext.Extensions)
+                    var candidatePath = Path.Combine(searchPath,
+                        cultureSubfolder,
+                        $"{assemblyName.Name}.dll");
+
+                    if (IsAssemblyAlreadyLoaded(candidatePath) ||
+                        !FileSystems.Default.FileExists(candidatePath))
                     {
-                        var candidatePath = Path.Combine(searchPath,
-                            cultureSubfolder,
-                            $"{assemblyName.Name}.{extension}");
-
-                        if (IsAssemblyAlreadyLoaded(candidatePath) ||
-                            !FileSystems.Default.FileExists(candidatePath))
-                        {
-                            continue;
-                        }
-
-                        AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
-                        if (candidateAssemblyName.Version != assemblyName.Version)
-                        {
-                            continue;
-                        }
-
-                        return LoadAndCache(context, candidatePath);
+                        continue;
                     }
+
+                    AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
+                    if (candidateAssemblyName.Version != assemblyName.Version)
+                    {
+                        continue;
+                    }
+
+                    return LoadAndCache(context, candidatePath);
                 }
             }
 

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.Shared
                 "Microsoft.Build.Utilities.Core",
             }.ToImmutableHashSet();
 
-        internal static readonly string[] Extensions = new[] { "ni.dll", "ni.exe", "dll", "exe" };
+        internal static readonly string[] Extensions = new[] { "dll", "exe" };
 
 
         public MSBuildLoadContext(string assemblyPath)

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -29,9 +29,6 @@ namespace Microsoft.Build.Shared
                 "Microsoft.Build.Utilities.Core",
             }.ToImmutableHashSet();
 
-        internal static readonly string[] Extensions = new[] { "dll", "exe" };
-
-
         public MSBuildLoadContext(string assemblyPath)
             : base($"MSBuild plugin {assemblyPath}")
         {
@@ -56,11 +53,9 @@ namespace Microsoft.Build.Shared
                 // bare search directory if that fails.
                 : new[] { assemblyName.CultureName, string.Empty })
             {
-                foreach (var extension in Extensions)
-                {
                     var candidatePath = Path.Combine(_directory,
                         cultureSubfolder,
-                        $"{assemblyName.Name}.{extension}");
+                        $"{assemblyName.Name}.dll");
 
                     if (!FileSystems.Default.FileExists(candidatePath))
                     {
@@ -74,7 +69,6 @@ namespace Microsoft.Build.Shared
                     }
 
                     return LoadFromAssemblyPath(candidatePath);
-                }
             }
 
             // If the Assembly is provided via a file path, the following rules are used to load the assembly:


### PR DESCRIPTION
We believe these were remnants of old pre-crossgen file naming patterns that haven't been used in a very long time.

Removing the checks to avoid filesystem activity on files that almost certainly will not exist.

Fixes #5042.