### PR TITLE
VS 1449000: Fix handling of satellite assemblies in ClickOnce

### DIFF
--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Build.Tasks
         // if signing manifests is on and not all app files are included, then the project can't be published.
         private bool _canPublish;
         private Dictionary<string, ITaskItem> _runtimePackAssets;
+        // map of satellite assemblies that are included in References
+        private SatelliteRefAssemblyMap satelliteRefAssemblyMap = new SatelliteRefAssemblyMap();
         #endregion
 
         #region Properties
@@ -380,6 +382,29 @@ namespace Microsoft.Build.Tasks
                 {
                     if (!IsFiltered(item))
                     {
+                        // ClickOnce for .NET 4.X should not publish duplicate satellite assemblies.
+                        // This will cause ClickOnce install to fail. This can happen if some package
+                        // decides to publish the en-us resource assemblies for other locales also.
+                        if (!LauncherBasedDeployment && satelliteRefAssemblyMap.ContainsItem(item))
+                        {
+                            Debug.Assert(false, "Duplicate satellite assembly skipped in _managedAssemblies");
+                            continue;
+                        }
+
+                        // If we get a resource assembly in managed references, determine whether to be publish it based on _targetCulture
+                        AssemblyIdentity identity = AssemblyIdentity.FromManagedAssembly(item.ItemSpec);
+                        if (identity != null && !String.Equals(identity.Culture, "neutral", StringComparison.Ordinal))
+                        {
+                            CultureInfo satelliteCulture = GetItemCulture(item);
+                            if (!PublishFlags.IsSatelliteIncludedByDefault(satelliteCulture, _targetCulture, _includeAllSatellites))
+                            {
+                                continue;
+                            }
+                            else
+                            {
+                                satelliteRefAssemblyMap.Add(item);
+                            }
+                        }
                         item.SetMetadata("AssemblyType", "Managed");
                         assemblyMap.Add(item);
                     }
@@ -574,6 +599,11 @@ namespace Microsoft.Build.Tasks
                 foreach (ITaskItem item in _satelliteAssemblies)
                 {
                     item.SetMetadata("AssemblyType", "Satellite");
+                    if (satelliteRefAssemblyMap.ContainsItem(item))
+                    {
+                        Debug.Assert(false, "Duplicate satellite assembly skipped in _satelliteAssemblies");
+                        continue;
+                    }
                     satelliteMap.Add(item, true);
                 }
             }
@@ -855,6 +885,56 @@ namespace Microsoft.Build.Tasks
         }
         #endregion
 
+        #region SatelliteRefAssemblyMap
+        private class SatelliteRefAssemblyMap : IEnumerable
+        {
+            private readonly Dictionary<string, MapEntry> _dictionary = new Dictionary<string, MapEntry>();
+
+            public MapEntry this[string fusionName]
+            {
+                get
+                {
+                    string key = fusionName.ToLowerInvariant();
+                    _dictionary.TryGetValue(key, out MapEntry entry);
+                    return entry;
+                }
+            }
+
+            public bool ContainsItem(ITaskItem item)
+            {
+                AssemblyIdentity identity = AssemblyIdentity.FromManagedAssembly(item.ItemSpec);
+                if (identity != null)
+                {
+                    string key = identity.ToString().ToLowerInvariant();
+                    return _dictionary.ContainsKey(key);
+                }
+                return false;
+            }
+
+            public void Add(ITaskItem item)
+            {
+                var entry = new MapEntry(item, true);
+                AssemblyIdentity identity = AssemblyIdentity.FromManagedAssembly(item.ItemSpec);
+                if (identity != null && !String.Equals(identity.Culture, "neutral", StringComparison.Ordinal))
+                {
+                    // Use satellite assembly strong name signature as key
+                    string key = identity.ToString().ToLowerInvariant();
+                    Debug.Assert(!_dictionary.ContainsKey(key), String.Format(CultureInfo.CurrentCulture, "Two or more items with same key '{0}' detected", key));
+                    if (!_dictionary.ContainsKey(key))
+                    {
+                        _dictionary.Add(key, entry);
+                    }
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return _dictionary.Values.GetEnumerator();
+            }
+        }
+        #endregion
+
+
         #region FileMap
         private class FileMap : IEnumerable
         {
@@ -1036,7 +1116,7 @@ namespace Microsoft.Build.Tasks
 
             public bool IsPublished { get; }
 
-            private static bool IsSatelliteIncludedByDefault(CultureInfo satelliteCulture, CultureInfo targetCulture, bool includeAllSatellites)
+            public static bool IsSatelliteIncludedByDefault(CultureInfo satelliteCulture, CultureInfo targetCulture, bool includeAllSatellites)
             {
                 // If target culture not specified then satellite is not included by default...
                 if (targetCulture == null)

--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Build.Tasks
         private bool _canPublish;
         private Dictionary<string, ITaskItem> _runtimePackAssets;
         // map of satellite assemblies that are included in References
-        private SatelliteRefAssemblyMap satelliteRefAssemblyMap = new SatelliteRefAssemblyMap();
+        private SatelliteRefAssemblyMap _satelliteAssembliesPassedAsReferences = new SatelliteRefAssemblyMap();
         #endregion
 
         #region Properties
@@ -385,24 +385,23 @@ namespace Microsoft.Build.Tasks
                         // ClickOnce for .NET 4.X should not publish duplicate satellite assemblies.
                         // This will cause ClickOnce install to fail. This can happen if some package
                         // decides to publish the en-us resource assemblies for other locales also.
-                        if (!LauncherBasedDeployment && satelliteRefAssemblyMap.ContainsItem(item))
+                        if (!LauncherBasedDeployment && _satelliteAssembliesPassedAsReferences.ContainsItem(item))
                         {
-                            Debug.Assert(false, $"Duplicate satellite assembly '{item.ItemSpec}' skipped in _managedAssemblies");
                             continue;
                         }
 
-                        // If we get a resource assembly in managed references, determine whether to be publish it based on _targetCulture
+                        // Apply the culture publishing rules to include or exclude satellite assemblies
                         AssemblyIdentity identity = AssemblyIdentity.FromManagedAssembly(item.ItemSpec);
                         if (identity != null && !String.Equals(identity.Culture, "neutral", StringComparison.Ordinal))
                         {
                             CultureInfo satelliteCulture = GetItemCulture(item);
-                            if (!PublishFlags.IsSatelliteIncludedByDefault(satelliteCulture, _targetCulture, _includeAllSatellites))
+                            if (PublishFlags.IsSatelliteIncludedByDefault(satelliteCulture, _targetCulture, _includeAllSatellites))
                             {
-                                continue;
+                                _satelliteAssembliesPassedAsReferences.Add(item);
                             }
                             else
                             {
-                                satelliteRefAssemblyMap.Add(item);
+                                continue;
                             }
                         }
                         item.SetMetadata("AssemblyType", "Managed");
@@ -599,9 +598,8 @@ namespace Microsoft.Build.Tasks
                 foreach (ITaskItem item in _satelliteAssemblies)
                 {
                     item.SetMetadata("AssemblyType", "Satellite");
-                    if (satelliteRefAssemblyMap.ContainsItem(item))
+                    if (_satelliteAssembliesPassedAsReferences.ContainsItem(item))
                     {
-                        Debug.Assert(false, $"Duplicate satellite assembly '{item.ItemSpec}' skipped in _satelliteAssemblies");
                         continue;
                     }
                     satelliteMap.Add(item, true);
@@ -888,14 +886,13 @@ namespace Microsoft.Build.Tasks
         #region SatelliteRefAssemblyMap
         private class SatelliteRefAssemblyMap : IEnumerable
         {
-            private readonly Dictionary<string, MapEntry> _dictionary = new Dictionary<string, MapEntry>();
+            private readonly Dictionary<string, MapEntry> _dictionary = new Dictionary<string, MapEntry>(StringComparer.InvariantCultureIgnoreCase);
 
             public MapEntry this[string fusionName]
             {
                 get
                 {
-                    string key = fusionName.ToLowerInvariant();
-                    _dictionary.TryGetValue(key, out MapEntry entry);
+                    _dictionary.TryGetValue(fusionName, out MapEntry entry);
                     return entry;
                 }
             }
@@ -905,8 +902,7 @@ namespace Microsoft.Build.Tasks
                 AssemblyIdentity identity = AssemblyIdentity.FromManagedAssembly(item.ItemSpec);
                 if (identity != null)
                 {
-                    string key = identity.ToString().ToLowerInvariant();
-                    return _dictionary.ContainsKey(key);
+                    return _dictionary.ContainsKey(identity.ToString());
                 }
                 return false;
             }
@@ -918,7 +914,7 @@ namespace Microsoft.Build.Tasks
                 if (identity != null && !String.Equals(identity.Culture, "neutral", StringComparison.Ordinal))
                 {
                     // Use satellite assembly strong name signature as key
-                    string key = identity.ToString().ToLowerInvariant();
+                    string key = identity.ToString();
                     Debug.Assert(!_dictionary.ContainsKey(key), String.Format(CultureInfo.CurrentCulture, "Two or more items with same key '{0}' detected", key));
                     if (!_dictionary.ContainsKey(key))
                     {

--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -387,7 +387,7 @@ namespace Microsoft.Build.Tasks
                         // decides to publish the en-us resource assemblies for other locales also.
                         if (!LauncherBasedDeployment && satelliteRefAssemblyMap.ContainsItem(item))
                         {
-                            Debug.Assert(false, "Duplicate satellite assembly skipped in _managedAssemblies");
+                            Debug.Assert(false, $"Duplicate satellite assembly '{item.ItemSpec}' skipped in _managedAssemblies");
                             continue;
                         }
 
@@ -601,7 +601,7 @@ namespace Microsoft.Build.Tasks
                     item.SetMetadata("AssemblyType", "Satellite");
                     if (satelliteRefAssemblyMap.ContainsItem(item))
                     {
-                        Debug.Assert(false, "Duplicate satellite assembly skipped in _satelliteAssemblies");
+                        Debug.Assert(false, $"Duplicate satellite assembly '{item.ItemSpec}' skipped in _satelliteAssemblies");
                         continue;
                     }
                     satelliteMap.Add(item, true);


### PR DESCRIPTION
Fixes AB#1449000

### Context
Satellite assemblies are not being handled correctly after ClickOnce changes for .NET Core publishing were made in VS 16.8.

Following issues have been observed post those changes:

1. If packages publish en-us resource assembly for other locales as well, we will end up adding all of them in the ClickOnce manifest. Since the strong name signature will be identical for all these resource assemblies, we will now have multiple assemblies with identical signature in the ClickOnce manifest. This will cause CO Install to fail.

2. The References item list can also contain resource assemblies. If these assemblies are also present in the SatelliteAssembly item list, we will now end up writing 2 entries for the same assembly in the manifest. This will cause CO install to fail.

### Changes Made
When we process the References item list, we will maintain a dictionary for satellite assemblies that are getting included in the list of assemblies. Later when we process the SatelliteAssemblies item list, we will look up in this dictionary and skip the entries that are already included through the References list.

### Testing
Ongoing

### Notes
