### PR TITLE
Remove import using `CoreCrossTargetingTargetsPath` property

### DIFF
--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -216,8 +216,4 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(DirectoryBuildTargetsPath)" Condition="'$(ImportDirectoryBuildTargets)' == 'true' and exists('$(DirectoryBuildTargetsPath)')"/>
 
-  <!-- TODO: https://github.com/Microsoft/msbuild/issues/1062: Remove this temporary hook when possible. -->
-  <Import Project="$(CoreCrossTargetingTargetsPath)"
-          Condition="'$(CoreCrossTargetingTargetsPath)' != '' and Exists('$(CoreCrossTargetingTargetsPath)')" />
-
 </Project>


### PR DESCRIPTION
Fixes #1062

### Context

The import based on this property was introduced as a temporary bootstrapping
mechanism before there was packaging extensibility available for multi-targeting.

The packaging mechanism (aka NuGet) now uses `buildCrossTargeting`/`buildMultiTargeting`,
similar to `build` package folder to hold and import multi-targeting logic via NuGet's Restore.

Thus, we don't need this workaround anymore.


### Changes Made

Removed the temporary import based on `CoreCrossTargetingTargetsPath`


### Testing

Since there are no tests for this property, as it is with all the workarounds… We'll see if we break anyone during the self-hosting period.


### Notes

This patch was already a part of #6161. Since, the change was approved independently, I have separated this into a new PR.