### PR TITLE
Revert "Ignore comments and whitespace when parsing read-only XML files (#6232)"

### DIFF
--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Text;
 using System.Xml;
 using Microsoft.Build.Shared;
-using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Internal
 {
@@ -28,16 +25,6 @@ namespace Microsoft.Build.Internal
         private static readonly Encoding s_utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         private readonly Stream _stream;
         private readonly StreamReader _streamReader;
-
-        /// <summary>
-        /// Caches a <see cref="PropertyInfo"/> representing the "Normalization" internal property on the <see cref="XmlReader"/>-derived
-        /// type returned from <see cref="XmlReader.Create(TextReader, XmlReaderSettings, string)"/>. The cache is process/AppDomain-wide
-        /// and lock-free, so we use volatile access for thread safety, i.e. to ensure that when the field is updated the PropertyInfo
-        /// it's pointing to is seen as fully initialized by all CPUs.
-        /// </summary>
-        private static volatile PropertyInfo _normalizationPropertyInfo;
-
-        private static bool _disableReadOnlyLoad;
 
         private XmlReaderExtension(string file, bool loadAsReadOnly)
         {
@@ -84,61 +71,15 @@ namespace Microsoft.Build.Internal
             _stream?.Dispose();
         }
 
-        /// <summary>
-        /// Returns <see cref="PropertyInfo"/> of the "Normalization" internal property on the given <see cref="XmlReader"/>-derived type.
-        /// </summary>
-        private static PropertyInfo GetNormalizationPropertyInfo(Type xmlReaderType)
-        {
-            PropertyInfo propertyInfo = _normalizationPropertyInfo;
-            if (propertyInfo == null)
-            {
-                BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.SetProperty | BindingFlags.Instance;
-                propertyInfo = xmlReaderType.GetProperty("Normalization", bindingFlags);
-                _normalizationPropertyInfo = propertyInfo;
-            }
-
-            return propertyInfo;
-        }
-
         private static XmlReader GetXmlReader(string file, StreamReader input, bool loadAsReadOnly, out Encoding encoding)
         {
             string uri = new UriBuilder(Uri.UriSchemeFile, string.Empty) { Path = file }.ToString();
 
-            XmlReader reader = null;
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10) && loadAsReadOnly && !_disableReadOnlyLoad)
-            {
-                // Create an XML reader with IgnoreComments and IgnoreWhitespace set if we know that we won't be asked
-                // to write the DOM back to a file. This is a performance optimization.
-                XmlReaderSettings settings = new XmlReaderSettings
-                {
-                    DtdProcessing = DtdProcessing.Ignore,
-                    IgnoreComments = true,
-                    IgnoreWhitespace = true,
-                };
-                reader = XmlReader.Create(input, settings, uri);
-
-                // Try to set Normalization to false. We do this to remain compatible with earlier versions of MSBuild
-                // where we constructed the reader with 'new XmlTextReader()' which has normalization enabled by default.
-                PropertyInfo normalizationPropertyInfo = GetNormalizationPropertyInfo(reader.GetType());
-                if (normalizationPropertyInfo != null)
-                {
-                    normalizationPropertyInfo.SetValue(reader, false);
-                }
-                else
-                {
-                    // Fall back to using XmlTextReader if the prop could not be bound.
-                    Debug.Fail("Could not set Normalization to false on the result of XmlReader.Create");
-                    _disableReadOnlyLoad = true;
-
-                    reader.Dispose();
-                    reader = null;
-                }
-            }
-
-            if (reader == null)
-            {
-                reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
-            }
+            
+            // Ignore loadAsReadOnly for now; using XmlReader.Create results in whitespace changes
+            // of attribute text, specifically newline removal.
+            // https://github.com/Microsoft/msbuild/issues/4210
+            XmlReader reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
 
             reader.Read();
             encoding = input.CurrentEncoding;


### PR DESCRIPTION
This reverts commit 1d1fec7c49795b247fc45fac0fb1fdd736c6a368.

Fixes #2576 

### Context

- The change hasn't proved impactful in the perf lab with any project types used in the runs.
- It uses reflection to access an internal member.
- It is causing an assert in `XmlTextReaderImpl` to fire for developers running Debug build of the BCL.

Altogether it appears to be a net loss and ripe for a revert.

### Changes Made

Reverting the commit.

### Testing

Build / smoke test.
