### PR TITLE
Avoid string allocation while searching for a char

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1759,7 +1759,7 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 List<ExpressionShredder.ItemExpressionCapture> matches;
-                if (s_invariantCompareInfo.IndexOf(expression, '@') == -1)
+                if (expression.IndexOf('@') == -1)
                 {
                     return null;
                 }
@@ -2539,7 +2539,7 @@ namespace Microsoft.Build.Evaluation
                             {
                                 // It may be that the itemspec has unescaped ';'s in it so we need to split here to handle
                                 // that case.
-                                if (s_invariantCompareInfo.IndexOf(metadataValue, ';') >= 0)
+                                if (metadataValue.IndexOf(';') >= 0)
                                 {
                                     var splits = ExpressionShredder.SplitSemiColonSeparatedList(metadataValue);
 


### PR DESCRIPTION
### Context
[CompareInfo.IndexOf(string, char, ...)](https://referencesource.microsoft.com/#mscorlib/system/globalization/compareinfo.cs,772) on .NET Framework has two paths:

**OrdinalIgnoreCase:** Which goes through string.IndexOf(string, ...)
**Everything else:** Win32's FindNLSStringEx

Both paths allocate a string that represents the char. Instead just call through string.IndexOf(char) which does a flat ordinal comparison which is what we want. This was about 0.3% of allocations in devenv opening a 500 project solution.

![image](https://user-images.githubusercontent.com/1103906/125601323-25f2da09-d135-4727-b4c0-8d2ed9e6f07b.png)

I walked every instance of this across the tree and found only the ones in the PR. It doesn't look like MSBuild uses the [banned API analyzer](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md) so I couldn't prevent future consumption of this.