### PR TITLE
Disable TP semaphore spinning for MSBuild processes

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -10,6 +10,7 @@
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
+      <ThreadPool_UnfairSemaphoreSpinLimit enabled="0" />
       <!-- Manually expanded list of quirks applied to a .NET 4.7.2 application, to work around CLR bug that doesn't apply them correctly
            https://referencesource.microsoft.com/#mscorlib/system/AppContext/AppContextDefaultValues.Defaults.cs,37
            Framework bug: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1148752 -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -10,6 +10,7 @@
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
+      <ThreadPool_UnfairSemaphoreSpinLimit enabled="0" />
       <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>


### PR DESCRIPTION
### Context

Profiles show significant time spent in `clr!ThreadpoolMgr::UnfairSemaphore::Wait` (rolled into `clr!ClrSleepEx` on 32-bit). Evidently, the default TP worker thread spinning doesn't work well with our TP usage patterns.

### Changes Made

Added `<ThreadPool_UnfairSemaphoreSpinLimit enabled="0" />` to both flavors of MSBuild.exe.config.

### Testing

- RPS tests show ~15% CPU time improvement in some scenarios, no wall-clock time impact. VS perf team has signed off.
- Full build of the OrchardCore solution shows ~3.5% CPU time improvement, no wall-clock time impact.

### Notes

We will likely add this setting to more VS processes, refer to [AB#1351333](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1351333) for details.