### PR TITLE
Identify 64-bit MSBuildToolsPath from 64-bit API consumer

### DIFF
--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -88,34 +88,6 @@ namespace Microsoft.Build.Engine.UnitTests
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "No Visual Studio install for netcore")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void FindOlderVisualStudioEnvironmentByEnvironmentVariable()
-        {
-            using (var env = new EmptyVSEnviroment("15.0"))
-            {
-                var msbuildBinDirectory = env.BuildDirectory;
-
-                var msBuildPath = Path.Combine(msbuildBinDirectory, MSBuildExeName);
-                var msBuildConfig = Path.Combine(msbuildBinDirectory, $"{MSBuildExeName}.config");
-                var vsMSBuildDirectory = Path.Combine(env.TempFolderRoot, "MSBuild");
-
-                env.WithEnvironment("MSBUILD_EXE_PATH", msBuildPath);
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock, () => false);
-
-                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
-                BuildEnvironmentHelper.Instance.MSBuildExtensionsPath.ShouldBe(vsMSBuildDirectory);
-                BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory.ShouldBe(msbuildBinDirectory);
-                BuildEnvironmentHelper.Instance.CurrentMSBuildExePath.ShouldBe(msBuildPath);
-                BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile.ShouldBe(msBuildConfig);
-                // This code is not running inside the Visual Studio devenv.exe process
-                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeFalse();
-                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
-                BuildEnvironmentHelper.Instance.RunningTests.ShouldBeFalse();
-            }
-        }
-
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "No Visual Studio install for netcore")]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void FindBuildEnvironmentFromCommandLineVisualStudio()
         {
             using (var env = new EmptyVSEnviroment())

--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -57,19 +57,14 @@ namespace Microsoft.Build.Engine.UnitTests
         /// If MSBUILD_EXE_PATH is explicitly set, we should detect it as a VisualStudio instance even in older scenarios
         /// (for example when the install path is under 15.0).
         /// </summary>
-        /// <param name="is64BitMSbuild">When true, run the test pointing to amd64 msbuild.exe.</param>
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "No Visual Studio install for netcore")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void FindVisualStudioEnvironmentByEnvironmentVariable(bool is64BitMSbuild)
+        public void FindVisualStudioEnvironmentByEnvironmentVariable()
         {
             using (var env = new EmptyVSEnviroment())
             {
-                var msbuildBinDirectory = is64BitMSbuild
-                    ? Path.Combine(env.BuildDirectory, "amd64")
-                    : env.BuildDirectory;
+                var msbuildBinDirectory = env.BuildDirectory;
 
                 var msBuildPath = Path.Combine(msbuildBinDirectory, MSBuildExeName);
                 var msBuildConfig = Path.Combine(msbuildBinDirectory, $"{MSBuildExeName}.config");
@@ -90,18 +85,14 @@ namespace Microsoft.Build.Engine.UnitTests
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "No Visual Studio install for netcore")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void FindOlderVisualStudioEnvironmentByEnvironmentVariable(bool is64BitMSbuild)
+        public void FindOlderVisualStudioEnvironmentByEnvironmentVariable()
         {
             using (var env = new EmptyVSEnviroment("15.0"))
             {
-                var msbuildBinDirectory = is64BitMSbuild
-                    ? Path.Combine(env.BuildDirectory, "amd64")
-                    : env.BuildDirectory;
+                var msbuildBinDirectory = env.BuildDirectory;
 
                 var msBuildPath = Path.Combine(msbuildBinDirectory, MSBuildExeName);
                 var msBuildConfig = Path.Combine(msbuildBinDirectory, $"{MSBuildExeName}.config");

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -320,7 +320,8 @@ namespace Microsoft.Build.Shared
         private static string GetVsRootFromMSBuildAssembly(string msBuildAssembly)
         {
             return FileUtilities.GetFolderAbove(msBuildAssembly,
-                Regex.IsMatch(msBuildAssembly, $@"\\Bin\\Amd64\\MSBuild\.exe", RegexOptions.IgnoreCase)
+                Path.GetDirectoryName(msBuildAssembly)
+                  .EndsWith(@"\amd64", StringComparison.OrdinalIgnoreCase)
                     ? 5
                     : 4);
         }

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Shared
 
             return msBuildExePath == null
                 ? null
-                : TryFromMSBuildAssemblyUnderVisualStudio(msBuildExePath, allowLegacyToolsVersion: true) ?? TryFromStandaloneMSBuildExe(msBuildExePath);
+                : TryFromMSBuildExeUnderVisualStudio(msBuildExePath, allowLegacyToolsVersion: true) ?? TryFromStandaloneMSBuildExe(msBuildExePath);
         }
 
         private static BuildEnvironment TryFromVisualStudioProcess()
@@ -183,7 +183,7 @@ namespace Microsoft.Build.Shared
             var msBuildDll = Path.Combine(FileUtilities.GetFolderAbove(buildAssembly), "MSBuild.dll");
 
             // First check if we're in a VS installation
-            var environment = TryFromMSBuildAssemblyUnderVisualStudio(buildAssembly);
+            var environment = TryFromMSBuildExeUnderVisualStudio(msBuildExe);
             if (environment != null)
             {
                 return environment;
@@ -208,19 +208,19 @@ namespace Microsoft.Build.Shared
             return null;
         }
 
-        private static BuildEnvironment TryFromMSBuildAssemblyUnderVisualStudio(string msbuildAssembly, bool allowLegacyToolsVersion = false)
+        private static BuildEnvironment TryFromMSBuildExeUnderVisualStudio(string msbuildExe, bool allowLegacyToolsVersion = false)
         {
             string msBuildPathPattern = allowLegacyToolsVersion
                 ? $@".*\\MSBuild\\({CurrentToolsVersion}|\d+\.0)\\Bin\\.*"
                 : $@".*\\MSBuild\\{CurrentToolsVersion}\\Bin\\.*";
 
             if (NativeMethodsShared.IsWindows &&
-                Regex.IsMatch(msbuildAssembly, msBuildPathPattern, RegexOptions.IgnoreCase))
+                Regex.IsMatch(msbuildExe, msBuildPathPattern, RegexOptions.IgnoreCase))
             {
-                string visualStudioRoot = GetVsRootFromMSBuildAssembly(msbuildAssembly);
+                string visualStudioRoot = GetVsRootFromMSBuildAssembly(msbuildExe);
                 return new BuildEnvironment(
                         BuildEnvironmentMode.VisualStudio,
-                        GetMSBuildExeFromVsRoot(visualStudioRoot),
+                        msbuildExe,
                         runningTests: s_runningTests(),
                         runningInVisualStudio: false,
                         visualStudioPath: visualStudioRoot);


### PR DESCRIPTION
Fixes #6681.

### Context

The change to make Visual Studio 64-bit means that projects loaded in Visual Studio get the 64-bit MSBuild, and other tools are more likely to be loading our API in a 64-bit process as well. That found this difference between the way projects are evaluated in `devenv.exe` and in `vcxprojReader.exe`.

### Changes Made

Find the VS root from the current assembly and then reconstruct the path to the appropriate MSBuild.exe based on that + the current process's bitness, ensuring that API consumers and MSBuild.exe/devenv.exe see the same MSBuildToolsPath.

### Testing

Manual overlay with a trivial API consumer.