### PR TITLE
Expose the MSBuildGlob regex for caching

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1531,6 +1531,7 @@ namespace Microsoft.Build.Globbing
         public string FilenamePart { get { throw null; } }
         public string FixedDirectoryPart { get { throw null; } }
         public bool IsLegal { get { throw null; } }
+        public System.Text.RegularExpressions.Regex Regex { get { throw null; } }
         public string WildcardDirectoryPart { get { throw null; } }
         public bool IsMatch(string stringToMatch) { throw null; }
         public Microsoft.Build.Globbing.MSBuildGlob.MatchInfoResult MatchInfo(string stringToMatch) { throw null; }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1525,6 +1525,7 @@ namespace Microsoft.Build.Globbing
         public string FilenamePart { get { throw null; } }
         public string FixedDirectoryPart { get { throw null; } }
         public bool IsLegal { get { throw null; } }
+        public System.Text.RegularExpressions.Regex Regex { get { throw null; } }
         public string WildcardDirectoryPart { get { throw null; } }
         public bool IsMatch(string stringToMatch) { throw null; }
         public Microsoft.Build.Globbing.MSBuildGlob.MatchInfoResult MatchInfo(string stringToMatch) { throw null; }

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -71,6 +71,11 @@ namespace Microsoft.Build.Globbing
         public string FilenamePart => _state.Value.FilenamePart;
 
         /// <summary>
+        ///     The regex
+        /// </summary>
+        public Regex Regex => _state.Value.Regex;
+
+        /// <summary>
         ///     Whether the glob was parsed sucsesfully from a string.
         ///     Illegal glob strings contain:
         ///     - invalid path characters (other than the wildcard characters themselves)


### PR DESCRIPTION
### Context
This enables caching of the MSBuildGlob pattern directly on the CPS side. The codepath accessing this pattern glob matching is in solution close and constructing the string has proven to be buggy and slow. It would make more sense to acquire it directly it from the source instead of trying to mimic the code badly in different project systems.