### PR TITLE
Absolutize ref assembly path

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -325,7 +325,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <TargetPath Condition=" '$(TargetPath)' == '' ">$(TargetDir)$(TargetFileName)</TargetPath>
 
     <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(ProduceReferenceAssembly)' == 'true' and ('$(ProduceReferenceAssemblyInOutDir)' == 'true' or '$([MSBuild]::AreFeaturesEnabled(17.0))' != 'true' ) ">$([MSBuild]::NormalizePath($(TargetDir), 'ref', $(TargetFileName)))</TargetRefPath>
-    <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(ProduceReferenceAssembly)' == 'true' ">$([MSBuild]::NormalizePath($(IntermediateOutputPath), 'ref', $(TargetFileName)))</TargetRefPath>
+    <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(ProduceReferenceAssembly)' == 'true' ">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(IntermediateOutputPath), 'ref', $(TargetFileName)))</TargetRefPath>
 
     <!-- Example, C:\MyProjects\MyProject\ -->
     <ProjectDir Condition=" '$(ProjectDir)' == '' ">$([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))</ProjectDir>


### PR DESCRIPTION
Fixes #6543 

### Context

#6560 made `TargetRefPath` relative by mistake, which broke build in Visual Studio.

### Changes Made

Use `MSBuildProjectDirectory` to properly root the path.

### Testing

Verified that VS build works with this fix.

### Notes

```
0:010> !pe
Exception object: 0000020fa4de3a90
Exception type:   System.IO.DirectoryNotFound
ExceptionMessage:          Could not find a part of the path 'C:\WINDOWS\system32\obj\Debug\net6.0\ref\HelloWorld.dll'.

0:010> !clrstack
OS Thread Id: 0x95c (10)        Child SP               IP Call Site
000000bc6023cf88 00007ffb12634ed9 [HelperMethodFrame: 000000bc6023cf88]
000000bc6023d070 00007ffb037dba49 System.IO.__Error.WinIOError(Int32, System.String)
000000bc6023d0c0 00007ffb0408d7e6 System.IO.File.InternalCopy(System.String, System.String, Boolean, Boolean)
000000bc6023d150 00007ffaa7303d70 Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly.Copy()
000000bc6023d1b0 00007ffaa7303bad Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly.Execute()
```