### PR TITLE
Skip Updating CopyComplete Marker When Not Necessary

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -194,8 +194,6 @@ namespace Microsoft.Build.Tasks
     {
         public Copy() { }
         [Microsoft.Build.Framework.OutputAttribute]
-        public bool CopiedAtLeastOneFile { get { throw null; } }
-        [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] CopiedFiles { get { throw null; } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } set { } }
@@ -209,6 +207,8 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
         public bool UseHardlinksIfPossible { get { throw null; } set { } }
         public bool UseSymboliclinksIfPossible { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public bool WroteAtLeastOneFile { get { throw null; } }
         public void Cancel() { }
         public override bool Execute() { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -194,6 +194,8 @@ namespace Microsoft.Build.Tasks
     {
         public Copy() { }
         [Microsoft.Build.Framework.OutputAttribute]
+        public bool CopiedAtLeastOneFile { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] CopiedFiles { get { throw null; } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } set { } }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -124,6 +124,8 @@ namespace Microsoft.Build.Tasks
     {
         public Copy() { }
         [Microsoft.Build.Framework.OutputAttribute]
+        public bool CopiedAtLeastOneFile { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] CopiedFiles { get { throw null; } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } set { } }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -124,8 +124,6 @@ namespace Microsoft.Build.Tasks
     {
         public Copy() { }
         [Microsoft.Build.Framework.OutputAttribute]
-        public bool CopiedAtLeastOneFile { get { throw null; } }
-        [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] CopiedFiles { get { throw null; } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } set { } }
@@ -139,6 +137,8 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
         public bool UseHardlinksIfPossible { get { throw null; } set { } }
         public bool UseSymboliclinksIfPossible { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public bool WroteAtLeastOneFile { get { throw null; } }
         public void Cancel() { }
         public override bool Execute() { throw null; }
     }

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -300,13 +300,10 @@ namespace Microsoft.Build.Tasks
                 Log.LogMessage(MessageImportance.Normal, FileComment, sourceFilePath, destinationFilePath);
 
                 File.Copy(sourceFileState.Name, destinationFileState.Name, true);
-                CopiedAtLeastOneFile = true;
             }
-            else
-            {
-                // Properly linked files will be considered successfully copied files.
-                CopiedAtLeastOneFile = true;
-            }
+
+            // Files were successfully copied or linked. Those are equivalent here.
+           CopiedAtLeastOneFile = true;
 
             destinationFileState.Reset();
 

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Build.Tasks
         public ITaskItem[] CopiedFiles { get; private set; }
 
         [Output]
-        public bool CopiedAtLeastOneFile { get; private set; }
+        public bool WroteAtLeastOneFile { get; private set; }
 
         /// <summary>
         /// Whether to overwrite files in the destination
@@ -301,9 +301,9 @@ namespace Microsoft.Build.Tasks
 
                 File.Copy(sourceFileState.Name, destinationFileState.Name, true);
             }
-
+            
             // Files were successfully copied or linked. Those are equivalent here.
-           CopiedAtLeastOneFile = true;
+            WroteAtLeastOneFile = true;
 
             destinationFileState.Reset();
 

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -139,6 +139,9 @@ namespace Microsoft.Build.Tasks
         [Output]
         public ITaskItem[] CopiedFiles { get; private set; }
 
+        [Output]
+        public bool CopiedAtLeastOneFile { get; private set; }
+
         /// <summary>
         /// Whether to overwrite files in the destination
         /// that have the read-only attribute set.
@@ -297,6 +300,7 @@ namespace Microsoft.Build.Tasks
                 Log.LogMessage(MessageImportance.Normal, FileComment, sourceFilePath, destinationFilePath);
 
                 File.Copy(sourceFileState.Name, destinationFileState.Name, true);
+                CopiedAtLeastOneFile = true;
             }
 
             destinationFileState.Reset();

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -302,6 +302,11 @@ namespace Microsoft.Build.Tasks
                 File.Copy(sourceFileState.Name, destinationFileState.Name, true);
                 CopiedAtLeastOneFile = true;
             }
+            else
+            {
+                // Properly linked files will be considered successfully copied files.
+                CopiedAtLeastOneFile = true;
+            }
 
             destinationFileState.Reset();
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4696,6 +4696,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <Output TaskParameter="DestinationFiles" ItemName="FileWritesShareable"/>
       <Output TaskParameter="CopiedFiles" ItemName="ReferencesCopiedInThisBuild"/>
+      <Output TaskParameter="CopiedAtLeastOneFile" PropertyName="CopiedAtLeastOneFile"/>
 
     </Copy>
 
@@ -4705,7 +4706,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          input to projects that reference this one. -->
     <Touch Files="@(CopyUpToDateMarker)"
            AlwaysCreate="true"
-           Condition="'@(ReferencesCopiedInThisBuild)' != ''">
+           Condition="'@(ReferencesCopiedInThisBuild)' != '' and '$(CopiedAtLeastOneFile)' == 'true'">
         <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
     </Touch>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4696,7 +4696,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <Output TaskParameter="DestinationFiles" ItemName="FileWritesShareable"/>
       <Output TaskParameter="CopiedFiles" ItemName="ReferencesCopiedInThisBuild"/>
-      <Output TaskParameter="CopiedAtLeastOneFile" PropertyName="CopiedAtLeastOneFile"/>
+      <Output TaskParameter="WroteAtLeastOneFile" PropertyName="WroteAtLeastOneFile"/>
 
     </Copy>
 
@@ -4706,7 +4706,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          input to projects that reference this one. -->
     <Touch Files="@(CopyUpToDateMarker)"
            AlwaysCreate="true"
-           Condition="'@(ReferencesCopiedInThisBuild)' != '' and '$(CopiedAtLeastOneFile)' == 'true'">
+           Condition="'@(ReferencesCopiedInThisBuild)' != '' and '$(WroteAtLeastOneFile)' == 'true'">
         <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
     </Touch>
 


### PR DESCRIPTION
Fixes #https://github.com/dotnet/msbuild/issues/6576

### Context
https://github.com/dotnet/msbuild/issues/6576 revealed that the `.copycomplete` file marker is updated even when the `Copy` task in `_GetCopyFilesMarkedLocal` doesn't _actually_ copy anything. This can mess with incremental builds.

### Changes Made
This change adds an output parameter, `CopiedAtLeastOneFile` to the `Copy` task that the `Touch` task is now conditioned off of.

### Testing
Tested local builds

### Notes
This could also be done by having an ITaskItem[] that contains all files that were actually copied. Then the touch task could check if that item were empty. I opted for the straightforward route since the ITaskItem[] solution isn't needed yet, and this implementation can easily be changed when we do need that.