### PR TITLE
Miscellaneous event tweaks

### DIFF
--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -104,14 +104,14 @@ namespace Microsoft.Build.Eventing
         /// Call this method to notify listeners of how the project data was evaluated.
         /// </summary>
         /// <param name="projectFile">Filename of the project being evaluated.</param>
-        [Event(11, Keywords = Keywords.All)]
+        [Event(11, Keywords = Keywords.All | Keywords.PerformanceLog)]
         public void EvaluateStart(string projectFile)
         {
             WriteEvent(11, projectFile);
         }
 
         /// <param name="projectFile">Filename of the project being evaluated.</param>
-        [Event(12, Keywords = Keywords.All)]
+        [Event(12, Keywords = Keywords.All | Keywords.PerformanceLog)]
         public void EvaluateStop(string projectFile)
         {
             WriteEvent(12, projectFile);

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -279,14 +279,14 @@ namespace Microsoft.Build.Eventing
         /// Call this method to notify listeners of profiling for the function that parses an XML document into a ProjectRootElement.
         /// </summary>
         /// <param name="projectFileName">Filename of the project being evaluated.</param>
-        [Event(33, Keywords = Keywords.All | Keywords.PerformanceLog)]
+        [Event(33, Keywords = Keywords.All)]
         public void ParseStart(string projectFileName)
         {
             WriteEvent(33, projectFileName);
         }
 
         /// <param name="projectFileName">Filename of the project being evaluated.</param>
-        [Event(34, Keywords = Keywords.All | Keywords.PerformanceLog)]
+        [Event(34, Keywords = Keywords.All)]
         public void ParseStop(string projectFileName)
         {
             WriteEvent(34, projectFileName);

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -103,98 +103,98 @@ namespace Microsoft.Build.Eventing
         /// <summary>
         /// Call this method to notify listeners of how the project data was evaluated.
         /// </summary>
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(11, Keywords = Keywords.All)]
         public void EvaluateStart(string projectFile)
         {
             WriteEvent(11, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(12, Keywords = Keywords.All)]
         public void EvaluateStop(string projectFile)
         {
             WriteEvent(12, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(13, Keywords = Keywords.All)]
         public void EvaluatePass0Start(string projectFile)
         {
             WriteEvent(13, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(14, Keywords = Keywords.All)]
         public void EvaluatePass0Stop(string projectFile)
         {
             WriteEvent(14, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(15, Keywords = Keywords.All)]
         public void EvaluatePass1Start(string projectFile)
         {
             WriteEvent(15, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(16, Keywords = Keywords.All)]
         public void EvaluatePass1Stop(string projectFile)
         {
             WriteEvent(16, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(17, Keywords = Keywords.All)]
         public void EvaluatePass2Start(string projectFile)
         {
             WriteEvent(17, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(18, Keywords = Keywords.All)]
         public void EvaluatePass2Stop(string projectFile)
         {
             WriteEvent(18, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(19, Keywords = Keywords.All)]
         public void EvaluatePass3Start(string projectFile)
         {
             WriteEvent(19, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(20, Keywords = Keywords.All)]
         public void EvaluatePass3Stop(string projectFile)
         {
             WriteEvent(20, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(21, Keywords = Keywords.All)]
         public void EvaluatePass4Start(string projectFile)
         {
             WriteEvent(21, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(22, Keywords = Keywords.All)]
         public void EvaluatePass4Stop(string projectFile)
         {
             WriteEvent(22, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(23, Keywords = Keywords.All)]
         public void EvaluatePass5Start(string projectFile)
         {
             WriteEvent(23, projectFile);
         }
 
-        /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFile">Filename of the project being evaluated.</param>
         [Event(24, Keywords = Keywords.All)]
         public void EvaluatePass5Stop(string projectFile)
         {
@@ -278,14 +278,14 @@ namespace Microsoft.Build.Eventing
         /// <summary>
         /// Call this method to notify listeners of profiling for the function that parses an XML document into a ProjectRootElement.
         /// </summary>
-        /// <param name="projectFileName">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFileName">Filename of the project being evaluated.</param>
         [Event(33, Keywords = Keywords.All | Keywords.PerformanceLog)]
         public void ParseStart(string projectFileName)
         {
             WriteEvent(33, projectFileName);
         }
 
-        /// <param name="projectFileName">Relevant information about where in the run of the progam it is.</param>
+        /// <param name="projectFileName">Filename of the project being evaluated.</param>
         [Event(34, Keywords = Keywords.All | Keywords.PerformanceLog)]
         public void ParseStop(string projectFileName)
         {

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -112,91 +112,91 @@ namespace Microsoft.Build.Eventing
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(12, Keywords = Keywords.All)]
-        public void EvaluatePass0Start(string projectFile)
+        public void EvaluateStop(string projectFile)
         {
             WriteEvent(12, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(13, Keywords = Keywords.All)]
-        public void EvaluatePass0Stop(string projectFile)
+        public void EvaluatePass0Start(string projectFile)
         {
             WriteEvent(13, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(14, Keywords = Keywords.All)]
-        public void EvaluatePass1Start(string projectFile)
+        public void EvaluatePass0Stop(string projectFile)
         {
             WriteEvent(14, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(15, Keywords = Keywords.All)]
-        public void EvaluatePass1Stop(string projectFile)
+        public void EvaluatePass1Start(string projectFile)
         {
             WriteEvent(15, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(16, Keywords = Keywords.All)]
-        public void EvaluatePass2Start(string projectFile)
+        public void EvaluatePass1Stop(string projectFile)
         {
             WriteEvent(16, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(17, Keywords = Keywords.All)]
-        public void EvaluatePass2Stop(string projectFile)
+        public void EvaluatePass2Start(string projectFile)
         {
             WriteEvent(17, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(18, Keywords = Keywords.All)]
-        public void EvaluatePass3Start(string projectFile)
+        public void EvaluatePass2Stop(string projectFile)
         {
             WriteEvent(18, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(19, Keywords = Keywords.All)]
-        public void EvaluatePass3Stop(string projectFile)
+        public void EvaluatePass3Start(string projectFile)
         {
             WriteEvent(19, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(20, Keywords = Keywords.All)]
-        public void EvaluatePass4Start(string projectFile)
+        public void EvaluatePass3Stop(string projectFile)
         {
             WriteEvent(20, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(21, Keywords = Keywords.All)]
-        public void EvaluatePass4Stop(string projectFile)
+        public void EvaluatePass4Start(string projectFile)
         {
             WriteEvent(21, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(22, Keywords = Keywords.All)]
-        public void EvaluatePass5Start(string projectFile)
+        public void EvaluatePass4Stop(string projectFile)
         {
             WriteEvent(22, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(23, Keywords = Keywords.All)]
-        public void EvaluatePass5Stop(string projectFile)
+        public void EvaluatePass5Start(string projectFile)
         {
             WriteEvent(23, projectFile);
         }
 
         /// <param name="projectFile">Relevant information about where in the run of the progam it is.</param>
         [Event(24, Keywords = Keywords.All)]
-        public void EvaluateStop(string projectFile)
+        public void EvaluatePass5Stop(string projectFile)
         {
             WriteEvent(24, projectFile);
         }


### PR DESCRIPTION
- Make EvaluateStop event adjacent to EvaluateStart

  It's not well documented, but EventSource requires that the start and stop event IDs for a single thing be separated by exactly one. Since this one didn't, we weren't getting DURATION_MSEC computed for overall evaluation time in our traces.
  
  See https://github.com/dotnet/runtime/blob/f83a9d9689433ce522b91e74a9631c83847e3b64/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L3270.
- Update Evaluate* event doc comments
- Include EvaluateStart/Stop in DOTNET_PERFLOG
- Drop Parse from DOTNET_PERFLOG
