### PR TITLE
Introduce IDirectoryCache & IDirectoryCacheFactory

### DIFF
--- a/src/Build/FileSystem/IDirectoryCache.cs
+++ b/src/Build/FileSystem/IDirectoryCache.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+#if NETCOREAPP
+using System.IO.Enumeration;
+#else
+using Microsoft.IO.Enumeration;
+#endif
+
+namespace Microsoft.Build.FileSystem
+{
+    public interface IDirectoryCacheFactory
+    {
+        IDirectoryCache GetDirectoryCacheForProject(string projectPath);
+    }
+
+    public interface IDirectoryCache
+    {
+        bool FileExists(string path);
+
+        bool DirectoryExists(string path);
+
+        /// <summary>
+        /// Enumerates files in the given directory only (non-recursively).
+        /// </summary>
+        /// <typeparam name="TResult">The desired return type.</typeparam>
+        /// <param name="path">The directory to enumerate.</param>
+        /// <param name="predicate">A predicate to test whether a file should be included.</param>
+        /// <param name="transform">A transform from <see cref="FileSystemEntry"/> to <typeparamref name="TResult"/>.</param>
+        /// <returns></returns>
+        IEnumerable<TResult> EnumerateFiles<TResult>(string path, FileSystemEnumerable<TResult>.FindPredicate predicate, FileSystemEnumerable<TResult>.FindTransform transform);
+
+        /// <summary>
+        /// Enumerates subdirectories in the given directory only (non-recursively).
+        /// </summary>
+        /// <typeparam name="TResult">The desired return type.</typeparam>
+        /// <param name="path">The directory to enumerate.</param>
+        /// <param name="predicate">A predicate to test whether a directory should be included.</param>
+        /// <param name="transform">A transform from <see cref="FileSystemEntry"/> to <typeparamref name="TResult"/>.</param>
+        /// <returns></returns>
+        IEnumerable<TResult> EnumerateDirectories<TResult>(string path, FileSystemEnumerable<TResult>.FindPredicate predicate, FileSystemEnumerable<TResult>.FindTransform transform);
+    }
+}


### PR DESCRIPTION
Initial API proposal for #6068 

### Context
We're looking to use the CPS FS cache for file/directory enumeration and file/directory existence checks done by MSBuild during evaluation. The currently exposed `MSBuildFileSystemBase` does not work well for this purpose due to its use of `IEnumerable<string>` with full paths. We would like to use something more efficient, preferably close to the modern .NET Core file enumeration API, which we're switching to in a related effort.

### Changes Made
Added two new interfaces `IDirectoryCache` and `IDirectoryCacheFactory`.

### Testing
N/A, the code doesn't build yet.

### Notes
