### PR TITLE
Force ResolveComReference to 32-bit

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2918,6 +2918,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Note: This task should not be batched, since it relies on having all the COM references fed into it at once.
         -->
     <PropertyGroup>
+      <ResolveComReferenceMSBuildArchitecture Condition="$([MSBuild]::AreFeaturesEnabled('17.0'))">x86</ResolveComReferenceMSBuildArchitecture>
       <ResolveComReferenceMSBuildArchitecture Condition="'$(ResolveComReferenceMSBuildArchitecture)' == ''">$(PlatformTargetAsMSBuildArchitecture)</ResolveComReferenceMSBuildArchitecture>
 
       <ResolveComReferenceToolPath Condition="'$(ResolveComReferenceToolPath)' == ''">$(TargetFrameworkSDKToolsDirectory)</ResolveComReferenceToolPath>


### PR DESCRIPTION
This works around a runtime bug in an optprof test.

Fixes [AB#1338964](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1338964)

### Context
It turns out the optprof for our main branch has been failing for quite some time—ever since we switched to 64-bit. That could prevent us from getting accurate data on which code paths are called most often, preventing us from properly optimizing the positioning of various methods within our assemblies, but it doesn't appear to have affected that so dramatically, possibly because collecting data had been succeeding, but a test hadn't been. Upon further investigation, it appears the failing test was due to a bug in the runtime, but we do not regularly service .NET Framework, and this is such an obscure and bizarre scenario that we think it likely that no or virtually no customers are hitting it, so it is not worth an emergency release of a new version of .NET Framework. That's why, at least for now, the best option is to work around it.

The bug only occurs when:
1. You are running IBC Training
2. You are using the amd64 CLR.
3. An appdomain is unloaded.
4. The appdomain contains a number of assemblies that are not loaded multi-domain shareable.
5. For at least one of these assemblies, earlier execution within the appdomain triggered creation of one or more associated generic methods where the overall generic instantiation is spread across multiple assemblies.

(Those conditions came from a contact on the runtime team; I don't know what's special about IBC training that makes this happen.)

In any case, the only task that appears to be executing in the relevant test that uses an appdomain in that way is the ResolveComReference task.

### Changes Made
This forces the ResolveComReference task to always run in 32-bit unless otherwise specified via disabling the change wave.

### Testing
The test run was failing consistently without a very similar change and started passing once the change was implemented.