### PR TITLE
Remove depenency on MemberRef Parent of a custom attribute constructor being a TypeReference

### DIFF
--- a/src/Tasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyInformation.cs
@@ -405,6 +405,11 @@ namespace Microsoft.Build.Tasks
                         }
 
                         var container = metadataReader.GetMemberReference((MemberReferenceHandle) ctorHandle).Parent;
+                        if (container.Kind != HandleKind.TypeReference)
+                        {
+                            continue;
+                        }
+
                         var name = metadataReader.GetTypeReference((TypeReferenceHandle) container).Name;
                         if (!string.Equals(metadataReader.GetString(name), "TargetFrameworkAttribute"))
                         {


### PR DESCRIPTION
Fixes #6734 

Also fixes #6730

This fixes #6734 in my scenario.