### PR TITLE
Propagate solution configuration information to project cache plugins

### DIFF
--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -475,7 +475,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var graphResult = buildSession.BuildGraph(graph);
 
-            graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            graphResult.ShouldHaveSucceeded();
 
             buildSession.Dispose();
 
@@ -510,7 +510,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             {
                 var buildResult = buildSession.BuildProjectFile(node.ProjectInstance.FullPath);
 
-                buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                buildResult.ShouldHaveSucceeded();
 
                 nodesToBuildResults[node] = buildResult;
             }
@@ -565,7 +565,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                                 { SolutionProjectGenerator.CurrentSolutionConfigurationContents, solutionConfigurationGlobalProperty }
                             });
 
-                    buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                    buildResult.ShouldHaveSucceeded();
 
                     nodesToBuildResults[node] = buildResult;
                 }
@@ -653,12 +653,12 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 foreach (var task in referenceBuildTasks)
                 {
                     var buildResult = task.Result;
-                    buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                    buildResult.ShouldHaveSucceeded();
                 }
 
                 buildSession
                     .BuildProjectFile(rootNode.ProjectInstance.FullPath, globalProperties: globalProperties)
-                    .OverallResult.ShouldBe(BuildResultCode.Success);
+                    .ShouldHaveSucceeded();
 
                 buildSession.Dispose();
 
@@ -723,7 +723,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var graphResult = buildSession.BuildGraph(graph);
 
-            graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            graphResult.ShouldHaveSucceeded();
 
             buildSession.Dispose();
 
@@ -868,7 +868,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var buildResult = buildSession.BuildProjectFile(project1.Path);
 
-            buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            buildResult.ShouldHaveSucceeded();
 
             buildSession.Logger.ProjectStartedEvents.Count.ShouldBe(2);
 
@@ -900,7 +900,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var graphResult = buildSession.BuildGraph(graph);
 
-            graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            graphResult.ShouldHaveSucceeded();
 
             buildSession.Logger.FullLog.ShouldContain("Explicit entry-point based");
 
@@ -923,7 +923,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var graphResult = buildSession.BuildGraph(graph);
 
-            graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            graphResult.ShouldHaveSucceeded();
 
             buildSession.Logger.FullLog.ShouldContain("Static graph based");
 
@@ -977,10 +977,10 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             mockCache.Requests.Count.ShouldBe(2);
 
-            buildResult.ResultsByNode.First(r => GetProjectNumber(r.Key) == 2).Value.OverallResult.ShouldBe(BuildResultCode.Success);
-            buildResult.ResultsByNode.First(r => GetProjectNumber(r.Key) == 1).Value.OverallResult.ShouldBe(BuildResultCode.Failure);
+            buildResult.ResultsByNode.First(r => GetProjectNumber(r.Key) == 2).Value.ShouldHaveSucceeded();
+            buildResult.ResultsByNode.First(r => GetProjectNumber(r.Key) == 1).Value.ShouldHaveFailed();
 
-            buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
+            buildResult.ShouldHaveFailed();
 
             buildSession.Logger.FullLog.ShouldContain("Reference file [Invalid file] does not exist");
         }
@@ -1005,8 +1005,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var graphResult = buildSession.BuildGraph(graph);
             
-            graphResult.OverallResult.ShouldBe(BuildResultCode.Failure);
-            graphResult.Exception.Message.ShouldContain("A single project cache plugin must be specified but multiple where found:");
+            graphResult.ShouldHaveFailed("A single project cache plugin must be specified but multiple where found:");
         }
 
         [Fact]
@@ -1034,8 +1033,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var graphResult = buildSession.BuildGraph(graph);
             
-            graphResult.OverallResult.ShouldBe(BuildResultCode.Failure);
-            graphResult.Exception.Message.ShouldContain("When any static graph node defines a project cache, all nodes must define the same project cache.");
+            graphResult.ShouldHaveFailed("When any static graph node defines a project cache, all nodes must define the same project cache.");
         }
 
         public static IEnumerable<object[]> CacheExceptionLocationsTestData
@@ -1117,11 +1115,11 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 // so the build submission should be successful.
                 if (errorLocations == ErrorLocations.EndBuildAsync)
                 {
-                    buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                    buildResult.ShouldHaveSucceeded();
                 }
                 else
                 {
-                    buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
+                    buildResult.ShouldHaveFailed();
                 }
             }
             finally
@@ -1222,7 +1220,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 logger.FullLog.ShouldContain("Loading the following project cache plugin:");
 
                 // Static graph build initializes and tears down the cache plugin so all cache plugin exceptions should end up in the GraphBuildResult
-                buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
+                buildResult.ShouldHaveFailed();
 
                 buildResult.Exception.ShouldBeOfType<ProjectCacheException>();
 
@@ -1293,14 +1291,14 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var logger = buildSession.Logger;
 
-            GraphBuildResult? buildResult = null;
+            GraphBuildResult buildResult = null!;
             Should.NotThrow(
                 () =>
                 {
                     buildResult = buildSession.BuildGraph(new ProjectGraph(project.Path));
                 });
 
-            buildResult!.OverallResult.ShouldBe(BuildResultCode.Failure);
+            buildResult.ShouldHaveFailed();
             buildResult.Exception.InnerException!.ShouldNotBeNull();
             buildResult.Exception.InnerException!.Message.ShouldContain("Cache plugin exception from EndBuildAsync");
 
@@ -1365,9 +1363,9 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             var task3 = BuildProjectFileAsync(3);
             var task4 = BuildProjectFileAsync(4);
 
-            task3.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+            task3.Result.ShouldHaveSucceeded();
             completedCacheRequests.ShouldContain(3);
-            task4.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+            task4.Result.ShouldHaveSucceeded();
             completedCacheRequests.ShouldContain(4);
 
             // task 2 hasn't been instructed to finish yet
@@ -1376,11 +1374,11 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             task2Completion.SetResult(true);
 
-            task2.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+            task2.Result.ShouldHaveSucceeded();
             completedCacheRequests.ShouldContain(2);
 
             var task1 = BuildProjectFileAsync(1);
-            task1.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+            task1.Result.ShouldHaveSucceeded();
             completedCacheRequests.ShouldContain(1);
 
             Task<BuildResult> BuildProjectFileAsync(int projectNumber)
@@ -1452,14 +1450,14 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
                 foreach (var buildResultTask in buildResultTasks)
                 {
-                    buildResultTask.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+                    buildResultTask.Result.ShouldHaveSucceeded();
                 }
 
                 buildSession.BuildProjectFile(
                         graph.GraphRoots.First().ProjectInstance.FullPath,
                         globalProperties:
                         new Dictionary<string, string> {{"SolutionPath", graph.GraphRoots.First().ProjectInstance.FullPath}})
-                    .OverallResult.ShouldBe(BuildResultCode.Success);
+                    .ShouldHaveSucceeded();
 
                 StringShouldContainSubstring(buildSession.Logger.FullLog, $"{AssemblyMockCache}: GetCacheResultAsync for", graph.ProjectNodes.Count);
 
@@ -1504,7 +1502,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 
             var graphResult = buildSession.BuildGraph(graph);
 
-            graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            graphResult.ShouldHaveSucceeded();
             cache.QueryStartStops.Count.ShouldBe(graph.ProjectNodes.Count * 2);
         }
 
@@ -1590,7 +1588,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             foreach (var buildResult in buildTasks.Select(buildTask => buildTask.Result))
             {
                 buildResult.Exception.ShouldBeNull();
-                buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+                buildResult.ShouldHaveSucceeded();
             }
 
             buildSession.Logger.ProjectStartedEvents.Count.ShouldBe(2 * projectPaths.Length);

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -526,6 +526,29 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
         [MemberData(nameof(SuccessfulGraphsWithBuildParameters))]
         public void ProjectCacheByVsWorkaroundWorks(GraphCacheResponse testData, BuildParameters buildParameters)
         {
+            ProjectGraph? graph = null;
+
+            var (logger, nodesToBuildResults) = BuildGraphByVsWorkaround(
+                () =>
+                {
+                    graph = testData.CreateGraph(_env);
+                    return graph;
+                },
+                buildParameters);
+
+            graph.ShouldNotBeNull();
+
+            AssertCacheBuild(graph!, testData, null, logger, nodesToBuildResults);
+        }
+
+        private (MockLogger logger, Dictionary<ProjectGraphNode, BuildResult> nodesToBuildResults) BuildGraphByVsWorkaround(
+            Func<ProjectGraph> graphProducer,
+            BuildParameters? buildParameters = null
+        )
+        {
+            var nodesToBuildResults = new Dictionary<ProjectGraphNode, BuildResult>();
+            MockLogger? logger;
+
             var currentBuildEnvironment = BuildEnvironmentHelper.Instance;
 
             try
@@ -539,20 +562,22 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                         visualStudioPath: currentBuildEnvironment.VisualStudioInstallRootDirectory));
 
                 // Reset the environment variables stored in the build params to take into account TestEnvironmentChanges.
-                buildParameters = new BuildParameters(buildParameters, resetEnvironment: true);
+                buildParameters = buildParameters  is null
+                    ? new BuildParameters()
+                    : new BuildParameters(buildParameters, resetEnvironment: true);
 
                 BuildManager.ProjectCacheItems.ShouldBeEmpty();
 
-                var graph = testData.CreateGraph(_env);
+                var graph = graphProducer.Invoke();
+
+                BuildManager.ProjectCacheItems.ShouldHaveSingleItem();
+
                 var projectPaths = graph.ProjectNodes.Select(n => n.ProjectInstance.FullPath).ToArray();
 
                 // VS sets this global property on every project it builds.
                 var solutionConfigurationGlobalProperty = CreateSolutionConfigurationProperty(projectPaths);
 
-                BuildManager.ProjectCacheItems.ShouldHaveSingleItem();
-
                 using var buildSession = new Helpers.BuildManagerSession(_env, buildParameters);
-                var nodesToBuildResults = new Dictionary<ProjectGraphNode, BuildResult>();
 
                 foreach (var node in graph.ProjectNodesTopologicallySorted)
                 {
@@ -572,30 +597,32 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                     nodesToBuildResults[node] = buildResult;
                 }
 
-                buildSession.Logger.FullLog.ShouldContain("Visual Studio Workaround based");
-                buildSession.Logger.FullLog.ShouldContain("Running project cache with Visual Studio workaround");
+                logger = buildSession.Logger;
+
+                logger.FullLog.ShouldContain("Visual Studio Workaround based");
+                logger.FullLog.ShouldContain("Running project cache with Visual Studio workaround");
 
                 foreach (var projectPath in projectPaths)
                 {
                     var projectName = Path.GetFileNameWithoutExtension(projectPath);
 
                     // Ensure MSBuild passes config / platform information set by VS.
-                    buildSession.Logger.FullLog.ShouldContain($"EntryPoint: {projectPath}");
-                    buildSession.Logger.FullLog.ShouldContain($"Configuration:{projectName}Debug");
-                    buildSession.Logger.FullLog.ShouldContain($"Platform:{projectName}x64");
+                    logger.FullLog.ShouldContain($"EntryPoint: {projectPath}");
+                    logger.FullLog.ShouldContain($"Configuration:{projectName}Debug");
+                    logger.FullLog.ShouldContain($"Platform:{projectName}x64");
 
                     // Ensure MSBuild removes the inner build property if present.
-                    buildSession.Logger.FullLog.ShouldContain($"{PropertyNames.InnerBuildProperty}:TheInnerBuildProperty");
-                    buildSession.Logger.FullLog.ShouldNotContain("TheInnerBuildProperty:FooBar");
+                    logger.FullLog.ShouldContain($"{PropertyNames.InnerBuildProperty}:TheInnerBuildProperty");
+                    logger.FullLog.ShouldNotContain("TheInnerBuildProperty:FooBar");
                 }
-
-                AssertCacheBuild(graph, testData, null, buildSession.Logger, nodesToBuildResults);
             }
             finally
             {
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(currentBuildEnvironment);
                 BuildManager.ProjectCacheItems.Clear();
             }
+
+            return (logger, nodesToBuildResults);
         }
 
         private static string CreateSolutionConfigurationProperty(string[] projectPaths)

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -541,9 +541,64 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             AssertCacheBuild(graph!, testData, null, logger, nodesToBuildResults);
         }
 
+        [Fact]
+        public void ProjectCacheByVsWorkaroundIgnoresSlnDisabledProjects()
+        {
+            var testData = new GraphCacheResponse(
+                new Dictionary<int, int[]>
+                {
+                    {1, new[] {2}}
+                },
+                extraContentPerProjectNumber: new Dictionary<int, string>()
+                {
+                    {1, "<PropertyGroup> <BuildProjectInSolution>false</BuildProjectInSolution> </PropertyGroup>"}
+                });
+
+            ProjectGraph? graph = null;
+
+            var (logger, nodesToBuildResults) = BuildGraphByVsWorkaround(
+                graphProducer: () =>
+                {
+                    graph = testData.CreateGraph(_env);
+                    return graph;
+                },
+                assertBuildResults: false
+            );
+
+            graph.ShouldNotBeNull();
+
+            logger.FullLog.ShouldNotContain($"EntryPoint: {graph!.GraphRoots.First().ProjectInstance.FullPath}");
+            logger.FullLog.ShouldContain($"EntryPoint: {graph.GraphRoots.First().ProjectReferences.First().ProjectInstance.FullPath}");
+        }
+
+        [Fact]
+        public void ProjectCacheByVsWorkaroundShouldNotSupportSolutionOnlyDependencies()
+        {
+            var testData = new GraphCacheResponse(
+                new Dictionary<int, int[]>
+                {
+                    {1, Array.Empty<int>()}
+                },
+                extraContentPerProjectNumber: new Dictionary<int, string>()
+                {
+                    {1, $"<PropertyGroup> <ProjectDependency>{Guid.NewGuid()}</ProjectDependency> </PropertyGroup>"}
+                });
+
+            var (logger, nodeResults) = BuildGraphByVsWorkaround(
+                graphProducer: () => testData.CreateGraph(_env),
+                assertBuildResults: false);
+
+            nodeResults.ShouldHaveSingleItem();
+
+            var buildResult = nodeResults.First().Value;
+            buildResult.OverallResult.ShouldBe(BuildResultCode.Failure);
+            buildResult.Exception.Message.ShouldContain("Project cache service does not support solution only dependencies when running under Visual Studio.");
+        }
+
         private (MockLogger logger, Dictionary<ProjectGraphNode, BuildResult> nodesToBuildResults) BuildGraphByVsWorkaround(
             Func<ProjectGraph> graphProducer,
-            BuildParameters? buildParameters = null
+            BuildParameters? buildParameters = null,
+            bool assertBuildResults = true
         )
         {
             var nodesToBuildResults = new Dictionary<ProjectGraphNode, BuildResult>();
@@ -575,7 +630,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 var projectPaths = graph.ProjectNodes.Select(n => n.ProjectInstance.FullPath).ToArray();
 
                 // VS sets this global property on every project it builds.
-                var solutionConfigurationGlobalProperty = CreateSolutionConfigurationProperty(projectPaths);
+                var solutionConfigurationGlobalProperty = CreateSolutionConfigurationProperty(graph.ProjectNodes);
 
                 using var buildSession = new Helpers.BuildManagerSession(_env, buildParameters);
 
@@ -592,28 +647,35 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                                 { "TheInnerBuildProperty", "FooBar"},
                             });
 
-                    buildResult.ShouldHaveSucceeded();
+                    if (assertBuildResults)
+                    {
+                        buildResult.ShouldHaveSucceeded();
+                    }
 
                     nodesToBuildResults[node] = buildResult;
                 }
 
                 logger = buildSession.Logger;
 
-                logger.FullLog.ShouldContain("Visual Studio Workaround based");
-                logger.FullLog.ShouldContain("Running project cache with Visual Studio workaround");
-
-                foreach (var projectPath in projectPaths)
+                if (assertBuildResults)
                 {
-                    var projectName = Path.GetFileNameWithoutExtension(projectPath);
+                    logger.FullLog.ShouldContain("Visual Studio Workaround based");
+                    logger.FullLog.ShouldContain("Running project cache with Visual Studio workaround");
 
-                    // Ensure MSBuild passes config / platform information set by VS.
-                    logger.FullLog.ShouldContain($"EntryPoint: {projectPath}");
-                    logger.FullLog.ShouldContain($"Configuration:{projectName}Debug");
-                    logger.FullLog.ShouldContain($"Platform:{projectName}x64");
+                    foreach (var node in graph.ProjectNodes)
+                    {
+                        var projectPath = node.ProjectInstance.FullPath;
+                        var projectName = Path.GetFileNameWithoutExtension(projectPath);
 
-                    // Ensure MSBuild removes the inner build property if present.
-                    logger.FullLog.ShouldContain($"{PropertyNames.InnerBuildProperty}:TheInnerBuildProperty");
-                    logger.FullLog.ShouldNotContain("TheInnerBuildProperty:FooBar");
+                        // Ensure MSBuild passes config / platform information set by VS.
+                        logger.FullLog.ShouldContain($"EntryPoint: {projectPath}");
+                        logger.FullLog.ShouldContain($"Configuration:{projectName}Debug");
+                        logger.FullLog.ShouldContain($"Platform:{projectName}x64");
+
+                        // Ensure MSBuild removes the inner build property if present.
+                        logger.FullLog.ShouldContain($"{PropertyNames.InnerBuildProperty}:TheInnerBuildProperty");
+                        logger.FullLog.ShouldNotContain("TheInnerBuildProperty:FooBar");
+                    }
                 }
             }
             finally
@@ -625,16 +687,28 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             return (logger, nodesToBuildResults);
         }
 
-        private static string CreateSolutionConfigurationProperty(string[] projectPaths)
+        private static string CreateSolutionConfigurationProperty(IReadOnlyCollection<ProjectGraphNode> projectNodes)
         {
             var sb = new StringBuilder();
 
             sb.AppendLine("<SolutionConfiguration>");
 
-            foreach (var projectPath in projectPaths)
+            foreach (var node in projectNodes)
             {
+                var projectPath = node.ProjectInstance.FullPath;
                 var projectName = Path.GetFileNameWithoutExtension(projectPath);
-                sb.AppendLine($"<ProjectConfiguration Project=\"{Guid.NewGuid()}\" AbsolutePath=\"{projectPath}\">{projectName}Debug|{projectName}x64</ProjectConfiguration>");
+
+                var buildProjectInSolutionValue = node.ProjectInstance.GetPropertyValue("BuildProjectInSolution");
+                var buildProjectInSolutionAttribute = string.IsNullOrWhiteSpace(buildProjectInSolutionValue)
+                    ? string.Empty
+                    : $"BuildProjectInSolution=\"{buildProjectInSolutionValue}\"";
+
+                var projectDependencyValue = node.ProjectInstance.GetPropertyValue("ProjectDependency");
+                var projectDependencyElement = string.IsNullOrWhiteSpace(projectDependencyValue)
+                    ? string.Empty
+                    : $"<ProjectDependency Project=\"{projectDependencyValue}\" />";
+
+                sb.AppendLine($"<ProjectConfiguration Project=\"{Guid.NewGuid()}\" AbsolutePath=\"{projectPath}\" {buildProjectInSolutionAttribute}>{projectName}Debug|{projectName}x64{projectDependencyElement}</ProjectConfiguration>");
             }
 
             sb.AppendLine("</SolutionConfiguration>");
@@ -1456,7 +1530,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 BuildManager.ProjectCacheItems.ShouldHaveSingleItem();
 
                 var solutionConfigurationGlobalProperty =
-                    CreateSolutionConfigurationProperty(graph.ProjectNodes.Select(n => n.ProjectInstance.FullPath).ToArray());
+                    CreateSolutionConfigurationProperty(graph.ProjectNodes);
 
                 using var buildSession = new Helpers.BuildManagerSession(_env, new BuildParameters
                 {

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Construction;
@@ -328,6 +329,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
             {
                 var (_, configuration) = request;
                 var solutionPath = configuration.Project.GetPropertyValue(SolutionProjectGenerator.SolutionPathPropertyName);
+                var solutionConfigurationXml = configuration.Project.GetPropertyValue(SolutionProjectGenerator.CurrentSolutionConfigurationContents);
 
                 ErrorUtilities.VerifyThrow(
                     solutionPath != null && !string.IsNullOrWhiteSpace(solutionPath) && solutionPath != "*Undefined*",
@@ -337,17 +339,78 @@ namespace Microsoft.Build.Experimental.ProjectCache
                     FileSystems.Default.FileExists(solutionPath),
                     $"Solution file does not exist: {solutionPath}");
 
+                ErrorUtilities.VerifyThrow(
+                    string.IsNullOrWhiteSpace(solutionConfigurationXml) is false,
+                    "Expected VS to set a xml with all the solution projects' configurations for the currently building solution configuration.");
+
+                // A solution supports multiple solution configurations (different values for Configuration and Platform).
+                // Each solution configuration generates a different static graph.
+                // Therefore, plugin implementations that rely on creating static graphs in their BeginBuild methods need access to the
+                // currently solution configuration used by VS.
+                //
+                // In this VS workaround, however, we do not have access to VS' solution configuration. The only information we have is a global property
+                // named "CurrentSolutionConfigurationContents" that VS sets on each built project. It does not contain the solution configuration itself, but
+                // instead it contains information on how the solution configuration maps to each project's configuration.
+                //
+                // So instead of using the solution file as the entry point, we parse this VS property and extract graph entry points from it, for every project
+                // mentioned in the "CurrentSolutionConfigurationContents" global property.
+                //
+                // Ideally, when the VS workaround is removed from MSBuild and moved into VS, VS should create ProjectGraphDescriptors with the solution path as
+                // the graph entrypoint file, and the VS solution configuration as the entry point's global properties.
+                var graphEntryPointsFromSolutionConfig = GenerateGraphEntryPointsFromSolutionConfigurationXml(
+                    solutionConfigurationXml,
+                    configuration.ProjectFullPath,
+                    configuration.Project.GlobalProperties);
+
                 await BeginBuildAsync(
                     ProjectCacheDescriptor.FromAssemblyPath(
                         _projectCacheDescriptor.PluginAssemblyPath!,
-                        new[]
-                        {
-                            new ProjectGraphEntryPoint(
-                                solutionPath,
-                                configuration.Project.GlobalProperties)
-                        },
+                        graphEntryPointsFromSolutionConfig,
                         projectGraph: null,
                         _projectCacheDescriptor.PluginSettings));
+            }
+
+            static IReadOnlyCollection<ProjectGraphEntryPoint> GenerateGraphEntryPointsFromSolutionConfigurationXml(
+                string solutionConfigurationXml,
+                string definingProjectPath,
+                IDictionary<string, string> definingProjectGlobalProperties
+            )
+            {
+                var doc = new XmlDocument();
+                doc.LoadXml(solutionConfigurationXml);
+
+                var root = doc.DocumentElement!;
+                var projectConfigurationNodes = root.GetElementsByTagName("ProjectConfiguration");
+
+                ErrorUtilities.VerifyThrow(projectConfigurationNodes.Count > 0, "Expected at least one project in solution");
+
+                var graphEntryPoints = new List<ProjectGraphEntryPoint>(projectConfigurationNodes.Count);
+
+                foreach (XmlNode node in projectConfigurationNodes)
+                {
+                    ErrorUtilities.VerifyThrowInternalNull(node.Attributes, nameof(node.Attributes));
+
+                    var projectPathAttribute = node.Attributes!["AbsolutePath"];
+                    ErrorUtilities.VerifyThrow(projectPathAttribute is not null, "Expected VS to set the project path on each ProjectConfiguration element.");
+
+                    var projectPath = projectPathAttribute!.Value;
+                    ErrorUtilities.VerifyThrow(FileSystems.Default.FileExists(projectPath), "Expected the projects in the solution to exist.");
+
+                    var (configuration, platform) = SolutionFile.ParseConfigurationName(node.InnerText, definingProjectPath, 0, solutionConfigurationXml);
+
+                    // Take the defining project global properties and override the configuration and platform.
+                    // It's sufficient to only set Configuration and Platform.
+                    // But we send everything to maximize the plugins' potential to quickly workaround potential MSBuild issues while the MSBuild fixes flow into VS.
+                    var globalProperties = new Dictionary<string, string>(definingProjectGlobalProperties, StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Configuration"] = configuration,
+                        ["Platform"] = platform
+                    };
+
+                    graphEntryPoints.Add(new ProjectGraphEntryPoint(projectPath, globalProperties));
+                }
+
+                return graphEntryPoints;
             }
 
             static bool MSBuildStringIsTrue(string msbuildString) =>
@@ -366,7 +429,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                     return CacheResult.IndicateNonCacheHit(CacheResultType.CacheNotApplicable);
                 }
             }
-			
+
             ErrorUtilities.VerifyThrowInternalNull(buildRequest.ProjectInstance, nameof(buildRequest.ProjectInstance));
 
             var queryDescription = $"{buildRequest.ProjectFullPath}" +

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -431,13 +431,19 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
                 void RemoveProjectSpecificGlobalProperties(Dictionary<string, string> globalProperties, ProjectInstance project)
                 {
-                    // Remove the inner build property from the graph entry point global properties.
-                    // If the inner build property is set (TargetFramework), it will propagate down the project graph and force all nodes to that innerbuild value, which is incorrect.
+                    // If any project specific property is set, it will propagate down the project graph and force all nodes to that property's specific side effects, which is incorrect.
+
+                    // TargetFramework for the managed sdk.
                     var innerBuildPropertyName = ProjectInterpretation.GetInnerBuildPropertyName(project);
 
-                    if (!string.IsNullOrWhiteSpace(innerBuildPropertyName) && globalProperties.ContainsKey(innerBuildPropertyName))
+                    IEnumerable<string> projectSpecificPropertyNames = new []{innerBuildPropertyName, "Configuration", "Platform", "TargetPlatform", "OutputType"};
+
+                    foreach (var propertyName in projectSpecificPropertyNames)
                     {
-                        globalProperties.Remove(innerBuildPropertyName);
+                        if (!string.IsNullOrWhiteSpace(propertyName) && globalProperties.ContainsKey(propertyName))
+                        {
+                            globalProperties.Remove(propertyName);
+                        }
                     }
                 }
             }

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -429,10 +429,9 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
                 return graphEntryPoints;
 
+                // If any project specific property is set, it will propagate down the project graph and force all nodes to that property's specific side effects, which is incorrect.
                 void RemoveProjectSpecificGlobalProperties(Dictionary<string, string> globalProperties, ProjectInstance project)
                 {
-                    // If any project specific property is set, it will propagate down the project graph and force all nodes to that property's specific side effects, which is incorrect.
-
                     // InnerBuildPropertyName is TargetFramework for the managed sdk.
                     var innerBuildPropertyName = ProjectInterpretation.GetInnerBuildPropertyName(project);
 

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -412,7 +412,6 @@ namespace Microsoft.Build.Experimental.ProjectCache
                     ErrorUtilities.VerifyThrow(projectPathAttribute is not null, "Expected VS to set the project path on each ProjectConfiguration element.");
 
                     var projectPath = projectPathAttribute!.Value;
-                    ErrorUtilities.VerifyThrow(FileSystems.Default.FileExists(projectPath), "Expected the projects in the solution to exist.");
 
                     var (configuration, platform) = SolutionFile.ParseConfigurationName(node.InnerText, definingProjectPath, 0, solutionConfigurationXml);
 

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -4,6 +4,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -17,6 +18,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.FileSystem;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Graph;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 
@@ -383,8 +385,10 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 ErrorUtilities.VerifyThrow(projectConfigurationNodes.Count > 0, "Expected at least one project in solution");
 
                 var definingProjectPath = project.FullPath;
-                var definingProjectGlobalProperties = project.GlobalProperties;
                 var graphEntryPoints = new List<ProjectGraphEntryPoint>(projectConfigurationNodes.Count);
+
+                var templateGlobalProperties = new Dictionary<string, string>(project.GlobalProperties, StringComparer.OrdinalIgnoreCase);
+                RemoveProjectSpecificGlobalProperties(templateGlobalProperties, project);
 
                 foreach (XmlNode node in projectConfigurationNodes)
                 {
@@ -401,13 +405,11 @@ namespace Microsoft.Build.Experimental.ProjectCache
                     // Take the defining project global properties and override the configuration and platform.
                     // It's sufficient to only set Configuration and Platform.
                     // But we send everything to maximize the plugins' potential to quickly workaround potential MSBuild issues while the MSBuild fixes flow into VS.
-                    var globalProperties = new Dictionary<string, string>(definingProjectGlobalProperties, StringComparer.OrdinalIgnoreCase)
+                    var globalProperties = new Dictionary<string, string>(templateGlobalProperties, StringComparer.OrdinalIgnoreCase)
                     {
                         ["Configuration"] = configuration,
                         ["Platform"] = platform
                     };
-
-                    RemoveProjectSpecificGlobalProperties(globalProperties, project);
 
                     graphEntryPoints.Add(new ProjectGraphEntryPoint(projectPath, globalProperties));
                 }

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -376,6 +376,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 ProjectInstance project
             )
             {
+                // TODO: fix code clone for parsing CurrentSolutionConfiguration xml: https://github.com/dotnet/msbuild/issues/6751
                 var doc = new XmlDocument();
                 doc.LoadXml(solutionConfigurationXml);
 

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -394,6 +394,19 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 {
                     ErrorUtilities.VerifyThrowInternalNull(node.Attributes, nameof(node.Attributes));
 
+                    var buildProjectInSolution = node.Attributes!["BuildProjectInSolution"];
+                    if (buildProjectInSolution is not null &&
+                        string.IsNullOrWhiteSpace(buildProjectInSolution.Value) is false &&
+                        bool.TryParse(buildProjectInSolution.Value, out var buildProject) &&
+                        buildProject is false)
+                    {
+                        continue;
+                    }
+
+                    ErrorUtilities.VerifyThrow(
+                        node.ChildNodes.OfType<XmlElement>().FirstOrDefault(e => e.Name == "ProjectDependency") is null,
+                        "Project cache service does not support solution only dependencies when running under Visual Studio.");
+
                     var projectPathAttribute = node.Attributes!["AbsolutePath"];
                     ErrorUtilities.VerifyThrow(projectPathAttribute is not null, "Expected VS to set the project path on each ProjectConfiguration element.");
 

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -433,7 +433,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 {
                     // If any project specific property is set, it will propagate down the project graph and force all nodes to that property's specific side effects, which is incorrect.
 
-                    // TargetFramework for the managed sdk.
+                    // InnerBuildPropertyName is TargetFramework for the managed sdk.
                     var innerBuildPropertyName = ProjectInterpretation.GetInnerBuildPropertyName(project);
 
                     IEnumerable<string> projectSpecificPropertyNames = new []{innerBuildPropertyName, "Configuration", "Platform", "TargetPlatform", "OutputType"};

--- a/src/Build/Construction/Solution/SolutionConfigurationInSolution.cs
+++ b/src/Build/Construction/Solution/SolutionConfigurationInSolution.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         internal const char ConfigurationPlatformSeparator = '|';
 
-        internal static readonly char[] ConfigurationPlatformSeparatorArray = new char[] { '|' };
+        internal static readonly char[] ConfigurationPlatformSeparatorArray = { '|' };
 
         /// <summary>
         /// Constructor

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -1384,7 +1384,6 @@ namespace Microsoft.Build.Construction
         internal void ParseSolutionConfigurations()
         {
             var nameValueSeparators = '=';
-            var configPlatformSeparators = new[] { SolutionConfigurationInSolution.ConfigurationPlatformSeparator };
 
             do
             {
@@ -1419,13 +1418,24 @@ namespace Microsoft.Build.Construction
                 ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(fullConfigurationName == configurationNames[1].Trim(), "SubCategoryForSolutionParsingErrors",
                     new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseInvalidSolutionConfigurationEntry", str);
 
-                string[] configurationPlatformParts = fullConfigurationName.Split(configPlatformSeparators);
+                var (configuration, platform) = ParseConfigurationName(fullConfigurationName, FullPath, _currentLineNumber, str);
 
-                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(configurationPlatformParts.Length == 2, "SubCategoryForSolutionParsingErrors",
-                    new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseInvalidSolutionConfigurationEntry", str);
-
-                _solutionConfigurations.Add(new SolutionConfigurationInSolution(configurationPlatformParts[0], configurationPlatformParts[1]));
+                _solutionConfigurations.Add(new SolutionConfigurationInSolution(configuration, platform));
             } while (true);
+        }
+
+        internal static (string Configuration, string Platform) ParseConfigurationName(string fullConfigurationName, string projectPath, int lineNumber, string containingString)
+        {
+            string[] configurationPlatformParts = fullConfigurationName.Split(SolutionConfigurationInSolution.ConfigurationPlatformSeparatorArray);
+
+            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(
+                configurationPlatformParts.Length == 2,
+                "SubCategoryForSolutionParsingErrors",
+                new BuildEventFileInfo(projectPath, lineNumber, 0),
+                "SolutionParseInvalidSolutionConfigurationEntry",
+                containingString);
+
+            return (configurationPlatformParts[0], configurationPlatformParts[1]);
         }
 
         /// <summary>

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Build.Construction
 #endif // FEATURE_ASPNET_COMPILER
 
         /// <summary>
+        /// Property set by VS when building projects. It's an XML containing the project configurations for ALL projects in the solution for the currently selected solution configuration.
+        /// </summary>
+        internal const string CurrentSolutionConfigurationContents = nameof(CurrentSolutionConfigurationContents);
+
+        /// <summary>
         /// The set of properties all projects in the solution should be built with
         /// </summary>
         private const string SolutionProperties = "BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)";

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -235,6 +235,7 @@ namespace Microsoft.Build.Construction
             };
             using (XmlWriter xw = XmlWriter.Create(solutionConfigurationContents, settings))
             {
+                // TODO: fix code clone for parsing CurrentSolutionConfiguration xml: https://github.com/dotnet/msbuild/issues/6751
                 xw.WriteStartElement("SolutionConfiguration");
 
                 // add a project configuration entry for each project in the solution

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -100,17 +100,17 @@ namespace Microsoft.Build.Graph
             }
         }
 
-        private static string GetInnerBuildPropertyValue(ProjectInstance project)
+        internal static string GetInnerBuildPropertyValue(ProjectInstance project)
         {
             return project.GetPropertyValue(GetInnerBuildPropertyName(project));
         }
 
-        private static string GetInnerBuildPropertyName(ProjectInstance project)
+        internal static string GetInnerBuildPropertyName(ProjectInstance project)
         {
             return project.GetPropertyValue(PropertyNames.InnerBuildProperty);
         }
 
-        private static string GetInnerBuildPropertyValues(ProjectInstance project)
+        internal static string GetInnerBuildPropertyValues(ProjectInstance project)
         {
             return project.GetPropertyValue(project.GetPropertyValue(PropertyNames.InnerBuildPropertyValues));
         }

--- a/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
+++ b/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Experimental.ProjectCache;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Graph;
 using Shouldly;
 
 namespace MockCacheFromAssembly
@@ -22,6 +23,15 @@ namespace MockCacheFromAssembly
         public override Task BeginBuildAsync(CacheContext context, PluginLoggerBase logger, CancellationToken cancellationToken)
         {
             logger.LogMessage($"{nameof(AssemblyMockCache)}: BeginBuildAsync", MessageImportance.High);
+
+            foreach (var ep in context.GraphEntryPoints ?? Enumerable.Empty<ProjectGraphEntryPoint>())
+            {
+                var globalPropertyString = ep.GlobalProperties is not null
+                    ? string.Join(", ", ep.GlobalProperties.Select(gp => $"{gp.Key}={gp.Value}"))
+                    : string.Empty;
+
+                logger.LogMessage($"EntryPoint: {ep.ProjectFile} ({globalPropertyString})");
+            }
 
             ErrorFrom(nameof(BeginBuildAsync), logger);
 

--- a/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
+++ b/src/Samples/ProjectCachePlugin/AssemblyMockCache.cs
@@ -27,10 +27,10 @@ namespace MockCacheFromAssembly
             foreach (var ep in context.GraphEntryPoints ?? Enumerable.Empty<ProjectGraphEntryPoint>())
             {
                 var globalPropertyString = ep.GlobalProperties is not null
-                    ? string.Join(", ", ep.GlobalProperties.Select(gp => $"{gp.Key}={gp.Value}"))
+                    ? string.Join("\n\t", ep.GlobalProperties.Select(gp => $"{gp.Key}:{gp.Value}"))
                     : string.Empty;
 
-                logger.LogMessage($"EntryPoint: {ep.ProjectFile} ({globalPropertyString})");
+                logger.LogMessage($"EntryPoint: {ep.ProjectFile} \n(\n\t{globalPropertyString}\n)");
             }
 
             ErrorFrom(nameof(BeginBuildAsync), logger);

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -155,6 +155,36 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+        internal static void ShouldHaveSucceeded(this BuildResult result)
+        {
+            result.OverallResult.ShouldBe(BuildResultCode.Success, result.Exception is not null ? result.Exception.ToString() : string.Empty);
+        }
+
+        internal static void ShouldHaveSucceeded(this GraphBuildResult result)
+        {
+            result.OverallResult.ShouldBe(BuildResultCode.Success, result.Exception is not null ? result.Exception.ToString() : string.Empty);
+        }
+
+        internal static void ShouldHaveFailed(this BuildResult result, string exceptionMessageSubstring = null)
+        {
+            result.OverallResult.ShouldBe(BuildResultCode.Failure);
+
+            if (exceptionMessageSubstring != null)
+            {
+                result.Exception.Message.ShouldContain(exceptionMessageSubstring);
+            }
+        }
+
+        internal static void ShouldHaveFailed(this GraphBuildResult result, string exceptionMessageSubstring = null)
+        {
+            result.OverallResult.ShouldBe(BuildResultCode.Failure);
+
+            if (exceptionMessageSubstring != null)
+            {
+                result.Exception.Message.ShouldContain(exceptionMessageSubstring);
+            }
+        }
+
         internal static string NormalizeSlashes(string path)
         {
             return path.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -157,12 +157,16 @@ namespace Microsoft.Build.UnitTests
 
         internal static void ShouldHaveSucceeded(this BuildResult result)
         {
-            result.OverallResult.ShouldBe(BuildResultCode.Success, result.Exception is not null ? result.Exception.ToString() : string.Empty);
+            result.OverallResult.ShouldBe(
+                BuildResultCode.Success,
+                customMessage: result.Exception is not null ? result.Exception.ToString() : string.Empty);
         }
 
         internal static void ShouldHaveSucceeded(this GraphBuildResult result)
         {
-            result.OverallResult.ShouldBe(BuildResultCode.Success, result.Exception is not null ? result.Exception.ToString() : string.Empty);
+            result.OverallResult.ShouldBe(
+                BuildResultCode.Success,
+                customMessage: result.Exception is not null ? result.Exception.ToString() : string.Empty);
         }
 
         internal static void ShouldHaveFailed(this BuildResult result, string exceptionMessageSubstring = null)

--- a/src/Tasks/ResolveProjectBase.cs
+++ b/src/Tasks/ResolveProjectBase.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal void CacheProjectElementsFromXml(string xmlString)
         {
+            // TODO: fix code clone for parsing CurrentSolutionConfiguration xml: https://github.com/dotnet/msbuild/issues/6751
             XmlDocument doc = null;
 
             if (!string.IsNullOrEmpty(xmlString))


### PR DESCRIPTION
### Context
Visual Studio has solution configurations and project configurations. A configuration is a (Configuration, Platform) tuple.
A solution configuration defines a specific project configuration for each project in the solution. It's like a mapping  from a solution configuration to a list of project configurations for each project.
At any moment a single solution configuration is active in VS.
When doing a real build in VS, the active solution configuration is propagated as global properties on each build request.

Up until now I didn't have a clear understanding of this, therefore the project cache setup has a bug when building under VS: it does not propagate the solution configuration information to the plugin instance.
This means that if the user selects a non-default solution configuration (or if the solution is more complicated and the default project configuration assignment is not straightforward), there will be a mismatch between the build requests issued by VS (reflecting the non-default solution configuration) and the state of the plugin (reflecting the default solution configuration).
The mismatches end up as build failures because the plugin is unable to match an incoming build request to an existing quickbuild build node (build node graph is created from MSBuild's static graph)

### Changes Made

Unfortunately MSBuild does not know what the active VS solution configuration is. So in this PR we parse the project configuration for each project from an XML that VS sets on each build request as a global property (however horrible the idea of that global property is, without it we could not have enabled the build-under-VS scenario). Previously, msbuild used the .sln file as the single entry-point to the plugin. Starting with this PR it creates one entry point for each project in the parsed XML, with its particular project configuration set as global properties.
This makes the static graph inside the plugin instance match the solution configuration.
These changes are in the VS workaround part of the code. Ideally, if VS passed in the project cache graph descriptor, it would have enough information to just use a single .sln based entrypoint and set the solution configuration on it. Maybe, one day ...

The PR also removes TargetFramework from the entry points. VS sets an empty `TargetFramework=""` global properties on outerbuilds (because why not). If we don't remove it it leaks into the graph entry-points, which propagates TF="" to all nodes in the graph, messing them up.

### Testing
Unit tests and manual testing.

### Notes
The meat of the implementation is here: https://github.com/dotnet/msbuild/pull/6738/files#diff-ac47163cf1a4ff2fbd79d56e0cf79ce9636b6a8331dfa89dae3fe8d3547f7fb3R345