### PR TITLE
Add PackageDescription to Microsoft.NET.StringTools

### DIFF
--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -15,6 +15,7 @@
     <SemanticVersioningV1>true</SemanticVersioningV1>
 
     <AssemblyName>Microsoft.NET.StringTools</AssemblyName>
+    <PackageDescription>This package contains the $(AssemblyName) assembly which implements common string-related functionality such as weak interning.</PackageDescription>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">


### PR DESCRIPTION
Fixes #6664

### Context

The package is missing a good package description.

### Changes Made

Added the `PackageDescription` property.

### Testing

Will check the next built package.