### PR TITLE
Fix Misleading NuGet SDK Resolver Error Message

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 {
                     result = (SdkResult)sdkResolver.Resolve(sdk, context, resultFactory);
                 }
-                catch (Exception e) when (e is FileNotFoundException || (e is FileLoadException && sdkResolver.GetType().GetTypeInfo().Name.Equals("NuGetSdkResolver", StringComparison.Ordinal)))
+                catch (Exception e) when ((e is FileNotFoundException || e is FileLoadException) && sdkResolver.GetType().GetTypeInfo().Name.Equals("NuGetSdkResolver", StringComparison.Ordinal))
                 {
                     // Since we explicitly add the NuGetSdkResolver, we special case this.  The NuGetSdkResolver has special logic
                     // to load NuGet assemblies at runtime which could fail if the user is not running installed MSBuild.  Rather


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6594

### Context
When the SDK's workload resolver would fail (with a filenotfound exception), we would complain about the NuGetSDKResolver. The condition was too flexible.

### Changes Made
Specified the condition to be: If (filenotfound OR fileload exception) AND it's the nugetsdkresolver, throw that nuget message.

Otherwise, generically log "this sdk resolver {0} failed because {1}"

### Testing
Tested locally.

### Notes
