### PR TITLE
Doc comments: fix validation issues in docs build

### DIFF
--- a/src/Build/Construction/ProjectElement.cs
+++ b/src/Build/Construction/ProjectElement.cs
@@ -415,7 +415,7 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Hook for subclasses to specify whether the given <param name="attribute"></param> should be cloned or not
+        /// Hook for subclasses to specify whether the given <paramref name="attribute"></param> should be cloned or not
         /// </summary>
         protected virtual bool ShouldCloneXmlAttribute(XmlAttribute attribute) => true;
 

--- a/src/Build/Construction/ProjectElement.cs
+++ b/src/Build/Construction/ProjectElement.cs
@@ -415,7 +415,7 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Hook for subclasses to specify whether the given <paramref name="attribute"></param> should be cloned or not
+        /// Hook for subclasses to specify whether the given <paramref name="attribute"></paramref> should be cloned or not
         /// </summary>
         protected virtual bool ShouldCloneXmlAttribute(XmlAttribute attribute) => true;
 

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         /// <remarks>
         /// It is safe to modify the children in this way
-        /// during enumeration. See <cref see="RemoveChild">RemoveChild</cref>.
+        /// during enumeration. See <see cref="M:Microsoft.Build.Construction.ProjectElementContainer.RemoveChild(Microsoft.Build.Construction.ProjectElement)" />.
         /// </remarks>
         public void RemoveAllChildren()
         {

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Evaluation
         /// - <see cref="ProjectItem.SetMetadataValue(string,string)"/>
         /// - <see cref="ProjectItem.SetMetadataValue(string,string, bool)"/>
         ///
-        /// When this property is set to true, the previous item operations throw an <exception cref="InvalidOperationException"></exception>
+        /// When this property is set to true, the previous item operations throw an <see cref="InvalidOperationException"></exception>
         /// instead of expanding the item element.
         /// </summary>
         public bool ThrowInsteadOfSplittingItemElement
@@ -2406,7 +2406,7 @@ namespace Microsoft.Build.Evaluation
             /// their previously stored value to find out, and if so perhaps decide to update their own state.
             /// Note that the number may not increase monotonically.
             ///
-            /// This number corresponds to the <seealso cref="BuildEventContext.EvaluationId"/> and can be used to connect
+            /// This number corresponds to the <see cref="BuildEventContext.EvaluationId"/> and can be used to connect
             /// evaluation logging events back to the Project instance.
             /// </summary>
             public override int LastEvaluationId => _data.EvaluationId;

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Evaluation
         /// - <see cref="ProjectItem.SetMetadataValue(string,string)"/>
         /// - <see cref="ProjectItem.SetMetadataValue(string,string, bool)"/>
         ///
-        /// When this property is set to true, the previous item operations throw an <see cref="InvalidOperationException"></exception>
+        /// When this property is set to true, the previous item operations throw an <see cref="InvalidOperationException"></see>
         /// instead of expanding the item element.
         /// </summary>
         public bool ThrowInsteadOfSplittingItemElement

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Evaluation
         /// - <see cref="ProjectItem.SetMetadataValue(string,string)"/>
         /// - <see cref="ProjectItem.SetMetadataValue(string,string, bool)"/>
         ///
-        /// When this property is set to true, the previous item operations throw an <see cref="InvalidOperationException"></see>
+        /// When this property is set to true, the previous item operations throw an <see cref="InvalidOperationException" />
         /// instead of expanding the item element.
         /// </summary>
         public bool ThrowInsteadOfSplittingItemElement

--- a/src/Framework/Sdk/SdkResolver.cs
+++ b/src/Framework/Sdk/SdkResolver.cs
@@ -29,10 +29,11 @@ namespace Microsoft.Build.Framework
         ///     An <see cref="SdkResult" /> containing the resolved SDKs or associated error / reason
         ///     the SDK could not be resolved.  Return <code>null</code> if the resolver is not
         ///     applicable for a particular <see cref="SdkReference"/>.
-        ///     <remarks>
-        ///         Note: You must use the <see cref="SdkResultFactory" /> to return a result.
-        ///     </remarks>
-        /// </returns>
+        ///  </returns>   
+        ///  <remarks>
+        ///    Note: You must use <xref:Microsoft.Build.Framework.SdkResultFactory> to return a result.
+        ///  </remarks>
+        /// 
         public abstract SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext,
             SdkResultFactory factory);
     }

--- a/src/Framework/Sdk/SdkResolver.cs
+++ b/src/Framework/Sdk/SdkResolver.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Framework
         ///     applicable for a particular <see cref="SdkReference"/>.
         ///  </returns>   
         ///  <remarks>
-        ///    Note: You must use <see cref="Microsoft.Build.Framework.SdkResultFactory"> to return a result.
+        ///    Note: You must use <see cref="Microsoft.Build.Framework.SdkResultFactory"/> to return a result.
         ///  </remarks>
         /// 
         public abstract SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext,

--- a/src/Framework/Sdk/SdkResolver.cs
+++ b/src/Framework/Sdk/SdkResolver.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Framework
         ///     applicable for a particular <see cref="SdkReference"/>.
         ///  </returns>   
         ///  <remarks>
-        ///    Note: You must use <xref:Microsoft.Build.Framework.SdkResultFactory> to return a result.
+        ///    Note: You must use <see cref="Microsoft.Build.Framework.SdkResultFactory"> to return a result.
         ///  </remarks>
         /// 
         public abstract SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext,

--- a/src/Framework/Sdk/SdkResolverContext.cs
+++ b/src/Framework/Sdk/SdkResolverContext.cs
@@ -37,11 +37,11 @@ namespace Microsoft.Build.Framework
 
         /// <summary>
         ///     Version of MSBuild currently running.
+        /// </summary>
         /// <remarks>
         ///     File version based on commit height from our public git repository. This is informational
         ///     and not equal to the assembly version.
         /// </remarks>
-        /// </summary>
         public virtual Version MSBuildVersion { get; protected set; }
 
         /// <summary>

--- a/src/Framework/Sdk/SdkResult.cs
+++ b/src/Framework/Sdk/SdkResult.cs
@@ -9,12 +9,7 @@ namespace Microsoft.Build.Framework
     ///     An abstract interface class to indicate SDK resolver success or failure.
     /// </summary>
     /// <remarks>
-    ///   <format type="text/markdown"><![CDATA[
-    
-            ## Remarks
-            > [!NOTE]
-            > Use <xref:Microsoft.Build.Framework.SdkResultFactory> to create instances of this class. Do not inherit from this class.
-           ]]></format>
+    ///   Note: Use <see cref="Microsoft.Build.Framework.SdkResultFactory"/> to create instances of this class. Do not inherit from this class.
     /// </remarks>
     public abstract class SdkResult
     {

--- a/src/Framework/Sdk/SdkResult.cs
+++ b/src/Framework/Sdk/SdkResult.cs
@@ -7,11 +7,15 @@ namespace Microsoft.Build.Framework
 {
     /// <summary>
     ///     An abstract interface class to indicate SDK resolver success or failure.
-    ///     <remarks>
-    ///         Note: Use <see cref="SdkResultFactory" /> to create instances of this class. Do not
-    ///         inherit from this class.
-    ///     </remarks>
     /// </summary>
+    /// <remarks>
+    ///   <format type="text/markdown"><![CDATA[
+    
+            ## Remarks
+            > [!NOTE]
+            > Use <xref:Microsoft.Build.Framework.SdkResultFactory> to create instances of this class. Do not inherit from this class.
+           ]]></format>
+    /// </remarks>
     public abstract class SdkResult
     {
         //  Explicit backing fields so that implementation in Microsoft.Build.dll can use them for translation

--- a/src/Tasks/CreateItem.cs
+++ b/src/Tasks/CreateItem.cs
@@ -31,12 +31,16 @@ namespace Microsoft.Build.Tasks
         /// A typical input: "metadataname1=metadatavalue1", "metadataname2=metadatavalue2", ...
         /// </summary>
         /// <remarks>
-        ///    The fact that this is a `string[]` makes the following illegal:
-        ///      `<CreateItem AdditionalMetadata="TargetPath=@(OutputPathItem)" />`
-        ///    The engine fails on this because it doesn't like item lists being concatenated with string
-        ///    constants when the data is being passed into an array parameter.  So the workaround is to 
-        ///    write this in the project file:
-        ///     `<CreateItem AdditionalMetadata="@(OutputPathItem-&gt;'TargetPath=%(Identity)')" />`
+        ///   <format type="text/markdown"><![CDATA[
+        ///     ## Remarks
+        ///     The fact that this is a `string[]` makes the following illegal:
+        ///         `<CreateItem AdditionalMetadata="TargetPath=@(OutputPathItem)" />`
+        ///     The engine fails on this because it doesn't like item lists being concatenated with string
+        ///     constants when the data is being passed into an array parameter.  So the workaround is to 
+        ///     write this in the project file:
+        ///         `<CreateItem AdditionalMetadata="@(OutputPathItem-&gt;'TargetPath=%(Identity)')" />`
+        ///     ]]>
+        ///   </format>
         /// </remarks>
         public string[] AdditionalMetadata { get; set; }
 

--- a/src/Tasks/CreateItem.cs
+++ b/src/Tasks/CreateItem.cs
@@ -31,14 +31,12 @@ namespace Microsoft.Build.Tasks
         /// A typical input: "metadataname1=metadatavalue1", "metadataname2=metadatavalue2", ...
         /// </summary>
         /// <remarks>
-        /// The fact that this is a string[] makes the following illegal:
-        ///     <CreateItem
-        ///         AdditionalMetadata="TargetPath=@(OutputPathItem)" />
-        /// The engine fails on this because it doesn't like item lists being concatenated with string
-        /// constants when the data is being passed into an array parameter.  So the workaround is to 
-        /// write this in the project file:
-        ///     <CreateItem
-        ///         AdditionalMetadata="@(OutputPathItem->'TargetPath=%(Identity)')" />
+        ///    The fact that this is a `string[]` makes the following illegal:
+        ///      `<CreateItem AdditionalMetadata="TargetPath=@(OutputPathItem)" />`
+        ///    The engine fails on this because it doesn't like item lists being concatenated with string
+        ///    constants when the data is being passed into an array parameter.  So the workaround is to 
+        ///    write this in the project file:
+        ///     `<CreateItem AdditionalMetadata="@(OutputPathItem-&gt;'TargetPath=%(Identity)')" />`
         /// </remarks>
         public string[] AdditionalMetadata { get; set; }
 

--- a/src/Tasks/CreateProperty.cs
+++ b/src/Tasks/CreateProperty.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Build.Tasks
         ///             Output TaskParameter="Value" PropertyName="MyTargetsToBuild"
         ///         /CreateProperty
         /// 
-        /// We need to respect the semicolon that he put in the value, and need to treat
-        /// this exactly as if he had done:
+        /// We need to respect the semicolon that they put in the value, and need to treat
+        /// this exactly as if they had done:
         /// 
         ///         PropertyGroup
         ///             MyTargetsToBuild="Clean;Build"

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Build.Tasks
 {
     /// <summary>
     /// Generates a hash of a given ItemGroup items. Metadata is not considered in the hash.
+    /// </summary>
     /// <remarks>
     /// Currently uses SHA1. Implementation subject to change between MSBuild versions. Not
     /// intended as a cryptographic security measure, only uniqueness between build executions.
     /// </remarks>
-    /// </summary>
     public class Hash : TaskExtension
     {
         private const char ItemSeparatorCharacter = '\u2028';

--- a/src/Tasks/MSBuild.cs
+++ b/src/Tasks/MSBuild.cs
@@ -55,14 +55,12 @@ namespace Microsoft.Build.Tasks
         /// A typical input: "propname1=propvalue1", "propname2=propvalue2", "propname3=propvalue3".
         /// </summary>
         /// <remarks>
-        /// The fact that this is a string[] makes the following illegal:
-        ///     <MSBuild
-        ///         Properties="TargetPath=@(OutputPathItem)" />
-        /// The engine fails on this because it doesn't like item lists being concatenated with string
-        /// constants when the data is being passed into an array parameter.  So the workaround is to 
-        /// write this in the project file:
-        ///     <MSBuild
-        ///         Properties="@(OutputPathItem->'TargetPath=%(Identity)')" />
+        ///     The fact that this is a `string[]` makes the following illegal:
+        ///       `<MSBuild Properties="TargetPath=@(OutputPathItem)" />`
+        ///     The engine fails on this because it doesn't like item lists being concatenated with string
+        ///     constants when the data is being passed into an array parameter.  So the workaround is to 
+        ///     write this in the project file:
+        ///       `<MSBuild Properties="@(OutputPathItem-&gt;'TargetPath=%(Identity)')" />`
         /// </remarks>
         public string[] Properties { get; set; }
 

--- a/src/Tasks/MSBuild.cs
+++ b/src/Tasks/MSBuild.cs
@@ -55,12 +55,16 @@ namespace Microsoft.Build.Tasks
         /// A typical input: "propname1=propvalue1", "propname2=propvalue2", "propname3=propvalue3".
         /// </summary>
         /// <remarks>
+        ///   <format type="text/markdown"><![CDATA[
+        ///     ## Remarks
         ///     The fact that this is a `string[]` makes the following illegal:
-        ///       `<MSBuild Properties="TargetPath=@(OutputPathItem)" />`
+        ///         `<MSBuild Properties="TargetPath=@(OutputPathItem)" />`
         ///     The engine fails on this because it doesn't like item lists being concatenated with string
         ///     constants when the data is being passed into an array parameter.  So the workaround is to 
         ///     write this in the project file:
-        ///       `<MSBuild Properties="@(OutputPathItem-&gt;'TargetPath=%(Identity)')" />`
+        ///         `<MSBuild Properties="@(OutputPathItem-&gt;'TargetPath=%(Identity)')" />`
+        ///     ]]>
+        ///   </format>
         /// </remarks>
         public string[] Properties { get; set; }
 

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1910,7 +1910,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="targetFrameworkVersion">Version being targeted</param>
         /// <param name="targetFrameworkProfile">Profile being targeted</param>
         /// <param name="targetFrameworkRootPath">Root directory which will be used to calculate the reference assembly path. The references assemblies will be
-        /// <param name="targetFrameworkFallbackSearchPaths">';' separated list of paths that are looked up if the framework cannot be found in @targetFrameworkRootPath</param>
+        /// <paramref name="targetFrameworkFallbackSearchPaths">';' separated list of paths that are looked up if the framework cannot be found in @targetFrameworkRootPath</param>
         /// generated in the following way TargetFrameworkRootPath\TargetFrameworkIdentifier\TargetFrameworkVersion\SubType\TargetFrameworkSubType.
         /// Uses the default path if this is null.
         /// </param>

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1910,7 +1910,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="targetFrameworkVersion">Version being targeted</param>
         /// <param name="targetFrameworkProfile">Profile being targeted</param>
         /// <param name="targetFrameworkRootPath">Root directory which will be used to calculate the reference assembly path. The references assemblies will be
-        /// <paramref name="targetFrameworkFallbackSearchPaths">';' separated list of paths that are looked up if the framework cannot be found in @targetFrameworkRootPath</param>
+        /// <paramref name="targetFrameworkFallbackSearchPaths"/>';' separated list of paths that are looked up if the framework cannot be found in @targetFrameworkRootPath
         /// generated in the following way TargetFrameworkRootPath\TargetFrameworkIdentifier\TargetFrameworkVersion\SubType\TargetFrameworkSubType.
         /// Uses the default path if this is null.
         /// </param>

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1903,14 +1903,14 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Returns the paths to the reference assemblies location for the given target framework.
         /// This method will assume the requested ReferenceAssemblyRoot path will be the ProgramFiles directory specified by Environment.SpecialFolder.ProgramFiles
-        /// In additon when the .NETFramework or .NET Framework targetFrameworkIdentifiers are seen and targetFrameworkVersion is 2.0, 3.0, 3.5 or 4.0 we will return the correctly chained reference assembly paths
+        /// In addition when the .NETFramework or .NET Framework targetFrameworkIdentifiers are seen and targetFrameworkVersion is 2.0, 3.0, 3.5 or 4.0 we will return the correctly chained reference assembly paths
         /// for the legacy .net frameworks. This chaining will use the existing GetPathToDotNetFrameworkReferenceAssemblies to build up the list of reference assembly paths.
         /// </summary>
         /// <param name="targetFrameworkIdentifier">Identifier being targeted</param>
         /// <param name="targetFrameworkVersion">Version being targeted</param>
         /// <param name="targetFrameworkProfile">Profile being targeted</param>
         /// <param name="targetFrameworkRootPath">Root directory which will be used to calculate the reference assembly path. The references assemblies will be
-        /// <paramref name="targetFrameworkFallbackSearchPaths"/>';' separated list of paths that are looked up if the framework cannot be found in @targetFrameworkRootPath
+        /// <param name="targetFrameworkFallbackSearchPaths">';' separated list of paths that are looked up if the framework cannot be found in <paramref name="targetFrameworkRootPath"/></param>
         /// generated in the following way TargetFrameworkRootPath\TargetFrameworkIdentifier\TargetFrameworkVersion\SubType\TargetFrameworkSubType.
         /// Uses the default path if this is null.
         /// </param>

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -366,8 +366,9 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Searches %PATH% for the location of Tracker.exe, and returns the first 
         /// path that matches. 
-        /// <returns>Matching full path to Tracker.exe or null if a matching path is not found.</returns>
         /// </summary>
+        /// <returns>The full path to Tracker.exe, or <see langword="null" /> if a matching path is not found.</returns>
+        
         public static string FindTrackerOnPath()
         {
             string[] paths = Environment.GetEnvironmentVariable(pathEnvironmentVariableName).Split(pathSeparatorArray, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6743

### Context
The doc build is throwing some validation errors on some XML code comment constructs, such as invalid tags or improper nesting of tags.

### Changes Made
Fix several XML comments

### Testing


### Notes
No change other than code comments