### PR TITLE
Recalculate MSBuild path from VS Root

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Build.Shared
                 string visualStudioRoot = GetVsRootFromMSBuildAssembly(msbuildExe);
                 return new BuildEnvironment(
                         BuildEnvironmentMode.VisualStudio,
-                        msbuildExe,
+                        GetMSBuildExeFromVsRoot(visualStudioRoot),
                         runningTests: s_runningTests(),
                         runningInVisualStudio: false,
                         visualStudioPath: visualStudioRoot);


### PR DESCRIPTION
A 64-bit application is now (after #6683) getting a good VS root path,
but may still use toolsets from the wrong directory, because if it
loaded (AnyCPU) assemblies from the 'x86' location it wouldn't pass
a path containing amd64 to the BuildEnvironment constructor, so
the logic there wouldn't find the right MSBuildToolsDirectory and
config file.

Fix this in the lowest-impact way by rederiving the path to the
'correct' MSBuild.exe from the VS root and passing that to the
BuildEnvironment constructor.

Fixes #6681.