### PR TITLE
Add .NET Core solution open to OptProf training scenarios

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -22,6 +22,12 @@
           "testCases": [
             "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
+        },
+        {
+          "container": "Microsoft.VisualStudio.ProjectSystem.DDRIT",
+          "testCases": [
+            "Microsoft.VisualStudio.ProjectSystem.DDRIT.OptProfOpenCloseTest.OpenAndCloseProjectTestSolution"
+          ]
         }  
       ]
     }


### PR DESCRIPTION
Fixes #6067

### Context

There is a few dozen milliseconds worth of avoidable JITting happening in MSBuild assemblies on VS solution open. The respective methods are considered cold and not part of our NGEN images because they are not executed by current training scenarios.

### Changes Made

Added an additional scenario to specifically cover .NET Core projects.

### Testing

Ran the OptProf pipeline with this change and then Perf.DDRITs with a build optimized using the resulting optimization data.

- 50 ms less CPU spent JITting Microsoft.Build!*
- Perf.DDRITs showing improvements:
  - WebToolsVS64.SolutionManagement 0100.Open Solution - devenv methods JITted down by 24.4%
  - WebToolsVS64.SolutionManagement 0200.Rebuild Solution - non-devenv methods JITted down by 4.5%
  - ManagedLangsVS64.RebuildSolution 0100.Rebuild Solution - non-devenv methods JITted down by 12.1%
  - CPlusPlusVS64.SolutionManagement 0300.Change Solution Configuration - Cold - devenv methods JITted down by 2.1%
  - A few RefSet counters improved by a bit as well.
- Impact on native image size is +490 kB  (+4 %).
