### PR TITLE
Delete manual Markdown ToCs

### DIFF
--- a/documentation/specs/project-cache.md
+++ b/documentation/specs/project-cache.md
@@ -1,16 +1,3 @@
-- [Summary](#summary)
-- [Motivation](#motivation)
-- [Plugin requirements](#plugin-requirements)
-- [High-level design](#high-level-design)
-- [APIs and calling patterns](#apis-and-calling-patterns)
-  - [From BuildManager API users who have a project dependency graph at hand and want to manually issue builds for each graph node in reverse topo sort order.](#from-buildmanager-api-users-who-have-a-project-dependency-graph-at-hand-and-want-to-manually-issue-builds-for-each-graph-node-in-reverse-topo-sort-order)
-  - [From command line](#from-command-line)
-  - [From Visual Studio, a temporary workaround](#from-visual-studio-a-temporary-workaround)
-- [Details](#details)
-- [Caveats](#caveats)
-- [Future work](#future-work)
-- [Potential work of dubious value](#potential-work-of-dubious-value)
-
 # Summary
 
 Project cache is a new assembly-based plugin extension point in MSBuild which determines whether a build request (a project) can be skipped during build. The main expected benefit is reduced build times via [caching and/or distribution](https://github.com/dotnet/msbuild/blob/master/documentation/specs/static-graph.md#weakness-of-the-old-model-caching-and-distributability).

--- a/documentation/specs/static-graph-implementation-details.md
+++ b/documentation/specs/static-graph-implementation-details.md
@@ -1,8 +1,3 @@
-- [Single project isolated builds: implementation details](#single-project-isolated-builds-implementation-details)
-  - [Input / Output cache implementation](#input--output-cache-implementation)
-  - [Isolation implementation](#isolation-implementation)
-    - [How isolation exemption complicates everything](#how-isolation-exemption-complicates-everything)
-
 # Single project isolated builds: implementation details
 
 <!-- workflow -->
@@ -17,7 +12,7 @@ The presence of either input or output caches turns on [isolated build constrain
 
 ## Input / Output cache implementation
 <!-- cache structure -->
-The cache files contain the serialized state of MSBuild's [ConfigCache](https://github.com/dotnet/msbuild/blob/main/src/Build/BackEnd/Components/Caching/ConfigCache.cs) and [ResultsCache](https://github.com/dotnet/msbuild/blob/master/src/Build/BackEnd/Components/Caching/ResultsCache.cs). These two caches have been traditionally used by the engine to cache build results. For example, it is these caches which ensure that a target is only built once per build submission. The `ConfigCache` entries are instances of [BuildRequestConfiguration](https://github.com/microsoft/msbuild/blob/37c5a9fec416b403212a63f95f15b03dbd5e8b5d/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs#L25). The `ResultsCache` entries are instances of [BuildResult](https://github.com/microsoft/msbuild/blob/37c5a9fec416b403212a63f95f15b03dbd5e8b5d/src/Build/BackEnd/Shared/BuildResult.cs#L34), which contain or more instances of [TargetResult](https://github.com/microsoft/msbuild/blob/37c5a9fec416b403212a63f95f15b03dbd5e8b5d/src/Build/BackEnd/Shared/TargetResult.cs#L22). 
+The cache files contain the serialized state of MSBuild's [ConfigCache](https://github.com/dotnet/msbuild/blob/main/src/Build/BackEnd/Components/Caching/ConfigCache.cs) and [ResultsCache](https://github.com/dotnet/msbuild/blob/master/src/Build/BackEnd/Components/Caching/ResultsCache.cs). These two caches have been traditionally used by the engine to cache build results. For example, it is these caches which ensure that a target is only built once per build submission. The `ConfigCache` entries are instances of [BuildRequestConfiguration](https://github.com/microsoft/msbuild/blob/37c5a9fec416b403212a63f95f15b03dbd5e8b5d/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs#L25). The `ResultsCache` entries are instances of [BuildResult](https://github.com/microsoft/msbuild/blob/37c5a9fec416b403212a63f95f15b03dbd5e8b5d/src/Build/BackEnd/Shared/BuildResult.cs#L34), which contain or more instances of [TargetResult](https://github.com/microsoft/msbuild/blob/37c5a9fec416b403212a63f95f15b03dbd5e8b5d/src/Build/BackEnd/Shared/TargetResult.cs#L22).
 
 One can view the two caches as the following mapping: `(project path, global properties) -> results`. `(project path, global properties)` is represented by a `BuildRequestConfiguration`, and the results are represented by `BuildResult` and `TargetResult`.
 

--- a/documentation/specs/static-graph.md
+++ b/documentation/specs/static-graph.md
@@ -1,36 +1,5 @@
 # Static Graph
 
-- [Static Graph](#static-graph)
-  - [What is static graph for?](#what-is-static-graph-for)
-    - [Weakness of the old model: project-level scheduling](#weakness-of-the-old-model-project-level-scheduling)
-    - [Weakness of the old model: incrementality](#weakness-of-the-old-model-incrementality)
-    - [Weakness of the old model: caching and distributability](#weakness-of-the-old-model-caching-and-distributability)
-  - [What is static graph?](#what-is-static-graph)
-  - [Design documentation](#design-documentation)
-    - [Design goals](#design-goals)
-  - [Project Graph](#project-graph)
-    - [Constructing the project graph](#constructing-the-project-graph)
-    - [Build dimensions](#build-dimensions)
-      - [Multitargeting](#multitargeting)
-    - [Executing targets on a graph](#executing-targets-on-a-graph)
-      - [Command line](#command-line)
-      - [APIs](#apis)
-    - [Inferring which targets to run for a project within the graph](#inferring-which-targets-to-run-for-a-project-within-the-graph)
-      - [Multitargeting details](#multitargeting-details)
-    - [Underspecified graphs](#underspecified-graphs)
-    - [Public API](#public-api)
-  - [Isolated builds](#isolated-builds)
-    - [Isolated graph builds](#isolated-graph-builds)
-    - [Single project isolated builds](#single-project-isolated-builds)
-      - [APIs](#apis-1)
-      - [Command line](#command-line-1)
-      - [Exempting references from isolation constraints](#exempting-references-from-isolation-constraints)
-  - [I/O Tracking](#io-tracking)
-    - [Detours](#detours)
-    - [Isolation requirement](#isolation-requirement)
-    - [Tool servers](#tool-servers)
-  - [Examples](#examples)
-
 ## What is static graph for?
 
 As a repo gets bigger and more complex, weaknesses in MSBuild's scheduling and incrementality models become more apparent. MSBuild's static graph features are intended to ameliorate these weaknesses while remaining as compatible as possible with existing projects and SDKs.


### PR DESCRIPTION
GitHub now [generates navigation options][1] in Markdown files, so no need to have them here manually.

[1]: https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/
