### PR TITLE
Fail Builds Fast When SDKResolvers Throw Exceptions

### DIFF
--- a/documentation/specs/sdk-resolvers.md
+++ b/documentation/specs/sdk-resolvers.md
@@ -1,0 +1,29 @@
+> 🚧 Note
+>
+> This page is a work in progress.
+
+### Failed SDK Resolution
+SDK resolvers previously attempted to continue when one critically fails (throws an unhandled exception). This lead to misleading error messages such as:
+
+```
+warning MSB4242: The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed to run. 's' is an invalid start of a property name. Expected a '"'. LineNumber: 14 | BytePositionInLine: 8.
+error MSB4236: The SDK 'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' specified could not be found. [C:\foo\bar.csproj]
+```
+
+`MSB4236` is a red herring while `MSB4242` is the real error despite being logged as a warning. Because of this, SDK resolvers now fail the build _immediately_ upon unhandled exceptions. These exceptions are propogated as `SdkResolverException`s, and `MSB4242` has been promoted to an error code. The new error message appears like so:
+
+```
+C:\src\temp\8-18>"C:\foo\dotnet-sdk-6.0.100-preview.7.21379.14-win-x64\dotnet.exe" build    
+Microsoft (R) Build Engine version 17.0.0-dev-21420-01+5df152759 for .NET
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+C:\foo\bar.csproj : error MSB4242: SDK Resolver Failure: "The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed while attempting to resolve the SDK "Microsoft.NET.Sdk". Exception: "'s' is an invalid start of a property name. Expected a '"'. LineNumber: 14 | BytePositionInLine: 8."".
+
+Build FAILED.
+
+C:\foo\bar.csproj : error MSB4242: SDK Resolver Failure: "The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed while attempting to resolve the SDK "Microsoft.NET.Sdk". Exception: "'s' is an invalid start of a property name. Expected a '"'. LineNumber: 14 | BytePositionInLine: 8."".
+    0 Warning(s)
+    1 Error(s)
+
+Time Elapsed 00:00:00.15
+```

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1,5 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace Microsoft.Build.BackEnd.SdkResolution
+{
+    public partial class SdkResolverException : System.Exception
+    {
+        public SdkResolverException(string resourceName, Microsoft.Build.Framework.SdkResolver resolver, Microsoft.Build.Framework.SdkReference sdk, System.Exception innerException, params string[] args) { }
+        public Microsoft.Build.Framework.SdkResolver Resolver { get { throw null; } }
+        public Microsoft.Build.Framework.SdkReference Sdk { get { throw null; } }
+    }
+}
 namespace Microsoft.Build.Construction
 {
     public abstract partial class ElementLocation

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1,5 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace Microsoft.Build.BackEnd.SdkResolution
+{
+    public partial class SdkResolverException : System.Exception
+    {
+        public SdkResolverException(string resourceName, Microsoft.Build.Framework.SdkResolver resolver, Microsoft.Build.Framework.SdkReference sdk, System.Exception innerException, params string[] args) { }
+        public Microsoft.Build.Framework.SdkResolver Resolver { get { throw null; } }
+        public Microsoft.Build.Framework.SdkReference Sdk { get { throw null; } }
+    }
+}
 namespace Microsoft.Build.Construction
 {
     public abstract partial class ElementLocation

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -93,8 +93,9 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
-            result.Path.ShouldBe("resolverpath1");
-            _logger.Warnings.Select(i => i.Message).ShouldBe(new [] { "The SDK resolver \"MockSdkResolverThrows\" failed to run. EXMESSAGE" });
+            result.Path.ShouldBe(null);
+            _logger.ErrorCount.ShouldBe(1);
+            _logger.Errors.First().Code.ShouldBe("MSB4242");
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -92,7 +92,9 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("1sdkName", "version1", "minimumVersion");
 
             // When an SDK resolver throws, the expander will catch it and stop the build.
-            Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false));
+            SdkResolverException e = Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false));
+            e.Message.ShouldContain("MockSdkResolverThrows");
+            e.Message.ShouldContain("EXMESSAGE");
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             // When an SDK resolver throws, the expander will catch it and stop the build.
             SdkResolverException e = Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false));
-            e.Message.ShouldContain("MockSdkResolverThrows");
-            e.Message.ShouldContain("EXMESSAGE");
+            e.Resolver.Name.ShouldBe("MockSdkResolverThrows");
+            e.Sdk.Name.ShouldBe("1sdkName");
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("1sdkName", "version1", "minimumVersion");
 
             // When an SDK resolver throws, the expander will catch it and stop the build.
-            Should.Throw<Exception>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false));
+            Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false));
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -85,17 +85,14 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         [Fact]
-        public void AssertErrorLoggedWhenResolverThrows()
+        public void AssertResolverThrows()
         {
             SdkResolverService.Instance.InitializeForTests(new MockLoaderStrategy(includeErrorResolver: true));
 
             SdkReference sdk = new SdkReference("1sdkName", "version1", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
-
-            result.Path.ShouldBe(null);
-            _logger.ErrorCount.ShouldBe(1);
-            _logger.Errors.First().Code.ShouldBe("MSB4242");
+            // When an SDK resolver throws, the expander will catch it and stop the build.
+            Should.Throw<Exception>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false));
         }
 
         [Fact]

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverException.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverException.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.BackEnd.SdkResolution
+{
+    /// <summary>
+    /// Represents an exception that occurs when an SdkResolver throws an unhandled exception.
+    /// </summary>
+    public class SdkResolverException : Exception
+    {
+        public SdkResolver Resolver { get; private set; }
+
+        public SdkReference Sdk { get; private set; }
+
+        public SdkResolverException(string resourceName, SdkResolver resolver, SdkReference sdk, Exception innerException, params string[] args)
+            : base(string.Format(ResourceUtilities.GetResourceString(resourceName), args), innerException)
+        {
+            Resolver = resolver;
+            Sdk = sdk;
+        }
+    }
+}

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -124,14 +124,14 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     // than give them a generic error, we want to give a more specific message.  This exception cannot be caught by
                     // the resolver itself because it is usually thrown before the class is loaded
                     // MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}
-                    loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "CouldNotRunNuGetSdkResolver", MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName, e.Message);
-                    continue;
+                    loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "CouldNotRunNuGetSdkResolver", MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName, e.Message);
+                    return new SdkResult(sdk, null, null);
                 }
                 catch (Exception e)
                 {
-                    // MSB4242: The SDK resolver "{0}" failed to run. {1}
-                    loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "CouldNotRunSdkResolver", sdkResolver.Name, e.Message);
-                    continue;
+                    // MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}
+                    loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "CouldNotRunSdkResolver", sdkResolver.Name, sdk.ToString(), e.Message);
+                    return new SdkResult(sdk, null, null);
                 }
 
                 SetResolverState(submissionId, sdkResolver, context.State);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -124,12 +124,12 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     // than give them a generic error, we want to give a more specific message.  This exception cannot be caught by
                     // the resolver itself because it is usually thrown before the class is loaded
                     // The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}
-                    throw new SdkResolverException("CouldNotRunNuGetSdkResolver", sdkResolver, sdk, e, MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName, e.Message);
+                    throw new SdkResolverException("CouldNotRunNuGetSdkResolver", sdkResolver, sdk, e, MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName, e.ToString());
                 }
                 catch (Exception e)
                 {
                     // The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}
-                    throw new SdkResolverException("SDKResolverFailed", sdkResolver, sdk, e, sdkResolver.Name, sdk.ToString(), e.Message);
+                    throw new SdkResolverException("SDKResolverFailed", sdkResolver, sdk, e, sdkResolver.Name, sdk.ToString(), e.ToString());
                 }
 
                 SetResolverState(submissionId, sdkResolver, context.State);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -123,13 +123,13 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     // to load NuGet assemblies at runtime which could fail if the user is not running installed MSBuild.  Rather
                     // than give them a generic error, we want to give a more specific message.  This exception cannot be caught by
                     // the resolver itself because it is usually thrown before the class is loaded
-                    // MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}
-                    throw new Exception(string.Format(ResourceUtilities.GetResourceString("CouldNotRunNuGetSdkResolver"), MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName, e.Message));
+                    // The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}
+                    throw new SdkResolverException("CouldNotRunNuGetSdkResolver", sdkResolver, sdk, e, MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName, e.Message);
                 }
                 catch (Exception e)
                 {
-                    // MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}
-                    throw new Exception(string.Format(ResourceUtilities.GetResourceString("SDKResolverFailed"), sdkResolver.Name, sdk.ToString(), e.Message));
+                    // The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}
+                    throw new SdkResolverException("SDKResolverFailed", sdkResolver, sdk, e, sdkResolver.Name, sdk.ToString(), e.Message);
                 }
 
                 SetResolverState(submissionId, sdkResolver, context.State);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -124,14 +124,12 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     // than give them a generic error, we want to give a more specific message.  This exception cannot be caught by
                     // the resolver itself because it is usually thrown before the class is loaded
                     // MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}
-                    loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "CouldNotRunNuGetSdkResolver", MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName, e.Message);
-                    return new SdkResult(sdk, null, null);
+                    throw new Exception(string.Format(ResourceUtilities.GetResourceString("CouldNotRunNuGetSdkResolver"), MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName, e.Message));
                 }
                 catch (Exception e)
                 {
                     // MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}
-                    loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "CouldNotRunSdkResolver", sdkResolver.Name, sdk.ToString(), e.Message);
-                    return new SdkResult(sdk, null, null);
+                    throw new Exception(string.Format(ResourceUtilities.GetResourceString("SDKResolverFailed"), sdkResolver.Name, sdk.ToString(), e.Message));
                 }
 
                 SetResolverState(submissionId, sdkResolver, context.State);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1785,7 +1785,14 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 // Combine SDK path with the "project" relative path
-                sdkResult = _sdkResolverService.ResolveSdk(_submissionId, sdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive, _isRunningInVisualStudio);
+                try
+                {
+                    sdkResult = _sdkResolverService.ResolveSdk(_submissionId, sdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive, _isRunningInVisualStudio);
+                }
+                catch (Exception e)
+                {
+                    ProjectErrorUtilities.ThrowInvalidProject(importElement.SdkLocation, "SDKResolverCriticalFailure", e.Message);
+                }
 
                 if (!sdkResult.Success)
                 {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1791,6 +1791,8 @@ namespace Microsoft.Build.Evaluation
                 }
                 catch (SdkResolverException e)
                 {
+                    // We throw using e.Message because e.Message already contains the stack trace
+                    // https://github.com/dotnet/msbuild/pull/6763
                     ProjectErrorUtilities.ThrowInvalidProject(importElement.SdkLocation, "SDKResolverCriticalFailure", e.Message);
                 }
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1789,7 +1789,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     sdkResult = _sdkResolverService.ResolveSdk(_submissionId, sdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive, _isRunningInVisualStudio);
                 }
-                catch (Exception e)
+                catch (SdkResolverException e)
                 {
                     ProjectErrorUtilities.ThrowInvalidProject(importElement.SdkLocation, "SDKResolverCriticalFailure", e.Message);
                 }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -157,6 +157,7 @@
     <Compile Include="BackEnd\Components\Caching\ConfigCacheWithOverride.cs" />
     <Compile Include="BackEnd\Components\Caching\ResultsCacheWithOverride.cs" />
     <Compile Include="BackEnd\Components\ProjectCache\*.cs" />
+    <Compile Include="BackEnd\Components\SdkResolution\SdkResolverException.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\TranslationHelpers.cs" />
     <Compile Include="FileSystem\*.cs" />
     <Compile Include="Utilities\NuGetFrameworkWrapper.cs" />

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1286,7 +1286,7 @@
     <comment>{StrBegin="MSB4244: "}</comment>
   </data>
   <data name="SDKResolverCriticalFailure" xml:space="preserve">
-    <value>MSB4242: SDK Resolver Failure: "{0}".</value>
+    <value>MSB4242: SDK Resolver Failure: "{0}"</value>
     <comment>{StrBegin="MSB4242: "}</comment>
   </data>
   <data name="SDKResolverFailed" xml:space="preserve">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1286,7 +1286,7 @@
     <comment>{StrBegin="MSB4244: "}</comment>
   </data>
   <data name="CouldNotRunSdkResolver" xml:space="preserve">
-    <value>MSB4242: The SDK resolver "{0}" failed to run. {1}</value>
+    <value>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</value>
     <comment>{StrBegin="MSB4242: "}</comment>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1285,13 +1285,15 @@
     <value>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</value>
     <comment>{StrBegin="MSB4244: "}</comment>
   </data>
-  <data name="CouldNotRunSdkResolver" xml:space="preserve">
-    <value>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</value>
+  <data name="SDKResolverCriticalFailure" xml:space="preserve">
+    <value>MSB4242: SDK Resolver Failure: "{0}".</value>
     <comment>{StrBegin="MSB4242: "}</comment>
   </data>
+  <data name="SDKResolverFailed" xml:space="preserve">
+    <value>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</value>
+  </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">
-    <value>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>
-    <comment>{StrBegin="MSB4243: "}</comment>
+    <value>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>
   </data>
   <data name="SdkResolverManifestInvalid" xml:space="preserve">
     <value>MSB4245: SDK Resolver manifest file is invalid. This may indicate a corrupt or invalid installation of MSBuild. Manifest file path '{0}'. Message: {1}</value>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: Zakázání uzlu inproc způsobí snížení výkonu při používání modulů plug-in mezipaměti projektu, které vysílají žádosti o sestavení proxy serveru.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: Projekt {0} přeskočil omezení izolace grafu v odkazovaném projektu {1}.</target>
@@ -2379,15 +2389,10 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
         <target state="translated">MSB4244: Sestavení překladače sady SDK {0} nebylo možné načíst. {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: Překladač sady SDK založený na NuGet se nepodařilo spustit, protože sestavení NuGet se nenašla. Zkontrolujte instalaci nástroje MSBuild nebo nastavte proměnnou prostředí {0} na složku, která obsahuje požadovaná sestavení NuGet. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: Překladač sady SDK založený na NuGet se nepodařilo spustit, protože sestavení NuGet se nenašla. Zkontrolujte instalaci nástroje MSBuild nebo nastavte proměnnou prostředí {0} na složku, která obsahuje požadovaná sestavení NuGet. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -2380,8 +2380,8 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: Překladač sady SDK {0} se nepodařilo spustit. {1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: Das Deaktivieren des In-Process-Knotens führt zu Leistungseinbußen bei der Verwendung von Projektcache-Plug-Ins, die Proxybuildanforderungen ausgeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: Das Projekt "{0}" hat Graphisolationseinschränkungen für das referenzierte Projekt "{1}" übersprungen.</target>
@@ -2379,15 +2389,10 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
         <target state="translated">MSB4244: Die SDK-Resolverassembly "{0}" konnte nicht geladen werden. {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: Fehler beim NuGet-basierten SDK-Resolver, weil die NuGet-Assemblys nicht gefunden wurden. Überprüfen Sie Ihre Installation von MSBuild, oder legen Sie die Umgebungsvariable "{0}" auf den Ordner fest, der die erforderlichen NuGet-Assemblys enthält. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: Fehler beim NuGet-basierten SDK-Resolver, weil die NuGet-Assemblys nicht gefunden wurden. Überprüfen Sie Ihre Installation von MSBuild, oder legen Sie die Umgebungsvariable "{0}" auf den Ordner fest, der die erforderlichen NuGet-Assemblys enthält. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -2380,8 +2380,8 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: Der SDK-Resolver "{0}" konnte nicht ausgeführt werden. {1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -1,34 +1,34 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
+  <file datatype="xml" source-language="en" target-language="en" original="../Strings.resx">
     <body>
       <trans-unit id="AmbiguousTaskParameterError">
         <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
-        <target state="translated">MSB4001: A tarefa "{0}" tem mais de um parâmetro denominado "{1}".</target>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
         <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="translated">MSB4249: Não foi possível compilar o projeto do site da Web "{0}". O compilador do ASP.NET está disponível apenas na versão .NET Framework do MSBuild.</target>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
-        <target state="translated">MSB4002: Houve uma falha ao recuperar os atributos dos parâmetros na tarefa "{0}". {1}</target>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
         <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
     retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
     they are defined in cannot be found, or the classes themselves cannot be found.</note>
       </trans-unit>
       <trans-unit id="BadlyCasedSpecialTaskAttribute">
         <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
-        <target state="translated">MSB4003: "{0}" é um atributo reservado do elemento &lt;{1}&gt; e deve ser escrito com o uso correto de maiúsculas e minúsculas. Esse atributo não pode ser usado como um parâmetro da tarefa "{2}".</target>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BuildInProgress">
         <source>The operation cannot be completed because a build is already in progress.</source>
-        <target state="translated">A operação não pode ser concluída porque uma compilação está em andamento.</target>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
         <note />
       </trans-unit>
       <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
@@ -41,14 +41,14 @@
     - the reference was called with global properties that do not match the static graph inferred nodes
     - the reference was not explicitly specified as a ProjectReference item in project "{0}"
     </source>
-        <target state="translated">MSB4252: o projeto "{0}" com propriedades globais
+        <target state="new">MSB4252: Project "{0}" with global properties
     ({1})
-    está criando o projeto "{2}" com propriedades globais
+    is building project "{2}" with global properties
     ({3})
-    com ({4}) destino(s), mas o resultado do build para o projeto criado não está no cache do mecanismo. Em builds isolados, isso pode significar um dos seguintes:
-    – a referência foi chamada com um destino que não está especificado no item de ProjectReferenceTargets no projeto "{0}"
-    – a referência foi chamada com propriedades globais que não correspondem aos nós inferidos do gráfico estático
-    – a referência não foi especificada explicitamente como um item de ProjectReference no projeto "{0}"
+    with the ({4}) target(s) but the build result for the built project is not in the engine cache. In isolated builds this could mean one of the following:
+    - the reference was called with a target which is not specified in the ProjectReferenceTargets item in project "{0}"
+    - the reference was called with global properties that do not match the static graph inferred nodes
+    - the reference was not explicitly specified as a ProjectReference item in project "{0}"
     </target>
         <note>
       {StrBegin="MSB4252:"}
@@ -57,30 +57,30 @@
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
-        <target state="translated">MSB4248: Não é possível expandir os metadados na expressão "{0}". {1}</target>
+        <target state="new">MSB4248: Cannot expand metadata in expression "{0}". {1}</target>
         <note>{StrBegin="MSB4248: "}UE: This message is shown when metadata cannot be expanded in an expression for some reason e.g. trying to apply
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
       <trans-unit id="ChangeWave_InvalidFormat">
         <source>MSB4271: Environment variable MSBuildDisableFeaturesFromVersion is set to an invalid format. Enabling all change wave versions. Entered value: {0}. Current Change Waves: {1}.</source>
-        <target state="translated">MSB4271: A variável de ambiente MSBuildDisableFeaturesFromVersion está definida com um formato inválido. Habilitando todas as versões do ciclo de alterações. Valor inserido: {0}. Ciclos de Alterações Atuais: {1}.</target>
+        <target state="new">MSB4271: Environment variable MSBuildDisableFeaturesFromVersion is set to an invalid format. Enabling all change wave versions. Entered value: {0}. Current Change Waves: {1}.</target>
         <note>{StrBegin="MSB4271: "}UE: Value should be of the format: xx.yy</note>
       </trans-unit>
       <trans-unit id="ChangeWave_OutOfRotation">
         <source>MSB4272: Environment variable MSBuildDisableFeaturesFromVersion is set to a version that is out of rotation. Defaulting to Change Wave version: {0}. Entered value: {1}. Current Change Waves: {2}.</source>
-        <target state="translated">MSB4272: A variável de ambiente MSBuildDisableFeaturesFromVersion está definida como uma versão fora de rotação. Usando como padrão a versão do Ciclo de Alterações: {0}. Valor inserido: {1}. Ciclos de Alterações Atuais: {2}.</target>
+        <target state="new">MSB4272: Environment variable MSBuildDisableFeaturesFromVersion is set to a version that is out of rotation. Defaulting to Change Wave version: {0}. Entered value: {1}. Current Change Waves: {2}.</target>
         <note>{StrBegin="MSB4272: "}</note>
       </trans-unit>
       <trans-unit id="CircularDependency">
         <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
-        <target state="translated">MSB4006: Há uma dependência circular no elemento gráfico de dependência circular de destino envolvendo o destino "{0}".</target>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="CircularDependencyInProjectGraph">
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
-        <target state="translated">MSB4251: Uma dependência circular envolve os seguintes projetos: {0}</target>
+        <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
       {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
@@ -88,102 +88,102 @@
       </trans-unit>
       <trans-unit id="CircularDependencyInTargetGraph">
         <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}". Since "{1}" has "{2}" dependence on "{3}", the circular is "{4}".</source>
-        <target state="translated">MSB4006: há uma dependência circular no grafo de dependência de destino envolvendo o destino "{0}". Como "{1}" tem a dependência "{2}" em "{3}", a circular é "{4}".</target>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}". Since "{1}" has "{2}" dependence on "{3}", the circular is "{4}".</target>
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="EmptyOutputCacheFile">
         <source>MSB4257: The specified output result cache file is empty.</source>
-        <target state="translated">MSB4257: o arquivo de cache do resultado de saída especificado está vazio.</target>
+        <target state="new">MSB4257: The specified output result cache file is empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
         <source>Read environment variable "{0}"</source>
-        <target state="translated">Ler a variável de ambiente "{0}"</target>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
-        <target state="translated">MSB4256: a leitura dos arquivos de cache do resultado de entrada do caminho "{0}" encontrou um erro: {1}</target>
+        <target state="new">MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorWritingCacheFile">
         <source>MSB4258: Writing output result cache file in path "{0}" encountered an error: {1}</source>
-        <target state="translated">MSB4258: a gravação do arquivo de cache do resultado de saída no caminho "{0}" encontrou um erro: {1}</target>
+        <target state="new">MSB4258: Writing output result cache file in path "{0}" encountered an error: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4259: espaço inesperado na posição "{1}" da condição "{0}". Você esqueceu de remover um espaço?</target>
+        <target state="new">MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
-        <target state="translated">MSB4255: os arquivos de cache do resultado de entrada a seguir não existem: "{0}"</target>
+        <target state="new">MSB4255: The following input result cache files do not exist: "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
-        <target state="translated">A cadeia de caracteres de versão não estava em um formato correto.</target>
+        <target state="new">Version string was not in a correct format.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
         <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">Os objetos EvaluationContext criados com SharingPolicy.Isolated não são compatíveis com o recebimento de um sistema de arquivos MSBuildFileSystemBase.</target>
+        <target state="new">EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</target>
         <note />
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
-        <target state="translated">Encerrando o processo com o PID = {0}.</target>
+        <target state="new">Killing process with pid = {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoadingProjectCachePlugin">
         <source>Loading the following project cache plugin:
     {0}</source>
-        <target state="translated">Carregando o seguinte plug-in do projeto:
+        <target state="new">Loading the following project cache plugin:
     {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
-        <target state="translated">O detalhamento do log está definido como: {0}.</target>
+        <target state="new">Logging verbosity is set to: {0}.</target>
         <note>
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
-        <target state="translated">Os parâmetros foram truncados além deste ponto. Para exibir todos os parâmetros, limpe a variável de ambiente MSBUILDTRUNCATETASKINPUTLOGGING.</target>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
-        <target state="translated">Metaprojeto "{0}" gerado.</target>
+        <target state="new">Metaproject "{0}" generated.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
-        <target state="translated">A operação não pode ser concluída porque BeginBuild ainda não foi chamado.</target>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectCachePluginFoundInAssembly">
         <source>MSB4270: No project cache plugins found in assembly "{0}". Expected one.</source>
-        <target state="translated">MSB4270: não foi encontrado nenhum plug-in de cache do projeto no assembly "{0}". Era esperado um plug-in.</target>
+        <target state="new">MSB4270: No project cache plugins found in assembly "{0}". Expected one.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotAllNodesDefineACacheItem">
         <source>MSB4269: When any static graph node defines a project cache, all nodes must define the same project cache. The following project(s) do not contain a "{0}" item declaration: {1}</source>
-        <target state="translated">MSB4269: quando algum nó de grafo estático define um cache do projeto, todos os nós precisam definir o mesmo cache do projeto. Os seguintes projetos não contêm uma declaração de item "{0}": {1}</target>
+        <target state="new">MSB4269: When any static graph node defines a project cache, all nodes must define the same project cache. The following project(s) do not contain a "{0}" item declaration: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetAssemblyNotFound">
         <source>A required NuGet assembly was not found. Expected Path: {0}</source>
-        <target state="translated">Um assembly NuGet necessário não foi encontrado. Caminho Esperado: {0}</target>
+        <target state="new">A required NuGet assembly was not found. Expected Path: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="NullReferenceFromProjectInstanceFactory">
         <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
-        <target state="translated">MSB4253: Uma referência nula foi devolvida de um retorno de chamada do ProjectInstanceFactoryFunc fornecido pelo usuário. Isso não é permitido.</target>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
         <note>
       {StrBegin="MSB4253: "}
       LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
@@ -191,57 +191,57 @@
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataIsRestrictedToReferencedItems">
         <source>Only item types may be referenced when removing with MatchOnMetadata.</source>
-        <target state="translated">Somente tipos de item podem ser referenciados durante a remoção com MatchOnMetadata.</target>
+        <target state="new">Only item types may be referenced when removing with MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOnlyApplicableToRemoveItems">
         <source>MatchOnMetadata only applies to Remove operations on items.</source>
-        <target state="translated">MatchOnMetadata só se aplica a operações de Remoção em itens.</target>
+        <target state="new">MatchOnMetadata only applies to Remove operations on items.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchOnMetadataOptionsOnlyApplicableToItemsWithMatchOnMetadata">
         <source>MatchOnMetadataOptions is valid only when removing items using MatchOnMetadata.</source>
-        <target state="translated">MatchOnMetadataOptions é válido somente ao remover itens usando MatchOnMetadata.</target>
+        <target state="new">MatchOnMetadataOptions is valid only when removing items using MatchOnMetadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_NoMatchOnMetadataOutsideTargets">
         <source>MatchOnMetadata cannot be used outside of a &lt;Target&gt;.</source>
-        <target state="translated">MatchOnMetadata não pode ser usado fora de um &lt;Target&gt;.</target>
+        <target state="new">MatchOnMetadata cannot be used outside of a &lt;Target&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
-        <target state="translated">O método {0} não pode ser chamado com uma coleção que contém nomes de destino nulos ou vazios.</target>
+        <target state="new">Method {0} cannot be called with a collection containing null or empty target names.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyOneCachePluginMustBeSpecified">
         <source>MSB4265: A single project cache plugin must be specified but multiple where found: {0}</source>
-        <target state="translated">MSB4265: é necessário especificar só um plug-in de cache do projeto, mas foram encontrados vários: {0}</target>
+        <target state="new">MSB4265: A single project cache plugin must be specified but multiple where found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheException">
         <source>MSB4273: The project cache threw an unhandled exception from the {0} method.</source>
-        <target state="translated">MSB4273: O cache do projeto lançou uma exceção sem tratamento do método {0}.</target>
+        <target state="new">MSB4273: The project cache threw an unhandled exception from the {0} method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheInitializationFailed">
         <source>MSB4266: Failed to initialize the project cache.</source>
-        <target state="translated">MSB4266: falha ao inicializar o cache do projeto.</target>
+        <target state="new">MSB4266: Failed to initialize the project cache.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheQueryFailed">
         <source>MSB4267: The project cache failed while being queried for the following project: {0}. The cache is queried in parallel for multiple projects so this specific project might not be the cause.</source>
-        <target state="translated">MSB4267: falha no cache do projeto durante a consulta do seguinte projeto: {0}. O cache é consultado em paralelo quanto a vários projetos, portanto, esse projeto específico pode não ser a causa.</target>
+        <target state="new">MSB4267: The project cache failed while being queried for the following project: {0}. The cache is queried in parallel for multiple projects so this specific project might not be the cause.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCacheShutdownFailed">
         <source>MSB4268: The project cache failed to shut down properly.</source>
-        <target state="translated">MSB4268: falha ao desligar o cache do projeto corretamente.</target>
+        <target state="new">MSB4268: The project cache failed to shut down properly.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
-        <target state="translated">MSB4250: O ProjectGraph não tem suporte para os itens ProjectReference com o conjunto de metadados ToolsVersion. O ProjectReference "{0}" foi encontrado com ToolsVersion no arquivo "{1}"</target>
+        <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>
         <note>
       {StrBegin="MSB4250: "}
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
@@ -249,47 +249,47 @@
       </trans-unit>
       <trans-unit id="ProjectImportSkippedExpressionEvaluatedToEmpty">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the expression evaluating to an empty string.</source>
-        <target state="translated">O projeto "{0}" não foi importado por "{1}" em ({2},{3}), porque a expressão foi avaliada como uma cadeia de caracteres vazia.</target>
+        <target state="new">Project "{0}" was not imported by "{1}" at ({2},{3}), due to the expression evaluating to an empty string.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="translated">Valor inicial da propriedade: $({0})="{1}" Origem: {2}</target>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProxyRequestNotScheduledOnInprocNode">
         <source>MSB4274: Disabling the inproc node leads to performance degradation when using project cache plugins that emit proxy build requests.</source>
-        <target state="translated">MSB4274: desativar o nó inproc leva à degradação do desempenho ao usar plug-ins de cache de projeto que emitem solicitações de construção de proxy.</target>
+        <target state="new">MSB4274: Disabling the inproc node leads to performance degradation when using project cache plugins that emit proxy build requests.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
-        <target state="translated">MSB4260: o projeto "{0}" ignorou as restrições de isolamento do gráfico no projeto referenciado "{1}"</target>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
         <note>
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
-        <target state="translated">"MSB4264: propriedade $(SolutionPath) inválida: {0}"</target>
+        <target state="new">"MSB4264: Invalid $(SolutionPath) property: {0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="StaticGraphAcceptsSingleSolutionEntryPoint">
         <source>MSB4261: Multiple entry points with solutions detected: {0}. If static graph is loaded from a solution, that that solution must be the only entry point.</source>
-        <target state="translated">MSB4261: Vários pontos de entrada com soluções detectados: {0}. Se o grafo estático for carregado de uma solução, ela precisará ser o único ponto de entrada.</target>
+        <target state="new">MSB4261: Multiple entry points with solutions detected: {0}. If static graph is loaded from a solution, that that solution must be the only entry point.</target>
         <note>
       LOCALIZATION: {0} is a semicolon delimited list of files
     </note>
       </trans-unit>
       <trans-unit id="StaticGraphConstructionMetrics">
         <source>Static graph loaded in {0} seconds: {1} nodes, {2} edges</source>
-        <target state="translated">Grafo estático carregado em {0} segundos: {1} nós, {2} bordas</target>
+        <target state="new">Static graph loaded in {0} seconds: {1} nodes, {2} edges</target>
         <note />
       </trans-unit>
       <trans-unit id="StaticGraphDoesNotSupportSlnReferences">
         <source>MSB4263: Project "{0}" has a reference to solution file "{1}". Referencing solutions is not supported in static graph.
     </source>
-        <target state="translated">MSB4263: o projeto "{0}" tem uma referência ao arquivo de solução "{1}". Não há suporte para fazer referência a soluções no grafo estático.
+        <target state="new">MSB4263: Project "{0}" has a reference to solution file "{1}". Referencing solutions is not supported in static graph.
     </target>
         <note>
       LOCALIZATION: {0} and {1} are file paths
@@ -300,9 +300,9 @@
            Warnings: {1}
            Errors: {2}
     </source>
-        <target state="translated">MSB4262: o arquivo de solução "{0}" contém os seguintes avisos e erros:
-           Avisos: {1}
-           Erros: {2}
+        <target state="new">MSB4262: Solution file "{0}" contains the following warnings and errors:
+           Warnings: {1}
+           Errors: {2}
     </target>
         <note>
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
@@ -310,27 +310,27 @@
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
-        <target state="translated">A tarefa "{0}" solicitou {1} núcleos, adquiriu {2} núcleos e agora contém {3} núcleos no total.</target>
+        <target state="new">Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
-        <target state="translated">A tarefa "{0}" liberou {1} núcleos e agora contém {2} núcleos no total.</target>
+        <target state="new">Task "{0}" released {1} cores and now holds {2} cores total.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskReleasedCoresWarning">
         <source>Task "{0}" asked to release {1} cores while holding only {2} and now holds {3} cores total.</source>
-        <target state="translated">A tarefa "{0}" solicitou a liberação de {1} núcleos enquanto continha somente {2} e agora contém {3} núcleos no total.</target>
+        <target state="new">Task "{0}" asked to release {1} cores while holding only {2} and now holds {3} cores total.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskReturnedFalseButDidNotLogError">
         <source>MSB4181: The "{0}" task returned false but did not log an error.</source>
-        <target state="translated">MSB4181: A tarefa "{0}" retornou false, mas não registrou um erro.</target>
+        <target state="new">MSB4181: The "{0}" task returned false but did not log an error.</target>
         <note>{StrBegin="MSB4181: "}</note>
       </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: a tarefa MSBuild está criando projetos "{0}" que não estão especificados no item ProjectReference. Nos builds isolados, isso provavelmente significa que as referências não estão explicitamente especificadas como um item ProjectReference em "{1}"</target>
+        <target state="new">MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
@@ -338,206 +338,206 @@
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
-        <target state="translated">Ler a propriedade não inicializada "{0}"</target>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
-        <target state="translated">Usando caches de resultados de build de entrada: {0}</target>
+        <target state="new">Using input build results caches: {0}</target>
         <note>
       LOCALIZATION: {0} is a list of semicolon separated file paths
     </note>
       </trans-unit>
       <trans-unit id="WaitingForEndOfBuild">
         <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
-        <target state="translated">A operação não pode ser concluída porque EndBuild já foi chamado, mas os envios existentes ainda não foram concluídos.</target>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SubmissionAlreadyComplete">
         <source>The operation cannot be completed because the submission has already been executed.</source>
-        <target state="translated">A operação não pode ser concluída porque o envio já foi executado.</target>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
         <source>Cannot dispose the build manager because it is not idle.</source>
-        <target state="translated">Não é possível descartar o gerenciador de compilação porque ele não está ocioso.</target>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildAbortedWithMessage">
         <source>MSB4197: Build was canceled. {0}</source>
-        <target state="translated">MSB4197: A compilação foi cancelada. {0}</target>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
         <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
       </trans-unit>
       <trans-unit id="BuildFinishedFailure">
         <source>Build FAILED.</source>
-        <target state="translated">FALHA da compilação.</target>
+        <target state="new">Build FAILED.</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildFinishedSuccess">
         <source>Build succeeded.</source>
-        <target state="translated">Compilação com êxito.</target>
+        <target state="new">Build succeeded.</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildStartedWithTime">
         <source>Build started {0}.</source>
-        <target state="translated">Compilação de {0} iniciada.</target>
+        <target state="new">Build started {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildTargetCompletely">
         <source>Building target "{0}" completely.</source>
-        <target state="translated">Compilação de destino "{0}" concluída.</target>
+        <target state="new">Building target "{0}" completely.</target>
         <note>{0} is the name of the target.</note>
       </trans-unit>
       <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
         <source>No input files were specified.</source>
-        <target state="translated">Não há arquivos de entrada especificados.</target>
+        <target state="new">No input files were specified.</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildTargetCompletelyInputNewer">
         <source>Input file "{0}" is newer than output file "{1}".</source>
-        <target state="translated">O arquivo de entrada "{0}" é mais recente do que o arquivo de saída "{1}".</target>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
         <note>{0} and {1} are filenames on disk.</note>
       </trans-unit>
       <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
         <source>Output file "{0}" does not exist.</source>
-        <target state="translated">O arquivo de saída "{0}" não existe.</target>
+        <target state="new">Output file "{0}" does not exist.</target>
         <note>{0} is a filename on disk.</note>
       </trans-unit>
       <trans-unit id="BuildTargetCompletelyInputDoesntExist">
         <source>Input file "{0}" does not exist.</source>
-        <target state="translated">O arquivo de entrada "{0}" não existe.</target>
+        <target state="new">Input file "{0}" does not exist.</target>
         <note>{0} is a filename on disk.</note>
       </trans-unit>
       <trans-unit id="BuildTargetPartially">
         <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
-        <target state="translated">Compilando o destino "{0}" parcialmente, pois alguns arquivos de saída estão desatualizados em relação aos arquivos de entrada.</target>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
         <note>{0} is the name of the target.</note>
       </trans-unit>
       <trans-unit id="BuildTargetPartiallyInputNewer">
         <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
-        <target state="translated">[{0}: Input={1}, Output={2}] O arquivo de entrada é mais recente do que o arquivo de saída.</target>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
         <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
       </trans-unit>
       <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
         <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
-        <target state="translated">[{0}: Input={1}, Output={2}] O arquivo de saída não existe.</target>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
         <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
       </trans-unit>
       <trans-unit id="BuildTargetPartiallyInputDoesntExist">
         <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
-        <target state="translated">[{0}: Input={1}, Output={2}] O arquivo de entrada não existe.</target>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
         <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
       </trans-unit>
       <trans-unit id="CannotAccessKnownAttributes">
         <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
-        <target state="translated">O atributo "{0}" é conhecido como atributo do MSBuild, e não pode ser acessado com este método.</target>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotEvaluateItemMetadata">
         <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
-        <target state="translated">MSB4023: Não é possível avaliar o metadados do item "%({0})". {1}</target>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
         <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
     %(RootDir) to an item-spec that's not a valid path, would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
       <trans-unit id="CouldNotFindMSBuildExe">
         <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
-        <target state="translated">MSB4193: O arquivo MSBuild.exe não foi iniciado como um nó filho porque não foi encontrado em "{0}". Se necessário, especifique a localização correta nos BuildParameters ou com a variável de ambiente MSBUILD_EXE_PATH.</target>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
         <note>{StrBegin="MSB4193: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotConnectToMSBuildExe">
         <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
-        <target state="translated">MSB4218: Falha ao iniciar com êxito ou ao conectar a um processo MSBuild.exe filho. Verifique se MSBuild.exe "{0}" é iniciado com êxito e se está carregando a mesma microsoft.build.dll carregada pelo processo de início. Se a localização parecer incorreta, tente especificar a localização correta no objeto BuildParameters ou com a variável de ambiente MSBUILD_EXE_PATH.</target>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
         <note>{StrBegin="MSB4218: "}</note>
       </trans-unit>
       <trans-unit id="CannotModifyReservedItem">
         <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
-        <target state="translated">MSB4117: O nome de item "{0}" é reservado e não pode ser usado.</target>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
         <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
       </trans-unit>
       <trans-unit id="CannotModifyReservedItemMetadata">
         <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
-        <target state="translated">MSB4118: O nome de metadados de item "{0}" é reservado e não pode ser usado.</target>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
         <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
       </trans-unit>
       <trans-unit id="CannotModifyReservedProperty">
         <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
-        <target state="translated">MSB4004: A propriedade "{0}" é reservada e não pode ser modificada.</target>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
         <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
       </trans-unit>
       <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
         <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
-        <target state="translated">MSB4094: "{0}" é um valor inválido para o parâmetro "{1}" da tarefa "{3}". Não é possível passar vários itens para um parâmetro do tipo "{2}".</target>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
         <note>{StrBegin="MSB4094: "}
             UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
     </note>
       </trans-unit>
       <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
         <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
-        <target state="translated">MSB4115: A função "{0}" aceita somente um valor escalar, mas seu argumento "{1}" é avaliado como "{2}", que não é um valor escalar.</target>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
         <note>{StrBegin="MSB4115: "}
         UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
     </note>
       </trans-unit>
       <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
         <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
-        <target state="translated">MSB4095: Os metadados de item %({0}) estão sendo usados como referência sem um nome de item.  Especifique o nome de item usando %(itemname.{0}).</target>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
         <note>{StrBegin="MSB4095: "}</note>
       </trans-unit>
       <trans-unit id="ChildElementsBelowRemoveNotAllowed">
         <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
-        <target state="translated">MSB4162: &lt;{0}&gt; não é válido. Elementos filho não são permitidos abaixo de um elemento de remoção de itens.</target>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
-        <target state="translated">MSB4166: O nó filho "{0}" foi encerrado prematuramente. Desligando. Informações de diagnóstico poderão ser encontradas nos arquivos em "{1}" e estarão nomeadas como MSBuild_*.failure.txt. Esse local pode ser alterado por meio da configuração da variável de ambiente MSBUILDDEBUGPATH para um diretório diferente.{2}</target>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</target>
         <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
-        <target state="translated">MSB4085: Um &lt;Choose&gt; deve conter pelo menos um &lt;When&gt;.</target>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
         <note>{StrBegin="MSB4085: "}</note>
       </trans-unit>
       <trans-unit id="ChooseOverflow">
         <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
-        <target state="translated">MSB4114: Os elementos &lt;Choose&gt; não podem ser aninhados a mais de {0} níveis de profundidade.</target>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
         <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
     LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
       </trans-unit>
       <trans-unit id="ComparisonOnNonNumericExpression">
         <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
-        <target state="translated">MSB4086: Houve uma tentativa de comparação numérica em "{1}", que é avaliada como "{2}" em vez de um número, na condição "{0}".</target>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
         <note>{StrBegin="MSB4086: "}</note>
       </trans-unit>
       <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
         <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
-        <target state="translated">MSB4130: A condição "{0}" pode ter sido avaliada incorretamente em uma versão anterior do MSBuild. Verifique se a ordem das cláusulas AND e OR está gravada da forma desejada. Para evitar este aviso, adicione parênteses para tornar explícita a ordem da avaliação.</target>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
         <note>{StrBegin="MSB4130: "}</note>
       </trans-unit>
       <trans-unit id="ConditionNotBoolean">
         <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
-        <target state="translated">MSB4087: A condição especificada "{0}" não é avaliada como booliana.</target>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
         <note>{StrBegin="MSB4087: "}</note>
       </trans-unit>
       <trans-unit id="ConditionNotBooleanDetail">
         <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
-        <target state="translated">MSB4113: A condição especificada "{0}" é avaliada como "{1}" em vez de booliana.</target>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
         <note>{StrBegin="MSB4113: "}</note>
       </trans-unit>
       <trans-unit id="ConfigFileReadError">
         <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
-        <target state="translated">MSB4136: Erro ao ler as informações do conjunto de ferramentas no arquivo de configuração "{0}". {1}</target>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
         <note>{StrBegin="MSB4136: "}</note>
       </trans-unit>
       <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
         <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
-        <target state="translated">MSB4142: MSBuildToolsPath não é o mesmo que MSBuildBinPath para ToolsVersion"{0}" definido em "{1}". Se ambos estiverem presentes, deverão ter o mesmo valor.</target>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
         <note>{StrBegin="MSB4142: "}</note>
       </trans-unit>
       <trans-unit id="DefaultTasksFileFailure">
         <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
-        <target state="translated">MSB4009: O arquivo de tarefas padrão não foi carregado com êxito. {0}</target>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
         <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
     be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
     separately to loggers.
@@ -545,14 +545,14 @@
       </trans-unit>
       <trans-unit id="DefaultTasksFileLoadFailureWarning">
         <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
-        <target state="translated">MSB4010: Os arquivos "{0}" não foram carregados com êxito da localização esperada "{1}". As tarefas padrão não estarão disponíveis. {2}</target>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
         <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
     found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
     LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">A importação do arquivo "{0}" no arquivo "{1}" resultará em uma dependência circular.</target>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -560,17 +560,17 @@
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">
         <source>Search paths being used for {0} are {1}</source>
-        <target state="translated">Os caminhos de pesquisa usados para {0} são {1}</target>
+        <target state="new">Search paths being used for {0} are {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TryingExtensionsPath">
         <source>Trying to import {0} using extensions path {1}</source>
-        <target state="translated">Tentando importar {0} usando o caminho das extensões {1}</target>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideTasksFileFailure">
         <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
-        <target state="translated">MSB4194: O arquivo de substituição de tarefas não foi carregado com êxito. {0}</target>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
         <note>
       {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
       be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
@@ -580,21 +580,21 @@
       </trans-unit>
       <trans-unit id="OverrideTaskNotRootedPath">
         <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
-        <target state="translated">O caminho das tarefas de substituição "{0}" não deve ser um caminho relativo e deve existir no disco. As tarefas padrão não serão substituídas.</target>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
         <note>
         UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
     </note>
       </trans-unit>
       <trans-unit id="OverrideTaskProblemWithPath">
         <source>A problem occurred loading the override tasks path "{0}". {1}</source>
-        <target state="translated">Problema ao carregar o caminho de tarefas de substituição "{0}". {1}</target>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
         <note>
         UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
     </note>
       </trans-unit>
       <trans-unit id="OverrideTasksFileLoadFailureWarning">
         <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
-        <target state="translated">MSB4196: Os arquivos "{0}" não foram carregados com êxito da localização esperada "{1}". As tarefas padrão não serão substituídas. {2}</target>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
         <note>
       {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
       found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
@@ -603,235 +603,255 @@
       </trans-unit>
       <trans-unit id="TasksPropertyBagError">
         <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
-        <target state="translated">MSB4195: Erro ao reunir propriedades para avaliação de arquivo de tarefas. {0}</target>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
         <note>
       {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
       </trans-unit>
       <trans-unit id="DefaultToolsVersionNotFound">
         <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
-        <target state="translated">MSB4133: Uma versão das ferramentas padrão "{0}" estava especificada, mas não foi possível localizar a sua definição.</target>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
         <note>{StrBegin="MSB4133: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateImport">
         <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
-        <target state="translated">MSB4011: não é possível importar "{0}" novamente. Esse item já foi importado em "{1}". É provável que esse seja um erro de criação do build. Essa importação subsequente será ignorada. {2}</target>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
         <note>{StrBegin="MSB4011: "}</note>
       </trans-unit>
       <trans-unit id="UsedUninitializedProperty">
         <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
-        <target state="translated">MSB4211: a propriedade "{0}" está sendo definida para um valor pela primeira vez, mas já foi consumida em "{1}".</target>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
         <note>{StrBegin="MSB4211: "}</note>
       </trans-unit>
       <trans-unit id="SelfImport">
         <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
-        <target state="translated">MSB4210: "{0}" está tentando se importar, direta ou indiretamente. É provável que esse seja um erro de criação do build. A importação será ignorada.</target>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
         <note>{StrBegin="MSB4210: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateProjectExtensions">
         <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
-        <target state="translated">MSB4079: O elemento &lt;ProjectExtensions&gt; ocorre mais de uma vez.</target>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
         <note>{StrBegin="MSB4079: "}</note>
       </trans-unit>
       <trans-unit id="EmbeddedItemVectorCannotBeItemized">
         <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
-        <target state="translated">MSB4012: A expressão "{0}" não pode ser usada neste contexto. As listas de itens não podem ser concatenadas com outras cadeias de caracteres em que uma lista de itens é esperada. Use ponto e vírgula para separar várias listas de itens.</target>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
         <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
     e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
       </trans-unit>
       <trans-unit id="EndOfInputTokenName">
         <source>end of input</source>
-        <target state="translated">fim de entrada</target>
+        <target state="new">end of input</target>
         <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
     unexpected char or token when the end of a conditional was unexpectedly reached.</note>
       </trans-unit>
       <trans-unit id="ErrorConvertedIntoWarning">
         <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
-        <target state="translated">O erro anterior foi convertido em aviso porque a tarefa foi chamada com ContinueOnError=true.</target>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorCount">
         <source>{0} Error(s)</source>
-        <target state="translated">{0} Erro(s)</target>
+        <target state="new">{0} Error(s)</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorCreatingToolset">
         <source>MSB4159: Error creating the toolset "{0}". {1}</source>
-        <target state="translated">MSB4159: Erro ao criar o conjunto de ferramentas "{0}". {1}</target>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
         <note>{StrBegin="MSB4159: "}</note>
       </trans-unit>
       <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
         <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
-        <target state="translated">MSB4146: Não é possível avaliar a expressão de propriedade "{0}" encontrada em "{1}". {2}</target>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
         <note>{StrBegin="MSB4146: "}</note>
       </trans-unit>
       <trans-unit id="ErrorWarningMessageNotSupported">
         <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
-        <target state="translated">Não há mais suporte para a marca &lt;{0}&gt; como filho do elemento &lt;Project&gt;. Posicione essa marca dentro de um destino e adicione o nome do destino ao atributo "InitialTargets" do elemento &lt;Project&gt;.</target>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EvaluationStarted">
+        <source>Evaluation started ("{0}")</source>
+        <target state="new">Evaluation started ("{0}")</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EvaluationFinished">
+        <source>Evaluation finished ("{0}")</source>
+        <target state="new">Evaluation finished ("{0}")</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingTaskInTaskHost">
         <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
-        <target state="translated">Iniciando a tarefa "{0}" do assembly "{1}" em um host de tarefas externo com um runtime "{2}" e uma arquitetura de processo "{3}".</target>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
         <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
-        <target state="translated">MSB4100: "{0}" esperado para ser avaliado como booliano em vez de "{1}", na condição "{2}".</target>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
         <note>{StrBegin="MSB4100: "}</note>
       </trans-unit>
       <trans-unit id="FailedToRetrieveTaskOutputs">
         <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
-        <target state="translated">MSB4028: As saídas da tarefa "{0}" não foram recuperadas a partir do parâmetro "{1}". {2}</target>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
         <note>{StrBegin="MSB4028: "}</note>
       </trans-unit>
       <trans-unit id="FatalBuildError">
         <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
-        <target state="translated">MSB4014: A compilação parou inesperadamente devido a uma falha interna.</target>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
         <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
     error in the build engine.</note>
       </trans-unit>
       <trans-unit id="FatalErrorDuringLoggerShutdown">
         <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
-        <target state="translated">MSB4015: A compilação parou inesperadamente porque o agente de log "{0}" falhou inesperadamente durante o desligamento.</target>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
         <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
     because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
     exception to abort the build.</note>
       </trans-unit>
       <trans-unit id="FatalErrorWhileInitializingLogger">
         <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
-        <target state="translated">MSB4016: A compilação parou inesperadamente porque o agente de log "{0}" falhou inesperadamente durante a inicialização.</target>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
         <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>
       </trans-unit>
       <trans-unit id="FatalErrorWhileLogging">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
-        <target state="translated">MSB4017: A compilação parou inesperadamente devido a uma falha do agente de log.</target>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>
       </trans-unit>
       <trans-unit id="FatalTaskError">
         <source>MSB4018: The "{0}" task failed unexpectedly.</source>
-        <target state="translated">MSB4018: Falha inesperada da tarefa "{0}".</target>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
         <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
     programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
     surfaced through the task when the task called into the engine.</note>
       </trans-unit>
       <trans-unit id="FailedToReceiveTaskThreadStatus">
         <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
-        <target state="translated">MSB4187: Falha ao receber uma resposta do thread de tarefa no período de tempo limite de "{0}" ms. Desligando.</target>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
         <note>{StrBegin="MSB4187: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedCondition">
         <source>MSB4088: Condition "{0}" is improperly constructed.</source>
-        <target state="translated">MSB4088: A condição "{0}" foi construída de modo inadequado.</target>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
         <note>{StrBegin="MSB4088: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedEqualsInCondition">
         <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
-        <target state="translated">MSB4105: Caractere "{2}" inesperado na posição {1} da condição "{0}". Você pretendia usar "=="?</target>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
         <note>{StrBegin="MSB4105: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
         <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
-        <target state="translated">MSB4106: Lista de itens esperada na posição {1} da condição "{0}". Você se esqueceu de inserir o parêntese de fechamento?</target>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
         <note>{StrBegin="MSB4106: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
         <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
-        <target state="translated">MSB4107: Lista de itens esperada na posição {1} da condição "{0}". Você se esqueceu de inserir o parêntese de abertura depois de "@"? Para usar "@" literal, use "%40".</target>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
         <note>{StrBegin="MSB4107: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedItemListQuoteInCondition">
         <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
-        <target state="translated">MSB4108: Lista de itens esperada na posição {1} da condição "{0}". Você se esqueceu de fechar aspas dentro da expressão da lista de itens?</target>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
         <note>{StrBegin="MSB4108: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
         <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
-        <target state="translated">MSB4109: Propriedade esperada na posição {1} da condição "{0}". Você se esqueceu de inserir o parêntese de fechamento?</target>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
         <note>{StrBegin="MSB4109: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
-        <target state="translated">MSB4110: Propriedade esperada na posição {1} da condição "{0}". Você se esqueceu de inserir o parêntese de abertura depois do caractere "$"? Para usar um "$" literal, use "%24".</target>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
         <note>{StrBegin="MSB4110: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedQuotedStringInCondition">
         <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: Aspas de fechamento esperadas depois da posição {1} da condição "{0}".</target>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
         <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}" is correct, and that the file exists on disk.</source>
-        <target state="translated">MSB4019: o projeto importado "{0}" não foi localizado. Confirme se a expressão na declaração Import "{1}" está correta e se o arquivo existe no disco.</target>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}" is correct, and that the file exists on disk.</target>
         <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
         <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
-        <target state="translated">MSB4226: o projeto importado "{0}" não foi encontrado. Além disso, houve uma tentativa de localizar "{1}" nos caminhos de pesquisa de fallback de {2} – {3}. Esses caminhos de pesquisa são definidos em "{4}". Confirme se o caminho na declaração &lt;Import&gt; está correto e se o arquivo existe no disco em um dos caminhos de pesquisa.</target>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
         <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
         <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
-        <target state="translated">MSB4226: o projeto importado "{0}" não foi encontrado. Além disso, houve uma tentativa de localizar "{1}" nos caminhos de pesquisa de fallback de {2} – {3}. Confirme se o caminho na declaração &lt;Import&gt; está correto e se o arquivo existe no disco em um dos caminhos de pesquisa.</target>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
         <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="IncorrectNumberOfFunctionArguments">
         <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
-        <target state="translated">MSB4089: Número incorreto de argumentos da função da condição "{0}". Encontrado(s) {1} argumento(s), mas esperava(m)-se {2}.</target>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
         <note>{StrBegin="MSB4089: "}</note>
       </trans-unit>
       <trans-unit id="InvalidAttributeValue">
         <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
-        <target state="translated">MSB4020: O valor "{0}" do atributo "{1}" no elemento &lt;{2}&gt; é inválido.</target>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
         <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
     attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
       </trans-unit>
+      <trans-unit id="InvalidAttributeExclusive">
+        <source>MSB4111: At most one of the include, remove, and update attributes may be specified for an item element.</source>
+        <target state="new">MSB4111: At most one of the include, remove, and update attributes may be specified for an item element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAttributeValueWithException">
         <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
-        <target state="translated">MSB4102: O valor "{0}" do atributo "{1}" no elemento &lt;{2}&gt; é inválido. {3}</target>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
         <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
         attributes. At the end of the message we show the exception text we got trying to use the value.</note>
       </trans-unit>
+      <trans-unit id="InvalidBinaryLoggerParameters">
+        <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
+        <target state="new">MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidContinueOnErrorAttribute">
         <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
-        <target state="translated">MSB4021: O atributo "ContinueOnError" da tarefa "{0}" não é válido. {1}</target>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
         <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
       </trans-unit>
       <trans-unit id="InvalidEvaluatedAttributeValue">
         <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
-        <target state="translated">MSB4022: O resultado "{0}" da avaliação do valor "{1}" do atributo "{2}" no elemento &lt;{3}&gt; não é válido.</target>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
         <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
     properties/items) assigned to an XML attribute of an XML element in the project file.</note>
       </trans-unit>
       <trans-unit id="InvalidFileLoggerFile">
         <source>MSB4104: Failed to write to log file "{0}". {1}</source>
-        <target state="translated">MSB4104: Falha ao gravar no arquivo de log "{0}". {1}</target>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
         <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
       </trans-unit>
       <trans-unit id="InvalidImportedProjectFile">
         <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
-        <target state="translated">MSB4024: O arquivo de projeto importado "{0}" não foi carregado. {1}</target>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
         <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
     filename is not part of the message because it is provided separately to loggers.
     LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
       </trans-unit>
       <trans-unit id="InvalidPropertyNameInToolset">
         <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
-        <target state="translated">MSB4147: A propriedade "{0}" em "{1}" não é válida. {2}</target>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
         <note>{StrBegin="MSB4147: "}</note>
       </trans-unit>
       <trans-unit id="InvalidProperty">
         <source>MSB4177: Invalid property. {0}</source>
-        <target state="translated">MSB4177: Propriedade inválida. {0}</target>
+        <target state="new">MSB4177: Invalid property. {0}</target>
         <note>{StrBegin="MSB4177: "}
       UE: {0} is a localized message indicating what the problem was.</note>
       </trans-unit>
       <trans-unit id="InvalidRegistryPropertyExpression">
         <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
-        <target state="translated">MSB4143: A expressão do Registro "{0}" não pode ser avaliada. {1}</target>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
         <note>{StrBegin="MSB4143: "}
       UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
       LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
@@ -839,7 +859,7 @@
       </trans-unit>
       <trans-unit id="InvalidFunctionPropertyExpression">
         <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
-        <target state="translated">MSB4184: A expressão "({0})" não pode ser avaliada. {1}</target>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
         <note>{StrBegin="MSB4184: "}
       Double quotes as the expression will typically have single quotes in it.
       UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
@@ -848,22 +868,22 @@
       </trans-unit>
       <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
         <source>The quotes were mismatched.</source>
-        <target state="translated">Aspas incompatíveis.</target>
+        <target state="new">The quotes were mismatched.</target>
         <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
       </trans-unit>
       <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
         <source>The parentheses were mismatched.</source>
-        <target state="translated">Parênteses incompatíveis.</target>
+        <target state="new">The parentheses were mismatched.</target>
         <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
       </trans-unit>
       <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
         <source>The square brackets were mismatched.</source>
-        <target state="translated">Os colchetes não correspondiam.</target>
+        <target state="new">The square brackets were mismatched.</target>
         <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
       </trans-unit>
       <trans-unit id="InvalidFunctionMethodUnavailable">
         <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
-        <target state="translated">MSB4185: a função "{0}" no tipo "{1}" não está disponível para execução como uma função de propriedade do MSBuild.</target>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
         <note>
       {StrBegin="MSB4185: "}
       UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
@@ -872,7 +892,7 @@
       </trans-unit>
       <trans-unit id="InvalidFunctionTypeUnavailable">
         <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
-        <target state="translated">MSB4212: Sintaxe de invocação de método estático inválida: "{0}". O tipo "{1}" não está disponível para execução em uma função de propriedade do MSBuild ou não foi encontrado.</target>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
         <note>
       {StrBegin="MSB4212: "}
       UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
@@ -881,7 +901,7 @@
       </trans-unit>
       <trans-unit id="InvalidFunctionStaticMethodSyntax">
         <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). Check that all parameters are defined, are of the correct type, and are specified in the right order.</source>
-        <target state="translated">MSB4186: Sintaxe de invocação de método estático inválida: "{0}". {1} A invocação do método estático deve estar no formato: $([FullTypeName]::Method()), por exemplo $([System.IO.Path]::Combine(`a`, `b`)). Verifique se todos os parâmetros estão definidos, se são do tipo correto e se estão especificados na ordem correta.</target>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). Check that all parameters are defined, are of the correct type, and are specified in the right order.</target>
         <note>{StrBegin="MSB4186: "}
       UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
       LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
@@ -889,7 +909,7 @@
       </trans-unit>
       <trans-unit id="InvalidItemFunctionExpression">
         <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
-        <target state="translated">MSB4198: A expressão "{0}" não pode ser avaliada no item "{1}". {2}</target>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
         <note>
       {StrBegin="MSB4198: "}
       Double quotes as the expression will typically have single quotes in it.
@@ -899,7 +919,7 @@
       </trans-unit>
       <trans-unit id="InvalidItemFunctionSyntax">
         <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
-        <target state="translated">MSB4199: Sintaxe de transformação "{0}" inválida. Não foi encontrada uma função de item com esse nome e parâmetros {1}.</target>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
         <note>
       {StrBegin="MSB4199: "}
       UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
@@ -908,7 +928,7 @@
       </trans-unit>
       <trans-unit id="UnknownItemFunction">
         <source>MSB4200: Unknown item transformation function "{0}".</source>
-        <target state="translated">MSB4200: Função de transformação de item "{0}" desconhecida.</target>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
         <note>
       {StrBegin="MSB4200: "}
       UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
@@ -917,430 +937,440 @@
       </trans-unit>
       <trans-unit id="InvalidTaskAttributeError">
         <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
-        <target state="translated">MSB4026: O parâmetro "{0}={1}" da tarefa "{2}" é inválido.</target>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
         <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
       </trans-unit>
       <trans-unit id="InvalidTaskItemsInTaskOutputs">
         <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
-        <target state="translated">MSB4027: A tarefa "{0}" gerou itens inválidos a partir do parâmetro de saída "{1}". {2}</target>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
         <note>{StrBegin="MSB4027: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTaskOutputSpecification">
         <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
-        <target state="translated">MSB4029: A tarefa "{0}" tem uma especificação de saída inválida. O atributo "TaskParameter" é obrigatório e o atributo "ItemName" ou "PropertyName" deve ser especificado (mas não os dois).</target>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
         <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidTaskParameterValueError">
         <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
-        <target state="translated">MSB4030: "{0}" é um valor inválido para o parâmetro "{1}" da tarefa "{3}". O parâmetro "{1}" é do tipo "{2}".</target>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
         <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
     and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
     is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
       </trans-unit>
       <trans-unit id="InvalidToolsetValueInConfigFileValue">
         <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
-        <target state="translated">MSB4137: Valor inválido especificado no arquivo de configuração em "{0}". O nome da propriedade ou o nome da versão das ferramentas é uma cadeia de caracteres vazia.</target>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
         <note>{StrBegin="MSB4137: "}</note>
       </trans-unit>
       <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
         <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
-        <target state="translated">MSB4163: &lt;ItemDefinitionGroup&gt; não permitido em um destino.</target>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
         <note>{StrBegin="MSB4163: "}</note>
       </trans-unit>
       <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
         <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
-        <target state="translated">MSB4096: O item "{0}" na lista de itens "{1}" não define um valor dos metadados "{2}".  Para usar esses metadados, qualifique-os especificando %({1}.{2}) ou assegure-se de que todos os itens na lista apresentem um valor definido para esses metadados.</target>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
         <note>{StrBegin="MSB4096: "}</note>
       </trans-unit>
       <trans-unit id="ItemListNotAllowedInThisConditional">
         <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
-        <target state="translated">MSB4099: Não é permitida uma referência a uma lista de itens na posição {1} da condição "{0}".</target>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
         <note>{StrBegin="MSB4099: "}</note>
       </trans-unit>
       <trans-unit id="CustomMetadataNotAllowedInThisConditional">
         <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
-        <target state="translated">MSB4191: A referência aos metadados personalizados "{2}" na posição {1} não é permitida nesta condição "{0}".</target>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
         <note>{StrBegin="MSB4191: "}</note>
       </trans-unit>
       <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
         <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
-        <target state="translated">MSB4190: A referência aos metadados internos "{2}" na posição {1} não é permitida nesta condição "{0}".</target>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
         <note>{StrBegin="MSB4190: "}</note>
       </trans-unit>
       <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
         <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
-        <target state="translated">MSB4033: "{0}" são metadados de item reservado e não pode ser redefinido como metadados personalizado no item.</target>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
         <note>{StrBegin="MSB4033: "}</note>
       </trans-unit>
       <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
         <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
-        <target state="translated">InternalLoggerException pode ser acionado somente pelo mecanismo MSBuild. Os construtores públicos desta classe não podem ser usados para criar uma instância da exceção.</target>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
         <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
     only the engine is allowed to create and throw this exception.
     LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
       </trans-unit>
       <trans-unit id="ItemListHeader">
         <source>Initial Items:</source>
-        <target state="translated">Itens iniciais:</target>
+        <target state="new">Initial Items:</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentHeader">
         <source>Environment at start of build:</source>
-        <target state="translated">Ambiente no início da compilação:</target>
+        <target state="new">Environment at start of build:</target>
         <note />
       </trans-unit>
       <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
         <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
-        <target state="translated">MSB4164: O valor "{0}" dos metadados "{1}" contém uma expressão de lista de itens. Essas expressões não são permitidas em valores de metadados padrão.</target>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
         <note>{StrBegin="MSB4164: "}</note>
       </trans-unit>
       <trans-unit id="MissingRequiredAttribute">
         <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
-        <target state="translated">MSB4035: o atributo "{0}" obrigatório está vazio ou não tem o elemento &lt;{1}&gt;.</target>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
         <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
     e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
       </trans-unit>
+      <trans-unit id="IncludeRemoveOrUpdate">
+        <source>MSB4232: Items that are outside Target elements must have one of the following operations: Include, Update, or Remove.</source>
+        <target state="new">MSB4232: Items that are outside Target elements must have one of the following operations: Include, Update, or Remove.</target>
+        <note>{StrBegin="MSB4232: "} Target, Include, Update, and Remove should not be localized and their casing should not be changed</note>
+      </trans-unit>
       <trans-unit id="MissingTaskError">
         <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
-        <target state="translated">MSB4036: A tarefa "{0}" não foi encontrada. Verifique se: 1.) O nome da tarefa no arquivo de projeto é o mesmo nome da classe da tarefa. 2.) A classe da tarefa é "public" e implementa a interface Microsoft.Build.Framework.ITask. 3.) A tarefa está declarada corretamente com &lt;UsingTask&gt; no arquivo de projeto ou nos arquivos *.tasks localizados no diretório "{1}".</target>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
         <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
       </trans-unit>
       <trans-unit id="MSBuildToolsPathIsNotSpecified">
         <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
-        <target state="translated">MSB4141: MSBuildToolsPath não está especificado para a ToolsVersion "{0}" definida em "{1}" ou o valor especificado resulta na cadeia de caracteres vazia.</target>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
         <note>{StrBegin="MSB4141: "}</note>
       </trans-unit>
       <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
         <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
-        <target state="translated">MSB4222: ToolsVersion "{0}", definido em "{1}", contém o subconjunto de ferramentas "{2}", que define MSBuildBinPath ou MSBuildToolsPath. Não há suporte para essa condição nos subconjuntos de ferramentas.</target>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleDefinitionsForSameToolset">
         <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
-        <target state="translated">MSB4144: Várias definições foram encontradas para o conjunto de ferramentas "{0}". </target>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
         <note>{StrBegin="MSB4144: "}</note>
       </trans-unit>
       <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
         <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
-        <target state="translated">MSB4225: O conjunto de ferramentas contém várias definições de searchPaths para o SO "{0}" em "{1}".</target>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
         <note>{StrBegin="MSB4225: "}</note>
       </trans-unit>
       <trans-unit id="MultipleDefinitionsForSameProperty">
         <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
-        <target state="translated">MSB4145: Várias definições foram encontradas para a propriedade "{0}".</target>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
         <note>{StrBegin="MSB4145: "}</note>
       </trans-unit>
       <trans-unit id="MultipleOtherwise">
         <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
-        <target state="translated">MSB4082: Choose tem mais de um elemento &lt;Otherwise&gt;.</target>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
         <note>{StrBegin="MSB4082: "}</note>
       </trans-unit>
       <trans-unit id="NodeMustBeLastUnderElement">
         <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
-        <target state="translated">MSB4038: O elemento &lt;{0}&gt; deve ser o último sob o elemento &lt;{1}&gt;. Encontrado o elemento &lt;{2}&gt;.</target>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
         <note>{StrBegin="MSB4038: "}</note>
       </trans-unit>
       <trans-unit id="NonStringDataInRegistry">
         <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
-        <target state="translated">MSB4138: Dados que não são de cadeia de caracteres foram especificados no local do Registro "{0}".</target>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
         <note>{StrBegin="MSB4138: "}</note>
       </trans-unit>
       <trans-unit id="NoRootProjectElement">
         <source>MSB4039: No "{0}" element was found in the project file.</source>
-        <target state="translated">MSB4039: Não foi encontrado nenhum elemento "{0}" no arquivo de projeto.</target>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
         <note>{StrBegin="MSB4039: "}</note>
       </trans-unit>
       <trans-unit id="NoTargetSpecified">
         <source>MSB4040: There is no target in the project.</source>
-        <target state="translated">MSB4040: Não há destino no projeto.</target>
+        <target state="new">MSB4040: There is no target in the project.</target>
         <note>{StrBegin="MSB4040: "}</note>
       </trans-unit>
       <trans-unit id="NullLoggerNotAllowed">
         <source>A null entry was found in the collection of loggers.</source>
-        <target state="translated">Uma entrada nula foi encontrada na coleção de agentes de log.</target>
+        <target state="new">A null entry was found in the collection of loggers.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxNodeCount">
         <source>MaxNodeCount may only be assigned a value greater than zero.</source>
-        <target state="translated">Somente um valor maior que zero pode ser atribuído a MaxNodeCount.</target>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverridingTarget">
         <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
-        <target state="translated">Substituindo o destino "{0}" no projeto "{1}" pelo destino "{2}" do projeto "{3}".</target>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="PerformanceLine">
         <source>{0} ms  {1} {2} calls</source>
-        <target state="translated">{0} ms {1} {2} chamadas</target>
+        <target state="new">{0} ms  {1} {2} calls</target>
         <note />
       </trans-unit>
       <trans-unit id="PerformanceReentrancyNote">
         <source>(* = timing was not recorded because of reentrancy)</source>
-        <target state="translated">(* = o tempo não foi gravado devido à reentrância)</target>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileNotFound">
         <source>The project file "{0}" was not found.</source>
-        <target state="translated">O arquivo de projeto "{0}" não foi encontrado.</target>
+        <target state="new">The project file "{0}" was not found.</target>
         <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
       </trans-unit>
       <trans-unit id="ProjectFinishedFailure">
         <source>Done building project "{0}" -- FAILED.</source>
-        <target state="translated">Projeto de compilação pronto "{0}" -- FALHA.</target>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFinishedSuccess">
         <source>Done building project "{0}".</source>
-        <target state="translated">Projeto de compilação pronto "{0}".</target>
+        <target state="new">Done building project "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
         <source>Done Building Project "{0}" ({1} target(s)).</source>
-        <target state="translated">Projeto de compilação pronto "{0}" ({1} destino(s)).</target>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
         <source>Done Building Project "{0}" (default targets).</source>
-        <target state="translated">Projeto de compilação pronto "{0}" (destinos padrão).</target>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
         <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
-        <target state="translated">Projeto de compilação pronto "{0}" ({1} destino(s)) -- FALHA.</target>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
         <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
-        <target state="translated">Projeto de compilação pronto "{0}" (destinos padrão) -- FALHA.</target>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: o namespace de XML padrão do projeto precisa ser o namespace de XML do MSBuild ou não ser nenhum namespace. Se o projeto foi criado no formato do MSBuild 2003, adicione xmlns="{0}" ao elemento &lt;Project&gt;. Se o projeto foi criado nos antigos formatos 1.0 ou 1.2, converta-o para o formato do MSBuild 2003.</target>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
       <trans-unit id="ProjectPerformanceSummary">
         <source>Project Performance Summary:</source>
-        <target state="translated">Resumo do Desempenho do Projeto:</target>
+        <target state="new">Project Performance Summary:</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
         <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
-        <target state="translated">O projeto "{0}" está compilando "{1}" ({2} destino(s)):</target>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
         <source>Project "{0}" is building "{1}" (default targets):</source>
-        <target state="translated">O projeto "{0}" está compilando "{1}" (destinos padrão):</target>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
         <source>Project "{0}" ({1} target(s)):</source>
-        <target state="translated">Projeto "{0}" ({1} destino(s)):</target>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
         <source>Project "{0}" (default targets):</source>
-        <target state="translated">Projeto "{0}" (destinos padrão):</target>
+        <target state="new">Project "{0}" (default targets):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectTaskNameEmpty">
         <source>Task name cannot be empty.</source>
-        <target state="translated">O nome da tarefa não pode ficar vazio.</target>
+        <target state="new">Task name cannot be empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
         <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: O arquivo de projeto "{0}" must deve ser aberto no IDE do Visual Studio e convertido na versão mais recente, para que possa ser compilado pelo MSBuild.</target>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">
         <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
-        <target state="translated">MSB4192: O arquivo de projeto "{0}" está no formato de arquivo ".vcproj", ao qual o MSBuild não dá mais suporte. Converta o projeto abrindo-o no IDE do Visual Studio ou executando a ferramenta de conversão ou use o MSBuild 3.5 ou anterior para compilá-lo.</target>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
         <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
       </trans-unit>
       <trans-unit id="PropertyListHeader">
         <source>Initial Properties:</source>
-        <target state="translated">Propriedades iniciais:</target>
+        <target state="new">Initial Properties:</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNameInRegistryHasZeroLength">
         <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
-        <target state="translated">MSB4148: O nome de uma propriedade armazenada na chave do Registro "{0}" tem comprimento zero.</target>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
         <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="PropertyReassignment">
+        <source>Property reassignment: $({0})="{1}" (previous value: "{2}") at {3}</source>
+        <target state="new">Property reassignment: $({0})="{1}" (previous value: "{2}") at {3}</target>
+        <note />
       </trans-unit>
       <trans-unit id="QualifiedMetadataInTransformNotAllowed">
         <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
-        <target state="translated">MSB4043: A referência aos metadados de item "{0}" é inválida porque está qualificada com um nome de item. Os metadados de item referenciados nas transformações não precisam ser qualificados porque o nome do item é deduzido automaticamente com base nos itens sendo transformados. Altere "{0}" para "%({1})".</target>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
         <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
     "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
     item list type.</note>
       </trans-unit>
       <trans-unit id="RegistryReadError">
         <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
-        <target state="translated">MSB4135: Erro ao ler as informações do conjunto de ferramentas no local do Registro "{0}". {1}</target>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
         <note>{StrBegin="MSB4135: "}</note>
       </trans-unit>
       <trans-unit id="RequiredPropertyNotSetError">
         <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
-        <target state="translated">MSB4044: A tarefa "{0}" não recebeu um valor para o parâmetro obrigatório "{1}".</target>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
         <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
       </trans-unit>
       <trans-unit id="SecurityProjectBuildDisabled">
         <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
-        <target state="translated">MSB4112: Os destinos neste projeto foram desabilitados pelo host e, portanto, não podem ser compilados neste momento. Esse procedimento deve ter sido executado por questão de segurança. Para habilitar os destinos, o host deve definir Project.BuildEnabled como "true".</target>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
         <note>{StrBegin="MSB4112: "}</note>
       </trans-unit>
       <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
         <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
-        <target state="translated">MSB4093: O parâmetro "{0}" da tarefa "{1}" não pode ser gravado porque não tem um acessador "set".</target>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
         <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
     accessor on the corresponding .NET property on the task class.</note>
       </trans-unit>
       <trans-unit id="SkipTargetBecauseNoInputs">
         <source>Skipping target "{0}" because it has no inputs.</source>
-        <target state="translated">Ignorando o destino "{0}" porque ele não tem entradas.</target>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkipTargetBecauseNoInputsDetail">
         <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
-        <target state="translated">Embora o destino tenha declarado suas entradas, a especificação da entrada faz referência somente às propriedades e/ou listas de itens vazias.</target>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkipTargetBecauseNoOutputs">
         <source>Skipping target "{0}" because it has no outputs.</source>
-        <target state="translated">Ignorando o destino "{0}" porque ele não tem saídas.</target>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkipTargetBecauseNoOutputsDetail">
         <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
-        <target state="translated">Embora o destino tenha declarado suas saídas, a especificação da saída faz referência somente às propriedades e/ou listas de itens vazias.</target>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkipTargetBecauseOutputsUpToDate">
         <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
-        <target state="translated">Ignorando o destino "{0}" porque todos os arquivos de saída estão atualizados em relação aos arquivos de entrada.</target>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkipTargetUpToDateInputs">
         <source>Input files: {0}</source>
-        <target state="translated">Arquivos de entrada: {0}</target>
+        <target state="new">Input files: {0}</target>
         <note>{0} is a semicolon-separated list of filenames.</note>
       </trans-unit>
       <trans-unit id="SkipTargetUpToDateOutputs">
         <source>Output files: {0}</source>
-        <target state="translated">Arquivos de saída: {0}</target>
+        <target state="new">Output files: {0}</target>
         <note>{0} is a semicolon-separated list of filenames.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
         <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
-        <target state="translated">{0}: O padrão usado para .NET Framework v{1} é a versão .NET Framework v4.0 do aspnet_compiler.exe. Para alterar a versão da ferramenta usada, defina o parâmetro "ToolPath" com o caminho correto da ferramenta.</target>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
         <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
-        <target state="translated">MSB4203: {0}: TargetFrameworkMoniker inválido {1}. A tarefa AspNetCompiler dá suporte apenas ao direcionamento do .NET Framework.</target>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
         <note>{StrBegin="MSB4203: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.20NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
-        <target state="translated">MSB4205: O projeto de site nesta solução está direcionando o runtime v2.0, mas ele não está instalado.</target>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
         <note>{StrBegin="MSB4205: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
         <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
-        <target state="translated">MSB4204: {0}: TargetFrameworkMoniker inválido {1}. {2}.</target>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
         <note>{StrBegin="MSB4204: "}</note>
       </trans-unit>
       <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
         <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
-        <target state="translated">Usando o gerador de wrapper da solução MSBuild v3.5 porque a versão das ferramentas foi definida como {0}.</target>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
         <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
-        <target state="translated">Usando o gerador de wrapper da solução MSBuild v3.5 com uma versão de ferramentas {0} porque o formato de arquivo da solução era versão {1} e nenhuma versão de ferramentas foi fornecida.</target>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionBuildingSolutionConfiguration">
         <source>Building solution configuration "{0}".</source>
-        <target state="translated">Compilando a configuração de solução "{0}".</target>
+        <target state="new">Building solution configuration "{0}".</target>
         <note>UE: This is not an error, so doesn't need an error code.</note>
       </trans-unit>
       <trans-unit id="SolutionCircularDependencyError">
         <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
-        <target state="translated">MSB4160: Foi detectada uma dependência circular envolvendo o projeto "{0}".</target>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
         <note>{StrBegin="MSB4160: "}</note>
       </trans-unit>
       <trans-unit id="SolutionInvalidSolutionConfiguration">
         <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
-        <target state="translated">MSB4126: A configuração da solução especificada "{0}" é inválida. Especifique uma configuração de solução válida com as propriedades Configuration e Platform (por exemplo, MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Qualquer CPU") ou deixe essas propriedades em branco para usar a configuração de solução padrão.</target>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
         <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseErrorReadingProject">
         <source>MSB4046: Error reading project file "{0}": {1}</source>
-        <target state="translated">MSB4046: Erro ao ler o arquivo de projeto "{0}": {1}</target>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
         <note>{StrBegin="MSB4046: "}</note>
       </trans-unit>
       <trans-unit id="SolutionParseInvalidProjectFileName">
         <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
-        <target state="translated">MSB4125: O nome de arquivo de projeto "{0}" é inválido. {1}</target>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
         <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseProjectDepNotFoundError">
         <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
-        <target state="translated">MSB4051: O projeto {0} está usando como referência um projeto com GUID {1}, mas o projeto com essa GUID não foi encontrado no arquivo .SLN.</target>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
         <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionParseUnknownProjectType">
         <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
-        <target state="translated">MSB4078: O MSBuild não dá suporte ao arquivo de projeto "{0}"; não é possível compilá-lo.</target>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
         <note>{StrBegin="MSB4078: "}</note>
       </trans-unit>
       <trans-unit id="SolutionParseUpgradeNeeded">
         <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4054: O arquivo de solução deve ser aberto no IDE do Visual Studio e convertido na versão mais recente antes de ser compilado pelo MSBuild.</target>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
         <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
       </trans-unit>
       <trans-unit id="SolutionProjectConfigurationMissing">
         <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
-        <target state="translated">MSB4121: A configuração do projeto "{0}" não foi especificada no arquivo de solução da configuração de solução "{1}".</target>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
         <note>{StrBegin="MSB4121: "}</note>
       </trans-unit>
       <trans-unit id="SolutionProjectSkippedForBuilding">
         <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
-        <target state="translated">O projeto "{0}" não está selecionado para compilação na configuração de solução "{1}".</target>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
         <note>
       UE: This is not an error, so doesn't need an error code.
     </note>
       </trans-unit>
       <trans-unit id="SolutionScanProjectDependenciesFailed">
         <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
-        <target state="translated">MSB4122: Falha no exame das dependências do projeto "{0}". {1}</target>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
         <note>{StrBegin="MSB4122: "}</note>
       </trans-unit>
       <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
         <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
-        <target state="translated">MSB4149: A versão das ferramentas "{0}" da solução não dá suporte à compilação de projetos com outra versão das ferramentas.</target>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
         <note>{StrBegin="MSB4149: "}</note>
       </trans-unit>
       <trans-unit id="SolutionVenusProjectNoClean">
         <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
-        <target state="translated">Os projetos da Web não dão suporte ao destino "Clean".  Prosseguindo com os projetos restantes...</target>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
         <note>UE: This is not an error, so doesn't need an error code.
     LOCALIZATION: Do not localize "Clean".</note>
       </trans-unit>
       <trans-unit id="SolutionVenusProjectNoPublish">
         <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
-        <target state="translated">Os projetos Web não dão suporte ao destino "Publish".  Prosseguindo com os projetos restantes...</target>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
         <note>UE: This is not an error, so doesn't need an error code.
     LOCALIZATION: Do not localize "Publish".</note>
       </trans-unit>
       <trans-unit id="SolutionVenusProjectSkipped">
         <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
-        <target state="translated">Ignorando porque a configuração "$(AspNetConfiguration)" não dá suporte a este projeto da Web. Você pode usar a propriedade AspNetConfiguration para substituir a configuração usada na compilação de projetos da Web adicionando /p:AspNetConfiguration=&lt;valor&gt; à linha de comando. Os projetos da Web atuais dão suporte somente às configurações Debug e Release.</target>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
         <note>
     UE: This is not an error, so doesn't need an error code.
     LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
@@ -1348,228 +1378,233 @@
       </trans-unit>
       <trans-unit id="TargetAlreadyCompleteFailure">
         <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
-        <target state="translated">Destino "{0}" ignorado. Compilado anteriormente sem êxito.</target>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetAlreadyCompleteSuccess">
         <source>Target "{0}" skipped. Previously built successfully.</source>
-        <target state="translated">Destino "{0}" ignorado. Compilado anteriormente com êxito.</target>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetConditionHasInvalidMetadataReference">
         <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
-        <target state="translated">MSB4116: A condição "{1}" no destino "{0}" tem uma referência aos metadados de item. Não são permitidas referências a metadados de item nas condições de destino, a menos que façam parte de uma transformação de item.</target>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
         <note>{StrBegin="MSB4116: "}</note>
       </trans-unit>
       <trans-unit id="TargetDoesNotExist">
         <source>MSB4057: The target "{0}" does not exist in the project.</source>
-        <target state="translated">MSB4057: O destino "{0}" não existe no projeto.</target>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
         <note>{StrBegin="MSB4057: "}</note>
       </trans-unit>
       <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
         <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
-        <target state="translated">O destino "{0}" listado em um atributo BeforeTargets em "{1}" não existe no projeto e será ignorado.</target>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetDoesNotExistAfterTargetMessage">
         <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
-        <target state="translated">O destino "{0}" listado em um atributo AfterTargets em "{1}" não existe no projeto e será ignorado.</target>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetFinishedFailure">
         <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
-        <target state="translated">Destino de compilação pronto "{0}" no projeto "{1}" -- FALHA.</target>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetFinishedSuccess">
         <source>Done building target "{0}" in project "{1}".</source>
-        <target state="translated">Destino de compilação pronto"{0}" no projeto "{1}".</target>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetMessageWithId">
         <source>{0}: (TargetId:{1})</source>
-        <target state="translated">{0}: (TargetId:{1})</target>
+        <target state="new">{0}: (TargetId:{1})</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetOutputItemsHeader">
         <source>Target output items:</source>
-        <target state="translated">Itens de saída de destino:</target>
+        <target state="new">Target output items:</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetOutputItem">
         <source>    {0}</source>
-        <target state="translated">    {0}</target>
+        <target state="new">    {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
         <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
-        <target state="translated">MSB4058: O destino "{0}" não tem a especificação de saída. Se o destino declarar as entradas, também deverá declarar as saídas.</target>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
         <note>{StrBegin="MSB4058: "}</note>
       </trans-unit>
       <trans-unit id="TargetPerformanceSummary">
         <source>Target Performance Summary:</source>
-        <target state="translated">Resumo do Desempenho do Destino:</target>
+        <target state="new">Target Performance Summary:</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetSkippedFalseCondition">
         <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
-        <target state="translated">Destino "{0}" ignorado devido à condição falsa; ({1}) foi avaliado como ({2}).</target>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
+        <source>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</source>
+        <target state="new">Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</target>
+        <note>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</note>
       </trans-unit>
       <trans-unit id="TargetStartedFileProject">
         <source>Target "{0}" in file "{1}" from project "{2}":</source>
-        <target state="translated">Destino "{0}" no arquivo "{1}" do projeto "{2}":</target>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedFileProjectEntry">
         <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
-        <target state="translated">Destino "{0}" no arquivo "{1}" do projeto "{2}" (ponto de entrada):</target>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedFileProjectDepends">
         <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
-        <target state="translated">Destino "{0}" no arquivo "{1}" do projeto "{2}" (o destino "{3}" depende dele):</target>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedFileProjectBefore">
         <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
-        <target state="translated">Destino "{0}" no arquivo "{1}" do projeto "{2}" (designado para execução antes do destino "{3}"):</target>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedFileProjectAfter">
         <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
-        <target state="translated">Destino "{0}" no arquivo "{1}" do projeto "{2}" (designado para execução após o destino "{3}"):</target>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStarted">
         <source>Target "{0}" in project "{1}":</source>
-        <target state="translated">Destino "{0}" no projeto "{1}":</target>
+        <target state="new">Target "{0}" in project "{1}":</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedProjectEntry">
         <source>Target "{0}" in project "{1}" (entry point):</source>
-        <target state="translated">Destino "{0}" no projeto "{1}" (ponto de entrada):</target>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedProjectDepends">
         <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
-        <target state="translated">Destino "{0}" no projeto "{1}" (o destino "{2}" depende dele):</target>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedProjectBefore">
         <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
-        <target state="translated">Destino "{0}" no projeto "{1}" (designado para execução antes do destino "{2}"):</target>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedProjectAfter">
         <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
-        <target state="translated">Destino "{0}" no projeto "{1}" (designado para execução após o destino "{2}"):</target>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedPrefix">
         <source>Target {0}:</source>
-        <target state="translated">Destino {0}:</target>
+        <target state="new">Target {0}:</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedFromFile">
         <source>Target "{0}" in file "{1}":</source>
-        <target state="translated">Destino "{0}" no arquivo "{1}":</target>
+        <target state="new">Target "{0}" in file "{1}":</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedPrefixInProject">
         <source>Target {0} from project "{1}":</source>
-        <target state="translated">Destino {0} do projeto "{1}":</target>
+        <target state="new">Target {0} from project "{1}":</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetStartedFromFileInProject">
         <source>Target "{0}" in file "{1}" from project "{2}":</source>
-        <target state="translated">Destino "{0}" no arquivo "{1}" do projeto "{2}":</target>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemGroupIncludeLogMessagePrefix">
         <source>Added Item(s): </source>
-        <target state="translated">Itens Adicionados: </target>
+        <target state="new">Added Item(s): </target>
         <note />
       </trans-unit>
       <trans-unit id="ItemGroupRemoveLogMessage">
         <source>Removed Item(s): </source>
-        <target state="translated">Itens Removidos: </target>
+        <target state="new">Removed Item(s): </target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyGroupLogMessage">
         <source>Set Property: {0}={1}</source>
-        <target state="translated">Definir Propriedade: {0}={1}</target>
+        <target state="new">Set Property: {0}={1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputItemParameterMessagePrefix">
         <source>Output Item(s): </source>
-        <target state="translated">Itens de Saída(s): </target>
+        <target state="new">Output Item(s): </target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPropertyLogMessage">
         <source>Output Property: {0}={1}</source>
-        <target state="translated">Propriedade de Saída: {0}={1}</target>
+        <target state="new">Output Property: {0}={1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskContinuedDueToContinueOnError">
         <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
-        <target state="translated">A compilação continua porque "{0}" na tarefa "{1}" está definido como "{2}".</target>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskDeclarationOrUsageError">
         <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
-        <target state="translated">MSB4060: A tarefa "{0}" foi declarada ou usada incorretamente ou ocorreu falha durante a construção. Verifique se os nomes da tarefa e do assembly estão escritos corretamente.</target>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
         <note>{StrBegin="MSB4060: "}</note>
       </trans-unit>
       <trans-unit id="TaskExistsButHasMismatchedIdentityError">
         <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
-        <target state="translated">MSB4214: A tarefa "{0}" foi definida, mas não pode ser usada porque a identidade definida na declaração UsingTask (Runtime="{1}", Architecture="{2}") não coincide com a identidade especificada pela chamada da tarefa (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
         <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
       </trans-unit>
       <trans-unit id="TaskFinishedFailure">
         <source>Done executing task "{0}" -- FAILED.</source>
-        <target state="translated">Tarefa em execução pronta "{0}" -- FALHA.</target>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskFinishedSuccess">
         <source>Done executing task "{0}".</source>
-        <target state="translated">Tarefa em execução pronta "{0}".</target>
+        <target state="new">Done executing task "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskMessageWithId">
         <source>{0} (TaskId:{1})</source>
-        <target state="translated">{0} (TaskId:{1})</target>
+        <target state="new">{0} (TaskId:{1})</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskFound">
         <source>Using "{0}" task from assembly "{1}".</source>
-        <target state="translated">Usando a tarefa "{0}" do assembly "{1}".</target>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
         <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
       </trans-unit>
       <trans-unit id="TaskFoundFromFactory">
         <source>Using "{0}" task from the task factory "{1}".</source>
-        <target state="translated">Usando a tarefa "{0}" da fábrica de tarefas "{1}".</target>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
         <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
       </trans-unit>
       <trans-unit id="TaskNeedsSTA">
         <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
-        <target state="translated">A tarefa "{0}" será executada em um thread STA (Single-Threaded Apartment).</target>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
         <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureError">
         <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
-        <target state="translated">MSB4061: A tarefa "{0}" não foi instanciada de "{1}". {2}</target>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
         <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
         <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
-        <target state="translated">MSB4127: A tarefa "{0}" não foi iniciada do assembly "{1}". Verifique se o assembly da tarefa foi compilado com a mesma versão de assembly do Microsoft.Build.Framework instalada em seu computador e se não está faltando um redirecionamento de associação para o Microsoft.Build.Framework no aplicativo host. {2}</target>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
         <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
       LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
       </trans-unit>
       <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
         <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
-        <target state="translated">MSB4180: O agente "{0}" não foi instanciado do assembly "{1}". Verifique se o assembly de agente foi compilado com a mesma versão de assembly do Microsoft.Build.Framework instalada em seu computador e se não está faltando um redirecionamento de associação para o Microsoft.Build.Framework no aplicativo host. {2}</target>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
         <note>
       {StrBegin="MSB4180: "}
       LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
@@ -1577,7 +1612,7 @@
       </trans-unit>
       <trans-unit id="LoggerCreationError">
         <source>MSB1021: Cannot create an instance of the logger. {0}</source>
-        <target state="translated">MSB1021: Não é possível criar uma instância do agente de log. {0}</target>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
         <note>{StrBegin="MSB1021: "}
       UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
       LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
@@ -1585,7 +1620,7 @@
       </trans-unit>
       <trans-unit id="LoggerNotFoundError">
         <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
-        <target state="translated">MSB1020: agente não foi encontrado. Verifique se: 1.) O nome do agente especificado é igual ao nome da classe de agente. 2.) A classe de agente é "public" e implementa a interface Microsoft.Build.Framework.ILogger. 3.) O caminho para o assembly de agente está correto ou o agente pode ser carregado somente com o nome do assembly fornecido.</target>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
         <note>
       {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
@@ -1595,198 +1630,243 @@
       </trans-unit>
       <trans-unit id="TaskFactoryInstanceCreationError">
         <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
-        <target state="translated">MSB4179: A instância da fábrica de tarefas para a tarefa "{0}" não foi instanciada da fábrica de tarefas "{1}". {2}</target>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
         <note>{StrBegin="MSB4179: "}
       LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
       </trans-unit>
       <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
         <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
-        <target state="translated">MSB4176: A fábrica de tarefas "{0}" não foi instanciada do assembly "{1}". Verifique se o assembly da tarefa foi compilado com a mesma versão de assembly do Microsoft.Build.Framework instalada em seu computador e se não está faltando um redirecionamento de associação para o Microsoft.Build.Framework no aplicativo host. {2}</target>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
         <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
       LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
       </trans-unit>
       <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
         <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
-        <target state="translated">MSB4219: TaskFactory "{0}" não implementa ITaskFactory2. Os atributos "{1}" e/ou"{2}" da declaração UsingTask para a tarefa "{3}" serão ignorados.</target>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
         <note>{StrBegin="MSB4219: "}
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="TaskFactoryTaskTypeIsNotSet">
+        <source>The task factory must return a value for the "TaskType" property.</source>
+        <target state="new">The task factory must return a value for the "TaskType" property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskLoadFailure">
         <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
-        <target state="translated">MSB4062: A tarefa "{0}" não foi carregada do assembly {1}. {2} Confirme se a declaração &lt;UsingTask&gt; está correta, se o assembly e todas as suas dependências estão disponíveis e se a tarefa contém uma classe pública que implementa Microsoft.Build.Framework.ITask.</target>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
         <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
     invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
     LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
         <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
-        <target state="translated">MSB4215: Não foi possível carregar a tarefa "{0}". "{1}" é um valor inválido para o parâmetro de host de tarefas "{2}". Os valores válidos são: "{3}", "{4}", "{5}" e "{6}"; não especificar um valor também é válido.</target>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
         <note>{StrBegin="MSB4215: "}</note>
       </trans-unit>
       <trans-unit id="InvalidTaskHostFactoryParameter">
         <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
-        <target state="translated">"{0}" é um valor inválido para o parâmetro de host de tarefas "{1}". Os valores válidos são: "{2}", "{3}", "{4}" e "{5}"; não especificar um valor também é válido.</target>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
         <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
-        <target state="translated">MSB4216: Não foi possível executar a tarefa "{0}" porque o MSBuild não pôde criar ou se conectar a um host de tarefas com runtime "{1}" e arquitetura "{2}".  Verifique se (1) o runtime e/ou a arquitetura solicitados estão disponíveis no computador e se (2) o executável necessário "{3}" existe e pode ser executado.</target>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>
       <trans-unit id="TaskHostNodeFailedToLaunch">
         <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
-        <target state="translated">MSB4221: Não foi possível executar a tarefa "{0}" porque o MSBuild não pôde criar ou se conectar a um host de tarefas com runtime "{1}" e arquitetura "{2}".  Verifique se (1) o runtime e/ou a arquitetura solicitados estão disponíveis no computador e se (2) o executável necessário "{3}" existe e pode ser executado. Erro {4} {5}.</target>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
         <note>{StrBegin="MSB4221: "}</note>
       </trans-unit>
       <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
         <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
-        <target state="translated">Uma tarefa solicitou o início da versão .NET 3.5 do host de tarefas MSBuild, mas o .NET 3.5 não está instalado neste computador e, portanto, não foi possível iniciar o host de tarefas.  Para corrigir este erro, instale o .NET 3.5 ou redirecione seu projeto.</target>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostExitedPrematurely">
         <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
-        <target state="translated">MSB4217: O nó do host de tarefas saiu prematuramente. É possível encontrar informações de diagnóstico em arquivos do diretório de arquivos temporários chamado MSBuild_*.failure.txt. {0}</target>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
         <note>{StrBegin="MSB4217: "}</note>
       </trans-unit>
       <trans-unit id="TaskParametersError">
         <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
-        <target state="translated">MSB4063: A tarefa "{0}" não foi iniciada com os seus parâmetros de entrada. {1}</target>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
         <note>{StrBegin="MSB4063: "}</note>
       </trans-unit>
       <trans-unit id="TaskParameterPrefix">
         <source>Task Parameter:</source>
-        <target state="translated">Parâmetro de Tarefa:</target>
+        <target state="new">Task Parameter:</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskPerformanceSummary">
         <source>Task Performance Summary:</source>
-        <target state="translated">Resumo do Desempenho da Tarefa:</target>
+        <target state="new">Task Performance Summary:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectEvaluationPerformanceSummary">
+        <source>Project Evaluation Performance Summary:</source>
+        <target state="new">Project Evaluation Performance Summary:</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskSkippedFalseCondition">
         <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
-        <target state="translated">A tarefa "{0}" foi ignorada devido a condição falsa; ({1}) foi avaliado como ({2}).</target>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskStarted">
         <source>Task "{0}"</source>
-        <target state="translated">Tarefa "{0}"</target>
+        <target state="new">Task "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TimeElapsed">
         <source>Time Elapsed {0}</source>
-        <target state="translated">Tempo Decorrido {0}</target>
+        <target state="new">Time Elapsed {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolsVersionInEffectForBuild">
         <source>Building with tools version "{0}".</source>
-        <target state="translated">Compilando com a versão das ferramentas "{0}".</target>
+        <target state="new">Building with tools version "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
         <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
-        <target state="translated">O arquivo de projeto contém ToolsVersion="{0}". Esse conjunto de ferramentas pode ser desconhecido ou estar ausente; nesse caso, você poderá resolver isso instalando a versão apropriada do MSBuild, ou o build talvez tenha sido forçado para uma ToolsVersion em particular por motivos de política. Tratando o projeto como se tivesse ToolsVersion="{1}". Para obter mais informações, consulte http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeferredMessages">
         <source>Deferred Messages</source>
-        <target state="translated">Mensagens adiadas</target>
+        <target state="new">Deferred Messages</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedCharacterInCondition">
         <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
-        <target state="translated">MSB4090: Encontrado um caractere "{2}" inesperado na posição {1} da condição "{0}".</target>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
         <note>{StrBegin="MSB4090: "}</note>
       </trans-unit>
       <trans-unit id="UndefinedFunctionCall">
         <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
-        <target state="translated">MSB4091: Encontrada uma chamada para uma função não definida "{1}" da condição "{0}".</target>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
         <note>{StrBegin="MSB4091: "}</note>
       </trans-unit>
       <trans-unit id="UnexpectedTaskAttribute">
         <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task loaded from assembly: {2} from the path: {3}. Verify that the parameter exists on the task, the &lt;UsingTask&gt; points to the correct assembly, and it is a settable public instance property.</source>
-        <target state="translated">MSB4064: o parâmetro "{0}" não é compatível com a tarefa "{1}" carregada do assembly: {2} do caminho: {3}. Verifique se o parâmetro existe na tarefa, se a tarefa &lt;UsingTask&gt; aponta para o assembly correto e se é uma propriedade de instância pública configurável.</target>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task loaded from assembly: {2} from the path: {3}. Verify that the parameter exists on the task, the &lt;UsingTask&gt; points to the correct assembly, and it is a settable public instance property.</target>
         <note>{StrBegin="MSB4064: "}</note>
       </trans-unit>
       <trans-unit id="UnexpectedTaskOutputAttribute">
         <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
-        <target state="translated">MSB4131: O parâmetro "{0}" não tem suporte na tarefa "{1}". Verifique se o parâmetro existe na tarefa e se é uma propriedade de instância pública que pode ser obtida.</target>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
         <note>{StrBegin="MSB4131: "}</note>
       </trans-unit>
       <trans-unit id="UnexpectedTokenInCondition">
         <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
-        <target state="translated">MSB4092: Um token "{1}" inesperado foi encontrado na posição de caractere {2} da condição "{0}".</target>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
         <note>{StrBegin="MSB4092: "}</note>
       </trans-unit>
       <trans-unit id="UnmarkedOutputTaskParameter">
         <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
-        <target state="translated">MSB4065: O parâmetro "{0}" não é marcado para saída pela tarefa "{1}".</target>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
         <note>{StrBegin="MSB4065: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedAttribute">
         <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
-        <target state="translated">MSB4066: O atributo "{0}" no elemento &lt;{1}&gt; não é reconhecido.</target>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
         <note>{StrBegin="MSB4066: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedChildElement">
         <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
-        <target state="translated">MSB4067: O elemento &lt;{0}&gt; abaixo do elemento &lt;{1}&gt; não é reconhecido.</target>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
         <note>{StrBegin="MSB4067: "}</note>
       </trans-unit>
       <trans-unit id="InvalidChildElementDueToDuplication">
         <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
-        <target state="translated">MSB4173: O elemento &lt;{0}&gt; sob o elemento &lt;{1}&gt; é inválido porque já existe um elemento filho com esse nome</target>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
         <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeDueToDuplication">
+        <source>MSB4227: The attribute "{0}" on element &lt;{1}&gt; is invalid because an attribute with that name already exists</source>
+        <target state="new">MSB4227: The attribute "{0}" on element &lt;{1}&gt; is invalid because an attribute with that name already exists</target>
+        <note>{StrBegin="MSB4227: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidMetadataAsAttribute">
+        <source>MSB4228: The name "{0}" is not valid for metadata expressed as an attribute (on element &lt;{1}&gt;)</source>
+        <target state="new">MSB4228: The name "{0}" is not valid for metadata expressed as an attribute (on element &lt;{1}&gt;)</target>
+        <note>{StrBegin="MSB4228: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidSdkFormat">
+        <source>MSB4229: The value "{0}" is not valid for an Sdk specification. The attribute should be a semicolon-delimited list of Sdk-name/minimum-version pairs, separated by a forward slash.</source>
+        <target state="new">MSB4229: The value "{0}" is not valid for an Sdk specification. The attribute should be a semicolon-delimited list of Sdk-name/minimum-version pairs, separated by a forward slash.</target>
+        <note>{StrBegin="MSB4229: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotResolveSdk">
+        <source>MSB4236: The SDK '{0}' specified could not be found.</source>
+        <target state="new">MSB4236: The SDK '{0}' specified could not be found.</target>
+        <note>{StrBegin="MSB4236: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolver">
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="new">MSB4237: The SDK resolver type "{0}" failed to load. {1}</target>
+        <note>{StrBegin="MSB4237: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidSdkElementName">
+        <source>MSB4238: The name "{0}" is not a valid SDK name.</source>
+        <target state="new">MSB4238: The name "{0}" is not a valid SDK name.</target>
+        <note>{StrBegin="MSB4238: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedParentElement">
         <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
-        <target state="translated">MSB4189: &lt;{1}&gt; não é um filho válido do elemento &lt;{0}&gt;.</target>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
         <note>{StrBegin="MSB4189: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedElement">
         <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
-        <target state="translated">MSB4068: O elemento &lt;{0}&gt; não é reconhecido, ou não há suporte para ele no contexto.</target>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
         <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedLogFileFormat">
+        <source>MSB4235: The log file format version is {0}, whereas this version of MSBuild only supports versions up to {1}.</source>
+        <target state="new">MSB4235: The log file format version is {0}, whereas this version of MSBuild only supports versions up to {1}.</target>
+        <note>{StrBegin="MSB4235: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedTaskParameterTypeError">
         <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
-        <target state="translated">MSB4069: Não há suporte no MSBuild para o tipo "{0}" do parâmetro "{1}" da tarefa "{2}".</target>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
         <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UsingTaskAssemblySpecification">
         <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
-        <target state="translated">MSB4072: Um elemento &lt;{0}&gt; deve conter o atributo "{1}" ou "{2}" (mas não os dois).</target>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
         <note>{StrBegin="MSB4072: "}</note>
       </trans-unit>
       <trans-unit id="WarningCount">
         <source>{0} Warning(s)</source>
-        <target state="translated">{0} Aviso(s)</target>
+        <target state="new">{0} Warning(s)</target>
         <note />
       </trans-unit>
       <trans-unit id="WhenNotAllowedAfterOtherwise">
         <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
-        <target state="translated">MSB4084: O elemento &lt;When&gt; não acompanha um elemento &lt;Otherwise&gt; em &lt;Choose&gt;.</target>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
         <note>{StrBegin="MSB4084: "}</note>
       </trans-unit>
       <trans-unit id="MustCallInitializeBeforeApplyParameter">
         <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
-        <target state="translated">MSB4150: É necessário iniciar o agente de log do console com o método de inicialização antes de usar ApplyParameter</target>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
         <note>{StrBegin="MSB4150: "}</note>
       </trans-unit>
       <trans-unit id="InvalidHostObjectOnOutOfProcProject">
         <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
-        <target state="translated">MSB4206: não é possível especificar um objeto de host não nulo para um projeto que tem uma afinidade definida para fora do processo.</target>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
         <note>{StrBegin="MSB4206: "}</note>
       </trans-unit>
       <trans-unit id="InvalidAffinityForProjectWithHostObject">
         <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
-        <target state="translated">MSB4207: Somente uma afinidade no processo pode ser especificada para projetos que registraram objetos de host.</target>
+        <target state="new">MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</target>
         <note>{StrBegin="MSB4207: "}</note>
       </trans-unit>
       <trans-unit id="ProjectInstanceConflictsWithAffinity">
         <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
-        <target state="translated">MSB4209: a instância de projeto especificada está em conflito com a afinidade especificada em HostServices.</target>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
         <note>{StrBegin="MSB4209: "}</note>
       </trans-unit>
       <trans-unit id="AffinityConflict">
@@ -1796,136 +1876,136 @@
       </trans-unit>
       <trans-unit id="UnableToCreateNode">
         <source>MSB4223: A node of the required type {0} could not be created.</source>
-        <target state="translated">MSB4223: Não foi possível criar um nó do tipo necessário {0}.</target>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
         <note>{StrBegin="MSB4223: "}</note>
       </trans-unit>
       <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
         <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
-        <target state="translated">MSB4224: KeepMetadata e RemoveMetadata são mutuamente exclusivos.</target>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
         <note>{StrBegin="MSB4224: "}</note>
       </trans-unit>
       <trans-unit id="ProjectStackWithTargetNames">
         <source>"{0}" ({1} target) ({2}) -&gt;</source>
-        <target state="translated">"{0}" ({1} destino) ({2}) -&gt;</target>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectStackWithDefaultTargets">
         <source>"{0}" (default target) ({1}) -&gt;</source>
-        <target state="translated">"{0}" (destino padrão) ({1}) -&gt;</target>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildEventContext">
         <source>{0} {1,5}</source>
-        <target state="translated">{0} {1,5}</target>
+        <target state="new">{0} {1,5}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
         <source>Project "{0}" on node {1} ({2} target(s)).</source>
-        <target state="translated">Projeto "{0}" no nó {1} ({2} destino(s)).</target>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
         <source>Project "{0}" on node {1} (default targets).</source>
-        <target state="translated">Projeto "{0}" no nó {1} (destinos padrão).</target>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectStartedWithTargetsMultiProc">
         <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
-        <target state="translated">O projeto "{0}" ({1}) está compilando "{2}" ({3}) no nó {4} ({5} destino(s)).</target>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
         <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
-        <target state="translated">O projeto "{0}" ({1}) está compilando "{2}" ({3}) no nó {4} (destinos padrão).</target>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorWarningInTarget">
         <source>({0} target) -&gt; </source>
-        <target state="translated">({0} destino) -&gt; </target>
+        <target state="new">({0} target) -&gt; </target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyOutputOverridden">
         <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
-        <target state="translated">A propriedade "{0}" com o valor "{1}" está sendo substituída por outro lote. Agora, a propriedade é: "{2}"</target>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
         <note />
       </trans-unit>
       <trans-unit id="WritingToOutputCache">
         <source>Writing build results caches to: {0}</source>
-        <target state="translated">Gravando caches de resultados de build em: {0}</target>
+        <target state="new">Writing build results caches to: {0}</target>
         <note>
       LOCALIZATION: {0} is a file path
     </note>
       </trans-unit>
       <trans-unit id="logfilePathNullOrEmpty">
         <source>The log file path cannot be null or empty.</source>
-        <target state="translated">O caminho do arquivo de log não pode ser nulo nem ficar em branco.</target>
+        <target state="new">The log file path cannot be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefaultTargets">
         <source>[default]</source>
-        <target state="translated">[padrão]</target>
+        <target state="new">[default]</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindFactory">
         <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
-        <target state="translated">MSB4174: A fábrica de tarefas "{0}" não foi encontrada no assembly "{1}".</target>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
         <note>{StrBegin="MSB4174: "}</note>
       </trans-unit>
       <trans-unit id="TaskFactoryLoadFailure">
         <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
-        <target state="translated">MSB4175: A fábrica de tarefas "{0}" não foi carregada do assembly "{1}". {2}</target>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
         <note>{StrBegin="MSB4175: "}</note>
       </trans-unit>
       <trans-unit id="UnableToCancel">
         <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
-        <target state="translated">MSB4201: A operação de cancelamento não foi concluída porque a tarefa atualmente em execução não está respondendo.</target>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
         <note>{StrBegin="MSB4201: "}</note>
       </trans-unit>
       <trans-unit id="UnableToCancelTask">
         <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
-        <target state="translated">MSB4220: Aguardando que a tarefa "{0}" atualmente em execução seja cancelada.</target>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
         <note>{StrBegin="MSB4220: "}</note>
       </trans-unit>
       <trans-unit id="MainThreadInUse">
         <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
-        <target state="translated">MSB4202: A solicitação para envio de compilação {0} não pode continuar porque o envio {1} já está usando o thread principal.</target>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
         <note>{StrBegin="MSB4202: "}</note>
       </trans-unit>
       <trans-unit id="ProjectAlreadyBuilding">
         <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
-        <target state="translated">A solicitação para compilar este envio não pode continuar porque um projeto com a mesma configuração já está em compilação.</target>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitializingTaskFactory">
         <source>Initializing task factory "{0}" from assembly "{1}".</source>
-        <target state="translated">Inicializando a fábrica de tarefas "{0}" do assembly "{1}".</target>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InitializingTaskHostFactory">
         <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
-        <target state="translated">Inicializando fábrica de host de tarefas para a tarefa "{0}" do assembly "{1}"</target>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
         <note />
       </trans-unit>
       <trans-unit id="CantWriteBuildPlan">
         <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
-        <target state="translated">Não foi possível gravar o plano de build.  Verifique se o processo de build tem permissões para gravar em {0}.</target>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CacheFileInaccessible">
         <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
-        <target state="translated">O arquivo de cache do MSBuild "{0}" está inacessível.  Verifique se você tem acesso ao diretório e se o arquivo não foi excluído durante o build. {1}</target>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
         <note>
       LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
     </note>
       </trans-unit>
       <trans-unit id="CantReadBuildPlan">
         <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
-        <target state="translated">Não foi possível ler o plano de build.  Verifique se o processo de build tem permissões para ler {0}.</target>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildPlanCorrupt">
         <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
-        <target state="translated">O plano de compilação em {0} parece estar corrompido e não pode ser usado.</target>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
         <note />
       </trans-unit>
       <trans-unit id="DetailedSummaryHeader">
@@ -1933,8 +2013,8 @@
 Detailed Build Summary
 ======================
     </source>
-        <target state="translated">
-Resumo Detalhado de Build
+        <target state="new">
+Detailed Build Summary
 ======================
     </target>
         <note />
@@ -1944,15 +2024,15 @@ Resumo Detalhado de Build
 ============================== Build Hierarchy (IDs represent configurations) =====================================================
 Id                  : Exclusive Time   Total Time   Path (Targets)
 -----------------------------------------------------------------------------------------------------------------------------------</source>
-        <target state="translated">
-============================== Hierarquia de Build (IDs representam configurações) =====================================================
-Id                  : Tempo Exclusivo   Tempo Total   Caminho (Destinos)
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
 -----------------------------------------------------------------------------------------------------------------------------------</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildHierarchyEntry">
         <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
-        <target state="translated">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
         <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="NodeUtilizationHeader">
@@ -1960,202 +2040,222 @@ Id                  : Tempo Exclusivo   Tempo Total   Caminho (Destinos)
 ============================== Node Utilization (IDs represent configurations) ====================================================
 Timestamp:            {0} Duration   Cumulative
 -----------------------------------------------------------------------------------------------------------------------------------</source>
-        <target state="translated">
-============================== Utilização do Nó (IDs representam configurações) ====================================================
-Carimbo de data/hora:            {0} Duração Cumulativa
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
 -----------------------------------------------------------------------------------------------------------------------------------</target>
         <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
       </trans-unit>
       <trans-unit id="NodeUtilizationEntry">
         <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
-        <target state="translated">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
         <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="NodeUtilizationSummary">
         <source>-----------------------------------------------------------------------------------------------------------------------------------
 Utilization:          {0} Average Utilization: {1:###.0}</source>
-        <target state="translated">-----------------------------------------------------------------------------------------------------------------------------------
-Utilização:          {0} Utilização Média: {1:###.0}</target>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
         <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
         <source>This collection cannot convert from the specified value to the backing value.</source>
-        <target state="translated">Esta coleção não pode fazer a conversão do valor especificado para o valor de backup.</target>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_CannotCreateReservedProperty">
         <source>The "{0}" property name is reserved.</source>
-        <target state="translated">O nome de propriedade "{0}" está reservado.</target>
+        <target state="new">The "{0}" property name is reserved.</target>
         <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
       </trans-unit>
       <trans-unit id="OM_EitherAttributeButNotBoth">
         <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
-        <target state="translated">O elemento &lt;{0}&gt; deve ter o atributo "{1}" ou o atributo "{2}", mas não ambos.</target>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OM_OneOfAttributeButNotMore">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute, the "{2}" attribute, or the "{3}" attribute, but not more than one.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute, the "{2}" attribute, or the "{3}" attribute, but not more than one.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_NoRemoveOutsideTargets">
         <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
-        <target state="translated">O atributo "Remove" não é permitido em um item fora de &lt;Target&gt;.</target>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_NoKeepMetadataOutsideTargets">
         <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
-        <target state="translated">O atributo "KeepMetadata" não é permitido em um item fora de um &lt;Target&gt;.</target>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
         <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
-        <target state="translated">O atributo "RemoveMetadata" não é permitido em um item fora de um &lt;Target&gt;.</target>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
         <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
-        <target state="translated">O atributo "KeepDuplicates" não é permitido em um item fora de um &lt;Target&gt;.</target>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_CannotGetSetCondition">
         <source>Elements of this type do not have a condition.</source>
-        <target state="translated">Elementos deste tipo não têm uma condição.</target>
+        <target state="new">Elements of this type do not have a condition.</target>
         <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
       </trans-unit>
       <trans-unit id="OM_NodeAlreadyParented">
         <source>The node already has a parent. Remove it from its parent before moving it.</source>
-        <target state="translated">O nó já tem um pai. Remova-o de seu pai antes de movê-lo.</target>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_NodeNotAlreadyParentedByThis">
         <source>The node is not parented by this object so it cannot be removed from it.</source>
-        <target state="translated">O nó não tem como pai este objeto; portanto, não pode ser removido dele.</target>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
         <source>The reference node is not a child of this node.</source>
-        <target state="translated">O nó de referência não é um filho deste nó.</target>
+        <target state="new">The reference node is not a child of this node.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_SelfAncestor">
         <source>Cannot make a node or an ancestor of that node a child of itself.</source>
-        <target state="translated">Não é possível criar um nó ou um ancestral desse nó filho dele mesmo.</target>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MustBeSameProject">
         <source>Cannot create a relationship between nodes that were created from different projects.</source>
-        <target state="translated">Não é possível criar uma relação entre nós que foram criados de projetos diferentes.</target>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_ParentNotParented">
         <source>The parent node is not itself parented.</source>
-        <target state="translated">O nó pai não é pai dele mesmo.</target>
+        <target state="new">The parent node is not itself parented.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_CannotAcceptParent">
         <source>This parent is not a valid parent for the item.</source>
-        <target state="translated">Este não é um pai válido para o item.</target>
+        <target state="new">This parent is not a valid parent for the item.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeOrUpdateOrRemove">
+        <source>An item not parented under a Target must have a value for Include or Update or Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include or Update or Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", "Update", and "Remove".</note>
       </trans-unit>
       <trans-unit id="OM_NameInvalid">
         <source>The name "{0}" contains an invalid character "{1}".</source>
-        <target state="translated">O nome "{0}" contém um caractere inválido "{1}".</target>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
         <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
-        <target state="translated">Um elemento &lt;Otherwise&gt; não pode estar localizado antes de um elemento &lt;When&gt; ou &lt;Otherwise&gt;.</target>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MustSetFileNameBeforeSave">
         <source>Project has not been given a path to save to.</source>
-        <target state="translated">Não foi fornecido ao projeto um caminho no qual salvá-lo.</target>
+        <target state="new">Project has not been given a path to save to.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MustSetRecordDuplicateInputs">
         <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
-        <target state="translated">O projeto não foi carregado com o sinalizador ProjectLoadSettings.RecordDuplicateImports.</target>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
         <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
-        <target state="translated">O arquivo de projeto ou destinos "{0}" foi carregado no modo somente leitura e não pode ser salvo.</target>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_IncorrectObjectAssociation">
         <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
-        <target state="translated">O objeto "{0}" especificado não pertence ao objeto "{1}" correto.</target>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_ReservedName">
         <source>The "{0}" name is reserved, and cannot be used.</source>
-        <target state="translated">O nome "{0}" está reservado e não pode ser usado.</target>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_GlobalProperty">
         <source>The "{0}" property is a global property, and cannot be modified.</source>
-        <target state="translated">A propriedade "{0}" é global e não pode ser modificada.</target>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchingProjectAlreadyInCollection">
         <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
-        <target state="translated">Um projeto equivalente (com as mesmas propriedades globais e a mesma versão das ferramentas) já está presente na coleção de projetos, com o caminho "{0}". Para carregar um equivalente nessa coleção de projetos, descarregue o projeto primeiro.</target>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_ProjectWasNotLoaded">
         <source>The project provided was not loaded in the collection.</source>
-        <target state="translated">O projeto fornecido não foi carregado na coleção.</target>
+        <target state="new">The project provided was not loaded in the collection.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
         <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
-        <target state="translated">Não é possível modificar um objeto avaliado proveniente de um arquivo importado "{0}".</target>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
         <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
-        <target state="translated">Não é possível remover os metadados denominados "{0}", pois eles são provenientes de uma definição de item e não definidos diretamente no item.</target>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OM_CannotSplitItemElementWhenSplittingIsDisabled">
+        <source>The requested operation needs to split the item element at location {0} into individual elements but item element splitting is disabled with {1}.</source>
+        <target state="new">The requested operation needs to split the item element at location {0} into individual elements but item element splitting is disabled with {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_ProjectIsNoLongerActive">
         <source>The project cannot be used as it is no longer loaded into a project collection.</source>
-        <target state="translated">O projeto não pode ser usado, pois não é mais carregado em uma coleção de projetos.</target>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_ObjectIsNoLongerActive">
         <source>The operation is not allowed because currently this object is not parented.</source>
-        <target state="translated">A operação não é permitida porque este objeto não no momento não tem pai.</target>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
         <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
-        <target state="translated">O arquivo XML de projeto "{0}" não pode ser descarregado porque pelo menos um projeto "{1}", que faz referência a esse XML de projeto, ainda está carregado.</target>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_ProjectInstanceImmutable">
         <source>Instance object was created as immutable.</source>
-        <target state="translated">O objeto de instância foi criado como imutável.</target>
+        <target state="new">Instance object was created as immutable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse">
+        <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
+        <target state="new">The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
         <source>All build submissions in a build must use project instances originating from the same project collection.</source>
-        <target state="translated">Todos os envios de compilação em uma compilação devem usar instâncias do projeto provenientes da mesma coleção de projetos.</target>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
         <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
       </trans-unit>
       <trans-unit id="BuildStarted">
         <source>Build started.</source>
-        <target state="translated">Compilação iniciada.</target>
+        <target state="new">Build started.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileLocation">
         <source>{0} ({1},{2})</source>
-        <target state="translated">{0} ({1},{2})</target>
+        <target state="new">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
       <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
         <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
-        <target state="translated">MSB3203: O caminho de saída "{0}" não pode ser restabelecido. {1}</target>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
         <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
       </trans-unit>
       <trans-unit id="MSBuild.ProjectFileNotFound">
         <source>MSB3202: The project file "{0}" was not found.</source>
-        <target state="translated">MSB3202: O arquivo de projeto "{0}" não foi encontrado.</target>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
         <note>
       {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
       and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
@@ -2163,42 +2263,42 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
         <source>Skipping project "{0}" because it was not found.</source>
-        <target state="translated">Ignorando o projeto "{0}" porque ele não foi encontrado.</target>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
         <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
       </trans-unit>
       <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
         <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
-        <target state="translated">MSB3204: O arquivo de projeto "{0}" está no formato de arquivo ".vcproj", ao qual o MSBuild não dá mais suporte. Converta o projeto abrindo-o no IDE do Visual Studio ou executando a ferramenta de conversão ou use o MSBuild 3.5 ou anterior para compilá-lo.</target>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
         <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
       </trans-unit>
       <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
         <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
-        <target state="translated">MSB3205: SkipNonexistentProject somente pode aceitar valores de "True", "False" e "Build".</target>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
         <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
       </trans-unit>
       <trans-unit id="MSBuild.SkippingRemainingProjects">
         <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
-        <target state="translated">A tarefa MSBuild está ignorando os projetos restantes porque o parâmetro StopOnFirstFailure foi definido como true.</target>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
         <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
       </trans-unit>
       <trans-unit id="MSBuild.SkippingRemainingTargets">
         <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
-        <target state="translated">A tarefa MSBuild está ignorando os destinos restantes porque o parâmetro StopOnFirstFailure foi definido como true.</target>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
         <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
       </trans-unit>
       <trans-unit id="MSBuild.NotBuildingInParallel">
         <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
-        <target state="translated">Substituindo a propriedade BuildingInParallel definindo-a como false. Isso ocorre porque o sistema está sendo executado no modo de processamento único com StopOnFirstFailure definido como true.</target>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
         <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
       </trans-unit>
       <trans-unit id="MSBuild.NoStopOnFirstFailure">
         <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
-        <target state="translated">StopOnFirstFailure não terá efeito quando estas condições existirem: 1) O sistema estiver sendo executado no modo de processamento múltiplo 2) A propriedade BuildInParallel for true. 3) A propriedade RunEachTargetSeparately for false.</target>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
         <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
       </trans-unit>
       <trans-unit id="General.InvalidPropertyError">
         <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
-        <target state="translated">MSB3100: A sintaxe do parâmetro "{0}" não é válida ({1}). A sintaxe correta é {0}="&lt;nome&gt;=&lt;valor&gt;".</target>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
         <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
     Properties="foo"              (missing property value)
     Properties="=4"               (missing property name)
@@ -2206,178 +2306,98 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="General.GlobalProperties">
         <source>Global Properties:</source>
-        <target state="translated">Propriedades globais:</target>
+        <target state="new">Global Properties:</target>
         <note />
       </trans-unit>
       <trans-unit id="General.UndefineProperties">
         <source>Removing Properties:</source>
-        <target state="translated">Removendo Propriedades:</target>
+        <target state="new">Removing Properties:</target>
         <note />
       </trans-unit>
       <trans-unit id="General.OverridingProperties">
         <source>Overriding Global Properties for project "{0}" with:</source>
-        <target state="translated">Substituindo as Propriedades Globais do projeto "{0}" por:</target>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
         <note />
       </trans-unit>
       <trans-unit id="General.AdditionalProperties">
         <source>Additional Properties for project "{0}":</source>
-        <target state="translated">Propriedades adicionais do projeto "{0}":</target>
+        <target state="new">Additional Properties for project "{0}":</target>
         <note />
       </trans-unit>
       <trans-unit id="General.ProjectUndefineProperties">
         <source>Removing Properties for project "{0}":</source>
-        <target state="translated">Removendo Propriedades do projeto "{0}":</target>
+        <target state="new">Removing Properties for project "{0}":</target>
         <note />
-      </trans-unit>
-      <trans-unit id="InvalidAttributeExclusive">
-        <source>MSB4111: At most one of the include, remove, and update attributes may be specified for an item element.</source>
-        <target state="translated">MSB4111: apenas um atributo de incluir, remover e atualizar pode ser especificado para um elemento de item.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAttributeDueToDuplication">
-        <source>MSB4227: The attribute "{0}" on element &lt;{1}&gt; is invalid because an attribute with that name already exists</source>
-        <target state="translated">MSB4227: o atributo "{0}" no elemento &lt;{1}&gt; é inválido porque já existe um atributo com esse nome</target>
-        <note>{StrBegin="MSB4227: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidMetadataAsAttribute">
-        <source>MSB4228: The name "{0}" is not valid for metadata expressed as an attribute (on element &lt;{1}&gt;)</source>
-        <target state="translated">MSB4228: o nome "{0}" não é válido para metadados expressos como um atributo (no elemento &lt;{1}&gt;)</target>
-        <note>{StrBegin="MSB4228: "}</note>
-      </trans-unit>
-      <trans-unit id="OM_OneOfAttributeButNotMore">
-        <source>The &lt;{0}&gt; element must have either the "{1}" attribute, the "{2}" attribute, or the "{3}" attribute, but not more than one.</source>
-        <target state="translated">O elemento &lt;{0}&gt; precisa ter o atributo "{1}", o atributo "{2}" ou o atributo "{3}", mas não mais de um.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeOrUpdateOrRemove">
-        <source>An item not parented under a Target must have a value for Include or Update or Remove.</source>
-        <target state="translated">Um item sem pai em um Target deve ter um valor para Include, Update ou Remove.</target>
-        <note>LOCALIZATION: Please do not localize "Target", "Include", "Update", and "Remove".</note>
-      </trans-unit>
-      <trans-unit id="OM_CannotSplitItemElementWhenSplittingIsDisabled">
-        <source>The requested operation needs to split the item element at location {0} into individual elements but item element splitting is disabled with {1}.</source>
-        <target state="translated">A operação solicitada precisa dividir o elemento do item no local {0} em elementos individuais, mas a divisão de elemento de item está desabilitada com {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidSdkFormat">
-        <source>MSB4229: The value "{0}" is not valid for an Sdk specification. The attribute should be a semicolon-delimited list of Sdk-name/minimum-version pairs, separated by a forward slash.</source>
-        <target state="translated">MSB4229: o valor "{0}" não é válido para uma especificação de SDK. O atributo deve ser uma lista delimitada por ponto e vírgula de pares de nome de SDK/versão mínima, separados por uma barra.</target>
-        <note>{StrBegin="MSB4229: "}</note>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: a tarefa "{0}" não pôde ser instanciada de "{1}". Essa versão do MSBuild não dá suporte ao {2}.</target>
+        <target state="new">MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
         <source>The parameter '{0}' can only be a file name and cannot include a directory.</source>
-        <target state="translated">O parâmetro '{0}' pode ser somente um nome de arquivo e não pode incluir um diretório.</target>
+        <target state="new">The parameter '{0}' can only be a file name and cannot include a directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileToReloadFromDoesNotExist">
         <source>MSB4229: File to reload from does not exist: {0}</source>
-        <target state="translated">MSB4229: o arquivo do qual recarregar não existe: {0}</target>
+        <target state="new">MSB4229: File to reload from does not exist: {0}</target>
         <note>{StrBegin="MSB4229: "}</note>
       </trans-unit>
       <trans-unit id="ValueNotSet">
         <source>MSB4230: Value not set: {0}</source>
-        <target state="translated">MSB4230: valor não definido: {0}</target>
+        <target state="new">MSB4230: Value not set: {0}</target>
         <note>{StrBegin="MSB4230: "}</note>
       </trans-unit>
       <trans-unit id="NoReloadOnUnsavedChanges">
         <source>MSB4231: ProjectRootElement can't reload if it contains unsaved changes.</source>
-        <target state="translated">MSB4231: o ProjectRootElement não poderá ser recarregado se ele contiver mudanças não salvas.</target>
+        <target state="new">MSB4231: ProjectRootElement can't reload if it contains unsaved changes.</target>
         <note>{StrBegin="MSB4231: "}</note>
-      </trans-unit>
-      <trans-unit id="EvaluationStarted">
-        <source>Evaluation started ("{0}")</source>
-        <target state="translated">Avaliação iniciada ("{0}")</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EvaluationFinished">
-        <source>Evaluation finished ("{0}")</source>
-        <target state="translated">Avaliação encerrada ("{0}")</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBinaryLoggerParameters">
-        <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: parâmetro de agente binário inválido: "{0}". Esperado: ProjectImports={{None,Embed,ZipFile}} e/ou [LogFile=]filePath.binlog (o nome do arquivo de log ou caminho deve ter a extensão ".binlog").</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IncludeRemoveOrUpdate">
-        <source>MSB4232: Items that are outside Target elements must have one of the following operations: Include, Update, or Remove.</source>
-        <target state="translated">MSB4232: os itens que estão fora dos elementos Target devem ter uma das seguintes operações: Include, Update ou Remove.</target>
-        <note>{StrBegin="MSB4232: "} Target, Include, Update, and Remove should not be localized and their casing should not be changed</note>
-      </trans-unit>
-      <trans-unit id="PropertyReassignment">
-        <source>Property reassignment: $({0})="{1}" (previous value: "{2}") at {3}</source>
-        <target state="translated">Reatribuição de propriedade: $({0})="{1}" (valor anterior: "{2}") em {3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotResolveSdk">
-        <source>MSB4236: The SDK '{0}' specified could not be found.</source>
-        <target state="translated">MSB4236: o SDK '{0}' especificado não pôde ser encontrado.</target>
-        <note>{StrBegin="MSB4236: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
-        <target state="translated">MSB4237: falha ao carregar o tipo de resolvedor "{0}" do SDK. {1}</target>
-        <note>{StrBegin="MSB4237: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidSdkElementName">
-        <source>MSB4238: The name "{0}" is not a valid SDK name.</source>
-        <target state="translated">MSB4238: o nome "{0}" não é um nome de SDK válido.</target>
-        <note>{StrBegin="MSB4238: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedLogFileFormat">
-        <source>MSB4235: The log file format version is {0}, whereas this version of MSBuild only supports versions up to {1}.</source>
-        <target state="translated">MSB4235: a versão de formato do arquivo de log é {0}, enquanto esta versão do MSBuild dá suporte apenas para versões até {1}.</target>
-        <note>{StrBegin="MSB4235: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectEvaluationPerformanceSummary">
-        <source>Project Evaluation Performance Summary:</source>
-        <target state="translated">Resumo de Desempenho de Avaliação do Projeto:</target>
-        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedFalseCondition">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to false condition; ({4}) was evaluated as ({5}).</source>
-        <target state="translated">O projeto "{0}" não foi importado por "{1}" em ({2},{3}), devido a uma condição falsa; ({4}) foi avaliado como ({5}).</target>
+        <target state="new">Project "{0}" was not imported by "{1}" at ({2},{3}), due to false condition; ({4}) was evaluated as ({5}).</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedNoMatches">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to no matching files.</source>
-        <target state="translated">O projeto "{0}" não foi importado por "{1}" em ({2},{3}), devido a nenhum arquivo correspondente.</target>
+        <target state="new">Project "{0}" was not imported by "{1}" at ({2},{3}), due to no matching files.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedEmptyFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being empty.</source>
-        <target state="translated">O projeto "{0}" não foi importado por "{1}" em ({2},{3}), devido ao arquivo estar vazio.</target>
+        <target state="new">Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="new">Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="new">Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectImported">
         <source>Importing project "{0}" into project "{1}" at ({2},{3}).</source>
-        <target state="translated">Importando o projeto "{0}" no projeto "{1}" em ({2},{3}).</target>
+        <target state="new">Importing project "{0}" into project "{1}" at ({2},{3}).</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
-        <source>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</source>
-        <target state="translated">"{0}" de destino ignorado. O destino não existe no projeto e SkipNonexistentTargets está definido como verdadeiro.</target>
-        <note>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</note>
-      </trans-unit>
-      <trans-unit id="TaskFactoryTaskTypeIsNotSet">
-        <source>The task factory must return a value for the "TaskType" property.</source>
-        <target state="translated">A fábrica de tarefas deve retornar um valor para a propriedade "TaskType".</target>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="new">MSBUILD : error MSB4239: Error writing profiling report. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse">
-        <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
-        <target state="translated">A API "{0}" especificada não está disponível porque ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition foi definido durante o carregamento do projeto.</target>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="new">Writing profiler report to '{0}'...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CouldNotLoadSdkResolverAssembly">
-        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
-        <target state="translated">MSB4244: não foi possível carregar o assembly do resolvedor "{0}" do SDK. {1}</target>
-        <note>{StrBegin="MSB4244: "}</note>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="new">Done writing report.</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
         <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
@@ -2386,68 +2406,48 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: falha ao executar o resolvedor do SDK baseado em NuGet porque não foi possível localizar os assemblies do NuGet. Verifique a instalação do MSBuild ou defina a variável de ambiente "{0}" para a pasta que contém os assemblies necessários do NuGet. {1}</target>
+        <target state="new">MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectImportSkippedInvalidFile">
-        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
-        <target state="translated">O projeto "{0}" não foi importado por "{1}" em ({2},{3}) porque o arquivo era inválido.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectImportSkippedMissingFile">
-        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
-        <target state="translated">O projeto "{0}" não foi importado por "{1}" em ({2},{3}) porque o arquivo não existia.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingProfilerReport">
-        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
-        <target state="translated">MSBUILD : error MSB4239: erro ao gravar relatório de criação de perfil. {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WritingProfilerReport">
-        <source>Writing profiler report to '{0}'...</source>
-        <target state="translated">Gravando relatório do criador de perfil em '{0}'...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WritingProfilerReportDone">
-        <source>Done writing report.</source>
-        <target state="translated">Gravação do relatório concluída.</target>
-        <note />
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="translated">MSB4240: Não é possível especificar várias versões do mesmo "{0}" do SDK. A versão do SDK resolvida anteriormente "{1}" do local "{2}" será usada e a versão "{3}" será ignorada.</target>
+        <target state="new">MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: a referência do SDK "{0}" versão "{1}" foi resolvida para a versão "{2}". Talvez você estava usando um versão diferente que a esperada caso não tenha atualizado a versão referenciada de maneira correspondente.</target>
+        <target state="new">MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResolving">
         <source>Resolving SDK '{0}'...</source>
-        <target state="translated">Resolvendo o SDK '{0}'...</target>
+        <target state="new">Resolving SDK '{0}'...</target>
         <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
       <trans-unit id="SdkResolverManifestInvalid">
         <source>MSB4245: SDK Resolver manifest file is invalid. This may indicate a corrupt or invalid installation of MSBuild. Manifest file path '{0}'. Message: {1}</source>
-        <target state="translated">MSB4245: O arquivo de manifesto do Resolvedor do SDK é inválido. Isso pode indicar uma instalação do MSBuild inválida ou corrompida. Caminho do arquivo de manifesto '{0}'. Mensagem: {1}</target>
+        <target state="new">MSB4245: SDK Resolver manifest file is invalid. This may indicate a corrupt or invalid installation of MSBuild. Manifest file path '{0}'. Message: {1}</target>
         <note>{StrBegin="MSB4245: "}</note>
       </trans-unit>
       <trans-unit id="SdkResolverNoDllOrManifest">
         <source>MSB4246: SDK Resolver folder exists but without an SDK Resolver DLL or manifest file. This may indicate a corrupt or invalid installation of MSBuild. SDK resolver path: {0}</source>
-        <target state="translated">MSB4246: A pasta do Resolvedor do SDK existe, mas sem um arquivo DLL ou de manifesto do Resolvedor do SDK. Isso pode indicar uma instalação do MSBuild inválida ou corrompida. Caminho do resolvedor do SDK: {0}</target>
+        <target state="new">MSB4246: SDK Resolver folder exists but without an SDK Resolver DLL or manifest file. This may indicate a corrupt or invalid installation of MSBuild. SDK resolver path: {0}</target>
         <note>{StrBegin="MSB4246: "}</note>
       </trans-unit>
       <trans-unit id="SdkResolverDllInManifestMissing">
         <source>MSB4247: Could not load SDK Resolver. A manifest file exists, but the path to the SDK Resolver DLL file could not be found. Manifest file path '{0}'. SDK resolver path: {1}</source>
-        <target state="translated">MSB4247: Não foi possível carregar o Resolvedor do SDK. Existe um arquivo de manifesto, mas o caminho para o arquivo DLL do Resolvedor do SDK não pôde ser encontrado. Caminho do arquivo de manifesto '{0}'. Caminho do resolvedor do SDK: {1}</target>
+        <target state="new">MSB4247: Could not load SDK Resolver. A manifest file exists, but the path to the SDK Resolver DLL file could not be found. Manifest file path '{0}'. SDK resolver path: {1}</target>
         <note>{StrBegin="MSB4247: "}</note>
       </trans-unit>
     </body>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -262,6 +262,16 @@
         <target state="new">MSB4274: Disabling the inproc node leads to performance degradation when using project cache plugins that emit proxy build requests.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
@@ -2399,15 +2409,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</target>
         <target state="new">Done writing report.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="new">MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="new">The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -2380,8 +2380,8 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: La resolución del SDK "{0}" no se pudo ejecutar. {1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: Al deshabilitar el nodo InProc, se degrada el rendimiento cuando use los complementos de caché de proyectos que emiten solicitudes de compilación de proxy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: El proyecto "{0}" ha omitido las restricciones de aislamiento de gráficos en el proyecto "{1}" al que se hace referencia.</target>
@@ -2379,15 +2389,10 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
         <target state="translated">MSB4244: El ensamblado de la resolución del SDK "{0}" no se pudo cargar. {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: La resolución del SDK basado en NuGet no se pudo ejecutar porque no se encontraron los ensamblados de NuGet. Compruebe su instalación de MSBuild o configure la variable del entorno "{0}" en la carpeta que contiene los ensamblados de NuGet requeridos. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: La resolución del SDK basado en NuGet no se pudo ejecutar porque no se encontraron los ensamblados de NuGet. Compruebe su instalación de MSBuild o configure la variable del entorno "{0}" en la carpeta que contiene los ensamblados de NuGet requeridos. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -2380,8 +2380,8 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: Impossible d'exécuter la résolution de SDK "{0}". {1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: la désactivation du nœud inproc entraîne une détérioration des performances lors de l’utilisation de plug-ins de cache de projet qui émettent des requêtes de build proxy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: le projet "{0}" a ignoré les contraintes d'isolement de graphe dans le projet référencé "{1}"</target>
@@ -2379,15 +2389,10 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
         <target state="translated">MSB4244: Impossible de charger l'assembly de résolution de SDK "{0}". {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: Impossible d'exécuter la résolution de SDK NuGet parce que les assemblys NuGet n'ont pas pu être localisés. Vérifiez votre installation de MSBuild ou définissez la variable d'environnement "{0}" dans le dossier qui contient les assemblys NuGet obligatoires. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: Impossible d'exécuter la résolution de SDK NuGet parce que les assemblys NuGet n'ont pas pu être localisés. Vérifiez votre installation de MSBuild ou définissez la variable d'environnement "{0}" dans le dossier qui contient les assemblys NuGet obligatoires. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -2380,8 +2380,8 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: non è stato possibile eseguire il resolver SDK "{0}". {1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: la disabilitazione del nodo InProc porta a una riduzione del livello delle prestazioni quando si usano plug-in della cache del progetto che emettono richieste di compilazione proxy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: il progetto "{0}" ha ignorato i vincoli di isolamento del grafico nel progetto di riferimento "{1}"</target>
@@ -2379,15 +2389,10 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
         <target state="translated">MSB4244: non è stato possibile caricare l'assembly "{0}" del resolver SDK. {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: non è stato possibile eseguire il resolver SDK basato su NuGet perché non sono stati trovati assembly NuGet. Controllare l'installazione di MSBuild oppure impostare la variabile di ambiente "{0}" sulla cartella che contiene gli assembly NuGet richiesti. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: non è stato possibile eseguire il resolver SDK basato su NuGet perché non sono stati trovati assembly NuGet. Controllare l'installazione di MSBuild oppure impostare la variabile di ambiente "{0}" sulla cartella che contiene gli assembly NuGet richiesti. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -2380,8 +2380,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: SDK 競合回避モジュール "{0}" を実行できませんでした。{1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: プロキシ・ビルド要求を出すプロジェクト キャッシュ プラグインを使用する場合、InProc ノードを無効にするとパフォーマンスが低下します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: プロジェクト "{0}" は、参照先のプロジェクト "{1}" で、グラフの分離制約をスキップしました</target>
@@ -2379,15 +2389,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <target state="translated">MSB4244: SDK 競合回避モジュールのアセンブリ "{0}" を読み込めませんでした。{1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: NuGet アセンブリを見つけることができなかったため、NuGet ベースの SDK 競合回避モジュールを実行できませんでした。MSBuild のインストールを確認するか、環境変数 "{0}" を、必要な NuGet アセンブリが含まれているフォルダーに設定してください。{1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: NuGet アセンブリを見つけることができなかったため、NuGet ベースの SDK 競合回避モジュールを実行できませんでした。MSBuild のインストールを確認するか、環境変数 "{0}" を、必要な NuGet アセンブリが含まれているフォルダーに設定してください。{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -2380,8 +2380,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: SDK 확인자 "{0}"을(를) 실행하지 못했습니다. {1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: 프록시 빌드 요청을 내보내는 프로젝트 캐시 플러그 인을 사용할 때 inproc 노드를 사용하지 않도록 설정하면 성능이 저하됩니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 프로젝트 "{0}"에서 참조된 프로젝트 "{1}"의 그래프 격리 제약 조건을 건너뛰었습니다.</target>
@@ -2379,15 +2389,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <target state="translated">MSB4244: SDK 확인자 어셈블리 "{0}"을(를) 로드할 수 없습니다. {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: NuGet 어셈블리를 찾을 수 없어 NuGet 기반 SDK 확인자를 실행하지 못했습니다. MSBuild 설치를 확인하거나 환경 변수 "{0}"을(를) 필요한 NuGet 어셈블리가 포함된 폴더로 설정하세요. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: NuGet 어셈블리를 찾을 수 없어 NuGet 기반 SDK 확인자를 실행하지 못했습니다. MSBuild 설치를 확인하거나 환경 변수 "{0}"을(를) 필요한 NuGet 어셈블리가 포함된 폴더로 설정하세요. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: wyłączenie węzła InProc prowadzi do obniżenia wydajności, gdy używane są wtyczki pamięci podręcznej projektu, które emitują żądania kompilowania serwera proxy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: W przypadku projektu „{0}” pominięto ograniczenia izolacji grafu dla przywoływanego projektu „{1}”</target>
@@ -2379,15 +2389,10 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
         <target state="translated">MSB4244: Nie można załadować zestawu programu rozpoznawania zestawu SDK „{0}”. {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: Nie można uruchomić programu rozpoznawania zestawu SDK opartego na narzędziu NuGet, ponieważ nie można zlokalizować zestawów NuGet. Sprawdź instalację programu MSBuild lub ustaw zmienną środowiskową „{0}” na folder zawierający wymagane zestawy NuGet. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: Nie można uruchomić programu rozpoznawania zestawu SDK opartego na narzędziu NuGet, ponieważ nie można zlokalizować zestawów NuGet. Sprawdź instalację programu MSBuild lub ustaw zmienną środowiskową „{0}” na folder zawierający wymagane zestawy NuGet. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -2380,8 +2380,8 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: Nie można uruchomić programu rozpoznawania zestawu SDK „{0}”. {1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: desativar o nó inproc leva à degradação do desempenho ao usar plug-ins de cache de projeto que emitem solicitações de construção de proxy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: o projeto "{0}" ignorou as restrições de isolamento do gráfico no projeto referenciado "{1}"</target>
@@ -2379,15 +2389,10 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
         <target state="translated">MSB4244: não foi possível carregar o assembly do resolvedor "{0}" do SDK. {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: falha ao executar o resolvedor do SDK baseado em NuGet porque não foi possível localizar os assemblies do NuGet. Verifique a instalação do MSBuild ou defina a variável de ambiente "{0}" para a pasta que contém os assemblies necessários do NuGet. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: falha ao executar o resolvedor do SDK baseado em NuGet porque não foi possível localizar os assemblies do NuGet. Verifique a instalação do MSBuild ou defina a variável de ambiente "{0}" para a pasta que contém os assemblies necessários do NuGet. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -2380,8 +2380,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: не удалось запустить сопоставитель SDK "{0}". {1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: Отключение внутрипроцессного узла приводит к замедлению при использовании плагинов кэша проекта, которые создают запросы на сборку прокси-сервера.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: проект "{0}" пропустил ограничения изоляции графа в проекте "{1}", на который указывает ссылка.</target>
@@ -2379,15 +2389,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <target state="translated">MSB4244: не удалось загрузить сборку сопоставителя SDK типа "{0}". {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: не удалось запустить сопоставитель SDK на базе NuGet, так как не удалось найти сборки NuGet. Проверьте свою установку MSBuild или укажите папку, содержащую требуемые сборки NuGet, в качестве значения переменной среды "{0}". {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: не удалось запустить сопоставитель SDK на базе NuGet, так как не удалось найти сборки NuGet. Проверьте свою установку MSBuild или укажите папку, содержащую требуемые сборки NuGet, в качестве значения переменной среды "{0}". {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -2380,8 +2380,8 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: "{0}" SDK çözümleyicisi çalıştırılamadı. {1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: InProc düğümünün devre dışı bırakılması, ara sunucu oluşturma istekleri gönderen proje önbelleği eklentileri kullanılırken performans düşüşüne yol açar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: "{0}" projesi, başvurulan "{1}" projesindeki graf yalıtımı kısıtlamalarını atladı</target>
@@ -2379,15 +2389,10 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
         <target state="translated">MSB4244: "{0}" SDK çözümleyicisi bütünleştirilmiş kodu yüklenemedi. {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: NuGet bütünleştirilmiş kodları bulunamadığından NuGet tabanlı SDK çözümleyicisi çalıştırılamadı. MSBuild yüklemenizi denetleyin veya "{0}" ortam değişkenini gerekli NuGet bütünleştirilmiş kodlarını içeren klasör olarak ayarlayın. {1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: NuGet bütünleştirilmiş kodları bulunamadığından NuGet tabanlı SDK çözümleyicisi çalıştırılamadı. MSBuild yüklemenizi denetleyin veya "{0}" ortam değişkenini gerekli NuGet bütünleştirilmiş kodlarını içeren klasör olarak ayarlayın. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -2380,8 +2380,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: SDK 解析程序“{0}”运行失败。{1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: 使用发出代理构建请求的项目缓存插件时，禁用 inproc 节点会导致性能下降。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 项目“{0}”已跳过所引用的项目“{1}”上的图形隔离约束</target>
@@ -2379,15 +2389,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <target state="translated">MSB4244: 无法加载 SDK 解析程序程序集“{0}”。{1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: 基于 NuGet 的 SDK 解析程序运行失败，因为无法找到 NuGet 程序集。请检查你安装的 MSBuild 或将环境变量“{0}”设置为包含所需 NuGet 程序集的文件夹。{1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: 基于 NuGet 的 SDK 解析程序运行失败，因为无法找到 NuGet 程序集。请检查你安装的 MSBuild 或将环境变量“{0}”设置为包含所需 NuGet 程序集的文件夹。{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -263,8 +263,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
-        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
-        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <source>MSB4242: SDK Resolver Failure: "{0}"</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}"</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="SDKResolverFailed">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -2380,8 +2380,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
-        <target state="translated">MSB4242: SDK 解析程式 "{0}" 無法執行。{1}</target>
+        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
+        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
         <note>{StrBegin="MSB4242: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -262,6 +262,16 @@
         <target state="translated">MSB4274: 停用 inproc 節點會在使用可發出 proxy 組建要求的專案快取外掛程式時，導致效能降低。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverCriticalFailure">
+        <source>MSB4242: SDK Resolver Failure: "{0}".</source>
+        <target state="new">MSB4242: SDK Resolver Failure: "{0}".</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="SDKResolverFailed">
+        <source>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</source>
+        <target state="new">The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 專案 "{0}" 已跳過參考專案 "{1}" 上的圖形隔離條件約束</target>
@@ -2379,15 +2389,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <target state="translated">MSB4244: 無法載入 SDK 解析程式組件 "{0}"。{1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotRunSdkResolver">
-        <source>MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</source>
-        <target state="new">MSB4242: The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}</target>
-        <note>{StrBegin="MSB4242: "}</note>
-      </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
-        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: 因為找不到 NuGet 組件，所以 NuGet 型 SDK 解析程式無法執行。請檢查您的 MSBuild 安裝，或將環境變數 "{0}" 設定為包含必要 NuGet 組件的資料夾。{1}</target>
-        <note>{StrBegin="MSB4243: "}</note>
+        <source>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="needs-review-translation">MSB4243: 因為找不到 NuGet 組件，所以 NuGet 型 SDK 解析程式無法執行。請檢查您的 MSBuild 安裝，或將環境變數 "{0}" 設定為包含必要 NuGet 組件的資料夾。{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>


### PR DESCRIPTION
Fixes #6762 

### Context
When SDK Resolvers fail, we currently log a warning and try to continue the build. This leads to a failure at some point in the future, which is confusing for customers.

### Changes Made
- SdkResolverService now catches exceptions and throws an `SdkResolverException`
- Evaluator catches SdkResolverException and fails the build, providing the inner-error message along with `MSB4242`.
- MSB4243 freed up. See notes below

### Testing
Tested on a local standalone sdk. See comments below.

### Notes
- MSB4242 now has a slightly different meaning. It's a catch-all "sdk resolvers failed somehow" exception. It will then report whatever the resolver's message was, so the resolver's error codes had to had to be removed. Removing the other error codes prevents this sort of message: `MSB4242: Sdk Resolver Failure: MSB4243: blah blah`.