### PR TITLE
Opt out of implicit namespaces

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,9 @@
     <!-- Ensure that compiler errors emit full paths so that files
          can be correctly annotated in GitHub. -->
     <GenerateFullPaths>true</GenerateFullPaths>
+    
+    <!-- https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces -->
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 
     <!-- Do not mangle paths for test assemblies, because Shoudly assertions want actual on-disk paths. -->
     <DeterministicSourcePaths Condition="'$(IsTestProject)' == 'true'">false</DeterministicSourcePaths>


### PR DESCRIPTION
### Context
https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces

Staying opted in results in many errors of ambiguous references between MSBuild's Task type and System.Threading's Task type.

### Changes Made
Set `DisableImplicitNamespaceImports` to true in src/Directory.Build.props

### Testing


### Notes
