### PR TITLE
Block Execution of GetType() in Evaluation

### DIFF
--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4769,6 +4769,23 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 });
         }
 
+        [Fact]
+        public void VerifyGetTypeEvaluationBlocked()
+        {
+            string projectContents = ObjectModelHelpers.CleanupFileContents(@"
+                             <Project>
+                               <PropertyGroup>
+                                 <TestProp>$(MSBuildRuntimeType.GetType())</TestProp>
+                               </PropertyGroup>
+                             </Project>");
+
+            ProjectCollection fakeProjectCollection =
+                GetProjectCollectionWithFakeToolset(null /* no global properties */);
+
+            Should.Throw<InvalidProjectFileException>(() =>
+                new Project(XmlReader.Create(new StringReader(projectContents)), null, "Fake", fakeProjectCollection));
+        }
+
         private void VerifyPropertyTrackingLoggingScenario(string envVarValue, Action<MockLogger> loggerEvaluatorAction)
         {
             // The default is that only reassignments are logged.

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -1928,7 +1928,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
-            string result = expander.ExpandIntoStringLeaveEscaped("$([System.Convert]::ChangeType('null',$(SomeStuff.GetType())))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+            string result = expander.ExpandIntoStringLeaveEscaped("$([System.Convert]::ChangeType('null',$(SomeStuff.GetTypeCode())))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
             Assert.Equal("null", result);
         }

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3352,6 +3352,12 @@ namespace Microsoft.Build.Evaluation
                     }
                     else
                     {
+                        // Check that the function that we're going to call is valid to call
+                        if (!IsInstanceMethodAvailable(_methodMethodName))
+                        {
+                            ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "InvalidFunctionMethodUnavailable", _methodMethodName, _receiverType.FullName);
+                        }
+
                         _bindingFlags |= BindingFlags.Instance;
 
                         // The object that we're about to call methods on may have escaped characters
@@ -5015,6 +5021,19 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 return AvailableStaticMethods.GetTypeInformationFromTypeCache(receiverType.FullName, methodName) != null;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static bool IsInstanceMethodAvailable(string methodName)
+            {
+                if (Traits.Instance.EnableAllPropertyFunctions)
+                {
+                    // anything goes
+                    return true;
+                }
+
+                // This could be expanded to an allow / deny list.
+                return methodName != "GetType";
             }
 
             /// <summary>

--- a/src/Shared/ResourceUtilities.cs
+++ b/src/Shared/ResourceUtilities.cs
@@ -231,12 +231,14 @@ namespace Microsoft.Build.Shared
                 // FormatResourceString calls ToString() which returns the full name of the type!
                 foreach (object param in args)
                 {
-                    // Check it has a real implementation of ToString()
+                    // Check it has a real implementation of ToString() and the type is not actually System.String
                     if (param != null)
                     {
-                        if (String.Equals(param.GetType().ToString(), param.ToString(), StringComparison.Ordinal))
+                        if (string.Equals(param.GetType().ToString(), param.ToString(), StringComparison.Ordinal) &&
+                            param.GetType() != typeof(string))
                         {
-                            ErrorUtilities.ThrowInternalError("Invalid resource parameter type, was {0}", param.GetType().FullName);
+                            ErrorUtilities.ThrowInternalError("Invalid resource parameter type, was {0}",
+                                param.GetType().FullName);
                         }
                     }
                 }


### PR DESCRIPTION
Stop allowing execution of `GetType()`. This can lead to calling methods that really should not be called during evaluation.