### PR TITLE
Help GenerateResource find assemblies when built with MSBuildLocator

### DIFF
--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -794,16 +794,15 @@ namespace Microsoft.Build.Tasks
                                     AppDomain.CurrentDomain.SetupInformation
                                 );
 
-                                object obj = appDomain.CreateInstanceFromAndUnwrap
+                                process = appDomain.CreateInstanceFromAndUnwrap
                                    (
                                        typeof(ProcessResourceFiles).Module.FullyQualifiedName,
                                        typeof(ProcessResourceFiles).FullName
-                                   );
+                                   ) as ProcessResourceFiles;
 
-                                Type processType = obj.GetType();
-                                ErrorUtilities.VerifyThrow(processType == typeof(ProcessResourceFiles), "Somehow got a wrong and possibly incompatible type for ProcessResourceFiles.");
+                                ErrorUtilities.VerifyThrow(process is not null, "Somehow got a wrong and possibly incompatible type for ProcessResourceFiles.");
 
-                                process = (ProcessResourceFiles)obj;
+                                process.Setup();
 
                                 RecordItemsForDisconnectIfNecessary(_references);
                                 RecordItemsForDisconnectIfNecessary(inputsToProcess);
@@ -814,6 +813,7 @@ namespace Microsoft.Build.Tasks
                             {
                                 process = new ProcessResourceFiles();
                             }
+
 
                             process.Run(Log,
                                         _references,
@@ -2391,6 +2391,24 @@ namespace Microsoft.Build.Tasks
         private bool _useSourcePath = false;
 
 #endregion
+        internal void Setup()
+        {
+            static Assembly TryLoadAssembly(AssemblyName assemblyName)
+            {
+                // Look in the MSBuild folder for any unresolved reference. It may be a dependency
+                // of MSBuild or a task.
+                string msbuildDirectoryPath = Path.GetDirectoryName(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
+                string targetAssembly = Path.Combine(msbuildDirectoryPath, assemblyName.Name + ".dll");
+                if (File.Exists(targetAssembly))
+                {
+                    return Assembly.LoadFrom(targetAssembly);
+                }
+
+                return null;
+            }
+            AppDomain dom = AppDomain.CurrentDomain;
+            dom.AssemblyResolve += (_, eventArgs) => TryLoadAssembly(new AssemblyName(eventArgs.Name));
+        }
 
         /// <summary>
         /// Process all files.

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -814,7 +814,6 @@ namespace Microsoft.Build.Tasks
                                 process = new ProcessResourceFiles();
                             }
 
-
                             process.Run(Log,
                                         _references,
                                         inputsToProcess,


### PR DESCRIPTION
If GenerateResource is forced to create a new App Domain, it loses modifications made to the parent app domain. With mainline MSBuild, this is no problem because we don't make modifications. With MSBuildLocator, we do, and losing those modifications (specifically that MSBuildLocator teaches it to find MSBuild and related assemblies) prevents it from finding the assemblies it needs to execute this task.

This adds an extra "Setup" method before we use the new app domain that adds assemblies next to MSBuild to the app domain.

Fixes [AB#1371725](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1371725)

(See that bug)

Tested it with the attached repro project, and it no longer repros. I also verified that this still works when building with MSBuild.exe directly.