### PR TITLE
Add InternalsVisibleTo to common types schema

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -5808,4 +5808,32 @@ elementFormDefault="qualified">
     </xs:complexType>
   </xs:element>
 
+  <xs:element name="InternalsVisibleTo" substitutionGroup="msb:Item">
+  <xs:annotation>
+    <xs:documentation>
+      <!-- _locID_text="InternalsVisibleTo" _locComment="" -->Specifies that types that are ordinarily visible only within the assembly are visible to the specified assemblies.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:attribute name="Include" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="InternalsVisibleTo_Include" _locComment="" -->The name of the friend assembly to make internal types visible to, e.g. Microsoft.AspNetCore.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="PublicKey" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="InternalsVisibleTo_PublicKey" _locComment="" -->Optional public key associated with the strong name signature of the friend assembly.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
 </xs:schema>


### PR DESCRIPTION
Fixes #6777

Since [.NET 5](https://github.com/dotnet/sdk/blob/2a515cdbd8f6be1b019ae2c8d7f21952592f0697/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets#L39), the `<InternalsVisibleTo Include="MyProject.Assmebly" />` item type has been supported to generate the `System.Runtime.CompilerServices.InternalsVisibleTo` for the output assembly. The definition for this item type should be in the [common types schema file](https://github.com/dotnet/msbuild/blob/main/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd) so that editors (like Visual Studio) provide statement completion and a QuickInfo tooltip for it.