### PR TITLE
Cache Embedded Resources during compilation task

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3655,6 +3655,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
       <CoreCompileCache Include="@(Compile)" />
+      <CoreCompileCache Include="@(EmbeddedResource)" />
       <CoreCompileCache Include="@(ReferencePath)" />
       <CoreCompileCache Include="$(DefineConstants)" />
     </ItemGroup>


### PR DESCRIPTION
Fixes #5334

### Context

Fast up-to-date check with SDK project doesn't see new embedded resources!

### Changes Made

To cache the `EmbeddedResource` items, we just add those to the existing inputs
through `CoreCompileCache` item, to include them in the cache file which gets
included in the `CoreCompile` target.

### Testing

Manually verified using MSBuild Log Viewer with the repro present [hyrmn/ReproGlobsNotEmbedding](/hyrmn/ReproGlobsNotEmbedding).

### Notes

See dotnet/project-system#5794 for more details.