### PR TITLE
Update System.Text.Json to 5.0.2

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -35,7 +35,7 @@
     <PackageReference Update="System.Security.Permissions" Version="4.7.0" />
     <PackageReference Update="System.Security.Principal.Windows" Version="4.7.0" />
     <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
-    <PackageReference Update="System.Text.Json" Version="4.7.0" />
+    <PackageReference Update="System.Text.Json" Version="5.0.2" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Update="xunit.assert" Version="$(XUnitVersion)" />
     <PackageReference Update="xunit.console" Version="$(XUnitVersion)" />

--- a/src/Build/System.Text.Encodings.Web.pkgdef
+++ b/src/Build/System.Text.Encodings.Web.pkgdef
@@ -1,7 +1,0 @@
-[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{1A1A9DA4-9F25-4AC8-89BF-BCEF74875CA8}]
-"name"="System.Text.Encodings.Web"
-"codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\System.Text.Encodings.Web.dll"
-"publicKeyToken"="cc7b13ffcd2ddd51"
-"culture"="neutral"
-"oldVersion"="0.0.0.0-5.0.0.1"
-"newVersion"="5.0.0.1"

--- a/src/Build/System.Text.Encodings.Web.pkgdef
+++ b/src/Build/System.Text.Encodings.Web.pkgdef
@@ -3,5 +3,5 @@
 "codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\System.Text.Encodings.Web.dll"
 "publicKeyToken"="cc7b13ffcd2ddd51"
 "culture"="neutral"
-"oldVersion"="0.0.0.0-4.0.5.0"
-"newVersion"="4.0.5.0"
+"oldVersion"="0.0.0.0-5.0.0.1"
+"newVersion"="5.0.0.1"

--- a/src/Build/System.Text.Json.pkgdef
+++ b/src/Build/System.Text.Json.pkgdef
@@ -3,5 +3,5 @@
 "codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\System.Text.Json.dll"
 "publicKeyToken"="cc7b13ffcd2ddd51"
 "culture"="neutral"
-"oldVersion"="0.0.0.0-4.0.1.0"
-"newVersion"="4.0.1.0"
+"oldVersion"="0.0.0.0-5.0.0.2"
+"newVersion"="5.0.0.2"

--- a/src/Build/System.Text.Json.pkgdef
+++ b/src/Build/System.Text.Json.pkgdef
@@ -1,7 +1,0 @@
-[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{1F1A9DA4-9F25-4AB8-89BF-BCEF73875178}]
-"name"="System.Text.Json"
-"codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\System.Text.Json.dll"
-"publicKeyToken"="cc7b13ffcd2ddd51"
-"culture"="neutral"
-"oldVersion"="0.0.0.0-5.0.0.2"
-"newVersion"="5.0.0.2"

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -25,11 +25,17 @@
 
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ApplicationManifest>MSBuild.exe.manifest</ApplicationManifest>
+
     <AppConfig>app.config</AppConfig>
     <!-- Temporary solution for
          https://github.com/Microsoft/msbuild/issues/834 Long term
          two files should be generated from a single source. -->
     <AppConfig Condition="'$(Platform)' == 'x64'">app.amd64.config</AppConfig>
+    <!-- Disable binding redirect generation: we want to be deliberate
+         about the redirects we expose plugins to, and we explicitly
+         redirect ValueTuple _down_ to match VS. -->
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+
     <IsPackable>true</IsPackable>
     <ContentTargetFolders>contentFiles</ContentTargetFolders>
     <BuildOutputTargetFolder>contentFiles\any\</BuildOutputTargetFolder>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -108,7 +108,10 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+          <!-- It is unusual to redirect down, but in this case it's ok: 4.0.3.0 forwards
+               to 4.0.0.0 in the GAC, so this just removes the need to redistribute a file
+               and makes that resolution faster. -->
+          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.0.0" />
         </dependentAssembly>
 
         <!-- Redirects for components dropped by Visual Studio -->

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -92,11 +92,11 @@
       </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+          <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+          <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -98,7 +98,10 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+          <!-- It is unusual to redirect down, but in this case it's ok: 4.0.3.0 forwards
+               to 4.0.0.0 in the GAC, so this just removes the need to redistribute a file
+               and makes that resolution faster. -->
+          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.0.0" />
         </dependentAssembly>
 
         <!-- Redirects for components dropped by Visual Studio -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -82,11 +82,11 @@
       </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+          <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+          <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -42,7 +42,6 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.Bcl.AsyncInterfaces.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Text.Encodings.Web.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Threading.Tasks.Extensions.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
-  file source=$(X86BinPath)System.ValueTuple.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Resources.Extensions.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
@@ -187,7 +186,6 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)Microsoft.Bcl.AsyncInterfaces.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Text.Encodings.Web.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Extensions.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.ValueTuple.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Resources.Extensions.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -310,8 +310,6 @@ folder InstallDir:\Common7\IDE\CommonExtensions\MSBuild
   file source=$(SourceDir)Package\MSBuild.VSSetup\MSBuild.clientenabledpkg
   file source=$(SourceDir)Framework\Microsoft.Build.Framework.pkgdef
   file source=$(SourceDir)Build\Microsoft.Build.pkgdef
-  file source=$(SourceDir)Build\System.Text.Encodings.Web.pkgdef
-  file source=$(SourceDir)Build\System.Text.Json.pkgdef
   file source=$(SourceDir)StringTools\StringTools.pkgdef
   file source=$(SourceDir)Tasks\Microsoft.Build.Tasks.Core.pkgdef
   file source=$(SourceDir)Tasks\System.Resources.Extensions.pkgdef


### PR DESCRIPTION
Fixes conflicts in VS 2022 for extensions that would like to use libraries that need System.Text.Json 5.0.0 or newer.

### Context
Fixes conflicts in VS 2022 for extensions that would like to use libraries that need System.Text.Json 5.0.0 or newer.

### Changes Made
Updated packages.

### Testing
None :)

### Notes
