### PR TITLE
Only set debug path when MSBuildDebugEngine is set

### DIFF
--- a/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
+++ b/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Shared;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests
+{
+    public class DebugUtils_Tests
+    {
+        [Fact]
+        public void DumpExceptionToFileShouldWriteInTempPathByDefault()
+        {
+            Directory.GetFiles(Path.GetTempPath(), "MSBuild_*failure.txt").ShouldBeEmpty();
+
+            string[] exceptionFiles = null;
+
+            try
+            {
+                ExceptionHandling.DumpExceptionToFile(new Exception("hello world"));
+                exceptionFiles = Directory.GetFiles(Path.GetTempPath(), "MSBuild_*failure.txt");
+            }
+            finally
+            {
+                exceptionFiles.ShouldNotBeNull();
+                exceptionFiles.ShouldHaveSingleItem();
+
+                var exceptionFile = exceptionFiles.First();
+                File.ReadAllText(exceptionFile).ShouldContain("hello world");
+                File.Delete(exceptionFile);
+            }
+        }
+    }
+}

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Build.Internal
             // The DebugUtils static constructor can set the MSBUILDDEBUGPATH environment variable to propagate the debug path to out of proc nodes.
             // Need to ensure that constructor is called before this method returns in order to capture its env var write.
             // Otherwise the env var is not captured and thus gets deleted when RequiestBuilder resets the environment based on the cached results of this method.
-            ErrorUtilities.VerifyThrowInternalNull(DebugUtils.DebugPath, nameof(DebugUtils.DebugPath));
+            ErrorUtilities.VerifyThrowInternalNull(DebugUtils.ProcessInfoString, nameof(DebugUtils.DebugPath));
 #endif
 
             Dictionary<string, string> table = new Dictionary<string, string>(200, StringComparer.OrdinalIgnoreCase); // Razzle has 150 environment variables

--- a/src/Shared/Debugging/DebugUtils.cs
+++ b/src/Shared/Debugging/DebugUtils.cs
@@ -26,13 +26,17 @@ namespace Microsoft.Build.Shared.Debugging
             if (Traits.Instance.DebugEngine)
             {
                 debugDirectory ??= Path.Combine(Directory.GetCurrentDirectory(), "MSBuild_Logs");
-                FileUtilities.EnsureDirectoryExists(debugDirectory);
 
                 // Out of proc nodes do not know the startup directory so set the environment variable for them.
                 if (string.IsNullOrWhiteSpace(environmentDebugPath))
                 {
                     Environment.SetEnvironmentVariable("MSBUILDDEBUGPATH", debugDirectory);
                 }
+            }
+
+            if (debugDirectory is not null)
+            {
+                FileUtilities.EnsureDirectoryExists(debugDirectory);
             }
 
             DebugPath = debugDirectory;

--- a/src/Shared/Debugging/DebugUtils.cs
+++ b/src/Shared/Debugging/DebugUtils.cs
@@ -21,10 +21,11 @@ namespace Microsoft.Build.Shared.Debugging
         static DebugUtils()
         {
             string environmentDebugPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
-            var debugDirectory = environmentDebugPath ?? Path.Combine(Directory.GetCurrentDirectory(), "MSBuild_Logs");
+            var debugDirectory = environmentDebugPath;
 
             if (Traits.Instance.DebugEngine)
             {
+                debugDirectory ??= Path.Combine(Directory.GetCurrentDirectory(), "MSBuild_Logs");
                 FileUtilities.EnsureDirectoryExists(debugDirectory);
 
                 // Out of proc nodes do not know the startup directory so set the environment variable for them.


### PR DESCRIPTION
### Context
Fixes #6772, fixes AB#1386501

### Changes Made
In #6639 I thought it would be a good idea to always expose exceptions by always setting msbuild's debug path, fallbacking to the current working directory. But apparently that's a breaking change :)
Also, some processes (like VS helpers) do not propagate the user's CWD and thus end up writing under Program Files which fails with permission exceptions.

So only set the debug path to the current working directory when `MSBuildDebugEngine` is set.

### Testing
Unit test and manual tests

### Notes
I couldn't actually repro #6772. What I did instead was to change the oop nodes to crash right after completing the handshake, and checked that `MSBuild_Logs` does not appear in the CWD, but instead the exception dumps appear under Temp.