### PR TITLE
Add invariant check to InternableString.ExpensiveConvertToString

### DIFF
--- a/src/StringTools/InternableString.cs
+++ b/src/StringTools/InternableString.cs
@@ -265,6 +265,14 @@ namespace Microsoft.NET.StringTools
                         }
                     }
                 }
+
+                // The invariant that Length is the sum of span lengths is critical in this unsafe method.
+                // Violating it may lead to memory corruption and, since this code tends to run under a lock,
+                // to hangs caused by the lock getting orphaned.
+                if (destPtr != resultPtr + Length)
+                {
+                    throw new InvalidOperationException("Length property does not match sum of span lengths");
+                }
             }
             return result;
         }

--- a/src/StringTools/InternableString.cs
+++ b/src/StringTools/InternableString.cs
@@ -272,7 +272,7 @@ namespace Microsoft.NET.StringTools
                 // before the corruption causes further problems.
                 if (destPtr != resultPtr + Length)
                 {
-                    throw new InvalidOperationException("Length property does not match sum of span lengths");
+                    throw new InvalidOperationException($"Length of {Length} does not match the sum of span lengths of {destPtr - resultPtr}.");
                 }
             }
             return result;

--- a/src/StringTools/InternableString.cs
+++ b/src/StringTools/InternableString.cs
@@ -268,7 +268,8 @@ namespace Microsoft.NET.StringTools
 
                 // The invariant that Length is the sum of span lengths is critical in this unsafe method.
                 // Violating it may lead to memory corruption and, since this code tends to run under a lock,
-                // to hangs caused by the lock getting orphaned.
+                // to hangs caused by the lock getting orphaned. Attempt to detect that and throw now, 
+                // before the corruption causes further problems.
                 if (destPtr != resultPtr + Length)
                 {
                     throw new InvalidOperationException("Length property does not match sum of span lengths");


### PR DESCRIPTION
Fixes [AB#1343753](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1343753)

### Context
We're getting hang dumps where a lock taken by the concurrent flavor of `WeakStringCache` is orphaned. This can possibly be caused by `InternableString.ExpensiveConvertToString`, which is running unsafe code under the lock, throwing a corrupting exception, thus preventing the lock-releasing finally blocks from running.

### Changes Made
Since no bug has been found in stress runs and by extensive code inspection, I am adding a cheap invariant check to the unsafe method, hoping that it would help us figure out the issue.

### Testing
Smoke-tested the invariant.
