### PR TITLE
Switch to 1ES Hosted Pools

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -8,7 +8,7 @@ jobs:
   displayName: "Windows Full"
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
   steps:
   - task: BatchScript@1
     displayName: cibuild_bootstrapped_msbuild.cmd
@@ -55,7 +55,7 @@ jobs:
   displayName: "Windows Core"
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
   steps:
   - task: BatchScript@1
     displayName: cibuild_bootstrapped_msbuild.cmd
@@ -103,7 +103,7 @@ jobs:
   displayName: "Windows Full Release (no bootstrap)"
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
   steps:
   - task: BatchScript@1
     displayName: cibuild.cmd
@@ -151,7 +151,7 @@ jobs:
   displayName: "Windows Code Indexing"
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2022.Pre.Open
   steps:
   - task: BatchScript@1
     displayName: build.cmd

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -7,7 +7,7 @@ jobs:
 - job: BootstrapMSBuildOnFullFrameworkWindows
   displayName: "Windows Full"
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   steps:
   - task: BatchScript@1
@@ -54,7 +54,7 @@ jobs:
 - job: BootstrapMSBuildOnCoreWindows
   displayName: "Windows Core"
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   steps:
   - task: BatchScript@1
@@ -102,7 +102,7 @@ jobs:
 - job: FullReleaseOnWindows
   displayName: "Windows Full Release (no bootstrap)"
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   steps:
   - task: BatchScript@1
@@ -150,7 +150,7 @@ jobs:
 - job: RichCodeNavIndex
   displayName: "Windows Code Indexing"
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   steps:
   - task: BatchScript@1
@@ -167,7 +167,7 @@ jobs:
 - job: CoreBootstrappedOnLinux
   displayName: "Linux Core"
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -8,7 +8,7 @@ jobs:
   displayName: "Windows Full"
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   steps:
   - task: BatchScript@1
     displayName: cibuild_bootstrapped_msbuild.cmd
@@ -55,7 +55,7 @@ jobs:
   displayName: "Windows Core"
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   steps:
   - task: BatchScript@1
     displayName: cibuild_bootstrapped_msbuild.cmd
@@ -103,7 +103,7 @@ jobs:
   displayName: "Windows Full Release (no bootstrap)"
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   steps:
   - task: BatchScript@1
     displayName: cibuild.cmd
@@ -151,7 +151,7 @@ jobs:
   displayName: "Windows Code Indexing"
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   steps:
   - task: BatchScript@1
     displayName: build.cmd
@@ -168,7 +168,7 @@ jobs:
   displayName: "Linux Core"
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Ubuntu.2004.Amd64.Open.svc
+    demands: ImageOverride -equals Ubuntu.2004.Amd64.Open
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build
@@ -203,7 +203,7 @@ jobs:
   displayName: "macOS Core"
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals OSX.1015.Amd64
+    demands: ImageOverride -equals OSX.1015.Amd64.Open
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -168,7 +168,7 @@ jobs:
   displayName: "Linux Core"
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Ubuntu.2004.Amd64.Open
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -7,7 +7,8 @@ jobs:
 - job: BootstrapMSBuildOnFullFrameworkWindows
   displayName: "Windows Full"
   pool:
-    vmImage: 'windows-2019'
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
   steps:
   - task: BatchScript@1
     displayName: cibuild_bootstrapped_msbuild.cmd
@@ -53,7 +54,8 @@ jobs:
 - job: BootstrapMSBuildOnCoreWindows
   displayName: "Windows Core"
   pool:
-    vmImage: 'windows-2019'
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
   steps:
   - task: BatchScript@1
     displayName: cibuild_bootstrapped_msbuild.cmd
@@ -100,7 +102,8 @@ jobs:
 - job: FullReleaseOnWindows
   displayName: "Windows Full Release (no bootstrap)"
   pool:
-    vmImage: 'windows-2019'
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
   steps:
   - task: BatchScript@1
     displayName: cibuild.cmd
@@ -147,7 +150,8 @@ jobs:
 - job: RichCodeNavIndex
   displayName: "Windows Code Indexing"
   pool:
-    vmImage: 'windows-latest'
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
   steps:
   - task: BatchScript@1
     displayName: build.cmd
@@ -163,7 +167,8 @@ jobs:
 - job: CoreBootstrappedOnLinux
   displayName: "Linux Core"
   pool:
-    vmImage: 'ubuntu-latest'
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Ubuntu.2004.Amd64.Open.svc
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build
@@ -197,7 +202,8 @@ jobs:
 - job: CoreOnMac
   displayName: "macOS Core"
   pool:
-    vmImage: 'macOS-10.14'
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals OSX.1015.Amd64
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -202,8 +202,7 @@ jobs:
 - job: CoreOnMac
   displayName: "macOS Core"
   pool:
-    name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals OSX.1015.Amd64.Open
+    vmImage: 'macOS-10.14'
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build


### PR DESCRIPTION
This may help speed builds up relative to the public
hosted pools that can only run 200 builds in parallel
across all of dotnet.
