### PR TITLE
Log message arguments for warnings and errors

### DIFF
--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -189,8 +189,10 @@ namespace Microsoft.Build.UnitTests
                 e => e.ThreadId.ToString());
         }
 
-        [Fact]
-        public void RoundtripBuildErrorEventArgs()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RoundtripBuildErrorEventArgs(bool useArguments)
         {
             var args = new BuildErrorEventArgs(
                 "Subcategory",
@@ -200,9 +202,11 @@ namespace Microsoft.Build.UnitTests
                 2,
                 3,
                 4,
-                "Message",
+                "Message with arguments: '{0}'",
                 "Help",
-                "SenderName");
+                "SenderName",
+                DateTime.Parse("9/1/2021 12:02:07 PM"),
+                useArguments ? new object[] { "argument0" } : null);
 
             Roundtrip(args,
                 e => e.Code,
@@ -213,11 +217,14 @@ namespace Microsoft.Build.UnitTests
                 e => e.LineNumber.ToString(),
                 e => e.Message,
                 e => e.ProjectFile,
-                e => e.Subcategory);
+                e => e.Subcategory,
+                e => string.Join(", ", e.RawArguments ?? Array.Empty<object>()));
         }
 
-        [Fact]
-        public void RoundtripBuildWarningEventArgs()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RoundtripBuildWarningEventArgs(bool useArguments)
         {
             var args = new BuildWarningEventArgs(
                 "Subcategory",
@@ -227,9 +234,11 @@ namespace Microsoft.Build.UnitTests
                 2,
                 3,
                 4,
-                "Message",
+                "Message with arguments: '{0}'",
                 "Help",
-                "SenderName");
+                "SenderName",
+                DateTime.Parse("9/1/2021 12:02:07 PM"),
+                useArguments ? new object[] { "argument0" } : null);
 
             Roundtrip(args,
                 e => e.Code,
@@ -240,11 +249,14 @@ namespace Microsoft.Build.UnitTests
                 e => e.LineNumber.ToString(),
                 e => e.Message,
                 e => e.ProjectFile,
-                e => e.Subcategory);
+                e => e.Subcategory,
+                e => string.Join(", ", e.RawArguments ?? Array.Empty<object>()));
         }
 
-        [Fact]
-        public void RoundtripBuildMessageEventArgs()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RoundtripBuildMessageEventArgs(bool useArguments)
         {
             var args = new BuildMessageEventArgs(
                 "Subcategory",
@@ -258,7 +270,8 @@ namespace Microsoft.Build.UnitTests
                 "Help",
                 "SenderName",
                 MessageImportance.High,
-                DateTime.Parse("12/12/2015 06:11:56 PM"));
+                DateTime.Parse("12/12/2015 06:11:56 PM"),
+                useArguments ? new object[] { "argument0" } : null);
 
             Roundtrip(args,
                 e => e.Code,
@@ -270,7 +283,8 @@ namespace Microsoft.Build.UnitTests
                 e => e.Message,
                 e => e.Importance.ToString(),
                 e => e.ProjectFile,
-                e => e.Subcategory);
+                e => e.Subcategory,
+                e => string.Join(", ", e.RawArguments ?? Array.Empty<object>()));
         }
 
         [Fact]

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -392,6 +392,7 @@ Build
         {
             Write(BinaryLogRecordKind.Error);
             WriteBuildEventArgsFields(e);
+            WriteArguments(e.RawArguments);
             WriteDeduplicatedString(e.Subcategory);
             WriteDeduplicatedString(e.Code);
             WriteDeduplicatedString(e.File);
@@ -406,6 +407,7 @@ Build
         {
             Write(BinaryLogRecordKind.Warning);
             WriteBuildEventArgsFields(e);
+            WriteArguments(e.RawArguments);
             WriteDeduplicatedString(e.Subcategory);
             WriteDeduplicatedString(e.Code);
             WriteDeduplicatedString(e.File);
@@ -564,7 +566,7 @@ Build
         private void WriteMessageFields(BuildMessageEventArgs e, bool writeMessage = true, bool writeImportance = false)
         {
             var flags = GetBuildEventArgsFieldFlags(e, writeMessage);
-            flags = GetMessageFlags(e, flags, writeMessage, writeImportance);
+            flags = GetMessageFlags(e, flags, writeImportance);
 
             Write((int)flags);
 
@@ -612,12 +614,7 @@ Build
 
             if ((flags & BuildEventArgsFieldFlags.Arguments) != 0)
             {
-                Write(e.RawArguments.Length);
-                for (int i = 0; i < e.RawArguments.Length; i++)
-                {
-                    string argument = Convert.ToString(e.RawArguments[i], CultureInfo.CurrentCulture);
-                    WriteDeduplicatedString(argument);
-                }
+                WriteArguments(e.RawArguments);
             }
 
             if ((flags & BuildEventArgsFieldFlags.Importance) != 0)
@@ -626,7 +623,23 @@ Build
             }
         }
 
-        private static BuildEventArgsFieldFlags GetMessageFlags(BuildMessageEventArgs e, BuildEventArgsFieldFlags flags, bool writeMessage = true, bool writeImportance = false)
+        private void WriteArguments(object[] arguments)
+        {
+            if (arguments == null || arguments.Length == 0)
+            {
+                return;
+            }
+
+            int count = arguments.Length;
+            Write(count);
+            for (int i = 0; i < count; i++)
+            {
+                string argument = Convert.ToString(arguments[i], CultureInfo.CurrentCulture);
+                WriteDeduplicatedString(argument);
+            }
+        }
+
+        private static BuildEventArgsFieldFlags GetMessageFlags(BuildMessageEventArgs e, BuildEventArgsFieldFlags flags, bool writeImportance = false)
         {
             if (e.Subcategory != null)
             {
@@ -668,11 +681,6 @@ Build
                 flags |= BuildEventArgsFieldFlags.EndColumnNumber;
             }
 
-            if (writeMessage && e.RawArguments != null && e.RawArguments.Length > 0)
-            {
-                flags |= BuildEventArgsFieldFlags.Arguments;
-            }
-
             if (writeImportance && e.Importance != MessageImportance.Low)
             {
                 flags |= BuildEventArgsFieldFlags.Importance;
@@ -697,6 +705,15 @@ Build
             if (writeMessage)
             {
                 flags |= BuildEventArgsFieldFlags.Message;
+
+                // We're only going to write the arguments for messages,
+                // warnings and errors. Only set the flag for these.
+                if (e is LazyFormattedBuildEventArgs lazyFormattedBuildEventArgs &&
+                    lazyFormattedBuildEventArgs.RawArguments is { Length: > 0 } &&
+                    (e is BuildMessageEventArgs or BuildWarningEventArgs or BuildErrorEventArgs))
+                {
+                    flags |= BuildEventArgsFieldFlags.Arguments;
+                }
             }
 
             // no need to waste space for the default sender name

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -708,9 +708,8 @@ Build
 
                 // We're only going to write the arguments for messages,
                 // warnings and errors. Only set the flag for these.
-                if (e is LazyFormattedBuildEventArgs lazyFormattedBuildEventArgs &&
-                    lazyFormattedBuildEventArgs.RawArguments is { Length: > 0 } &&
-                    (e is BuildMessageEventArgs or BuildWarningEventArgs or BuildErrorEventArgs))
+                if (e is LazyFormattedBuildEventArgs { RawArguments: { Length: > 0 } } and
+                    (BuildMessageEventArgs or BuildWarningEventArgs or BuildErrorEventArgs))
                 {
                     flags |= BuildEventArgsFieldFlags.Arguments;
                 }


### PR DESCRIPTION
We were only logging the arguments for messages, but not for errors or warnings. Fortunately we can fix this and avoid incrementing the binlog format version.

First this moves the logic to set the `Arguments` flag into a common code path close to `Message`, and only sets the flag when the arguments are present and we're either a message, warning or error. Previously it was only set for messages (and all types derived from `Message`).

Technically all `BuildStatusEventArgs` and `CustomBuildEventArgs` also inherit from `LazyFormattedBuildEventArgs`, but the serialization for them is fully manual and we don't even write the message for them at all. We ensure that if by any accident an instance of `BuildStatus` or some other random type such as `CustomBuildEventArgs` sets the `Arguments`, we don't set the flag because we're not going to be writing arguments for those.

For reference, the inheritance hierarchy of all event args is here:
https://github.com/dotnet/msbuild/blob/864047de115b74992485b08c5d2eaa43ca95ee68/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs#L146-L175

We extract a method to log the arguments, and call it for errors and warnings.

Note that this doesn't change the `BuildEventArgsReader` at all, which proves that a file format version change is not necessary.

This also ensures that the tests for error, warning and message hit both code paths, with and without arguments.

I've also verified that the codegen for the fancy new pattern matching syntax I used does what I want:
![image](https://user-images.githubusercontent.com/679326/131754759-44c4e7d8-2f36-42ca-89eb-3eb11765c76a.png)

Fixes https://github.com/dotnet/msbuild/issues/6790.

![image](https://user-images.githubusercontent.com/679326/131754535-cf2705fa-bbd5-4fe5-a646-3d82c1948ff6.png)

To test, I used an inline task that logs an error with format arguments:
https://github.com/KirillOsenkov/Misc/blob/main/InlineTask.proj