### PR TITLE
Update loc update branch

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -42,13 +42,13 @@ stages:
   displayName: Build
 
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/vs16.11') }}: # should track next-release's active dev branch
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}: # should track next-release's active dev branch
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
         MirrorRepo: 'msbuild'
-        MirrorBranch: 'vs16.11' # should match condition above
+        MirrorBranch: 'main' # should match condition above
 
   - job: Windows_NT
     pool:


### PR DESCRIPTION
### Context
We left the onelocbuild branch on 16.11, this updates it to main so we can get automatic loc updates.

Should we leave this as main, or consider 17.0 and manually update on each release (considering some automated future).