### PR TITLE
Define stand-in optional workloads targets

### DIFF
--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -193,4 +193,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <DisableLogTaskParameterItemMetadata_WriteLinesToFile_Lines>true</DisableLogTaskParameterItemMetadata_WriteLinesToFile_Lines>
   </PropertyGroup>
 
+   <!--
+        Define dummy optional workloads targets. Design-time builds use these targets
+        to determine whether the in-product acquisition experience should be enabled.
+        Since older SDKs do not have these targets, these dummy targets are defined here
+        to prevent builds using older SDKs and frameworks from failing. Ideally, they
+        would be Microsoft.Common.targets. Unfortunately, the workload targets are
+        imported before Microsoft.Common.targets and would therefore be overridden
+        by these dummy targets if they were defined in Microsoft.Common.targets. To work
+        around this issue, they are defined here in Microsoft.Common.props to ensure
+        they are the first workload targets defined.
+
+        See https://github.com/dotnet/project-system/issues/7561
+    -->
+  <Target Name="GetSuggestedWorkloads" />
+  <Target Name="CollectSuggestedWorkloads" />
+
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/7561

### Context
https://github.com/dotnet/project-system/pull/7432 added a design-time target called CollectSuggestedWorkloads to https://github.com/project-system/blob/main/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets. Unfortunately, that change did not account for the fact that this design-time targets file is used by non-SDK projects or projects using earlier SDKs. Such projects now fail with the error: The target "GetSuggestedWorkloads" does not exist in the project.

https://github.com/dotnet/project-system/pull/7553 temporarily worked around this by conditioning CollectSuggestedWorkloads on SDK projects with MissingWorkloadPacks. The correct fix is to move the dummy target (CollectSuggestedWorkloads) to Microsoft.Common.targets. That would also avoid bugs like https://github.com/dotnet/project-system/issues/7561 in which a project that doesn't include the design-time targets fails because the CollectSuggestedWorkloads design-time target cannot be found.

However, defining a dummy CollectSuggestedWorkloads in Microsoft.Common.targets would break the workload functionality for SDK projects because the SDK workload targets https://github.com/dotnet/sdk/blob/release/6.0.1xx/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets are imported before Microsoft.Common.targets. The dummy target would therefore override the real target.

### Changes Made
Define the dummy targets in Microsoft.Common.props as a workaround.

### Testing

1. Opened a solution that uses global.json to pin to .NET 5 (VS.RPC.Contracts) and verified that design-time builds succeeded and no errors are displayed in the error list
2. Create a new Windows Application Packaging Project and verified that design-time builds succeeded and no errors are displayed in the error list
3. Opened a shared project (.shproj) and verified that no errors are displayed in the error list
4. Opened a MAUI solution and verified that the suggested workloads are still correctly displayed to the user

### Notes
Please provide feedback on whether this approach is sensible work-around for these issues and if so, which branch to target.
Here is the import tree for a console app for reference.

![image](https://user-images.githubusercontent.com/643461/132057622-d80e7e60-ce15-4038-bba3-c21f332e252e.png)
