### PR TITLE
Optimize InternableString.GetHashCode

### DIFF
--- a/src/StringTools.UnitTests/SpanBasedStringBuilder_Tests.cs
+++ b/src/StringTools.UnitTests/SpanBasedStringBuilder_Tests.cs
@@ -97,6 +97,28 @@ namespace Microsoft.NET.StringTools.Tests
         }
 
         [Theory]
+        [InlineData("012345678")] // odd number of characters
+        [InlineData("0123456789")] // even number of characters
+        public void GetHashCodeIsStableRegadlessOfSpanLengths(string testString)
+        {
+            int hashCode = new InternableString(testString).GetHashCode();
+
+            // Chop up the string to 2-3 parts and verify that the hash code is unchanged.
+            for (int i = 0; i < testString.Length - 1; i++)
+            {
+                for (int j = i + 1; j < testString.Length; j++)
+                {
+                    SpanBasedStringBuilder stringBuilder = new SpanBasedStringBuilder();
+                    stringBuilder.Append(testString.Substring(0, i));
+                    stringBuilder.Append(testString.Substring(i, j - i));
+                    stringBuilder.Append(testString.Substring(j));
+                    InternableString internableString = new InternableString(stringBuilder);
+                    internableString.GetHashCode().ShouldBe(hashCode);
+                }
+            }
+        }
+
+        [Theory]
         [MemberData(nameof(TestData))]
         public void AppendAppendsString(InterningTestData.TestDatum datum)
         {

--- a/src/StringTools.UnitTests/SpanBasedStringBuilder_Tests.cs
+++ b/src/StringTools.UnitTests/SpanBasedStringBuilder_Tests.cs
@@ -99,11 +99,11 @@ namespace Microsoft.NET.StringTools.Tests
         [Theory]
         [InlineData("012345678")] // odd number of characters
         [InlineData("0123456789")] // even number of characters
-        public void GetHashCodeIsStableRegadlessOfSpanLengths(string testString)
+        public void GetHashCodeIsStableRegardlessOfSpanLength(string testString)
         {
             int hashCode = new InternableString(testString).GetHashCode();
 
-            // Chop up the string to 2-3 parts and verify that the hash code is unchanged.
+            // Chop the string into 2-3 parts and verify that the hash code is unchanged.
             for (int i = 0; i < testString.Length - 1; i++)
             {
                 for (int j = i + 1; j < testString.Length; j++)

--- a/src/StringTools.UnitTests/WeakStringCache_Tests.cs
+++ b/src/StringTools.UnitTests/WeakStringCache_Tests.cs
@@ -84,8 +84,8 @@ namespace Microsoft.NET.StringTools.Tests
 
             for (int i = 0; i < numberOfStrings; i++)
             {
-                string strPart2 = "1" + String.Concat(Enumerable.Repeat("4428939786", i));
-                hashCodes[i] = AddString("Random string ", strPart2, (string cachedString) =>
+                string strPart2 = string.Concat(Enumerable.Repeat("108066709210", i + 2));
+                hashCodes[i] = AddString(string.Empty, strPart2, (string cachedString) =>
                 {
                     _cache.GetDebugInfo().ShouldBe(new WeakStringCache.DebugInfo()
                     {

--- a/src/StringTools.UnitTests/WeakStringCache_Tests.cs
+++ b/src/StringTools.UnitTests/WeakStringCache_Tests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.NET.StringTools.Tests
 
             for (int i = 0; i < numberOfStrings; i++)
             {
-                string strPart2 = string.Concat(Enumerable.Repeat("108066709210", i + 2));
+                string strPart2 = string.Concat(Enumerable.Repeat("100570862200", i + 2));
                 hashCodes[i] = AddString(string.Empty, strPart2, (string cachedString) =>
                 {
                     _cache.GetDebugInfo().ShouldBe(new WeakStringCache.DebugInfo()

--- a/src/StringTools/InternableString.cs
+++ b/src/StringTools/InternableString.cs
@@ -349,15 +349,33 @@ namespace Microsoft.NET.StringTools
             while (length >= 2)
             {
                 length -= 2;
-                hash = ((hash << 5) + hash) ^ *ptr;
+                hash = (RotateLeft(hash, 5) + hash) ^ *ptr;
                 ptr += 1;
             }
 
             if (length > 0)
             {
-                hash = ((hash << 5) + hash) ^ (BitConverter.IsLittleEndian ? *((char*)ptr) : ((uint)*((char*)ptr) << 16));
+                hash = (RotateLeft(hash, 5) + hash) ^ (BitConverter.IsLittleEndian ? *((char*)ptr) : ((uint)*((char*)ptr) << 16));
                 hashedOddNumberOfCharacters = true;
             }
+        }
+
+        /// <summary>
+        /// Rotates an integer by the specified number of bits.
+        /// </summary>
+        /// <param name="value">The value to rotate.</param>
+        /// <param name="offset">The number of bits.</param>
+        /// <returns>The rotated value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint RotateLeft(uint value, int offset)
+        {
+#if NETCOREAPP
+            return System.Numerics.BitOperations.RotateLeft(value, offset);
+#else
+            // Copied from System\Numerics\BitOperations.cs in dotnet/runtime as the routine is not available on .NET Framework.
+            // The JIT recognized the pattern and generates efficient code, e.g. the rol instruction on x86/x64.
+            return (value << offset) | (value >> (32 - offset));
+#endif
         }
     }
 }

--- a/src/StringTools/InternableString.cs
+++ b/src/StringTools/InternableString.cs
@@ -299,9 +299,15 @@ namespace Microsoft.NET.StringTools
         }
 
         /// <summary>
-        /// Implements the simple yet very decently performing djb2 hash function (xor version).
+        /// Implements the simple yet very decently performing djb2-like hash function (xor version) as inspired by
+        /// https://github.com/dotnet/runtime/blob/6262ae8e6a33abac569ab6086cdccc470c810ea4/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs#L810-L840
         /// </summary>
         /// <returns>A stable hashcode of the string represented by this instance.</returns>
+        /// <remarks>
+        /// Unlike the BCL method, this implementation works only on two characters at a time to cut on the complexity with
+        /// characters that feed into the same operation but straddle multiple spans. Note that it must return the same value for
+        /// a given string regardless of how it's split into spans (e.g. { "AB" } and { "A", "B" } have the same hash code).
+        /// </remarks>
         public override unsafe int GetHashCode()
         {
             uint hash = (5381 << 16) + 5381;

--- a/src/StringTools/InternableString.cs
+++ b/src/StringTools/InternableString.cs
@@ -331,6 +331,7 @@ namespace Microsoft.NET.StringTools
         /// <param name="length">Number of characters at <paramref name="charPtr"/>.</param>
         /// <param name="hash">The running hash code.</param>
         /// <param name="hashedOddNumberOfCharacters">True if the incoming <paramref name="hash"/> was calculated from an odd number of characters.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void GetHashCodeHelper(char* charPtr, int length, ref uint hash, ref bool hashedOddNumberOfCharacters)
         {
             if (hashedOddNumberOfCharacters && length > 0)

--- a/src/StringTools/InternableString.cs
+++ b/src/StringTools/InternableString.cs
@@ -304,13 +304,12 @@ namespace Microsoft.NET.StringTools
         /// <returns>A stable hashcode of the string represented by this instance.</returns>
         public override unsafe int GetHashCode()
         {
-            int hashCode = 5381;
+            uint hash = (5381 << 16) + 5381;
+            bool hashedOddNumberOfCharacters = false;
+
             fixed (char* charPtr = _inlineSpan)
             {
-                for (int i = 0; i < _inlineSpan.Length; i++)
-                {
-                    hashCode = unchecked(hashCode * 33 ^ charPtr[i]);
-                }
+                GetHashCodeHelper(charPtr, _inlineSpan.Length, ref hash, ref hashedOddNumberOfCharacters);
             }
             if (_spans != null)
             {
@@ -318,14 +317,46 @@ namespace Microsoft.NET.StringTools
                 {
                     fixed (char* charPtr = span.Span)
                     {
-                        for (int i = 0; i < span.Length; i++)
-                        {
-                            hashCode = unchecked(hashCode * 33 ^ charPtr[i]);
-                        }
+                        GetHashCodeHelper(charPtr, span.Length, ref hash, ref hashedOddNumberOfCharacters);
                     }
                 }
             }
-            return hashCode;
+            return (int)(hash);
+        }
+
+        /// <summary>
+        /// Hashes a memory block specified by a pointer and length.
+        /// </summary>
+        /// <param name="charPtr">Pointer to the first character.</param>
+        /// <param name="length">Number of characters at <paramref name="charPtr"/>.</param>
+        /// <param name="hash">The running hash code.</param>
+        /// <param name="hashedOddNumberOfCharacters">True if the incoming <paramref name="hash"/> was calculated from an odd number of characters.</param>
+        private static unsafe void GetHashCodeHelper(char* charPtr, int length, ref uint hash, ref bool hashedOddNumberOfCharacters)
+        {
+            if (hashedOddNumberOfCharacters && length > 0)
+            {
+                // If the number of characters hashed so far is odd, the first character of the current block completes
+                // the calculation done with the last character of the previous block.
+                hash ^= BitConverter.IsLittleEndian ? ((uint)*charPtr << 16) : *charPtr;
+                length--;
+                charPtr++;
+                hashedOddNumberOfCharacters = false;
+            }
+
+            // The loop hashes two characters at a time.
+            uint* ptr = (uint*)charPtr;
+            while (length >= 2)
+            {
+                length -= 2;
+                hash = ((hash << 5) + hash) ^ *ptr;
+                ptr += 1;
+            }
+
+            if (length > 0)
+            {
+                hash = ((hash << 5) + hash) ^ (BitConverter.IsLittleEndian ? *((char*)ptr) : ((uint)*((char*)ptr) << 16));
+                hashedOddNumberOfCharacters = true;
+            }
         }
     }
 }


### PR DESCRIPTION
### Context

The current straightforward implementation is slow, especially on 64-bit Framework CLR. It is causing a measurable regression when evaluating large projects.

### Changes Made

Rewrote the routine using a similar approach as [this BCL method](https://github.com/dotnet/runtime/blob/6262ae8e6a33abac569ab6086cdccc470c810ea4/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs#L810-L840). Calculating only 2 and not 4 characters at a time, though, to reduce the complexity since our implementation works on a list of spans and not just one string. The additional perf benefit of going 4 at a time would be relatively small.

### Testing

- A new unit test to verify correctness.
- Micro-benchmark showing 1.6x boost on x86 and 2x boost on x64.
- Evaluation perf traces showing significant reduction in the time spent in GetHashCode, saving 110 ms (~6%) per evaluation of the Unreal Engine C++ project on 64-bit.