### PR TITLE
Disable vs16.11 loc updates

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -26,13 +26,13 @@ stages:
   displayName: Build
 
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/vs16.11') }}: # should track next-release's active dev branch
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}: # should track next-release's active dev branch
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
         MirrorRepo: 'msbuild'
-        MirrorBranch: 'vs16.11' # should match condition above
+        MirrorBranch: 'main' # should match condition above
 
   - job: Windows_NT
     pool:


### PR DESCRIPTION
### Context
The oneloc script should only run on one branch. This change updates the condition here to only run if `main` is the branch, effectively disabling oneloc on this branch.

### Notes
Decided not to delete the block of code in case we need to do some loc update to 16.11 for some unlikely reason.