### PR TITLE
Move to VS 1ES pool

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -36,7 +36,7 @@ stages:
 
   - job: Windows_NT
     pool:
-      name: VSEngSS-MicroBuild2019
+      name: VSEngSS-MicroBuild2019-1ES
       demands:
       - agent.os -equals Windows_NT
 


### PR DESCRIPTION
This is required by VSEng/1ES policy.

Successful build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=5180585&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=bb592630-4b9d-53ad-3960-d954a70a95cf