### PR TITLE
Binding redirect Tasks.Extensions 4.2.0.1

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -104,7 +104,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -94,7 +94,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />


### PR DESCRIPTION
Update the binding redirect for System.Threading.Tasks.Extensions to match the version we currently ship (4.2.0.1).

I also audited all other System.* assemblies we ship and this was the only mismatch.
