### PR TITLE
Process-wide caching of ToolsetConfigurationSection

### DIFF
--- a/src/Build/Definition/ToolsetConfigurationReader.cs
+++ b/src/Build/Definition/ToolsetConfigurationReader.cs
@@ -42,6 +42,13 @@ namespace Microsoft.Build.Evaluation
         private static readonly char[] s_separatorForExtensionsPathSearchPaths = MSBuildConstants.SemicolonChar;
 
         /// <summary>
+        /// Caching MSBuild exe configuration.
+        /// Used only by ReadApplicationConfiguration factory function (default) as oppose to unit tests config factory functions
+        /// which must not cache configs.
+        /// </summary>
+        private static readonly Lazy<Configuration> s_configurationCache = new Lazy<Configuration>(ReadOpenMappedExeConfiguration);
+
+        /// <summary>
         /// Cached values of tools version -> project import search paths table
         /// </summary>
         private readonly Dictionary<string, Dictionary<string, ProjectImportPathMatch>> _projectImportSearchPathsCache;
@@ -250,6 +257,18 @@ namespace Microsoft.Build.Evaluation
         /// Unit tests wish to avoid reading (nunit.exe) application configuration file.
         /// </summary>
         private static Configuration ReadApplicationConfiguration()
+        {
+            if (Environment.GetEnvironmentVariable("MSBUILDCACHETOOLSETCONFIGURATION") != "0")
+            {
+                return s_configurationCache.Value;
+            }
+            else
+            {
+                return ReadOpenMappedExeConfiguration();
+            }
+        }
+
+        private static Configuration ReadOpenMappedExeConfiguration()
         {
             // When running from the command-line or from VS, use the msbuild.exe.config file.
             if (BuildEnvironmentHelper.Instance.Mode != BuildEnvironmentMode.None &&

--- a/src/Build/Definition/ToolsetConfigurationReader.cs
+++ b/src/Build/Definition/ToolsetConfigurationReader.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.Utilities;
 using ErrorUtilities = Microsoft.Build.Shared.ErrorUtilities;
 using InvalidToolsetDefinitionException = Microsoft.Build.Exceptions.InvalidToolsetDefinitionException;
 
@@ -258,7 +259,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private static Configuration ReadApplicationConfiguration()
         {
-            if (Environment.GetEnvironmentVariable("MSBUILDCACHETOOLSETCONFIGURATION") != "0")
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
             {
                 return s_configurationCache.Value;
             }

--- a/src/Shared/ToolsetElement.cs
+++ b/src/Shared/ToolsetElement.cs
@@ -7,6 +7,7 @@ using System.Configuration;
 using System.IO;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -28,7 +29,7 @@ namespace Microsoft.Build.Evaluation
 
         internal static ToolsetConfigurationSection ReadToolsetConfigurationSection(Configuration configuration)
         {
-            if (Environment.GetEnvironmentVariable("MSBUILDCACHETOOLSETCONFIGURATION") != "0")
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
             {
                 if (configuration == null)
                 {

--- a/src/Shared/ToolsetElement.cs
+++ b/src/Shared/ToolsetElement.cs
@@ -15,7 +15,49 @@ namespace Microsoft.Build.Evaluation
     /// </summary>
     internal static class ToolsetConfigurationReaderHelpers
     {
+        /// <summary>
+        /// Lock for process wide ToolsetConfigurationSection section cache
+        /// </summary>
+        private static readonly object s_syncLock = new();
+
+        /// <summary>
+        /// Process wide ToolsetConfigurationSection section cache
+        /// </summary>
+        private static ToolsetConfigurationSection s_toolsetConfigurationSectionCache;
+        private static Configuration s_configurationOfCachedSection;
+
         internal static ToolsetConfigurationSection ReadToolsetConfigurationSection(Configuration configuration)
+        {
+            if (Environment.GetEnvironmentVariable("MSBUILDCACHETOOLSETCONFIGURATION") != "0")
+            {
+                if (configuration == null)
+                {
+                    return null;
+                }
+
+                lock (s_syncLock)
+                {
+                    // Cache 1st requested configuration section. In unit tests, different Configuration is provided for particular test cases.
+                    // During runtime, however, only MSBuild exe configuration file is provided to read toolset configuration from,
+                    //   and modifying MSBuild exe configuration during lifetime of msbuild nodes is neither expected nor supported.
+                    if (s_toolsetConfigurationSectionCache == null)
+                    {
+                        s_toolsetConfigurationSectionCache = GetToolsetConfigurationSection(configuration);
+                        s_configurationOfCachedSection = configuration;
+                    }
+
+                    return s_configurationOfCachedSection == configuration ?
+                        s_toolsetConfigurationSectionCache :
+                        GetToolsetConfigurationSection(configuration);
+                }
+            }
+            else
+            {
+                return GetToolsetConfigurationSection(configuration);
+            }
+        }
+
+        private static ToolsetConfigurationSection GetToolsetConfigurationSection(Configuration configuration)
         {
             ToolsetConfigurationSection configurationSection = null;
 


### PR DESCRIPTION
Fixes #6667 

### Context
Tools configuration is read from MSBuild.exe.config multiple time. We can simply cache related configuration section to optimize config file access.
Changes are under opt-out escape hatch.

### Changes Made
Cached in static variable. Caching is not applied in unit tests cases.

### Testing
Rebuilds and incremental build of orchard core.
ETL has been captured to verify reading from MSBuild.exe.config was optimized.

### Notes
When measured the real perf difference in both CPU and wall-clock time was negligible/non-verifiable. 