### PR TITLE
Fix deadlock in BuildManager vs LoggingService

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Build.Execution
 
             _projectStartedEventHandler = OnProjectStarted;
             _projectFinishedEventHandler = OnProjectFinished;
-            _loggingThreadExceptionEventHandler = OnThreadException;
+            _loggingThreadExceptionEventHandler = OnLoggingThreadException;
             _legacyThreadingData = new LegacyThreadingData();
             _instantiationTimeUtc = DateTime.UtcNow;
         }
@@ -2799,64 +2799,76 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Handler for thread exceptions (logging thread, communications thread).  This handler will only get called if the exception did not previously
+        /// Handler for thread exceptions. This handler will only get called if the exception did not previously
         /// get handled by a node exception handlers (for instance because the build is complete for the node.)  In this case we
         /// get the exception and will put it into the OverallBuildResult so that the host can see what happened.
         /// </summary>
         private void OnThreadException(Exception e)
         {
-            _workQueue.Post(() =>
+            lock (_syncLock)
             {
-                lock (_syncLock)
+                if (_threadException == null)
                 {
-                    if (_threadException == null)
+                    if (e is AggregateException ae && ae.InnerExceptions.Count == 1)
                     {
-                        if (e is AggregateException ae && ae.InnerExceptions.Count == 1)
+                        e = ae.InnerExceptions.First();
+                    }
+
+                    _threadException = ExceptionDispatchInfo.Capture(e);
+                    var submissions = new List<BuildSubmission>(_buildSubmissions.Values);
+                    foreach (BuildSubmission submission in submissions)
+                    {
+                        // Submission has not started
+                        if (submission.BuildRequest == null)
                         {
-                            e = ae.InnerExceptions.First();
+                            continue;
                         }
 
-                        _threadException = ExceptionDispatchInfo.Capture(e);
-                        var submissions = new List<BuildSubmission>(_buildSubmissions.Values);
-                        foreach (BuildSubmission submission in submissions)
+                        // Attach the exception to this submission if it does not already have an exception associated with it
+                        if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
                         {
-                            // Submission has not started
-                            if (submission.BuildRequest == null)
-                            {
-                                continue;
-                            }
+                            submission.BuildResult.Exception = e;
+                        }
+                        submission.CompleteLogging();
+                        submission.CompleteResults(new BuildResult(submission.BuildRequest, e));
 
-                            // Attach the exception to this submission if it does not already have an exception associated with it
-                            if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
-                            {
-                                submission.BuildResult.Exception = e;
-                            }
-                            submission.CompleteLogging();
-                            submission.CompleteResults(new BuildResult(submission.BuildRequest, e));
+                        CheckSubmissionCompletenessAndRemove(submission);
+                    }
 
-                            CheckSubmissionCompletenessAndRemove(submission);
+                    var graphSubmissions = new List<GraphBuildSubmission>(_graphBuildSubmissions.Values);
+                    foreach (GraphBuildSubmission submission in graphSubmissions)
+                    {
+                        if (!submission.IsStarted)
+                        {
+                            continue;
                         }
 
-                        var graphSubmissions = new List<GraphBuildSubmission>(_graphBuildSubmissions.Values);
-                        foreach (GraphBuildSubmission submission in graphSubmissions)
+                        // Attach the exception to this submission if it does not already have an exception associated with it
+                        if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
                         {
-                            if (!submission.IsStarted)
-                            {
-                                continue;
-                            }
-
-                            // Attach the exception to this submission if it does not already have an exception associated with it
-                            if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
-                            {
-                                submission.BuildResult.Exception = e;
-                            }
-                            submission.CompleteResults(submission.BuildResult ?? new GraphBuildResult(submission.SubmissionId, e));
-
-                            CheckSubmissionCompletenessAndRemove(submission);
+                            submission.BuildResult.Exception = e;
                         }
+                        submission.CompleteResults(submission.BuildResult ?? new GraphBuildResult(submission.SubmissionId, e));
+
+                        CheckSubmissionCompletenessAndRemove(submission);
                     }
                 }
-            });
+            }
+        }
+
+        /// <summary>
+        /// Handler for LoggingService thread exceptions.
+        /// </summary>
+        private void OnLoggingThreadException(Exception e)
+        {
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
+            {
+                _workQueue.Post(() => OnThreadException(e));
+            }
+            else
+            {
+                OnThreadException(e);
+            }
         }
 
         /// <summary>
@@ -2864,7 +2876,16 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void OnProjectFinished(object sender, ProjectFinishedEventArgs e)
         {
-            _workQueue.Post(() =>
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
+            {
+                _workQueue.Post(() => OnProjectFinishedBody(e));
+            }
+            else
+            {
+                OnProjectFinishedBody(e);
+            }
+
+            void OnProjectFinishedBody(ProjectFinishedEventArgs e)
             {
                 lock (_syncLock)
                 {
@@ -2881,7 +2902,7 @@ namespace Microsoft.Build.Execution
                         }
                     }
                 }
-            });
+            }
         }
 
         /// <summary>
@@ -2889,7 +2910,16 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void OnProjectStarted(object sender, ProjectStartedEventArgs e)
         {
-            _workQueue.Post(() =>
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
+            {
+                _workQueue.Post(() => OnProjectStartedBody(e));
+            }
+            else
+            {
+                OnProjectStartedBody(e);
+            }
+
+            void OnProjectStartedBody(ProjectStartedEventArgs e)
             {
                 lock (_syncLock)
                 {
@@ -2898,7 +2928,7 @@ namespace Microsoft.Build.Execution
                         _projectStartedEvents[e.BuildEventContext.SubmissionId] = e;
                     }
                 }
-            });
+            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -842,8 +842,6 @@ namespace Microsoft.Build.Execution
                     _workQueue.Completion.Wait();
                 }
 
-                _workQueue.Completion.Wait();
-
                 // Stop the graph scheduling thread(s)
                 _graphSchedulingCancellationSource?.Cancel();
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -832,11 +832,12 @@ namespace Microsoft.Build.Execution
                 ShutdownConnectedNodes(false /* normal termination */);
                 _noNodesActiveEvent.WaitOne();
 
-                // Wait for all of the actions in the work queue to drain.  _workQueue.Completion.Wait() could throw here if there was an unhandled exception
-                // in the work queue, but the top level exception handler there should catch everything and have forwarded it to the
+                // Wait for all of the actions in the work queue to drain.
+                // _workQueue.Completion.Wait() could throw here if there was an unhandled exception in the work queue,
+                // but the top level exception handler there should catch everything and have forwarded it to the
                 // OnThreadException method in this class already.
                 _workQueue.Complete();
-                Task.WaitAny(_workQueue.Completion);
+                _workQueue.Completion.Wait();
 
                 // Stop the graph scheduling thread(s)
                 _graphSchedulingCancellationSource?.Cancel();

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -832,10 +832,11 @@ namespace Microsoft.Build.Execution
                 ShutdownConnectedNodes(false /* normal termination */);
                 _noNodesActiveEvent.WaitOne();
 
-                // Wait for all of the actions in the work queue to drain.  Wait() could throw here if there was an unhandled exception
+                // Wait for all of the actions in the work queue to drain.  _workQueue.Completion.Wait() could throw here if there was an unhandled exception
                 // in the work queue, but the top level exception handler there should catch everything and have forwarded it to the
                 // OnThreadException method in this class already.
                 _workQueue.Complete();
+                Task.WaitAny(_workQueue.Completion);
 
                 // Stop the graph scheduling thread(s)
                 _graphSchedulingCancellationSource?.Cancel();
@@ -2804,55 +2805,58 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void OnThreadException(Exception e)
         {
-            lock (_syncLock)
+            _workQueue.Post(() =>
             {
-                if (_threadException == null)
+                lock (_syncLock)
                 {
-                    if (e is AggregateException ae && ae.InnerExceptions.Count == 1)
+                    if (_threadException == null)
                     {
-                        e = ae.InnerExceptions.First();
-                    }
-
-                    _threadException = ExceptionDispatchInfo.Capture(e);
-                    var submissions = new List<BuildSubmission>(_buildSubmissions.Values);
-                    foreach (BuildSubmission submission in submissions)
-                    {
-                        // Submission has not started
-                        if (submission.BuildRequest == null)
+                        if (e is AggregateException ae && ae.InnerExceptions.Count == 1)
                         {
-                            continue;
+                            e = ae.InnerExceptions.First();
                         }
 
-                        // Attach the exception to this submission if it does not already have an exception associated with it
-                        if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
+                        _threadException = ExceptionDispatchInfo.Capture(e);
+                        var submissions = new List<BuildSubmission>(_buildSubmissions.Values);
+                        foreach (BuildSubmission submission in submissions)
                         {
-                            submission.BuildResult.Exception = e;
+                            // Submission has not started
+                            if (submission.BuildRequest == null)
+                            {
+                                continue;
+                            }
+
+                            // Attach the exception to this submission if it does not already have an exception associated with it
+                            if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
+                            {
+                                submission.BuildResult.Exception = e;
+                            }
+                            submission.CompleteLogging();
+                            submission.CompleteResults(new BuildResult(submission.BuildRequest, e));
+
+                            CheckSubmissionCompletenessAndRemove(submission);
                         }
-                        submission.CompleteLogging();
-                        submission.CompleteResults(new BuildResult(submission.BuildRequest, e));
 
-                        CheckSubmissionCompletenessAndRemove(submission);
-                    }
-
-                    var graphSubmissions = new List<GraphBuildSubmission>(_graphBuildSubmissions.Values);
-                    foreach (GraphBuildSubmission submission in graphSubmissions)
-                    {
-                        if (!submission.IsStarted)
+                        var graphSubmissions = new List<GraphBuildSubmission>(_graphBuildSubmissions.Values);
+                        foreach (GraphBuildSubmission submission in graphSubmissions)
                         {
-                            continue;
-                        }
+                            if (!submission.IsStarted)
+                            {
+                                continue;
+                            }
 
-                        // Attach the exception to this submission if it does not already have an exception associated with it
-                        if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
-                        {
-                            submission.BuildResult.Exception = e;
-                        }
-                        submission.CompleteResults(submission.BuildResult ?? new GraphBuildResult(submission.SubmissionId, e));
+                            // Attach the exception to this submission if it does not already have an exception associated with it
+                            if (!submission.IsCompleted && submission.BuildResult != null && submission.BuildResult.Exception == null)
+                            {
+                                submission.BuildResult.Exception = e;
+                            }
+                            submission.CompleteResults(submission.BuildResult ?? new GraphBuildResult(submission.SubmissionId, e));
 
-                        CheckSubmissionCompletenessAndRemove(submission);
+                            CheckSubmissionCompletenessAndRemove(submission);
+                        }
                     }
                 }
-            }
+            });
         }
 
         /// <summary>
@@ -2860,21 +2864,24 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void OnProjectFinished(object sender, ProjectFinishedEventArgs e)
         {
-            lock (_syncLock)
+            _workQueue.Post(() =>
             {
-                if (_projectStartedEvents.TryGetValue(e.BuildEventContext.SubmissionId, out var originalArgs))
+                lock (_syncLock)
                 {
-                    if (originalArgs.BuildEventContext.Equals(e.BuildEventContext))
+                    if (_projectStartedEvents.TryGetValue(e.BuildEventContext.SubmissionId, out var originalArgs))
                     {
-                        _projectStartedEvents.Remove(e.BuildEventContext.SubmissionId);
-                        if (_buildSubmissions.TryGetValue(e.BuildEventContext.SubmissionId, out var submission))
+                        if (originalArgs.BuildEventContext.Equals(e.BuildEventContext))
                         {
-                            submission.CompleteLogging();
-                            CheckSubmissionCompletenessAndRemove(submission);
+                            _projectStartedEvents.Remove(e.BuildEventContext.SubmissionId);
+                            if (_buildSubmissions.TryGetValue(e.BuildEventContext.SubmissionId, out var submission))
+                            {
+                                submission.CompleteLogging();
+                                CheckSubmissionCompletenessAndRemove(submission);
+                            }
                         }
                     }
                 }
-            }
+            });
         }
 
         /// <summary>
@@ -2882,13 +2889,16 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void OnProjectStarted(object sender, ProjectStartedEventArgs e)
         {
-            lock (_syncLock)
+            _workQueue.Post(() =>
             {
-                if (!_projectStartedEvents.ContainsKey(e.BuildEventContext.SubmissionId))
+                lock (_syncLock)
                 {
-                    _projectStartedEvents[e.BuildEventContext.SubmissionId] = e;
+                    if (!_projectStartedEvents.ContainsKey(e.BuildEventContext.SubmissionId))
+                    {
+                        _projectStartedEvents[e.BuildEventContext.SubmissionId] = e;
+                    }
                 }
-            }
+            });
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -837,6 +837,11 @@ namespace Microsoft.Build.Execution
                 // but the top level exception handler there should catch everything and have forwarded it to the
                 // OnThreadException method in this class already.
                 _workQueue.Complete();
+                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0))
+                {
+                    _workQueue.Completion.Wait();
+                }
+
                 _workQueue.Completion.Wait();
 
                 // Stop the graph scheduling thread(s)


### PR DESCRIPTION
Fixes #6823

### Context
There is possible deadlock in BuildManager vs LoggingService when:
- verbosity=diagnostic or higher or /bl
- LoggingService works in `LoggerMode.Synchronous`

### Changes Made
LoggingService callbacks (OnProjectStarted, OnProjectFinished and OnThreadException) has been modified into async by leveraging existing workQueue.

### Testing
Compiled Orchardcore in CLI and VS2022.

### Notes
If these changes are considered safe, we can optionally revert PR #6717