### PR TITLE
Fix #6750 `SdkResultItem` equality

### DIFF
--- a/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests.BackEnd
+{
+    public class SdkResultItemComparison_Tests
+    {
+        [Fact]
+        public void SdkResultItem_Equal_WithDefaultCtor()
+        {
+            var sdkResultItem1 = new SdkResultItem();
+            sdkResultItem1.ItemSpec = "AnySpec";
+            sdkResultItem1.Metadata.Add("key1", "value1");
+            sdkResultItem1.Metadata.Add("key2", "value2");
+            var sdkResultItem2 = new SdkResultItem();
+            sdkResultItem2.ItemSpec = "AnySpec";
+            sdkResultItem2.Metadata.Add("key2", "value2");
+            sdkResultItem2.Metadata.Add("key1", "value1");
+
+            Assert.True(sdkResultItem1.Equals(sdkResultItem2));
+        }
+
+        [Fact]
+        public void SdkResultItem_Equal_CtorParam_MetadataNull()
+        {
+            var sdkResultItem1 = new SdkResultItem("anyspec", new Dictionary<string, string>());
+            var sdkResultItem2 = new SdkResultItem("anyspec", null);
+
+            Assert.True(!sdkResultItem1.Equals(sdkResultItem2));
+        }
+
+        [Fact]
+        public void SdkResultItem_GetHashCode_Compare_MetadataIgnoreKeyOrder()
+        {
+            var sdkResultItem1 = new SdkResultItem();
+            sdkResultItem1.ItemSpec = "AnySpec";
+            sdkResultItem1.Metadata.Add("key1", "value1");
+            sdkResultItem1.Metadata.Add("key2", "value2");
+            var hashSdkItem1 = sdkResultItem1.GetHashCode();
+
+            var sdkResultItem2 = new SdkResultItem();
+            sdkResultItem2.ItemSpec = "AnySpec";
+            sdkResultItem2.Metadata.Add("key2", "value2");
+            sdkResultItem2.Metadata.Add("key1", "value1");
+            var hashSdkItem2 = sdkResultItem2.GetHashCode();
+
+            Assert.True(hashSdkItem1 == hashSdkItem2);
+        }
+
+    }
+}

--- a/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var sdkResultItem1 = new SdkResultItem("anyspec", new Dictionary<string, string>());
             var sdkResultItem2 = new SdkResultItem("anyspec", null);
 
-            sdkResultItem1.ShouldNotBe(sdkResultItem2);
+            // Should bt the same, because passed null metadata will have value of new Dictionnary<String,String> like sdkResultItem1
+            sdkResultItem1.ShouldBe(sdkResultItem2);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var sdkResultItem1 = new SdkResultItem("anyspec", new Dictionary<string, string>());
             var sdkResultItem2 = new SdkResultItem("anyspec", null);
 
-            // Should bt the same, because passed null metadata will have value of new Dictionnary<String,String> like sdkResultItem1
-            sdkResultItem1.ShouldBe(sdkResultItem2);
+            // Should not be the same, because passing metadata = null is allowed and the Metadata property value allows null.
+            sdkResultItem1.ShouldNotBe(sdkResultItem2);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-//
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             sdkResultItem2.Metadata.Add("key2", "value2");
             sdkResultItem2.Metadata.Add("key1", "value1");
 
-            Assert.True(sdkResultItem1.Equals(sdkResultItem2));
+            sdkResultItem1.ShouldBe(sdkResultItem2);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResultItemComparison_Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Framework;
+using Shouldly;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -31,7 +32,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var sdkResultItem1 = new SdkResultItem("anyspec", new Dictionary<string, string>());
             var sdkResultItem2 = new SdkResultItem("anyspec", null);
 
-            Assert.True(!sdkResultItem1.Equals(sdkResultItem2));
+            sdkResultItem1.ShouldNotBe(sdkResultItem2);
         }
 
         [Fact]
@@ -49,7 +50,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             sdkResultItem2.Metadata.Add("key1", "value1");
             var hashSdkItem2 = sdkResultItem2.GetHashCode();
 
-            Assert.True(hashSdkItem1 == hashSdkItem2);
+            hashSdkItem1.ShouldBe(hashSdkItem2);
         }
 
     }

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Framework
             {
                 foreach (var kvp in Metadata)
                 {
-                    hashCode ^= $"{kvp.Key}: {kvp.Value ?? "V"}".GetHashCode();
+                    hashCode ^= StringComparer.OrdinalIgnoreCase.GetHashCode($"{kvp.Key}: {kvp.Value ?? "V"}");
                 }
             }
 

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Framework
 
         public SdkResultItem()
         {
-            ItemSpec = "";
+            ItemSpec = string.Empty;
             Metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="itemSpec">The value (itemspec) for the item</param>
         /// <param name="metadata">A dictionary of item metadata.  This should be created with <see cref="StringComparer.OrdinalIgnoreCase"/> for the comparer.</param>
-        public SdkResultItem(string itemSpec, Dictionary<string, string> metadata)
+        public SdkResultItem(string itemSpec, Dictionary<string, string>? metadata)
         {
             ItemSpec = itemSpec;
             Metadata = metadata;

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.Framework
                    ItemSpec == item.ItemSpec &&
                    Metadata?.Count == item.Metadata?.Count)
             {
-                foreach (var kvp in Metadata)
+                return Metadata.All(m => item.Metadata.TryGetValue(m.Key, out var itemValue) && itemValue == m.Value);
                 {
                     if (!item.Metadata.TryGetValue(kvp.Key, out var itemValue))
                     {

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Build.Framework
 {
+
+    #nullable enable
+    
     /// <summary>
     /// The value of an item and any associated metadata to be added by an SDK resolver.  See <see cref="SdkResult.ItemsToAdd"/>
     /// </summary>
@@ -65,8 +68,7 @@ namespace Microsoft.Build.Framework
             {
                 foreach (var kvp in Metadata)
                 {
-                    hashCode = hashCode ^ $"K{kvp.Key}".GetHashCode();
-                    hashCode = hashCode ^ (kvp.Value != null ? $"V{kvp.Value}".GetHashCode() : "V".GetHashCode());
+                    hashCode ^= $"{kvp.Key.GetHashCode()}: {(kvp.Value ?? "V").GetHashCode()}";
                 }
             }
 

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -40,21 +40,6 @@ namespace Microsoft.Build.Framework
                    Metadata?.Count == item.Metadata?.Count)
             {
                 return Metadata.All(m => item.Metadata.TryGetValue(m.Key, out var itemValue) && itemValue == m.Value);
-                {
-                    if (!item.Metadata.TryGetValue(kvp.Key, out var itemValue))
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        if (kvp.Value != itemValue)
-                        {
-                            return false;
-                        }
-                    }
-                }
-
-                return true;
             }
             return false;
         }

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -62,10 +62,13 @@ namespace Microsoft.Build.Framework
             int hashCode = -849885975;
             hashCode = hashCode ^ ItemSpec.GetHashCode();
 
-            foreach (var kvp in Metadata)
+            if (Metadata != null && Metadata.Count > 0)
             {
-                hashCode = hashCode ^ kvp.Key.GetHashCode();
-                hashCode = hashCode ^ kvp.Value.GetHashCode();
+                foreach (var kvp in Metadata)
+                {
+                    hashCode = hashCode ^ kvp.Key.GetHashCode();
+                    hashCode = hashCode ^ kvp.Value.GetHashCode();
+                }
             }
 
             return hashCode;

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Framework
             {
                 foreach (var kvp in Metadata)
                 {
-                    hashCode ^= $"{kvp.Key.GetHashCode()}: {(kvp.Value ?? "V").GetHashCode()}".GetHashCode();
+                    hashCode ^= $"{kvp.Key}: {kvp.Value ?? "V"}".GetHashCode();
                 }
             }
 

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Microsoft.Build.Framework
@@ -32,14 +33,14 @@ namespace Microsoft.Build.Framework
         public SdkResultItem(string itemSpec, Dictionary<string, string> metadata)
         {
             ItemSpec = itemSpec;
-            Metadata = metadata;
+            Metadata = metadata ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object obj)
         {
             if (obj is SdkResultItem item &&
                    ItemSpec == item.ItemSpec &&
-                   Metadata?.Count == item.Metadata?.Count)
+                   Metadata?.Count == item.Metadata.Count)
             {
                 return Metadata.All(m => item.Metadata.TryGetValue(m.Key, out var itemValue) && itemValue == m.Value);
             }

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Build.Framework
 
         public SdkResultItem()
         {
+            ItemSpec = "";
             Metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Framework
     public class SdkResultItem
     {
         public string ItemSpec { get; set; }
-        public Dictionary<string, string> Metadata { get;}
+        public Dictionary<string, string>? Metadata { get;}
 
         public SdkResultItem()
         {
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Framework
         {
             if (obj is SdkResultItem item &&
                    ItemSpec == item.ItemSpec &&
-                   item.Metadata != null &&
+                   item.Metadata is not null &&
                    Metadata?.Count == item.Metadata.Count)
             {
                 return Metadata.All(m => item.Metadata.TryGetValue(m.Key, out var itemValue) && itemValue == m.Value);

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -60,15 +60,12 @@ namespace Microsoft.Build.Framework
         public override int GetHashCode()
         {
             int hashCode = -849885975;
-            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(ItemSpec);
+            hashCode = hashCode ^ ItemSpec.GetHashCode();
 
-            if (Metadata != null)
+            foreach (var kvp in Metadata)
             {
-                foreach (var kvp in Metadata)
-                {
-                    hashCode = (hashCode * -1521134295) + kvp.Key.GetHashCode();
-                    hashCode = (hashCode * -1521134295) + kvp.Value.GetHashCode();
-                }
+                hashCode = hashCode ^ kvp.Key.GetHashCode();
+                hashCode = hashCode ^ kvp.Value.GetHashCode();
             }
 
             return hashCode;

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -33,13 +33,14 @@ namespace Microsoft.Build.Framework
         public SdkResultItem(string itemSpec, Dictionary<string, string> metadata)
         {
             ItemSpec = itemSpec;
-            Metadata = metadata ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            Metadata = metadata;
         }
 
         public override bool Equals(object obj)
         {
             if (obj is SdkResultItem item &&
                    ItemSpec == item.ItemSpec &&
+                   item.Metadata != null &&
                    Metadata?.Count == item.Metadata.Count)
             {
                 return Metadata.All(m => item.Metadata.TryGetValue(m.Key, out var itemValue) && itemValue == m.Value);

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Framework
         {
             if (obj is SdkResultItem item &&
                    ItemSpec == item.ItemSpec &&
-                   Metadata.Count == item.Metadata?.Count)
+                   Metadata?.Count == item.Metadata?.Count)
             {
                 foreach (var kvp in Metadata)
                 {
@@ -61,12 +61,12 @@ namespace Microsoft.Build.Framework
             int hashCode = -849885975;
             hashCode = hashCode ^ ItemSpec.GetHashCode();
 
-            if (Metadata != null && Metadata.Count > 0)
+            if (Metadata != null)
             {
                 foreach (var kvp in Metadata)
                 {
-                    hashCode = hashCode ^ kvp.Key.GetHashCode();
-                    hashCode = hashCode ^ kvp.Value.GetHashCode();
+                    hashCode = hashCode ^ $"K{kvp.Key}".GetHashCode();
+                    hashCode = hashCode ^ (kvp.Value != null ? $"V{kvp.Value}".GetHashCode() : "V".GetHashCode());
                 }
             }
 

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -38,8 +38,7 @@ namespace Microsoft.Build.Framework
             {
                 foreach (var kvp in Metadata)
                 {
-                    var itemValue = "";
-                    if (!item.Metadata.TryGetValue(kvp.Key, out itemValue))
+                    if (!item.Metadata.TryGetValue(kvp.Key, out var itemValue))
                     {
                         return false;
                     }

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -34,13 +34,18 @@ namespace Microsoft.Build.Framework
         {
             if (obj is SdkResultItem item &&
                    ItemSpec == item.ItemSpec &&
-                   Metadata?.Count == item.Metadata?.Count)
+                   Metadata.Count == item.Metadata?.Count)
             {
-                if (Metadata != null)
+                foreach (var kvp in Metadata)
                 {
-                    foreach (var kvp in Metadata)
+                    var itemValue = "";
+                    if (!item.Metadata.TryGetValue(kvp.Key, out itemValue))
                     {
-                        if (item.Metadata[kvp.Key] != kvp.Value)
+                        return false;
+                    }
+                    else
+                    {
+                        if (kvp.Value != itemValue)
                         {
                             return false;
                         }

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Framework
             {
                 foreach (var kvp in Metadata)
                 {
-                    hashCode ^= StringComparer.OrdinalIgnoreCase.GetHashCode($"{kvp.Key}: {kvp.Value ?? "V"}");
+                    hashCode ^= StringComparer.OrdinalIgnoreCase.GetHashCode(kvp.Key) * (StringComparer.OrdinalIgnoreCase.GetHashCode(kvp.Value ?? "V") + 1);
                 }
             }
 

--- a/src/Framework/Sdk/SdkResultItem.cs
+++ b/src/Framework/Sdk/SdkResultItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Build.Framework
 {
@@ -53,7 +54,7 @@ namespace Microsoft.Build.Framework
             {
                 foreach (var kvp in Metadata)
                 {
-                    hashCode ^= $"{kvp.Key.GetHashCode()}: {(kvp.Value ?? "V").GetHashCode()}";
+                    hashCode ^= $"{kvp.Key.GetHashCode()}: {(kvp.Value ?? "V").GetHashCode()}".GetHashCode();
                 }
             }
 


### PR DESCRIPTION
Fixes #6750 

### Context
The issue #6750 describes that implementation of Equals and GetHashCode is still buggy, and it is not reliable. This change ensures that: 

1. Equals won't throw Exception,
2. Equals compare Key and its value between each KeyValues in Metadata's Key and values
3. Remove additional null check on Metadata, because Metadata property will not be null

### Changes Made
Refactor Equals and GetHashCode methods to ensure reliable comparison as suggested in https://github.com/dotnet/msbuild/issues/6750#issue-967522986

### Testing


### Notes
