### PR TITLE
Skip Updating CopyComplete Marker When Not Necessary

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.11.0</VersionPrefix>
+    <VersionPrefix>16.11.1</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -207,6 +207,8 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
         public bool UseHardlinksIfPossible { get { throw null; } set { } }
         public bool UseSymboliclinksIfPossible { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public bool WroteAtLeastOneFile { get { throw null; } }
         public void Cancel() { }
         public override bool Execute() { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -137,6 +137,8 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
         public bool UseHardlinksIfPossible { get { throw null; } set { } }
         public bool UseSymboliclinksIfPossible { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public bool WroteAtLeastOneFile { get { throw null; } }
         public void Cancel() { }
         public override bool Execute() { throw null; }
     }

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -139,6 +139,9 @@ namespace Microsoft.Build.Tasks
         [Output]
         public ITaskItem[] CopiedFiles { get; private set; }
 
+        [Output]
+        public bool WroteAtLeastOneFile { get; private set; }
+
         /// <summary>
         /// Whether to overwrite files in the destination
         /// that have the read-only attribute set.
@@ -298,6 +301,9 @@ namespace Microsoft.Build.Tasks
 
                 File.Copy(sourceFileState.Name, destinationFileState.Name, true);
             }
+            
+            // Files were successfully copied or linked. Those are equivalent here.
+            WroteAtLeastOneFile = true;
 
             destinationFileState.Reset();
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4690,6 +4690,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <Output TaskParameter="DestinationFiles" ItemName="FileWritesShareable"/>
       <Output TaskParameter="CopiedFiles" ItemName="ReferencesCopiedInThisBuild"/>
+      <Output TaskParameter="WroteAtLeastOneFile" PropertyName="WroteAtLeastOneFile"/>
 
     </Copy>
 
@@ -4699,7 +4700,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          input to projects that reference this one. -->
     <Touch Files="@(CopyUpToDateMarker)"
            AlwaysCreate="true"
-           Condition="'@(ReferencesCopiedInThisBuild)' != ''">
+           Condition="'@(ReferencesCopiedInThisBuild)' != '' and '$(WroteAtLeastOneFile)' == 'true'">
         <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
     </Touch>
 


### PR DESCRIPTION
Backporting fix for #6576
See base PR #6698

### Context
https://github.com/dotnet/msbuild/issues/6576 revealed that the `.copycomplete` file marker is updated even when the `Copy` task in `_GetCopyFilesMarkedLocal` doesn't _actually_ copy anything. This can mess with incremental builds.

### Changes Made
This change adds an output parameter, `CopiedAtLeastOneFile` to the `Copy` task that the `Touch` task is now conditioned off of.

### Testing
Tested local builds

### Notes
This could also be done by having an ITaskItem[] that contains all files that were actually copied. Then the touch task could check if that item were empty. I opted for the straightforward route since the ITaskItem[] solution isn't needed yet, and this implementation can easily be changed when we do need that.