### PR TITLE
Add enumeration values for DebugType in XSD

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1254,7 +1254,7 @@ elementFormDefault="qualified">
     </xs:element>
     <xs:element name="DebugType" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="DebugType" _locComment="" -->none, pdbonly, embedded, portable or full. From C# 6 onwards, pdbonly is the same as full.</xs:documentation>
+            <xs:documentation><!-- _locID_text="DebugType" _locComment="" -->none, pdbonly, embedded, portable, or full. From C# 6 onwards, pdbonly is the same as full.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
             <xs:restriction base="xs:string">

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1252,7 +1252,7 @@ elementFormDefault="qualified">
             <xs:documentation><!-- _locID_text="DebugSymbols" _locComment="" -->Whether to emit symbols (boolean)</xs:documentation>
         </xs:annotation>
     </xs:element>
-    <xs:element name="DebugType" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:element name="DebugType" substitutionGroup="msb:Property">
         <xs:annotation>
             <xs:documentation><!-- _locID_text="DebugType" _locComment="" -->none, pdbonly, embedded, portable or full. From C# 6 onwards, pdbonly is the same as full.</xs:documentation>
         </xs:annotation>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1254,8 +1254,17 @@ elementFormDefault="qualified">
     </xs:element>
     <xs:element name="DebugType" type="msb:StringPropertyType" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="DebugType" _locComment="" -->none, pdbonly, or full</xs:documentation>
+            <xs:documentation><!-- _locID_text="DebugType" _locComment="" -->none, pdbonly, embedded, portable or full. From C# 6 onwards, pdbonly is the same as full.</xs:documentation>
         </xs:annotation>
+        <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="none" />
+              <xs:enumeration value="pdbonly" />
+              <xs:enumeration value="embedded" />
+              <xs:enumeration value="portable" />
+              <xs:enumeration value="full" />
+            </xs:restriction>
+        </xs:simpleType>
     </xs:element>
     <xs:element name="DefaultClientScript" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="DefaultHTMLPageLayout" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>


### PR DESCRIPTION
### Context

The `DebugType` property has a set of expected values, and is not just a plain text property.

Currently completion on the `DebugType` property offers no guidance:

![image](https://user-images.githubusercontent.com/350947/133356543-843e642c-3b5d-4727-a2bd-4c691d72105f.png)

### Changes Made

This change adds those values so they appear in completion. It also documents that `pdbonly` is equivalent to `full` in recent compilers.

### Testing

None.

### Notes

None.