### PR TITLE
Update to SDK 5.0.401

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.102",
+    "dotnet": "5.0.401",
     "runtimes": {
       "dotnet/x64": [
         "2.1.7"


### PR DESCRIPTION
Avoids NuGet signing issues and is generally newer and better.

Hopefully avoids errors like:

```
/Users/runner/work/1/s/artifacts/toolset/restore.proj : error : Package 'Microsoft.DotNet.Arcade.Sdk 5.0.0-beta.21458.11' from source 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json': The author primary signature's timestamp found a chain building issue: ExplicitDistrust: The trust setting for this policy was set to Deny.
```

https://dev.azure.com/dnceng/public/_build/results?buildId=1366516&view=logs&j=0ddb6181-8b1d-5386-35d2-ca21a772cde8&t=a36a8187-bb52-5aa3-80a2-ccc76a822779&l=46