### PR TITLE
Initialize XmlReaders using StreamReaders

### DIFF
--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using System.Xml;
 using System.Xml.Xsl;
 using System.Xml.XPath;
@@ -334,7 +335,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (XmlMode == XmlModes.XmlFile)
                 {
-                    return XmlReader.Create(_data[itemPos]);
+                    return XmlReader.Create(new StreamReader(_data[itemPos], new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), detectEncodingFromByteOrderMarks: true));
                 }
                 else // xmlModes.Xml 
                 {
@@ -459,7 +460,7 @@ namespace Microsoft.Build.Tasks
                             _log.LogMessageFromResources(MessageImportance.Low, "XslTransform.UseTrustedSettings", _data);
                         }
 
-                        xslct.Load(new XPathDocument(XmlReader.Create(_data)), settings, new XmlUrlResolver());
+                        xslct.Load(new XPathDocument(XmlReader.Create(new StreamReader(_data, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), detectEncodingFromByteOrderMarks: true))), settings, new XmlUrlResolver());
                         break;
                     case XslModes.XsltCompiledDll:
 #if FEATURE_COMPILED_XSL

--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (XmlMode == XmlModes.XmlFile)
                 {
-                    return XmlReader.Create(new StreamReader(_data[itemPos]));
+                    return XmlReader.Create(new StreamReader(_data[itemPos]), null, _data[itemPos]);
                 }
                 else // xmlModes.Xml 
                 {
@@ -459,7 +459,7 @@ namespace Microsoft.Build.Tasks
                             _log.LogMessageFromResources(MessageImportance.Low, "XslTransform.UseTrustedSettings", _data);
                         }
 
-                        xslct.Load(new XPathDocument(XmlReader.Create(new StreamReader(_data))), settings, new XmlUrlResolver());
+                        xslct.Load(new XPathDocument(XmlReader.Create(new StreamReader(_data), null, _data)), settings, new XmlUrlResolver());
                         break;
                     case XslModes.XsltCompiledDll:
 #if FEATURE_COMPILED_XSL

--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Text;
 using System.Xml;
 using System.Xml.Xsl;
 using System.Xml.XPath;
@@ -335,7 +334,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (XmlMode == XmlModes.XmlFile)
                 {
-                    return XmlReader.Create(new StreamReader(_data[itemPos], new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), detectEncodingFromByteOrderMarks: true));
+                    return XmlReader.Create(new StreamReader(_data[itemPos]));
                 }
                 else // xmlModes.Xml 
                 {
@@ -460,7 +459,7 @@ namespace Microsoft.Build.Tasks
                             _log.LogMessageFromResources(MessageImportance.Low, "XslTransform.UseTrustedSettings", _data);
                         }
 
-                        xslct.Load(new XPathDocument(XmlReader.Create(new StreamReader(_data, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), detectEncodingFromByteOrderMarks: true))), settings, new XmlUrlResolver());
+                        xslct.Load(new XPathDocument(XmlReader.Create(new StreamReader(_data))), settings, new XmlUrlResolver());
                         break;
                     case XslModes.XsltCompiledDll:
 #if FEATURE_COMPILED_XSL


### PR DESCRIPTION
Fixes #6847

### Context
When XmlReader.Create is called and a file path is passed in, it's converted to a URI under the hood. This can mangle multi-byte characters. The solution (in the link above) is to initialize the XmlReader using a stream to the file instead of the path alone.

### Changes Made
Call XmlReader.Create with a stream that will detect encodings.

### Testing
Tested using repro in #6847

### Notes
