### PR TITLE
Use static CoreClrAssemblyLoader in the SdkResolverLoader

### DIFF
--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
         /// i.e. falling back to FileSystem.Default.
         /// </summary>
         private sealed class DefaultMSBuildFileSystem : MSBuildFileSystemBase { }
-      
+
         // Use NullableBool to make it work with Interlock.CompareExchange (doesn't accept bool?).
         // Assume that if one request is a design time build, all of them are.
         // Volatile because it is read by the BuildManager thread and written by one project cache service thread pool thread.
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 #if !FEATURE_ASSEMBLYLOADCONTEXT
                 return Assembly.LoadFrom(resolverPath);
 #else
-                return _loader.LoadFromPath(resolverPath);
+                return s_loader.LoadFromPath(resolverPath);
 #endif
             }
 
@@ -213,7 +213,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
         }
 
 #if FEATURE_ASSEMBLYLOADCONTEXT
-        private static readonly CoreClrAssemblyLoader _loader = new CoreClrAssemblyLoader();
+        private static readonly CoreClrAssemblyLoader s_loader = new CoreClrAssemblyLoader();
 #endif
 
         public void PostCacheRequest(CacheRequest cacheRequest)

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
     internal class SdkResolverLoader
     {
 #if FEATURE_ASSEMBLYLOADCONTEXT
-        private readonly CoreClrAssemblyLoader _loader = new CoreClrAssemblyLoader();
+        private static readonly CoreClrAssemblyLoader s_loader = new CoreClrAssemblyLoader();
 #endif
 
         private readonly string IncludeDefaultResolver = Environment.GetEnvironmentVariable("MSBUILDINCLUDEDEFAULTSDKRESOLVER");
@@ -35,7 +35,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         internal virtual IList<SdkResolver> LoadResolvers(LoggingContext loggingContext,
             ElementLocation location)
         {
-            var resolvers = !String.Equals(IncludeDefaultResolver, "false", StringComparison.OrdinalIgnoreCase) ? 
+            var resolvers = !String.Equals(IncludeDefaultResolver, "false", StringComparison.OrdinalIgnoreCase) ?
                 new List<SdkResolver> {new DefaultSdkResolver()}
                 : new List<SdkResolver>();
 
@@ -192,7 +192,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 #if !FEATURE_ASSEMBLYLOADCONTEXT
             return Assembly.LoadFrom(resolverPath);
 #else
-            return _loader.LoadFromPath(resolverPath);
+            return s_loader.LoadFromPath(resolverPath);
 #endif
         }
 


### PR DESCRIPTION

Fixes https://github.com/dotnet/msbuild/issues/6842#issuecomment-921168797

### Context

We use static for the `CoreClrAssemblyLoader` field so each unique SDK resolver assembly is loaded into memory and JITted only once. All subsequent load requests will return assembly from the assembly loader's cache instead of loading it again from disk. This change increases the performance of SDK resolution and at the same time avoids leaking memory due to loading the same SDK resolver assembly multiple times and never unloading it.

### Changes Made

The `CoreClrAssemblyLoader` field in the `SdkResolverLoader` class was changed from non-static to static member. The same instance of `CoreClrAssemblyLoader` will be used by all instances of `SdkResolverLoader`. It is consistent now with other uses of `CoreClrAssemblyLoader` in msbuild.

### Testing

Tested manually using repro from https://github.com/dotnet/msbuild/issues/5037#issuecomment-917981250

### Notes

Alternative approach would be to use collectible `CoreClrAssemblyLoader` / `AssemblyLoadContext` - that would fix the leak as well but it would be less performant as it wouldn't benefit from re-using already loaded and JITed assemblies.  