### PR TITLE
Revert "Define stand-in optional workloads targets (#6813)"

### DIFF
--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -193,20 +193,4 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <DisableLogTaskParameterItemMetadata_WriteLinesToFile_Lines>true</DisableLogTaskParameterItemMetadata_WriteLinesToFile_Lines>
   </PropertyGroup>
 
-   <!--
-        Define dummy optional workloads targets. Design-time builds use these targets
-        to determine whether the in-product acquisition experience should be enabled.
-        Since older SDKs do not have these targets, these dummy targets are defined here
-        to prevent builds using older SDKs and frameworks from failing. Ideally, they
-        would be Microsoft.Common.targets. Unfortunately, the workload targets are
-        imported before Microsoft.Common.targets and would therefore be overridden
-        by these dummy targets if they were defined in Microsoft.Common.targets. To work
-        around this issue, they are defined here in Microsoft.Common.props to ensure
-        they are the first workload targets defined.
-
-        See https://github.com/dotnet/project-system/issues/7561
-    -->
-  <Target Name="GetSuggestedWorkloads" />
-  <Target Name="CollectSuggestedWorkloads" />
-
 </Project>


### PR DESCRIPTION
This reverts commit 74e9935a4a2e0108343533b3445516ad111e87ea.

### Context
dotnet/project-system#7432 added a design-time target called CollectSuggestedWorkloads to [Microsoft.Managed.DesignTime.targets](https://github.com/dotnet/project-system/blob/main/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets). However, WAP projects do not import the managed design-time targets so their design-time builds fail because the CollectSuggestedWorkloads design-time target cannot be found (see dotnet/project-system#7561).

#6813 worked around this by defining dummy targets in Microsoft.Common.props. This change cleans up that work-around by removing the dummy design-time targets.

### Changes Made
Reverted #6813

### Testing
1. Opened a solution that uses global.json to pin to .NET 5 (VS.RPC.Contracts) and verified that design-time builds succeeded and no errors are displayed in the error list
2. Create a new Windows Application Packaging Project and verified that design-time builds will fail as expected without this workaround
3. Opened a MAUI solution and verified that the suggested workloads are still correctly displayed to the user.

### Notes
Moving these dummy targets out of the props file into Microsoft.Common.targets would override the real target needed by the project system because [Microsoft.Managed.DesignTime.targets](https://github.com/dotnet/project-system/blob/main/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets) is [imported before Microsoft.Common.targets](https://github.com/dotnet/msbuild/blob/main/src/Tasks/Microsoft.CSharp.CurrentVersion.targets#L326)

The WAP project system should therefore define these targets in an appropriate import file they own.