### PR TITLE
Add labels documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,25 @@ MSBuild can be run on Unix systems that support .NET Core. Set-up instructions c
 
 You can turn on localized builds via the `/p:LocalizedBuild=true` command line argument. For more information on localized builds and how to make contributions to MSBuild's translations, see our [localization documentation](documentation/wiki/Localization.md)
 
-#### Getting Started
-
+### Interested in contributing?
 Before you contribute, please read through the contributing and developer guides to get an idea of what kinds of pull requests we accept.
 
 * [Contributing Guide](documentation/wiki/Contributing-Code.md)
-
 * **Developer Guide on:**
    - [.NET Core](documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md)
    - [Full Framework](documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md)
    - [Mono](documentation/wiki/Building-Testing-and-Debugging-on-Mono-MSBuild.md)
 
-Looking for something to work on? This list of [up for grabs issues](https://github.com/Microsoft/msbuild/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs) is a great place to start.
+* See our [up for grabs issues](https://github.com/Microsoft/msbuild/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs) for a list of issues we think are great to onboard new developers.
+   - **Note:** Please leave a comment asking to be assigned the issue if you want to work on it.
+* See our [label documentation](documentation/wiki/labels.md) if you're confused about a label we've applied to a contribution.
 
-You are also encouraged to start a discussion by filing an issue or creating a gist.
+### Other ways to contribute
+We encourage any contributions you decide to make to the repo!
+
+* [File an issue](https://github.com/dotnet/msbuild/issues/new/choose)
+* [Submit a pull request](https://github.com/dotnet/msbuild/issues/new/choose)
+* [Start a discussion](https://github.com/dotnet/msbuild/compare)
 
 ### MSBuild Components
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,13 @@ Before you contribute, please read through the contributing and developer guides
 
 * See our [up for grabs issues](https://github.com/Microsoft/msbuild/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs) for a list of issues we think are great to onboard new developers.
    - **Note:** Please leave a comment asking to be assigned the issue if you want to work on it.
-* See our [label documentation](documentation/wiki/labels.md) if you're confused about a label we've applied to a contribution.
+* See our [label documentation](documentation/wiki/labels.md) for descriptions of labels we use throughout the repo.
 
 ### Other ways to contribute
 We encourage any contributions you decide to make to the repo!
 
 * [File an issue](https://github.com/dotnet/msbuild/issues/new/choose)
-* [Submit a pull request](https://github.com/dotnet/msbuild/issues/new/choose)
-* [Start a discussion](https://github.com/dotnet/msbuild/compare)
+* [Start a discussion](https://github.com/dotnet/msbuild/discussions)
 
 ### MSBuild Components
 

--- a/documentation/wiki/Labels.md
+++ b/documentation/wiki/Labels.md
@@ -1,0 +1,12 @@
+# MSBuild Labels
+Here's a brief explanation on the labels most often used by the MSBuild team excluding obvious ones such as `bug`.
+
+| Label             | Applied When | Notes |
+|-------------------|--------------|-------|
+| `needs-triage`    | Team has yet to determine what area/prioritization applies to the issue. | This is the primary label queried during a regular bug triage meeting. Automatically removed when `needs-more-info` is applied. |
+| `needs-attention` | An issue requires the team look at it during bug triage. | Automatically applied when a stale issue receives a comment. |
+| `needs-more-info` | Team asked for info needed to continue an investigation. | If no response is given within 7 days, the `stale` label is applied. |
+| `initial-investigation` | A member of the team does a "first pass" investigation. | `needs-triage` is applied and team member and unassigns themselves after the initial investigation is complete. |
+| `stale` | An issue marked with `needs-more-info` is inactive for 7 days. | The issue will be closed after 30 days of inactivity while the `stale` label is applied. |
+| `For consideration` | An issue should get higher prioritization when planning the next set of features. | |
+| `up-for-grabs` | Anyone can take ownership over this issue. | If a contributor wants to take the issue on, they should ask that it be assigned to them BEFORE doing development work.  |

--- a/documentation/wiki/Labels.md
+++ b/documentation/wiki/Labels.md
@@ -1,5 +1,5 @@
 # MSBuild Labels
-Here's a brief explanation on the labels most often used by the MSBuild team excluding obvious ones such as `bug`.
+Here's a brief explanation on the labels most often used by the MSBuild team excluding hopefully self-evident ones such as `bug`.
 
 | Label             | Applied When | Notes |
 |-------------------|--------------|-------|

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,8 +20,6 @@
 
     <ProduceReferenceAssembly Condition="'$(IsTestProject)' != 'true'">true</ProduceReferenceAssembly>
 
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-
     <!-- Set up BeforeCommon.targets -->
     <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Directory.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,8 @@
 
     <ProduceReferenceAssembly Condition="'$(IsTestProject)' != 'true'">true</ProduceReferenceAssembly>
 
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+
     <!-- Set up BeforeCommon.targets -->
     <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Directory.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
 


### PR DESCRIPTION
### Context
Added a doc with a table explaining some of the more frequently used labels, and the underlying processes that apply to them.

### Notes
Once this is merged I'll update the bot's "close a stale issue" message with a link to the doc.