### PR TITLE
Make SDK resolvers more static

### DIFF
--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         [Fact]
         public void AssertAllResolverErrorsLoggedWhenSdkNotResolved()
         {
-            SdkResolverService.Instance.InitializeForTests(new MockLoaderStrategy());
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, new MockLoaderStrategy());
 
             SdkReference sdk = new SdkReference("notfound", "referencedVersion", "minimumVersion");
 
@@ -63,8 +63,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
             var sdk = new SdkReference("foo", "1.0.0", null);
 
-            SdkResolverService.Instance.InitializeForTests(
-                null,
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance,
+            null,
                 new List<SdkResolver>
                 {
                     new SdkUtilities.ConfigurableMockSdkResolver(
@@ -87,7 +87,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         [Fact]
         public void AssertResolverThrows()
         {
-            SdkResolverService.Instance.InitializeForTests(new MockLoaderStrategy(includeErrorResolver: true));
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, new MockLoaderStrategy(includeErrorResolver: true));
 
             SdkReference sdk = new SdkReference("1sdkName", "version1", "minimumVersion");
 
@@ -100,7 +100,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         [Fact]
         public void AssertFirstResolverCanResolve()
         {
-            SdkResolverService.Instance.InitializeForTests(new MockLoaderStrategy());
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, new MockLoaderStrategy());
 
             SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
 
@@ -113,7 +113,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         [Fact]
         public void AssertFirstResolverErrorsSupressedWhenResolved()
         {
-            SdkResolverService.Instance.InitializeForTests(new MockLoaderStrategy());
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, new MockLoaderStrategy());
 
             // 2sdkName will cause MockSdkResolver1 to fail with an error reason. The error will not
             // be logged because MockSdkResolver2 will succeed.
@@ -137,7 +137,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
             const int submissionId = 5;
 
-            SdkResolverService.Instance.InitializeForTests(new MockLoaderStrategy());
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, new MockLoaderStrategy());
 
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
@@ -153,7 +153,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
             const int submissionId = BuildEventContext.InvalidSubmissionId;
 
-            SdkResolverService.Instance.InitializeForTests(new MockLoaderStrategy());
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, new MockLoaderStrategy());
 
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     ));
 
             var service = new CachingSdkResolverService();
-            service.InitializeForTests(
+            using ResettableSdkResolverServiceState state = new(service, 
                 null,
                 new List<SdkResolver>
                 {
@@ -282,7 +282,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     warnings: null
                     ));
 
-            SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, null, new List<SdkResolver>() { resolver });
 
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
@@ -319,7 +319,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     warnings: null
                     ));
 
-            SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, null, new List<SdkResolver>() { resolver });
 
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
@@ -366,7 +366,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     warnings: null
                     ));
 
-            SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, null, new List<SdkResolver>() { resolver });
 
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
@@ -412,7 +412,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     warnings: null
                     ));
 
-            SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
+            using ResettableSdkResolverServiceState state = new(SdkResolverService.Instance, null, new List<SdkResolver>() { resolver });
 
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
@@ -451,7 +451,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 ));
 
             var service = new CachingSdkResolverService();
-            service.InitializeForTests(
+            using ResettableSdkResolverServiceState state = new(service, 
                 null,
                 new List<SdkResolver>
                 {
@@ -480,7 +480,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             var service = new CachingSdkResolverService();
 
-            service.InitializeForTests(
+            using ResettableSdkResolverServiceState state = new(service, 
                 resolvers: new List<SdkResolver>
                 {
                     new SdkUtilities.ConfigurableMockSdkResolver((sdkRference, resolverContext, factory) =>
@@ -511,7 +511,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             bool isRunningInVisualStudio = false;
 
             var service = new CachingSdkResolverService();
-            service.InitializeForTests(
+            using ResettableSdkResolverServiceState state = new(service, 
                 resolvers: new List<SdkResolver>
                 {
                     new SdkUtilities.ConfigurableMockSdkResolver((sdkRference, resolverContext, factory) =>

--- a/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -845,10 +845,11 @@ namespace Microsoft.Build.UnitTests.Preprocessor
             {
                 string testSdkDirectory = env.CreateFolder().Path;
 
-                var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(new Dictionary<string, string>
+                using var state = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(new Dictionary<string, string>
                 {
                     {"MSBuildUnitTestSdk", testSdkDirectory}
-                }));
+                }),
+                out var projectOptions);
 
 
                 string sdkPropsPath = Path.Combine(testSdkDirectory, "Sdk.props");
@@ -949,7 +950,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
                     }
                 };
 
-                var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
+                using var state = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
                     new Build.BackEnd.SdkResolution.SdkResult(
                         new SdkReference("TestPropsAndItemsFromResolverSdk", null, null),
                         new [] { testDirectory},
@@ -957,7 +958,8 @@ namespace Microsoft.Build.UnitTests.Preprocessor
                         propertiesToAdd,
                         itemsToAdd,
                         warnings: null
-                        )));
+                        )),
+                    out var projectOptions);
 
                 string content = @"<Project>
 <Import Project='Import.props' Sdk='TestPropsAndItemsFromResolverSdk' />
@@ -1051,11 +1053,12 @@ namespace Microsoft.Build.UnitTests.Preprocessor
                 string sdk1 = env.CreateFolder().Path;
                 string sdk2 = env.CreateFolder().Path;
 
-                var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(new Dictionary<string, string>
+                var state = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(new Dictionary<string, string>
                 {
                     {"MSBuildUnitTestSdk1", sdk1},
                     {"MSBuildUnitTestSdk2", sdk2},
-                }));
+                }),
+                out var projectOptions);
 
                 string sdkPropsPath1 = Path.Combine(sdk1, "Sdk.props");
                 string sdkTargetsPath1 = Path.Combine(sdk1, "Sdk.targets");

--- a/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
@@ -340,7 +340,8 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             // Use custom SDK resolution to ensure resolver context is logged.
             var mapping = new Dictionary<string, string> { { SdkName, _testSdkDirectory } };
-            var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(mapping));
+            using var state = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(mapping),
+                out var projectOptions);
 
             // Create a normal project (p1) which imports an SDK style project (p2).
             var projectFolder = _env.CreateFolder().Path;
@@ -622,8 +623,9 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 null
             );
 
-            var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(
-                new MockExpandedSdkResolver(_testSdkDirectory)
+            using var state = SdkUtilities.CreateProjectOptionsWithResolver(
+                new MockExpandedSdkResolver(_testSdkDirectory),
+                out var projectOptions
             );
 
             void AddProperty(string name, string value) =>

--- a/src/Build.UnitTests/Evaluation/SdkResultEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/SdkResultEvaluation_Tests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 CreateMockSdkResultPropertiesAndItems(out propertiesToAdd, out itemsToAdd);
             }
 
-            var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
+            using var state = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
                 new Build.BackEnd.SdkResolution.SdkResult(
                         new SdkReference("TestPropsAndItemsFromResolverSdk", null, null),
                         Enumerable.Empty<string>(),
@@ -118,7 +118,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
                         propertiesToAdd,
                         itemsToAdd,
                         warnings: null
-                    ))
+                    )),
+                out var projectOptions
                 );
 
             string projectContent = @"
@@ -168,7 +169,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
                     itemsToAdd,
                     warnings: null);
 
-            var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(sdkResult));
+            using var state = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(sdkResult),
+                out var projectOptions);
 
             string projectContent = @"
                     <Project>
@@ -246,7 +248,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 CreateMockSdkResultPropertiesAndItems(out propertiesToAdd, out itemsToAdd);
             }
 
-            var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
+            using var state = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
                 new Build.BackEnd.SdkResolution.SdkResult(
                         new SdkReference("TestPropsAndItemsFromResolverSdk", null, null),
                         new[] {
@@ -257,7 +259,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
                         propertiesToAdd,
                         itemsToAdd,
                         warnings: null
-                    ))
+                    )),
+                out var projectOptions
                 );
 
             string projectContent = @"
@@ -350,7 +353,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Dictionary<string, SdkResultItem> itemsToAdd;
             CreateMockSdkResultPropertiesAndItems(out propertiesToAdd, out itemsToAdd);
 
-            var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
+            using var state = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
                 new Build.BackEnd.SdkResolution.SdkResult(
                         new SdkReference("TestPropsAndItemsFromResolverSdk", null, null),
                         new[] { Path.Combine(_testFolder, "Sdk") },
@@ -358,7 +361,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
                         propertiesToAdd,
                         itemsToAdd,
                         warnings: null
-                    ))
+                    )),
+                out var projectOptions
                 );
 
             string projectContent = @"
@@ -434,7 +438,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 }
             };
 
-            var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
+            using var state = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
                 new Build.BackEnd.SdkResolution.SdkResult(
                         new SdkReference("TestSpecialCharactersFromSdkResolver", null, null),
                         Enumerable.Empty<string>(),
@@ -442,7 +446,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
                         propertiesToAdd,
                         itemsToAdd,
                         warnings: null
-                    ))
+                    )),
+                out var projectOptions
                 );
 
             string projectContent = @"


### PR DESCRIPTION
It doesn't make sense to change SdkResolvers while MSBuild is running.
Even in the node-reuse scenario, adding or removing a resolver means
changing files in the MSBuild installation directory, which should be
done with all MSBuild processes closed.

Additionally changed tests to use a disposable object that resets test
state when modifying ResolverService state; without this the static
field remains corrupted and any subsequent tests might fail to load an
SDK.

Noticed these when reviewing #6864.