### PR TITLE
Clean up minimum Windows version checks

### DIFF
--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1092,7 +1092,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</comment>
   </data>
   <data name="UnsupportedOS" UESanitized="true" Visibility="Public">
-    <value>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</value>
+    <value>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</value>
     <comment>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</comment>
   </data>
   <data name="Using35Engine" UESanitized="true" Visibility="Public">

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1092,7 +1092,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</comment>
   </data>
   <data name="UnsupportedOS" UESanitized="true" Visibility="Public">
-    <value>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</value>
+    <value>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</value>
     <comment>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</comment>
   </data>
   <data name="Using35Engine" UESanitized="true" Visibility="Public">

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1330,7 +1330,7 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild nejde spustit v této verzi operačního systému. Podporuje se jenom v systémech Windows 2000, Windows XP a novějších verzích.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1330,8 +1330,8 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild nejde spustit v této verzi operačního systému. Podporuje se jenom v systémech Windows 2000, Windows XP a novějších verzích.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild nejde spustit v této verzi operačního systému. Podporuje se jenom v systémech Windows 2000, Windows XP a novějších verzích.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1322,7 +1322,7 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild kann unter dieser Version des Betriebssystems nicht ausgeführt werden. Nur Windows 2000, Windows XP und Folgeversionen werden unterstützt.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1322,8 +1322,8 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild kann unter dieser Version des Betriebssystems nicht ausgeführt werden. Nur Windows 2000, Windows XP und Folgeversionen werden unterstützt.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild kann unter dieser Version des Betriebssystems nicht ausgeführt werden. Nur Windows 2000, Windows XP und Folgeversionen werden unterstützt.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1331,7 +1331,7 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild no se puede ejecutar en esta versión del sistema operativo. Solo es compatible con Windows 2000, Windows XP y versiones posteriores.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1331,8 +1331,8 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild no se puede ejecutar en esta versión del sistema operativo. Solo es compatible con Windows 2000, Windows XP y versiones posteriores.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild no se puede ejecutar en esta versión del sistema operativo. Solo es compatible con Windows 2000, Windows XP y versiones posteriores.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1322,7 +1322,7 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild ne s'exécute pas sur cette version du système d'exploitation. Il est pris en charge uniquement sur Windows 2000, Windows XP et les versions ultérieures.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1322,8 +1322,8 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild ne s'exécute pas sur cette version du système d'exploitation. Il est pris en charge uniquement sur Windows 2000, Windows XP et les versions ultérieures.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild ne s'exécute pas sur cette version du système d'exploitation. Il est pris en charge uniquement sur Windows 2000, Windows XP et les versions ultérieures.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1344,7 +1344,7 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild non può essere eseguito su questa versione del sistema operativo. È supportato solo in Windows 2000, Windows XP e versioni successive.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1344,8 +1344,8 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild non può essere eseguito su questa versione del sistema operativo. È supportato solo in Windows 2000, Windows XP e versioni successive.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild non può essere eseguito su questa versione del sistema operativo. È supportato solo in Windows 2000, Windows XP e versioni successive.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1322,7 +1322,7 @@ Copyright (C) Microsoft Corporation.All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild はこのバージョンのオペレーティング システムでは実行できません。Windows 2000、Windows XP およびそれ以降のバージョンでのみサポートされています。</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1322,8 +1322,8 @@ Copyright (C) Microsoft Corporation.All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild はこのバージョンのオペレーティング システムでは実行できません。Windows 2000、Windows XP およびそれ以降のバージョンでのみサポートされています。</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild はこのバージョンのオペレーティング システムでは実行できません。Windows 2000、Windows XP およびそれ以降のバージョンでのみサポートされています。</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1322,7 +1322,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: 이 운영 체제 버전에서는 MSBuild를 실행할 수 없습니다. MSBuild는 Windows 2000 및 Windows XP 이상 버전에서만 지원됩니다.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1322,8 +1322,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: 이 운영 체제 버전에서는 MSBuild를 실행할 수 없습니다. MSBuild는 Windows 2000 및 Windows XP 이상 버전에서만 지원됩니다.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: 이 운영 체제 버전에서는 MSBuild를 실행할 수 없습니다. MSBuild는 Windows 2000 및 Windows XP 이상 버전에서만 지원됩니다.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1336,7 +1336,7 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: Program MSBuild nie działa w tej wersji systemu operacyjnego. Jest obsługiwany tylko w systemie Windows 2000, Windows XP oraz nowszych wersjach.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1336,8 +1336,8 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: Program MSBuild nie działa w tej wersji systemu operacyjnego. Jest obsługiwany tylko w systemie Windows 2000, Windows XP oraz nowszych wersjach.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: Program MSBuild nie działa w tej wersji systemu operacyjnego. Jest obsługiwany tylko w systemie Windows 2000, Windows XP oraz nowszych wersjach.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1323,7 +1323,7 @@ isoladamente.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: O MSBuild não é executado nesta versão de sistema operacional. Há suporte para ele somente nas versões Windows 2000, Windows XP e versões posteriores.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1323,8 +1323,8 @@ isoladamente.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: O MSBuild não é executado nesta versão de sistema operacional. Há suporte para ele somente nas versões Windows 2000, Windows XP e versões posteriores.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: O MSBuild não é executado nesta versão de sistema operacional. Há suporte para ele somente nas versões Windows 2000, Windows XP e versões posteriores.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1321,7 +1321,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild не работает в этой версии операционной системы. Он поддерживается только в Windows 2000, Windows XP и более поздних версиях.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1321,8 +1321,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild не работает в этой версии операционной системы. Он поддерживается только в Windows 2000, Windows XP и более поздних версиях.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild не работает в этой версии операционной системы. Он поддерживается только в Windows 2000, Windows XP и более поздних версиях.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1326,7 +1326,7 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild işletim sisteminin bu sürümünde çalışmaz. Yalnızca Windows 2000, Windows XP ve sonraki sürümlerde desteklenir.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1326,8 +1326,8 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild işletim sisteminin bu sürümünde çalışmaz. Yalnızca Windows 2000, Windows XP ve sonraki sürümlerde desteklenir.</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild işletim sisteminin bu sürümünde çalışmaz. Yalnızca Windows 2000, Windows XP ve sonraki sürümlerde desteklenir.</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1322,7 +1322,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild 不能在此版本的操作系统上运行。它仅在 Windows 2000、Windows XP 及更高版本的操作系统上受支持。</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1322,8 +1322,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild 不能在此版本的操作系统上运行。它仅在 Windows 2000、Windows XP 及更高版本的操作系统上受支持。</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild 不能在此版本的操作系统上运行。它仅在 Windows 2000、Windows XP 及更高版本的操作系统上受支持。</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1322,7 +1322,7 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 7 and later versions.</source>
         <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild 在此版本的作業系統上不會執行。只有在 Windows 2000、Windows XP 及更新版本才受支援。</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1322,8 +1322,8 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="UnsupportedOS">
-        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
-        <target state="translated">MSBUILD : error MSB1015: MSBuild 在此版本的作業系統上不會執行。只有在 Windows 2000、Windows XP 及更新版本才受支援。</target>
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 10 and later versions.</source>
+        <target state="needs-review-translation">MSBUILD : error MSB1015: MSBuild 在此版本的作業系統上不會執行。只有在 Windows 2000、Windows XP 及更新版本才受支援。</target>
         <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
       <trans-unit id="Using35Engine">

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -90,11 +90,6 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
-        /// True if the Main method was invoked. False indicates that we're running hosted in another process (e.g. unit tests).
-        /// </summary>
-        private static bool s_executingMainEntryPoint;
-
-        /// <summary>
         /// Whether the static constructor ran successfully.
         /// </summary>
         private static bool s_initialized;
@@ -219,8 +214,6 @@ namespace Microsoft.Build.CommandLine
 #endif
             )
         {
-            s_executingMainEntryPoint = true;
-
             using PerformanceLogEventListener eventListener = PerformanceLogEventListener.Create();
 
             if (Environment.GetEnvironmentVariable("MSBUILDDUMPPROCESSCOUNTERS") == "1")
@@ -1552,14 +1545,8 @@ namespace Microsoft.Build.CommandLine
         private static void VerifyThrowSupportedOS()
         {
 #if FEATURE_OSVERSION
-            // We require Windows 10 but the OS may lie about the version if the .exe is not properly manifested
-            // (such as e.g. the unit test console runner).
-            var minimumVersion = s_executingMainEntryPoint
-                ? new Version(10, 0) // Windows 10
-                : new Version(6, 2); // Windows 10 pretending to be Windows 8
-
             if (Environment.OSVersion.Platform != PlatformID.Win32NT ||
-                Environment.OSVersion.Version < minimumVersion)
+                Environment.OSVersion.Version.Major < 10) // Windows 10 is minimum
             {
                 // If we're running on any of the unsupported OS's, fail immediately.  This way,
                 // we don't run into some obscure error down the line, totally confusing the user.

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1546,7 +1546,8 @@ namespace Microsoft.Build.CommandLine
         {
 #if FEATURE_OSVERSION
             if (Environment.OSVersion.Platform != PlatformID.Win32NT ||
-                Environment.OSVersion.Version.Major < 10) // Windows 10 is minimum
+                Environment.OSVersion.Version.Major < 6 ||
+                (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor < 1)) // Windows 7 is minimum
             {
                 // If we're running on any of the unsupported OS's, fail immediately.  This way,
                 // we don't run into some obscure error down the line, totally confusing the user.

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -89,12 +89,10 @@ namespace Microsoft.Build.CommandLine
             ProjectCacheFailure
         }
 
-#if FEATURE_OSVERSION
         /// <summary>
         /// True if the Main method was invoked. False indicates that we're running hosted in another process (e.g. unit tests).
         /// </summary>
         private static bool s_executingMainEntryPoint;
-#endif
 
         /// <summary>
         /// Whether the static constructor ran successfully.
@@ -221,9 +219,7 @@ namespace Microsoft.Build.CommandLine
 #endif
             )
         {
-#if FEATURE_OSVERSION
             s_executingMainEntryPoint = true;
-#endif
 
             using PerformanceLogEventListener eventListener = PerformanceLogEventListener.Create();
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1550,8 +1550,7 @@ namespace Microsoft.Build.CommandLine
             {
                 // If we're running on any of the unsupported OS's, fail immediately.  This way,
                 // we don't run into some obscure error down the line, totally confusing the user.
-                InitializationException.Throw($"Platform {Environment.OSVersion.Platform}, version {Environment.OSVersion.Version}", "");
-                //InitializationException.VerifyThrow(false, "UnsupportedOS");
+                InitializationException.VerifyThrow(false, "UnsupportedOS");
             }
 #endif
         }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -90,6 +90,11 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
+        /// True if the Main method was invoked. False indicates that we're running hosted in another process (e.g. unit tests).
+        /// </summary>
+        private static bool s_executingMainEntryPoint;
+
+        /// <summary>
         /// Whether the static constructor ran successfully.
         /// </summary>
         private static bool s_initialized;
@@ -214,6 +219,8 @@ namespace Microsoft.Build.CommandLine
 #endif
             )
         {
+            s_executingMainEntryPoint = true;
+
             using PerformanceLogEventListener eventListener = PerformanceLogEventListener.Create();
 
             if (Environment.GetEnvironmentVariable("MSBUILDDUMPPROCESSCOUNTERS") == "1")
@@ -1545,8 +1552,14 @@ namespace Microsoft.Build.CommandLine
         private static void VerifyThrowSupportedOS()
         {
 #if FEATURE_OSVERSION
+            // We require Windows 10 but the OS may lie about the version if the .exe is not properly manifested
+            // (such as e.g. the unit test console runner).
+            var minimumVersion = s_executingMainEntryPoint
+                ? new Version(10, 0) // Windows 10
+                : new Version(6, 2); // Windows 10 pretending to be Windows 8
+
             if (Environment.OSVersion.Platform != PlatformID.Win32NT ||
-                Environment.OSVersion.Version.Major < 10) // Windows 10 is minimum
+                Environment.OSVersion.Version < minimumVersion)
             {
                 // If we're running on any of the unsupported OS's, fail immediately.  This way,
                 // we don't run into some obscure error down the line, totally confusing the user.

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -89,10 +89,12 @@ namespace Microsoft.Build.CommandLine
             ProjectCacheFailure
         }
 
+#if FEATURE_OSVERSION
         /// <summary>
         /// True if the Main method was invoked. False indicates that we're running hosted in another process (e.g. unit tests).
         /// </summary>
         private static bool s_executingMainEntryPoint;
+#endif
 
         /// <summary>
         /// Whether the static constructor ran successfully.
@@ -219,7 +221,9 @@ namespace Microsoft.Build.CommandLine
 #endif
             )
         {
+#if FEATURE_OSVERSION
             s_executingMainEntryPoint = true;
+#endif
 
             using PerformanceLogEventListener eventListener = PerformanceLogEventListener.Create();
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1545,11 +1545,8 @@ namespace Microsoft.Build.CommandLine
         private static void VerifyThrowSupportedOS()
         {
 #if FEATURE_OSVERSION
-            if ((Environment.OSVersion.Platform == PlatformID.Win32S) ||        // Win32S
-                (Environment.OSVersion.Platform == PlatformID.Win32Windows) ||  // Windows 95, Windows 98, Windows ME
-                (Environment.OSVersion.Platform == PlatformID.WinCE) ||         // Windows CE
-                ((Environment.OSVersion.Platform == PlatformID.Win32NT) &&      // Windows NT 4.0 and earlier
-                (Environment.OSVersion.Version.Major <= 4)))
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT ||
+                Environment.OSVersion.Version.Major < 10) // Windows 10 is minimum
             {
                 // If we're running on any of the unsupported OS's, fail immediately.  This way,
                 // we don't run into some obscure error down the line, totally confusing the user.

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1550,7 +1550,8 @@ namespace Microsoft.Build.CommandLine
             {
                 // If we're running on any of the unsupported OS's, fail immediately.  This way,
                 // we don't run into some obscure error down the line, totally confusing the user.
-                InitializationException.VerifyThrow(false, "UnsupportedOS");
+                InitializationException.Throw($"Platform {Environment.OSVersion.Platform}, version {Environment.OSVersion.Version}", "");
+                //InitializationException.VerifyThrow(false, "UnsupportedOS");
             }
 #endif
         }

--- a/src/Shared/EncodingUtilities.cs
+++ b/src/Shared/EncodingUtilities.cs
@@ -219,16 +219,6 @@ namespace Microsoft.Build.Shared
 
             string useUtf8 = string.IsNullOrEmpty(encodingSpecification) ? EncodingUtilities.UseUtf8Detect : encodingSpecification;
 
-#if FEATURE_OSVERSION
-            // UTF8 is only supported in Windows 7 (6.1) or greater.
-            var windows7 = new Version(6, 1);
-
-            if (Environment.OSVersion.Version < windows7)
-            {
-                useUtf8 = EncodingUtilities.UseUtf8Never;
-            }
-#endif
-
             switch (useUtf8.ToUpperInvariant())
             {
                 case EncodingUtilities.UseUtf8Always:

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -876,33 +876,6 @@ namespace Microsoft.Build.Shared
 
 #endregion
 
-#region Set Error Mode (copied from BCL)
-
-        private static readonly Version s_threadErrorModeMinOsVersion = new Version(6, 1, 0x1db0);
-
-        internal static int SetErrorMode(int newMode)
-        {
-#if FEATURE_OSVERSION
-            if (Environment.OSVersion.Version < s_threadErrorModeMinOsVersion)
-            {
-                return SetErrorMode_VistaAndOlder(newMode);
-            }
-#endif
-            int num;
-            SetErrorMode_Win7AndNewer(newMode, out num);
-            return num;
-        }
-
-        [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Class name is NativeMethodsShared for increased clarity")]
-        [DllImport("kernel32.dll", EntryPoint = "SetThreadErrorMode", SetLastError = true)]
-        private static extern bool SetErrorMode_Win7AndNewer(int newMode, out int oldMode);
-
-        [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Class name is NativeMethodsShared for increased clarity")]
-        [DllImport("kernel32.dll", EntryPoint = "SetErrorMode", ExactSpelling = true)]
-        private static extern int SetErrorMode_VistaAndOlder(int newMode);
-
-#endregion
-
 #region Wrapper methods
 
         /// <summary>
@@ -1636,8 +1609,10 @@ namespace Microsoft.Build.Shared
 
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-
         internal static extern bool CloseHandle(IntPtr hObject);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool SetThreadErrorMode(int newMode, out int oldMode);
 
 #endregion
 

--- a/src/Tasks/FileState.cs
+++ b/src/Tasks/FileState.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Build.Tasks
                     // there is no disk in drive A:, please insert one.  We don't want that. 
                     // SetErrorMode will let us disable this, but we should set the error
                     // mode back, since this may have wide-ranging effects.
-                    oldMode = NativeMethodsShared.SetErrorMode(1 /* ErrorModes.SEM_FAILCRITICALERRORS */);
+                    NativeMethodsShared.SetThreadErrorMode(1 /* ErrorModes.SEM_FAILCRITICALERRORS */, out oldMode);
                 }
 
                 try
@@ -174,7 +174,7 @@ namespace Microsoft.Build.Tasks
                     // Reset the error mode on Windows
                     if (NativeMethodsShared.IsWindows)
                     {
-                        NativeMethodsShared.SetErrorMode(oldMode);
+                        NativeMethodsShared.SetThreadErrorMode(oldMode, out _);
                     }
                 }
             }


### PR DESCRIPTION
### Context

Per https://docs.microsoft.com/en-us/visualstudio/releases/2022/system-requirements, Visual Studio 2022 is not supported on pre-Windows 10 OS.

### Changes Made

Updated and removed Windows version checks accordingly.

### Testing

Build and smoke test on Windows 10.
