### PR TITLE
Enable File Scoped Namespaces For Resources

### DIFF
--- a/src/Tasks.UnitTests/CSharpParserUtilitites_Tests.cs
+++ b/src/Tasks.UnitTests/CSharpParserUtilitites_Tests.cs
@@ -18,28 +18,27 @@ namespace Microsoft.Build.UnitTests
         // Simplest case of getting a fully-qualified class name from
         // a c# file.
         [Theory]
-        [InlineData("namespace MyNamespace { class MyClass {} }", "MyNamespace.MyClass")]
-        [InlineData("namespace MyNamespace ; class MyClass {} ", "MyNamespace.MyClass")] // file-scoped namespaces
-        public void Simple(string fileContents, string expected)
+        [InlineData("namespace MyNamespace { class MyClass {} }")]
+        [InlineData("namespace MyNamespace ; class MyClass {} ")] // file-scoped namespaces
+        public void Simple(string fileContents)
         {
-            AssertParse(fileContents, expected);
-            AssertParse("namespace MyNamespace { class MyClass {} }", "MyNamespace.MyClass");
+            AssertParse(fileContents, "MyNamespace.MyClass");
         }
 
         [Theory]
-        [InlineData("namespace /**/ MyNamespace /**/ { /**/ class /**/ MyClass/**/{}} //", "MyNamespace.MyClass")]
-        [InlineData("namespace /**/ MyNamespace /**/ ; /**/ class /**/ MyClass/**/{} //", "MyNamespace.MyClass")] // file-scoped namespaces
-        public void EmbeddedComment(string fileContents, string expected)
+        [InlineData("namespace /**/ MyNamespace /**/ { /**/ class /**/ MyClass/**/{}} //")]
+        [InlineData("namespace /**/ MyNamespace /**/ ; /**/ class /**/ MyClass/**/{} //")] // file-scoped namespaces
+        public void EmbeddedComment(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "MyNamespace.MyClass");
         }
 
         [Theory]
-        [InlineData("namespace MyNamespace{class MyClass{}}", "MyNamespace.MyClass")]
-        [InlineData("namespace MyNamespace;class MyClass{}", "MyNamespace.MyClass")] // file-scoped namespaces
-        public void MinSpace(string fileContents, string expected)
+        [InlineData("namespace MyNamespace{class MyClass{}}")]
+        [InlineData("namespace MyNamespace;class MyClass{}")] // file-scoped namespaces
+        public void MinSpace(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "MyNamespace.MyClass");
         }
 
         [Fact]
@@ -49,19 +48,19 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Theory]
-        [InlineData("/*namespace MyNamespace { */ class MyClass {} /* } */", "MyClass")]
-        [InlineData("/*namespace MyNamespace ; */ class MyClass {}", "MyClass")] // file-scoped namespaces
-        public void SneakyComment(string fileContents, string expected)
+        [InlineData("/*namespace MyNamespace { */ class MyClass {} /* } */")]
+        [InlineData("/*namespace MyNamespace ; */ class MyClass {}")] // file-scoped namespaces
+        public void SneakyComment(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "MyClass");
         }
 
         [Theory]
-        [InlineData("namespace MyNamespace.Feline { class MyClass {} }", "MyNamespace.Feline.MyClass")]
-        [InlineData("namespace MyNamespace.Feline ; class MyClass {} ", "MyNamespace.Feline.MyClass")] // file-scoped namespaces
-        public void CompoundNamespace(string fileContents, string expected)
+        [InlineData("namespace MyNamespace.Feline { class MyClass {} }")]
+        [InlineData("namespace MyNamespace.Feline ; class MyClass {} ")] // file-scoped namespaces
+        public void CompoundNamespace(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "MyNamespace.Feline.MyClass");
         }
 
         [Fact]
@@ -83,19 +82,19 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Theory]
-        [InlineData("namespace MyNamespace{class Feline{}class Bovine}", "MyNamespace.Feline")]
-        [InlineData("namespace MyNamespace;class Feline{}class Bovine", "MyNamespace.Feline")] // file-scoped namespaces
-        public void DoubleClass(string fileContents, string expected)
+        [InlineData("namespace MyNamespace{class Feline{}class Bovine}")]
+        [InlineData("namespace MyNamespace;class Feline{}class Bovine")] // file-scoped namespaces
+        public void DoubleClass(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "MyNamespace.Feline");
         }
 
         [Theory]
-        [InlineData("namespace MyNamespace{class @class{}}", "MyNamespace.class")]
-        [InlineData("namespace MyNamespace;class @class{}", "MyNamespace.class")] // file-scoped namespaces
-        public void EscapedKeywordClass(string fileContents, string expected)
+        [InlineData("namespace MyNamespace{class @class{}}")]
+        [InlineData("namespace MyNamespace;class @class{}")] // file-scoped namespaces
+        public void EscapedKeywordClass(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "MyNamespace.class");
         }
 
         [Fact]
@@ -190,11 +189,11 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Theory]
-        [InlineData("[assembly :MyString(\"namespace\")] namespace i { class a { } }", "i.a")]
-        [InlineData("[assembly :MyString(\"namespace\")] namespace i; class a { }", "i.a")]
-        public void AssemblyAttributeString(string fileContents, string expected)
+        [InlineData("[assembly :MyString(\"namespace\")] namespace i { class a { } }")]
+        [InlineData("[assembly :MyString(\"namespace\")] namespace i; class a { }")]
+        public void AssemblyAttributeString(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "i.a");
         }
 
         [Fact]
@@ -271,11 +270,11 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Theory]
-        [InlineData("namespace n { public struct s {  enum e {} } class c {} }", "n.c")]
-        [InlineData("namespace n; public struct s {  enum e {} } class c {}", "n.c")] // file-scoped namespace
-        public void NameSpaceStructEnum(string fileContents, string expected)
+        [InlineData("namespace n { public struct s {  enum e {} } class c {} }")]
+        [InlineData("namespace n; public struct s {  enum e {} } class c {}")] // file-scoped namespace
+        public void NameSpaceStructEnum(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "n.c");
         }
 
         [Fact]
@@ -354,7 +353,7 @@ namespace i
     }     
     #endregion
 }
-#endif // MY_CONSTANT ", "i.a")]
+#endif // MY_CONSTANT ")]
         [InlineData(@"
 #if MY_CONSTANT                
 namespace i;
@@ -363,10 +362,10 @@ namespace i;
     {
     }     
     #endregion
-#endif // MY_CONSTANT", "i.a")]
-        public void Preprocessor(string fileContents, string expected)
+#endif // MY_CONSTANT")]
+        public void Preprocessor(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "i.a");
         }
 
         [Fact(Skip = "Preprocessor is not yet implemented.")]
@@ -395,14 +394,14 @@ namespace i
         [InlineData(@"
 namespace n2
 // namespace n1
-{ class c {} }", "n2.c")]
+{ class c {} }")]
         [InlineData(@"
 namespace n2;
 // namespace n1
-class c {}", "n2.c")]
-        public void Regress_Mutation_SingleLineCommentsShouldBeIgnored(string fileContents, string expected)
+class c {}")]
+        public void Regress_Mutation_SingleLineCommentsShouldBeIgnored(string fileContents)
         {
-            AssertParse(fileContents, expected);
+            AssertParse(fileContents, "n2.c");
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/CSharpParserUtilitites_Tests.cs
+++ b/src/Tasks.UnitTests/CSharpParserUtilitites_Tests.cs
@@ -278,7 +278,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-
         public void PreprocessorControllingTwoNamespaces()
         {
             // This works by coincidence since preprocessor directives are currently ignored.
@@ -403,20 +402,6 @@ class c {}")]
         {
             AssertParse(fileContents, "n2.c");
         }
-
-        [Fact]
-        public void FileScoped_Namespace()
-        {
-            AssertParse
-            (
-                @"
-using System;
-namespace test;
-// namespace n1
-var abc;
-private sealed class c {}", "test.c");
-        }
-
 
         /*
         * Method:  AssertParse

--- a/src/Tasks.UnitTests/CSharpParserUtilitites_Tests.cs
+++ b/src/Tasks.UnitTests/CSharpParserUtilitites_Tests.cs
@@ -17,22 +17,29 @@ namespace Microsoft.Build.UnitTests
 
         // Simplest case of getting a fully-qualified class name from
         // a c# file.
-        [Fact]
-        public void Simple()
+        [Theory]
+        [InlineData("namespace MyNamespace { class MyClass {} }", "MyNamespace.MyClass")]
+        [InlineData("namespace MyNamespace ; class MyClass {} ", "MyNamespace.MyClass")] // file-scoped namespaces
+        public void Simple(string fileContents, string expected)
         {
+            AssertParse(fileContents, expected);
             AssertParse("namespace MyNamespace { class MyClass {} }", "MyNamespace.MyClass");
         }
 
-        [Fact]
-        public void EmbeddedComment()
+        [Theory]
+        [InlineData("namespace /**/ MyNamespace /**/ { /**/ class /**/ MyClass/**/{}} //", "MyNamespace.MyClass")]
+        [InlineData("namespace /**/ MyNamespace /**/ ; /**/ class /**/ MyClass/**/{} //", "MyNamespace.MyClass")] // file-scoped namespaces
+        public void EmbeddedComment(string fileContents, string expected)
         {
-            AssertParse("namespace /**/ MyNamespace /**/ { /**/ class /**/ MyClass/**/{}} //", "MyNamespace.MyClass");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void MinSpace()
+        [Theory]
+        [InlineData("namespace MyNamespace{class MyClass{}}", "MyNamespace.MyClass")]
+        [InlineData("namespace MyNamespace;class MyClass{}", "MyNamespace.MyClass")] // file-scoped namespaces
+        public void MinSpace(string fileContents, string expected)
         {
-            AssertParse("namespace MyNamespace{class MyClass{}}", "MyNamespace.MyClass");
+            AssertParse(fileContents, expected);
         }
 
         [Fact]
@@ -41,58 +48,76 @@ namespace Microsoft.Build.UnitTests
             AssertParse("class MyClass{}", "MyClass");
         }
 
-        [Fact]
-        public void SneakyComment()
+        [Theory]
+        [InlineData("/*namespace MyNamespace { */ class MyClass {} /* } */", "MyClass")]
+        [InlineData("/*namespace MyNamespace ; */ class MyClass {}", "MyClass")] // file-scoped namespaces
+        public void SneakyComment(string fileContents, string expected)
         {
-            AssertParse("/*namespace MyNamespace { */ class MyClass {} /* } */", "MyClass");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void CompoundNamespace()
+        [Theory]
+        [InlineData("namespace MyNamespace.Feline { class MyClass {} }", "MyNamespace.Feline.MyClass")]
+        [InlineData("namespace MyNamespace.Feline ; class MyClass {} ", "MyNamespace.Feline.MyClass")] // file-scoped namespaces
+        public void CompoundNamespace(string fileContents, string expected)
         {
-            AssertParse("namespace MyNamespace.Feline { class MyClass {} }", "MyNamespace.Feline.MyClass");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void NestedNamespace()
+        [Theory]
+        [InlineData("namespace MyNamespace{ namespace Feline {class MyClass {} }}", "MyNamespace.Feline.MyClass")]
+        [InlineData("namespace MyNamespace; namespace Feline ;class MyClass {} ", "MyNamespace.Feline.MyClass")] // file-scoped namespaces
+        public void NestedNamespace(string fileContents, string expected)
         {
-            AssertParse("namespace MyNamespace{ namespace Feline {class MyClass {} }}", "MyNamespace.Feline.MyClass");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void NestedNamespace2()
+        [Theory]
+        [InlineData("namespace MyNamespace{ namespace Feline {namespace Bovine{public sealed class MyClass {} }} }", "MyNamespace.Feline.Bovine.MyClass")]
+        [InlineData("namespace MyNamespace; namespace Feline ;namespace Bovine;public sealed class MyClass {}", "MyNamespace.Feline.Bovine.MyClass")] // file-scoped namespaces
+        public void NestedNamespace2(string fileContents, string expected)
         {
-            AssertParse("namespace MyNamespace{ namespace Feline {namespace Bovine{public sealed class MyClass {} }} }", "MyNamespace.Feline.Bovine.MyClass");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void NestedCompoundNamespace()
+        [Theory]
+        [InlineData("namespace MyNamespace/**/.A{ namespace Feline . B {namespace Bovine.C {sealed class MyClass {} }} }", "MyNamespace.A.Feline.B.Bovine.C.MyClass")]
+        [InlineData("namespace MyNamespace/**/.A; namespace Feline . B ;namespace Bovine.C ;sealed class MyClass {}", "MyNamespace.A.Feline.B.Bovine.C.MyClass")] // file-scoped namespaces
+        public void NestedCompoundNamespace(string fileContents, string expected)
         {
-            AssertParse("namespace MyNamespace/**/.A{ namespace Feline . B {namespace Bovine.C {sealed class MyClass {} }} }", "MyNamespace.A.Feline.B.Bovine.C.MyClass");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void DoubleClass()
+        [Theory]
+        [InlineData("namespace MyNamespace{class Feline{}class Bovine}", "MyNamespace.Feline")]
+        [InlineData("namespace MyNamespace;class Feline{}class Bovine", "MyNamespace.Feline")] // file-scoped namespaces
+        public void DoubleClass(string fileContents, string expected)
         {
-            AssertParse("namespace MyNamespace{class Feline{}class Bovine}", "MyNamespace.Feline");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void EscapedKeywordClass()
+        [Theory]
+        [InlineData("namespace MyNamespace{class @class{}}", "MyNamespace.class")]
+        [InlineData("namespace MyNamespace;class @class{}", "MyNamespace.class")] // file-scoped namespaces
+        public void EscapedKeywordClass(string fileContents, string expected)
         {
-            AssertParse("namespace MyNamespace{class @class{}}", "MyNamespace.class");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void LeadingUnderscore()
+        [Theory]
+        [InlineData("namespace _MyNamespace{class _MyClass{}}", "_MyNamespace._MyClass")]
+        [InlineData("namespace _MyNamespace; class _MyClass{}", "_MyNamespace._MyClass")] // file-scoped namespaces
+        public void LeadingUnderscore(string fileContents, string expected)
         {
-            AssertParse("namespace _MyNamespace{class _MyClass{}}", "_MyNamespace._MyClass");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void SkipInterveningNamespaces()
+        [Theory]
+        [InlineData("namespace MyNamespace { namespace XXX {} class MyClass {} }", "MyNamespace.MyClass")]
+        [InlineData("namespace MyNamespace; namespace XXX; class MyClass {}", "MyNamespace.XXX.MyClass")] // file-scoped namespaces
+        public void InterveningNamespaces(string fileContents, string expected)
         {
-            AssertParse("namespace MyNamespace { namespace XXX {} class MyClass {} }", "MyNamespace.MyClass");
+            AssertParse(fileContents, expected);
         }
 
 
@@ -168,136 +193,202 @@ namespace Microsoft.Build.UnitTests
             AssertParse("namespace i; namespace j { class a {} }", null);
         }
 
-        [Fact]
-        public void AssemblyAttributeBool()
+        [Theory]
+        [InlineData("[assembly :AssemblyDelaySign(false)] namespace i { class a { } }", "i.a")]
+        [InlineData("[assembly :AssemblyDelaySign(false)] namespace i; class a { }", "i.a")]
+        public void AssemblyAttributeBool(string fileContents, string expected)
         {
-            AssertParse("[assembly :AssemblyDelaySign(false)] namespace i { class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void AssemblyAttributeString()
+        [Theory]
+        [InlineData("[assembly :MyString(\"namespace\")] namespace i { class a { } }", "i.a")]
+        [InlineData("[assembly :MyString(\"namespace\")] namespace i; class a { }", "i.a")]
+        public void AssemblyAttributeString(string fileContents, string expected)
         {
-            AssertParse("[assembly :MyString(\"namespace\")] namespace i { class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void AssemblyAttributeInt()
+        [Theory]
+        [InlineData("[assembly :MyInt(55)] namespace i { class a { } }", "i.a")]
+        [InlineData("[assembly :MyInt(55)] namespace i; class a { }", "i.a")]
+        public void AssemblyAttributeInt(string fileContents, string expected)
         {
-            AssertParse("[assembly :MyInt(55)] namespace i { class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void AssemblyAttributeReal()
+        [Theory]
+        [InlineData("[assembly :MyReal(5.5)] namespace i { class a { } }", "i.a")]
+        [InlineData("[assembly :MyReal(5.5)] namespace i; class a { }", "i.a")]
+        public void AssemblyAttributeReal(string fileContents, string expected)
         {
-            AssertParse("[assembly :MyReal(5.5)] namespace i { class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void AssemblyAttributeNull()
+        [Theory]
+        [InlineData("[assembly :MyNull(null)] namespace i { class a { } }", "i.a")]
+        [InlineData("[assembly :MyNull(null)] namespace i; class a { }", "i.a")]
+        public void AssemblyAttributeNull(string fileContents, string expected)
         {
-            AssertParse("[assembly :MyNull(null)] namespace i { class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void AssemblyAttributeChar()
+        [Theory]
+        [InlineData("[assembly :MyChar('a')] namespace i { class a { } }", "i.a")]
+        [InlineData("[assembly :MyChar('a')] namespace i; class a { }", "i.a")]
+        public void AssemblyAttributeChar(string fileContents, string expected)
         {
-            AssertParse("[assembly :MyChar('a')] namespace i { class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
 
-        [Fact]
-        public void ClassAttributeBool()
+        [Theory]
+        [InlineData("namespace i { [ClassDelaySign(false)] class a { } }", "i.a")]
+        [InlineData("namespace i; [ClassDelaySign(false)] class a { }", "i.a")]
+        public void ClassAttributeBool(string fileContents, string expected)
         {
-            AssertParse("namespace i { [ClassDelaySign(false)] class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void ClassAttributeString()
+        [Theory]
+        [InlineData("namespace i { [MyString(\"class b\")] class a { } }", "i.a")]
+        [InlineData("namespace i; [MyString(\"class b\")] class a { }", "i.a")]
+        public void ClassAttributeString(string fileContents, string expected)
         {
-            AssertParse("namespace i { [MyString(\"class b\")] class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void ClassAttributeInt()
+        [Theory]
+        [InlineData("namespace i { [MyInt(55)] class a { } }", "i.a")]
+        [InlineData("namespace i; [MyInt(55)] class a { }", "i.a")]
+        public void ClassAttributeInt(string fileContents, string expected)
         {
-            AssertParse("namespace i { [MyInt(55)] class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void ClassAttributeReal()
+        [Theory]
+        [InlineData("namespace i { [MyReal(5.5)] class a { } }", "i.a")]
+        [InlineData("namespace i; [MyReal(5.5)] class a { }", "i.a")]
+        public void ClassAttributeReal(string fileContents, string expected)
         {
-            AssertParse("namespace i { [MyReal(5.5)] class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void ClassAttributeNull()
+        [Theory]
+        [InlineData("[namespace i { MyNull(null)] class a { } }", "i.a")]
+        [InlineData("[namespace i; MyNull(null)] class a { } ", "i.a")]
+        public void ClassAttributeNull(string fileContents, string expected)
         {
-            AssertParse("[namespace i { MyNull(null)] class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void ClassAttributeChar()
+        [Theory]
+        [InlineData("namespace i { [MyChar('a')] class a { } }", "i.a")]
+        [InlineData("namespace i; [MyChar('a')] class a { } ", "i.a")]
+        public void ClassAttributeChar(string fileContents, string expected)
         {
-            AssertParse("namespace i { [MyChar('a')] class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void ClassAttributeCharIsCloseScope()
+        [Theory]
+        [InlineData("namespace i { [MyChar('\x0000')] class a { } }", "i.a")]
+        [InlineData("namespace i; [MyChar('\x0000')] class a { }", "i.a")]
+        public void ClassAttributeCharIsCloseScope(string fileContents, string expected)
         {
-            AssertParse("namespace i { [MyChar('\x0000')] class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void ClassAttributeStringIsCloseScope()
+        [Theory]
+        [InlineData("namespace i { [MyString(\"}\")] class a { } }", "i.a")]
+        [InlineData("namespace i; [MyString(\"}\")] class a { }", "i.a")]
+        public void ClassAttributeStringIsCloseScope(string fileContents, string expected)
         {
-            AssertParse("namespace i { [MyString(\"}\")] class a { } }", "i.a");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void NameSpaceStructEnum()
+        [Theory]
+        [InlineData("namespace n { public struct s {  enum e {} } class c {} }", "n.c")]
+        [InlineData("namespace n; public struct s {  enum e {} } class c {}", "n.c")]
+        public void NameSpaceStructEnum(string fileContents, string expected)
         {
-            AssertParse("namespace n { public struct s {  enum e {} } class c {} }", "n.c");
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void PreprocessorControllingTwoNamespaces()
-        {
-            // This works by coincidence since preprocessor directives are currently ignored.
-            AssertParse
-            (
-                @"
+        [Theory]
+        [InlineData(@"
 #if (false)
 namespace n1
 #else
 namespace n2
 #endif    
 { class c {} }
-                ", "n2.c");
-        }
-
-        [Fact]
-        public void PreprocessorControllingTwoNamespacesWithInterveningKeyword()
+                ", "n2.c")]
+        [InlineData(@"
+#if (false)
+namespace n1;
+#else
+namespace n2;
+#endif    
+class c {}
+                ", "n1.n2.c")] // File-scoped namespaces will append each namespace. Either way, this is invalid C#
+        public void PreprocessorControllingTwoNamespaces(string fileContents, string expected)
         {
             // This works by coincidence since preprocessor directives are currently ignored.
-            AssertParse
-            (
-                @"
+            // Note: If the condition were #if (true), the result would sitll be n2.c
+            AssertParse(fileContents, expected);
+        }
+
+        /// <summary>
+        /// The test "PreprocessorControllingTwoNamespaces" reveals that preprocessor directives are ignored.
+        /// This means that in the case of many namespaces before curly braces (despite that being invalid C#)
+        /// the last namespace would win. This test explicitly tests that.
+        /// </summary>
+        [Theory]
+        [InlineData(@"
+namespace n1
+namespace n2
+namespace n3
+namespace n4
+    { class c { } }", "n4.c")]
+        [InlineData(@"
+namespace n1;
+namespace n2;
+namespace n3;
+namespace n4;
+class c {} ", "n1.n2.n3.n4.c")] // file scoped namespaces append.
+        public void MultipleNamespaces_InvalidCSharp(string fileContents, string expected)
+        {
+            // This works by coincidence since preprocessor directives are currently ignored.
+            AssertParse(fileContents, expected);
+        }
+
+        /// <summary>
+        /// Note: Preprocessor conditions are not implemented
+        /// </summary>
+        [Theory]
+        [InlineData(@"
 #if (false)
 namespace n1
 #else
 using a=b;
 namespace n2
 #endif    
-{ class c {} }
-                ", "n2.c");
+{ class c {} }", "n2.c")]
+        [InlineData(@"
+#if (false)
+namespace n1;
+#else
+using a=b;
+namespace n2;
+#endif    
+{ class c {} }", "n1.n2.c")]
+        public void PreprocessorControllingTwoNamespacesWithInterveningKeyword(string fileContents, string expected)
+        {
+            AssertParse(fileContents, expected);
         }
 
-        [Fact]
-        public void Preprocessor()
-        {
-            AssertParse
-            (
-                @"
+        [Theory]
+        [InlineData(@"
 #if MY_CONSTANT                
 namespace i 
 {
@@ -307,8 +398,19 @@ namespace i
     }     
     #endregion
 }
-#endif // MY_CONSTANT
-                ", "i.a");
+#endif // MY_CONSTANT ", "i.a")]
+        [InlineData(@"
+#if MY_CONSTANT                
+namespace i;
+    #region Put the class in a region
+    class a 
+    {
+    }     
+    #endregion
+#endif // MY_CONSTANT", "i.a")]
+        public void Preprocessor(string fileContents, string expected)
+        {
+            AssertParse(fileContents, expected);
         }
 
         [Fact(Skip = "Preprocessor is not yet implemented.")]
@@ -333,17 +435,33 @@ namespace i
 
 
 
+        [Theory]
+        [InlineData(@"
+namespace n2
+// namespace n1
+{ class c {} }", "n2.c")]
+        [InlineData(@"
+namespace n2;
+// namespace n1
+class c {}", "n2.c")]
+        public void Regress_Mutation_SingleLineCommentsShouldBeIgnored(string fileContents, string expected)
+        {
+            AssertParse(fileContents, expected);
+        }
+
         [Fact]
-        public void Regress_Mutation_SingleLineCommentsShouldBeIgnored()
+        public void FileScoped_Namespace()
         {
             AssertParse
             (
                 @"
-namespace n2
+using System;
+namespace test;
 // namespace n1
-{ class c {} }
-                ", "n2.c");
+var abc;
+private sealed class c {}", "test.c");
         }
+
 
         /*
         * Method:  AssertParse

--- a/src/Tasks.UnitTests/CSharpParserUtilitites_Tests.cs
+++ b/src/Tasks.UnitTests/CSharpParserUtilitites_Tests.cs
@@ -64,28 +64,22 @@ namespace Microsoft.Build.UnitTests
             AssertParse(fileContents, expected);
         }
 
-        [Theory]
-        [InlineData("namespace MyNamespace{ namespace Feline {class MyClass {} }}", "MyNamespace.Feline.MyClass")]
-        [InlineData("namespace MyNamespace; namespace Feline ;class MyClass {} ", "MyNamespace.Feline.MyClass")] // file-scoped namespaces
-        public void NestedNamespace(string fileContents, string expected)
+        [Fact]
+        public void NestedNamespace()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace MyNamespace{ namespace Feline {class MyClass {} }}", "MyNamespace.Feline.MyClass");
         }
 
-        [Theory]
-        [InlineData("namespace MyNamespace{ namespace Feline {namespace Bovine{public sealed class MyClass {} }} }", "MyNamespace.Feline.Bovine.MyClass")]
-        [InlineData("namespace MyNamespace; namespace Feline ;namespace Bovine;public sealed class MyClass {}", "MyNamespace.Feline.Bovine.MyClass")] // file-scoped namespaces
-        public void NestedNamespace2(string fileContents, string expected)
+        [Fact]
+        public void NestedNamespace2()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace MyNamespace{ namespace Feline {namespace Bovine{public sealed class MyClass {} }} }", "MyNamespace.Feline.Bovine.MyClass");
         }
 
-        [Theory]
-        [InlineData("namespace MyNamespace/**/.A{ namespace Feline . B {namespace Bovine.C {sealed class MyClass {} }} }", "MyNamespace.A.Feline.B.Bovine.C.MyClass")]
-        [InlineData("namespace MyNamespace/**/.A; namespace Feline . B ;namespace Bovine.C ;sealed class MyClass {}", "MyNamespace.A.Feline.B.Bovine.C.MyClass")] // file-scoped namespaces
-        public void NestedCompoundNamespace(string fileContents, string expected)
+        [Fact]
+        public void NestedCompoundNamespace()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace MyNamespace/**/.A{ namespace Feline . B {namespace Bovine.C {sealed class MyClass {} }} }", "MyNamespace.A.Feline.B.Bovine.C.MyClass");
         }
 
         [Theory]
@@ -104,20 +98,16 @@ namespace Microsoft.Build.UnitTests
             AssertParse(fileContents, expected);
         }
 
-        [Theory]
-        [InlineData("namespace _MyNamespace{class _MyClass{}}", "_MyNamespace._MyClass")]
-        [InlineData("namespace _MyNamespace; class _MyClass{}", "_MyNamespace._MyClass")] // file-scoped namespaces
-        public void LeadingUnderscore(string fileContents, string expected)
+        [Fact]
+        public void LeadingUnderscore()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace _MyNamespace{class _MyClass{}}", "_MyNamespace._MyClass");
         }
 
-        [Theory]
-        [InlineData("namespace MyNamespace { namespace XXX {} class MyClass {} }", "MyNamespace.MyClass")]
-        [InlineData("namespace MyNamespace; namespace XXX; class MyClass {}", "MyNamespace.XXX.MyClass")] // file-scoped namespaces
-        public void InterveningNamespaces(string fileContents, string expected)
+        [Fact]
+        public void InterveningNamespaces()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace MyNamespace { namespace XXX {} class MyClass {} }", "MyNamespace.MyClass");
         }
 
 
@@ -193,12 +183,10 @@ namespace Microsoft.Build.UnitTests
             AssertParse("namespace i; namespace j { class a {} }", null);
         }
 
-        [Theory]
-        [InlineData("[assembly :AssemblyDelaySign(false)] namespace i { class a { } }", "i.a")]
-        [InlineData("[assembly :AssemblyDelaySign(false)] namespace i; class a { }", "i.a")]
-        public void AssemblyAttributeBool(string fileContents, string expected)
+        [Fact]
+        public void AssemblyAttributeBool()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("[assembly :AssemblyDelaySign(false)] namespace i { class a { } }", "i.a");
         }
 
         [Theory]
@@ -209,133 +197,101 @@ namespace Microsoft.Build.UnitTests
             AssertParse(fileContents, expected);
         }
 
-        [Theory]
-        [InlineData("[assembly :MyInt(55)] namespace i { class a { } }", "i.a")]
-        [InlineData("[assembly :MyInt(55)] namespace i; class a { }", "i.a")]
-        public void AssemblyAttributeInt(string fileContents, string expected)
+        [Fact]
+        public void AssemblyAttributeInt()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("[assembly :MyInt(55)] namespace i { class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("[assembly :MyReal(5.5)] namespace i { class a { } }", "i.a")]
-        [InlineData("[assembly :MyReal(5.5)] namespace i; class a { }", "i.a")]
-        public void AssemblyAttributeReal(string fileContents, string expected)
+        [Fact]
+        public void AssemblyAttributeReal()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("[assembly :MyReal(5.5)] namespace i { class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("[assembly :MyNull(null)] namespace i { class a { } }", "i.a")]
-        [InlineData("[assembly :MyNull(null)] namespace i; class a { }", "i.a")]
-        public void AssemblyAttributeNull(string fileContents, string expected)
+        [Fact]
+        public void AssemblyAttributeNull()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("[assembly :MyNull(null)] namespace i { class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("[assembly :MyChar('a')] namespace i { class a { } }", "i.a")]
-        [InlineData("[assembly :MyChar('a')] namespace i; class a { }", "i.a")]
-        public void AssemblyAttributeChar(string fileContents, string expected)
+        [Fact]
+        public void AssemblyAttributeChar()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("[assembly :MyChar('a')] namespace i { class a { } }", "i.a");
         }
 
 
-        [Theory]
-        [InlineData("namespace i { [ClassDelaySign(false)] class a { } }", "i.a")]
-        [InlineData("namespace i; [ClassDelaySign(false)] class a { }", "i.a")]
-        public void ClassAttributeBool(string fileContents, string expected)
+        [Fact]
+        public void ClassAttributeBool()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace i { [ClassDelaySign(false)] class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("namespace i { [MyString(\"class b\")] class a { } }", "i.a")]
-        [InlineData("namespace i; [MyString(\"class b\")] class a { }", "i.a")]
-        public void ClassAttributeString(string fileContents, string expected)
+        [Fact]
+        public void ClassAttributeString()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace i { [MyString(\"class b\")] class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("namespace i { [MyInt(55)] class a { } }", "i.a")]
-        [InlineData("namespace i; [MyInt(55)] class a { }", "i.a")]
-        public void ClassAttributeInt(string fileContents, string expected)
+        [Fact]
+        public void ClassAttributeInt()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace i { [MyInt(55)] class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("namespace i { [MyReal(5.5)] class a { } }", "i.a")]
-        [InlineData("namespace i; [MyReal(5.5)] class a { }", "i.a")]
-        public void ClassAttributeReal(string fileContents, string expected)
+        [Fact]
+        public void ClassAttributeReal()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace i { [MyReal(5.5)] class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("[namespace i { MyNull(null)] class a { } }", "i.a")]
-        [InlineData("[namespace i; MyNull(null)] class a { } ", "i.a")]
-        public void ClassAttributeNull(string fileContents, string expected)
+        [Fact]
+        public void ClassAttributeNull()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("[namespace i { MyNull(null)] class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("namespace i { [MyChar('a')] class a { } }", "i.a")]
-        [InlineData("namespace i; [MyChar('a')] class a { } ", "i.a")]
-        public void ClassAttributeChar(string fileContents, string expected)
+        [Fact]
+        public void ClassAttributeChar()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace i { [MyChar('a')] class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("namespace i { [MyChar('\x0000')] class a { } }", "i.a")]
-        [InlineData("namespace i; [MyChar('\x0000')] class a { }", "i.a")]
-        public void ClassAttributeCharIsCloseScope(string fileContents, string expected)
+        [Fact]
+        public void ClassAttributeCharIsCloseScope()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace i { [MyChar('\x0000')] class a { } }", "i.a");
         }
 
-        [Theory]
-        [InlineData("namespace i { [MyString(\"}\")] class a { } }", "i.a")]
-        [InlineData("namespace i; [MyString(\"}\")] class a { }", "i.a")]
-        public void ClassAttributeStringIsCloseScope(string fileContents, string expected)
+        [Fact]
+        public void ClassAttributeStringIsCloseScope()
         {
-            AssertParse(fileContents, expected);
+            AssertParse("namespace i { [MyString(\"}\")] class a { } }", "i.a");
         }
 
         [Theory]
         [InlineData("namespace n { public struct s {  enum e {} } class c {} }", "n.c")]
-        [InlineData("namespace n; public struct s {  enum e {} } class c {}", "n.c")]
+        [InlineData("namespace n; public struct s {  enum e {} } class c {}", "n.c")] // file-scoped namespace
         public void NameSpaceStructEnum(string fileContents, string expected)
         {
             AssertParse(fileContents, expected);
         }
 
-        [Theory]
-        [InlineData(@"
+        [Fact]
+
+        public void PreprocessorControllingTwoNamespaces()
+        {
+            // This works by coincidence since preprocessor directives are currently ignored.
+            // Note: If the condition were #if (true), the result would still be n1.c
+            AssertParse(@"
 #if (false)
 namespace n1
 #else
 namespace n2
 #endif    
 { class c {} }
-                ", "n2.c")]
-        [InlineData(@"
-#if (false)
-namespace n1;
-#else
-namespace n2;
-#endif    
-class c {}
-                ", "n1.n2.c")] // File-scoped namespaces will append each namespace. Either way, this is invalid C#
-        public void PreprocessorControllingTwoNamespaces(string fileContents, string expected)
-        {
-            // This works by coincidence since preprocessor directives are currently ignored.
-            // Note: If the condition were #if (true), the result would sitll be n2.c
-            AssertParse(fileContents, expected);
+                ", "n2.c");
         }
 
         /// <summary>
@@ -346,16 +302,16 @@ class c {}
         [Theory]
         [InlineData(@"
 namespace n1
-namespace n2
-namespace n3
-namespace n4
+    namespace n2
+    namespace n3
+    namespace n4
     { class c { } }", "n4.c")]
         [InlineData(@"
 namespace n1;
 namespace n2;
 namespace n3;
 namespace n4;
-class c {} ", "n1.n2.n3.n4.c")] // file scoped namespaces append.
+class c {} ", "n1.n2.n3.n4.c")]
         public void MultipleNamespaces_InvalidCSharp(string fileContents, string expected)
         {
             // This works by coincidence since preprocessor directives are currently ignored.

--- a/src/Tasks/CSharpParserUtilities.cs
+++ b/src/Tasks/CSharpParserUtilities.cs
@@ -79,7 +79,16 @@ namespace Microsoft.Build.Tasks
                 {
                     if (state.ResolvingNamespace)
                     {
-                        if (t.InnerText == ".")
+                        // If we see a ';' while resolving a namespace, we assume it's a file-scoped namespace
+                        // namespace foo.bar; <- At this point in code, we're at the semicolon.
+                        // class test { ... }
+                        // https://github.com/dotnet/msbuild/issues/6828
+                        if (t.InnerText == ";")
+                        {
+                            state.PushNamespacePart(state.Namespace);
+                            state.Reset();
+                        }
+                        else if (t.InnerText == ".")
                         {
                             state.Namespace += ".";
                         }

--- a/src/Tasks/CSharpParserUtilities.cs
+++ b/src/Tasks/CSharpParserUtilities.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Tasks
                         // If we see a ';' while resolving a namespace, we assume it's a file-scoped namespace
                         // namespace foo.bar; <- At this point in code, we're at the semicolon.
                         // class test { ... }
-                        // https://github.com/dotnet/msbuild/issues/6828
+                        // https://github.com/dotnet/csharplang/blob/088f20b6f9b714a7b68f6d792d54def0f3b3057e/proposals/csharp-10.0/file-scoped-namespaces.md
                         if (t.InnerText == ";")
                         {
                             state.PushNamespacePart(state.Namespace);

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Build.Tasks
             {
                 culture = item.GetMetadata("Culture");
                 // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
-                // https://github.com/dotnet/csharplang/blob/088f20b6f9b714a7b68f6d792d54def0f3b3057e/proposals/csharp-10.0/file-scoped-namespaces.md
+                // https://github.com/dotnet/msbuild/issues/3064
                 treatAsCultureNeutral = item.GetMetadata("WithCulture").Equals("false", StringComparison.OrdinalIgnoreCase);
             }
 

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Build.Tasks
             {
                 culture = item.GetMetadata("Culture");
                 // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
-                // https://github.com/dotnet/msbuild/issues/3064
+                // https://github.com/dotnet/csharplang/blob/088f20b6f9b714a7b68f6d792d54def0f3b3057e/proposals/csharp-10.0/file-scoped-namespaces.md
                 treatAsCultureNeutral = item.GetMetadata("WithCulture").Equals("false", StringComparison.OrdinalIgnoreCase);
             }
 


### PR DESCRIPTION
Fixes #6828

### Context
CreateCSharpManifestResourceName uses a c# file parser to extract the namespace and classname to create its resource name. See the original issue for a clear explanation on how this breaks with file-scoped namespaces.

### Changes Made
Modify the state machine within the csharp parser to stop looking for a namespace when we encounter a semicolon.

### Testing
- [x] Add tests for this

### Notes
Review the final diff