### PR TITLE
6732: Default to sha2 digest for clickonce manifest

### DIFF
--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -572,6 +572,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private static bool UseSha256Algorithm(X509Certificate2 cert)
         {
             Oid oid = cert.SignatureAlgorithm;
+            // Issue 6732: Clickonce does support sha384/sha512 hash so we default to sha256 
+            // for certs with that signature algorithm.
             return string.Equals(oid.FriendlyName, "sha256RSA", StringComparison.OrdinalIgnoreCase) ||
                    string.Equals(oid.FriendlyName, "sha384RSA", StringComparison.OrdinalIgnoreCase) ||
                    string.Equals(oid.FriendlyName, "sha512RSA", StringComparison.OrdinalIgnoreCase);

--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -572,7 +572,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private static bool UseSha256Algorithm(X509Certificate2 cert)
         {
             Oid oid = cert.SignatureAlgorithm;
-            // Issue 6732: Clickonce does support sha384/sha512 hash so we default to sha256 
+            // Issue 6732: Clickonce does not support sha384/sha512 file hash so we default to sha256 
             // for certs with that signature algorithm.
             return string.Equals(oid.FriendlyName, "sha256RSA", StringComparison.OrdinalIgnoreCase) ||
                    string.Equals(oid.FriendlyName, "sha384RSA", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -572,7 +572,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private static bool UseSha256Algorithm(X509Certificate2 cert)
         {
             Oid oid = cert.SignatureAlgorithm;
-            return string.Equals(oid.FriendlyName, "sha256RSA", StringComparison.OrdinalIgnoreCase);
+            return string.Equals(oid.FriendlyName, "sha256RSA", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(oid.FriendlyName, "sha384RSA", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(oid.FriendlyName, "sha512RSA", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
Default to sha2 digest instead of sha1 for clickonce manifest signing when certificate signing algorithm is sha256/384/512

Fixes #6732 

### Context
When using a certificate signed with sha384/sha512 as signature algorithm, ClickOnce defaults to the sha1 algorithm for it's digest hash.


### Changes Made
UseSha256Algorithm decides if we sign with sha1 or sha256 hash. The function has been updated to use sha256 hash when signature algorithm of the signing cert has sha256/sha384/sha512 signature algorithm.

### Testing
CTI has tested signing scenario for forms and wpf apps for all 4 hash types.

### Notes
