### PR TITLE
 Default to sha2 digest for clickonce manifest

### DIFF
--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -572,7 +572,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private static bool UseSha256Algorithm(X509Certificate2 cert)
         {
             Oid oid = cert.SignatureAlgorithm;
-            return string.Equals(oid.FriendlyName, "sha256RSA", StringComparison.OrdinalIgnoreCase);
+            return string.Equals(oid.FriendlyName, "sha256RSA", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(oid.FriendlyName, "sha384RSA", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(oid.FriendlyName, "sha512RSA", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
6732: Default to sha2 digest for clickonce manifest when certificate signing algorithm is sha256/384/512

Fixes #

### Context


### Changes Made


### Testing


### Notes
