### PR TITLE
Avoid appending x64 to AL path if x64 is already appended

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3878,7 +3878,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <PropertyGroup>
       <_ALExeToolPath>$(TargetFrameworkSDKToolsDirectory)</_ALExeToolPath>
-      <_ALExeToolPath Condition="'$(PlatformTarget)' == 'x64' and !$(_ALExeToolPath.EndsWith('x64\')">$(TargetFrameworkSDKToolsDirectory)x64\</_ALExeToolPath>
+      <_ALExeToolPath Condition="'$(PlatformTarget)' == 'x64' and !$(_ALExeToolPath.EndsWith('x64\'))">$(TargetFrameworkSDKToolsDirectory)x64\</_ALExeToolPath>
     </PropertyGroup>
 
     <MakeDir

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3878,7 +3878,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <PropertyGroup>
       <_ALExeToolPath>$(TargetFrameworkSDKToolsDirectory)</_ALExeToolPath>
-      <_ALExeToolPath Condition="'$(PlatformTarget)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</_ALExeToolPath>
+      <_ALExeToolPath Condition="'$(PlatformTarget)' == 'x64' and !$(_ALExeToolPath.EndsWith('x64\')">$(TargetFrameworkSDKToolsDirectory)x64\</_ALExeToolPath>
     </PropertyGroup>
 
     <MakeDir


### PR DESCRIPTION
Fixes users who previously worked around the issue of msbuild not using the x64 version of AL.exe.

### Context


### Changes Made
Only append `x64\` to `_AlExeToolPath` when `PlatformTarget` == `x64` AND `_AlExeToolPath` doesn't already end with `x64\`

### Testing
Tested locally

### Notes