### PR TITLE
SetPlatform: Use Platform Instead Of PlatformTarget

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1615,11 +1615,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ======================================================================================
   -->
 
-  <!-- Managed projects need to have PlatformTarget set for SetPlatform negotiation. Default to $(Platform), which is AnyCPU by default. -->
   <PropertyGroup>
-    <PlatformTarget Condition="'$(EnableDynamicPlatformResolution)' == 'true' and '$(PlatformTarget)' == ''
-                                and '$(MSBuildProjectExtension)' != '.vcxproj' and '$(MSBuildProjectExtension)' != '.nativeproj'">$(Platform)</PlatformTarget>
-
     <UseDefaultPlatformLookupTables Condition="'$(UseDefaultPlatformLookupTables)' == ''">true</UseDefaultPlatformLookupTables>
   </PropertyGroup>
 
@@ -1642,13 +1638,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                                               Condition="'%(_MSBuildProjectReferenceExistent.SkipGetPlatformProperties)' != 'true'"/>
     </ItemGroup>
 
-    <!-- $(PlatformTarget) in managed projects is guaranteed to be a valid value for the compiler.
-         For cpp it's $(Platform) -->
-    <PropertyGroup>
-      <CurrentPlatform>$(PlatformTarget)</CurrentPlatform>
-      <CurrentPlatform Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.nativeproj'">$(Platform)</CurrentPlatform>
-    </PropertyGroup>
-
     <!-- Assign default PlatformLookupTables when doing Managed <-> Unmanaged hops -->
     <ItemGroup>
       <!-- If we're looking at a c++ project from a managed project, map managed platforms to native platforms. -->
@@ -1664,7 +1653,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
 
     <GetCompatiblePlatform AnnotatedProjects="@(_ProjectReferencePlatformPossibilities)"
-                           CurrentProjectPlatform="$(CurrentPlatform)"
+                           CurrentProjectPlatform="$(Platform)"
                            PlatformLookupTable="$(PlatformLookupTable)"
                            Condition="'@(_ProjectReferencePlatformPossibilities)' != ''">
       <Output ItemName="_ProjectsWithPlatformAssignment" TaskParameter="AssignedProjectsWithPlatform" />

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1642,7 +1642,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                                               Condition="'%(_MSBuildProjectReferenceExistent.SkipGetPlatformProperties)' != 'true'"/>
     </ItemGroup>
 
-    <!-- Managed Platform "source of truth" is $(PlatformTarget). For cpp it's $(Platform) -->
+    <!-- $(PlatformTarget) in managed projects is guaranteed to be a valid value for the compiler.
+         For cpp it's $(Platform) -->
     <PropertyGroup>
       <CurrentPlatform>$(PlatformTarget)</CurrentPlatform>
       <CurrentPlatform Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.nativeproj'">$(Platform)</CurrentPlatform>
@@ -1675,13 +1676,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup Condition="'@(_ProjectsWithPlatformAssignment)' != ''">
       <ProjectsWithNearestPlatform Include="@(_ProjectsWithPlatformAssignment)"/>
       <ProjectsWithNearestPlatform Condition="'@(ProjectsWithNearestPlatform)' == '%(Identity)' and '%(ProjectsWithNearestPlatform.NearestPlatform)' != ''">
-        <SetPlatform>PlatformTarget=%(ProjectsWithNearestPlatform.NearestPlatform)</SetPlatform>
-        <SetPlatform Condition="'%(ProjectsWithNearestPlatform.IsVcxOrNativeProj)' == 'true'">Platform=%(ProjectsWithNearestPlatform.NearestPlatform)</SetPlatform>
+        <SetPlatform>Platform=%(ProjectsWithNearestPlatform.NearestPlatform)</SetPlatform>
       </ProjectsWithNearestPlatform>
 
+      <!-- When GetCompatiblePlatform fails to assign NearestPlatform, undefine Platform and let that project build "on its own" -->
       <ProjectsWithNearestPlatform Condition="'@(ProjectsWithNearestPlatform)' == '%(Identity)' and '%(ProjectsWithNearestPlatform.NearestPlatform)' == ''">
-        <UndefineProperties Condition="'%(ProjectsWithNearestPlatform.IsVcxOrNativeProj)' == 'true'">%(ProjectsWithNearestPlatform.UndefineProperties);Platform</UndefineProperties>
-        <UndefineProperties Condition="'%(ProjectsWithNearestPlatform.IsVcxOrNativeProj)' != 'true'">%(ProjectsWithNearestPlatform.UndefineProperties);PlatformTarget</UndefineProperties>
+        <UndefineProperties>%(ProjectsWithNearestPlatform.UndefineProperties);Platform</UndefineProperties>
       </ProjectsWithNearestPlatform>
 
       <_MSBuildProjectReferenceExistent Remove="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.SkipGetPlatformProperties)' != 'true'"/>


### PR DESCRIPTION
Fixes #6887
Discussion: https://github.com/dotnet/msbuild/discussions/6871

### Context
`PlatformTarget `was initially passed to managed projects because `PlatformTarget` is passed directly to the compiler, while Platform is passed to the cpp compiler. After a deeper investigation, it turns out we can pass `Platform` and `PlatformTarget` will be defined either in the project file or by the SDK _based on Platform_.

### Changes Made
Pass and undefine Platform instead of PlatformTarget.

Usage of PlatformTarget has been removed altogether, in favor of Platform.

### Testing
Tested on all projects here: https://github.com/BenVillalobos/setplatform-repro
Also confirmed by jhennessey that this solves the issue.
### Notes
