### PR TITLE
Find dotnet.exe instead of <name>.exe when building out-of-proc using MSBuildLocator

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -27,7 +27,6 @@ using Microsoft.Build.Utilities;
 
 using BackendNativeMethods = Microsoft.Build.BackEnd.NativeMethods;
 using Task = System.Threading.Tasks.Task;
-using DotNetFrameworkArchitecture = Microsoft.Build.Shared.DotNetFrameworkArchitecture;
 using Microsoft.Build.Framework;
 using Microsoft.Build.BackEnd.Logging;
 
@@ -434,9 +433,9 @@ namespace Microsoft.Build.BackEnd
 
             // Repeat the executable name as the first token of the command line because the command line
             // parser logic expects it and will otherwise skip the first argument
-            commandLineArgs = msbuildLocation + " " + commandLineArgs;
+            commandLineArgs = $"\"{msbuildLocation}\" {commandLineArgs}";
 
-            BackendNativeMethods.STARTUP_INFO startInfo = new BackendNativeMethods.STARTUP_INFO();
+            BackendNativeMethods.STARTUP_INFO startInfo = new();
             startInfo.cb = Marshal.SizeOf<BackendNativeMethods.STARTUP_INFO>();
 
             // Null out the process handles so that the parent process does not wait for the child process
@@ -466,8 +465,8 @@ namespace Microsoft.Build.BackEnd
                 creationFlags |= BackendNativeMethods.CREATE_NEW_CONSOLE;
             }
 
-            BackendNativeMethods.SECURITY_ATTRIBUTES processSecurityAttributes = new BackendNativeMethods.SECURITY_ATTRIBUTES();
-            BackendNativeMethods.SECURITY_ATTRIBUTES threadSecurityAttributes = new BackendNativeMethods.SECURITY_ATTRIBUTES();
+            BackendNativeMethods.SECURITY_ATTRIBUTES processSecurityAttributes = new();
+            BackendNativeMethods.SECURITY_ATTRIBUTES threadSecurityAttributes = new();
             processSecurityAttributes.nLength = Marshal.SizeOf<BackendNativeMethods.SECURITY_ATTRIBUTES>();
             threadSecurityAttributes.nLength = Marshal.SizeOf<BackendNativeMethods.SECURITY_ATTRIBUTES>();
 
@@ -480,8 +479,8 @@ namespace Microsoft.Build.BackEnd
             if (!NativeMethodsShared.IsMono)
             {
                 // Run the child process with the same host as the currently-running process.
-                exeName = GetCurrentHost();
-                commandLineArgs = "\"" + msbuildLocation + "\" " + commandLineArgs;
+                string dotnetExe = Path.Combine(FileUtilities.GetFolderAbove(exeName, 2), "dotnet.exe");
+                exeName = File.Exists(dotnetExe) ? dotnetExe : GetCurrentHost();
             }
 #endif
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -520,7 +520,7 @@ namespace Microsoft.Build.BackEnd
             {
 #if RUNTIME_TYPE_NETCORE
                 // Repeat the executable name in the args to suit CreateProcess
-                commandLineArgs = $"\"{exeName}\"{commandLineArgs}";
+                commandLineArgs = $"\"{exeName}\" {commandLineArgs}";
 #endif
 
                 BackendNativeMethods.PROCESS_INFORMATION processInfo = new();

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -465,11 +465,6 @@ namespace Microsoft.Build.BackEnd
                 creationFlags |= BackendNativeMethods.CREATE_NEW_CONSOLE;
             }
 
-            BackendNativeMethods.SECURITY_ATTRIBUTES processSecurityAttributes = new();
-            BackendNativeMethods.SECURITY_ATTRIBUTES threadSecurityAttributes = new();
-            processSecurityAttributes.nLength = Marshal.SizeOf<BackendNativeMethods.SECURITY_ATTRIBUTES>();
-            threadSecurityAttributes.nLength = Marshal.SizeOf<BackendNativeMethods.SECURITY_ATTRIBUTES>();
-
             CommunicationsUtilities.Trace("Launching node from {0}", msbuildLocation);
 
             string exeName = msbuildLocation;
@@ -479,8 +474,7 @@ namespace Microsoft.Build.BackEnd
             if (!NativeMethodsShared.IsMono)
             {
                 // Run the child process with the same host as the currently-running process.
-                string dotnetExe = Path.Combine(FileUtilities.GetFolderAbove(exeName, 2), "dotnet.exe");
-                exeName = File.Exists(dotnetExe) ? dotnetExe : GetCurrentHost();
+                exeName = GetCurrentHost();
             }
 #endif
 
@@ -525,14 +519,15 @@ namespace Microsoft.Build.BackEnd
             else
             {
 #if RUNTIME_TYPE_NETCORE
-                if (NativeMethodsShared.IsWindows)
-                {
-                    // Repeat the executable name in the args to suit CreateProcess
-                    commandLineArgs = "\"" + exeName + "\" " + commandLineArgs;
-                }
+                // Repeat the executable name in the args to suit CreateProcess
+                commandLineArgs = $"\"{exeName}\"{commandLineArgs}";
 #endif
 
-                BackendNativeMethods.PROCESS_INFORMATION processInfo = new BackendNativeMethods.PROCESS_INFORMATION();
+                BackendNativeMethods.PROCESS_INFORMATION processInfo = new();
+                BackendNativeMethods.SECURITY_ATTRIBUTES processSecurityAttributes = new();
+                BackendNativeMethods.SECURITY_ATTRIBUTES threadSecurityAttributes = new();
+                processSecurityAttributes.nLength = Marshal.SizeOf<BackendNativeMethods.SECURITY_ATTRIBUTES>();
+                threadSecurityAttributes.nLength = Marshal.SizeOf<BackendNativeMethods.SECURITY_ATTRIBUTES>();
 
                 bool result = BackendNativeMethods.CreateProcess
                     (
@@ -595,9 +590,18 @@ namespace Microsoft.Build.BackEnd
 #if RUNTIME_TYPE_NETCORE || MONO
             if (CurrentHost == null)
             {
-                using (Process currentProcess = Process.GetCurrentProcess())
+                string dotnetExe = Path.Combine(FileUtilities.GetFolderAbove(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, 2),
+                    NativeMethodsShared.IsWindows ? "dotnet.exe" : "dotnet");
+                if (File.Exists(dotnetExe))
                 {
-                    CurrentHost = currentProcess.MainModule.FileName;
+                    CurrentHost = dotnetExe;
+                }
+                else
+                {
+                    using (Process currentProcess = Process.GetCurrentProcess())
+                    {
+                        CurrentHost = currentProcess.MainModule.FileName;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #6782

### Context
When using MSBuildLocator, the first process you start is named after your app, not dotnet or msbuild, yet it still loads MSBuild assemblies. When it then starts an out-of-proc build on core, it tries to use the current host, which is normally dotnet.exe, but in this case is <yourApp>.exe. MSBuild can't find it to connect, so it assumes it launches another node. It should stop after that, but it just keeps going and makes hundreds or thousands of nodes until your computer crashes. That is bad. This defaults to looking for a nearby dotnet.exe (if you're on core) and uses that instead, falling back to <yourApp>.exe only on failure. This should handle any case in which you find MSBuild in an sdk installation.

### Changes Made
Look for a dotnet.exe instead of your current host.

### Testing
Broke repro.

### Notes
Do not try to reproduce this naively. Your computer will be unhappy.

Also, I suspect this may have been the cause of my 9/10 comment [here (internal link)](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1371725).