### PR TITLE
[RAR] Stop removing from file cache just because an assembly is cached in process

### DIFF
--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -741,13 +741,8 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private static void TryConvertToAssemblyName(string itemSpec, string fusionName, ref AssemblyNameExtension assemblyName)
         {
-            // FusionName is used if available.
-            string finalName = fusionName;
-            if (string.IsNullOrEmpty(finalName))
-            {
-                // Otherwise, its itemSpec.
-                finalName = itemSpec;
-            }
+            // FusionName is used if available; otherwise use itemspec.
+            string finalName = string.IsNullOrEmpty(fusionName) ? itemSpec : fusionName;
 
             bool pathRooted = false;
             try

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -366,15 +366,6 @@ namespace Microsoft.Build.Tasks
             // If the process-wide cache contains an up-to-date FileState, always use it
             if (isProcessFileStateUpToDate)
             {
-                // If a FileState already exists in this instance cache due to deserialization, remove it;
-                // another instance has taken responsibility for serialization, and keeping this would
-                // result in multiple instances serializing the same data to disk
-                if (isCachedInInstance)
-                {
-                    instanceLocalFileStateCache.Remove(path);
-                    isDirty = true;
-                }
-
                 return cachedProcessFileState;
             }
             // If the process-wide FileState is missing or out-of-date, this instance owns serialization;


### PR DESCRIPTION
Fixes #6844

### Context
RAR has several caches, including a process-wide cache and a (serialized) file cache. Previously, we had the process cache take priority (if it was up-to-date) and removed from the serialized cache, believing that meant some other process had taken "ownership" of serializing the assembly, but that doesn't actually make sense because that other process could be the same process currently looking at this assembly, and even if it were another process, that other process could have removed it from its own file cache. This removes that flawed logic so that we always write to the file cache any information we have. This improves incremental build times.

### Changes Made
Stopped removing from file cache when process-wide cache has information.

### Testing
Tried without this change and noted that the first few attempted cache lookups all missed. Tried with this change without killing processes and noted that they were cache hits; tried with this change after killing processes, and they were still cache hits.

Also noted that without this change, there were 0 things in the instanceLocalFileStateCache at the beginning of the first RAR execution. After it, there were 122.

All tests conducted with Ocelot repo.

### Notes
I actually mentioned that I didn't think it made sense to have this code here in the "questions" section of my RAR pre-caching document [here](https://microsoft-my.sharepoint.com/:w:/p/nmytelka/EfJOiPG6XPJMsDQ12Nk5-HIBm957qVk2DPB0R5XSpRx1RA?e=6bVaU6) but never looked into it more. Ah, well.