### PR TITLE
RAR: Log full path of bad-image failures

### DIFF
--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -214,6 +214,14 @@ namespace Microsoft.Build.Tasks
 
                     // ...falling through and relying on the targetAssemblyName==null behavior below...
                 }
+                catch (BadImageFormatException)
+                {
+                    // As above, this is weird: there's a valid reference to an assembly with a file on disk
+                    // that isn't a valid .NET assembly. Might be the result of mid-build corruption, but
+                    // could just be a name collision on one of the possible resolution paths.
+
+                    // as above, fall through.
+                }
 
                 if (searchLocation != null)
                 {

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1406,7 +1406,7 @@
     <value>Considered "{0}", which was not found in the GAC.</value>
   </data>
   <data name="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-    <value>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</value>
+    <value>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</value>
   </data>
   <data name="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
     <value>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</value>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">Byl proveden pokus o použití sestavení {0}, které sice existovalo, ale nemělo platnou identitu. Pravděpodobně nejde o sestavení.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">Byl proveden pokus o použití sestavení {0}, které sice existovalo, ale nemělo platnou identitu. Pravděpodobně nejde o sestavení.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">"{0}" wurde berücksichtigt und war vorhanden, besaß jedoch keine gültige Identität. Dies ist möglicherweise keine Assembly.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">"{0}" wurde berücksichtigt und war vorhanden, besaß jedoch keine gültige Identität. Dies ist möglicherweise keine Assembly.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">Se consideró "{0}", que existía, pero no tenía una identidad válida. Es posible que no sea un ensamblado.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">Se consideró "{0}", que existía, pero no tenía una identidad válida. Es posible que no sea un ensamblado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">"{0}" existe et a été envisagé, mais il ne comporte aucune identité valide. Il ne s'agit peut-être pas d'un assembly.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">"{0}" existe et a été envisagé, mais il ne comporte aucune identité valide. Il ne s'agit peut-être pas d'un assembly.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">È stato considerato "{0}", che è stato trovato, ma non aveva un'identità valida. Potrebbe non essere un assembly.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">È stato considerato "{0}", che è stato trovato, ma non aveva un'identità valida. Potrebbe non essere un assembly.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">存在しましたが、有効な ID を持たなかった "{0}" を考慮しました。これはアセンブリでない可能性があります。</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">存在しましたが、有効な ID を持たなかった "{0}" を考慮しました。これはアセンブリでない可能性があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">이미 있는 "{0}"(으)로 간주했지만 유효한 ID가 없습니다. 어셈블리가 아닐 수 있습니다.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">이미 있는 "{0}"(으)로 간주했지만 유효한 ID가 없습니다. 어셈블리가 아닐 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">Wybrano element „{0}”, który istnieje, ale nie ma prawidłowej tożsamości. Może on nie być zestawem.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">Wybrano element „{0}”, który istnieje, ale nie ma prawidłowej tożsamości. Może on nie być zestawem.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">"{0}" foi considerado e existia, mas não continha uma identidade válida. Talvez não seja um assembly.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">"{0}" foi considerado e existia, mas não continha uma identidade válida. Talvez não seja um assembly.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">Рассмотрено "{0}", существовавшее, но не имевшее допустимого идентификатора. Возможно, это не сборка.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">Рассмотрено "{0}", существовавшее, но не имевшее допустимого идентификатора. Возможно, это не сборка.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">Mevcut olan ancak geçerli bir kimliği olmayan "{0}" denendi. Bu, bir bütünleştirilmiş kod olmayabilir.</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">Mevcut olan ancak geçerli bir kimliği olmayan "{0}" denendi. Bu, bir bütünleştirilmiş kod olmayabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">已考虑使用“{0}”，它虽然存在，但没有有效的标识。这可能不是程序集。</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">已考虑使用“{0}”，它虽然存在，但没有有效的标识。这可能不是程序集。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1652,8 +1652,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
-        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
-        <target state="translated">已考慮 "{0}"，它雖然存在但沒有有效的識別。這可能不是組件。</target>
+        <source>Considered "{0}", which existed but did not appear to be a valid .NET assembly.</source>
+        <target state="needs-review-translation">已考慮 "{0}"，它雖然存在但沒有有效的識別。這可能不是組件。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">


### PR DESCRIPTION
When RAR is trying to find the closure of dependencies of the input
assemblies, it searches for assemblies based on identity in paths next
to currently known assemblies. Today, if there is a file of the expected
name that is not a well-formed managed assembly, RAR will silently
ignore it, without reporting any details about the file.

This changes the RAR output format

```
Dependency "DotLiquid, Version=2.0.174.0, Culture=neutral, PublicKeyToken=82e46016ecf9f07c".
    Could not find dependent files. Could not load file or assembly 'DotLiquid.dll' or one of its dependencies. An attempt was made to load a program with an incorrect format.
    Could not resolve this reference. Could not locate the assembly "DotLiquid, Version = 2.0.174.0, Culture=neutral, PublicKeyToken=82e46016ecf9f07c". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.
    For SearchPath "S:\repro\".
        Considered "S:\repro\\DotLiquid.winmd", but it didn't exist.
    Required by "Microsoft.Online.DirectoryServices.Management.dll".
```

To

```
Dependency "DotLiquid, Version=2.0.174.0, Culture=neutral, PublicKeyToken=82e46016ecf9f07c".
    Could not resolve this reference. Could not locate the assembly "DotLiquid, Version = 2.0.174.0, Culture=neutral, PublicKeyToken=82e46016ecf9f07c". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.
    For SearchPath "S:\repro\".
        Considered "S:\repro\\DotLiquid.winmd", but it didn't exist.
        Considered "S:\repro\\DotLiquid.dll", which existed but didn't have a valid identity. This may not be an assembly.
        Considered "S:\repro\\DotLiquid.exe", but it didn't exist.
    For SearchPath "{TargetFrameworkDirectory}".
        Considered "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\DotLiquid.winmd", but it didn't exist.
        Considered "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\DotLiquid.dll", but it didn't exist.
        Considered "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\DotLiquid.exe", but it didn't exist.
        Considered "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\Facades\DotLiquid.winmd", but it didn't exist.
        Considered "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\Facades\DotLiquid.dll", but it didn't exist.
        Considered "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\Facades\DotLiquid.exe", but it didn't exist.
    Required by "Microsoft.Online.DirectoryServices.Management.dll".
```
