### PR TITLE
Delete intermediate sourcebuild package

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,4 +1,4 @@
 ;; File passed to the SignCheck tool for exclusions
 
 ;; Ignore sourcebuild intermediate package. It is not expected to be signed.
-*.dll;Microsoft.SourceBuild.Intermediate*.nupkg;
+*.*;Microsoft.SourceBuild.Intermediate*.nupkg;

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,4 +1,4 @@
 ;; File passed to the SignCheck tool for exclusions
 
 ;; Ignore sourcebuild intermediate package. It is not expected to be signed.
-Microsoft.SourceBuild.Intermediate*.nupkg
+;Microsoft.SourceBuild.Intermediate*.nupkg;

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,4 +1,4 @@
 ;; File passed to the SignCheck tool for exclusions
 
 ;; Ignore sourcebuild intermediate package. It is not expected to be signed.
-;Microsoft.SourceBuild.Intermediate*.nupkg;
+*.dll;Microsoft.SourceBuild.Intermediate*.nupkg;

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,4 +1,0 @@
-;; File passed to the SignCheck tool for exclusions
-
-;; Ignore sourcebuild intermediate package. It is not expected to be signed.
-*.dll|*.nupkg;Microsoft.SourceBuild.Intermediate*.nupkg;

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,0 +1,4 @@
+;; File passed to the SignCheck tool for exclusions
+
+;; Ignore sourcebuild intermediate package. It is not expected to be signed.
+Microsoft.SourceBuild.Intermediate*.nupkg

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,4 +1,4 @@
 ;; File passed to the SignCheck tool for exclusions
 
 ;; Ignore sourcebuild intermediate package. It is not expected to be signed.
-*.*;Microsoft.SourceBuild.Intermediate*.nupkg;
+*.dll|*.nupkg;Microsoft.SourceBuild.Intermediate*.nupkg;

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -166,6 +166,11 @@ stages:
           inputs:
             filePath: eng\common\enable-cross-org-publishing.ps1
             arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+        
+        - task: DeleteFiles@1
+          inputs:
+            SourceFolder: $(Build.ArtifactStagingDirectory)/PackageArtifacts
+            Contents: Microsoft.SourceBuild.Intermediate*
 
         # Signing validation will optionally work with the buildmanifest file which is downloaded from
         # Azure DevOps above.


### PR DESCRIPTION
Fixes official builds

### Context
The msbuild intermediate sourcebuild package isn't expected to be signed and is causing failures because official builds think they are. Let's exclude the package.

### Changes Made


### Testing


### Notes
