### PR TITLE
Enable NuGet static-graph restore

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -2,6 +2,10 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
 
+  <PropertyGroup>
+    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+  </PropertyGroup>
+
   <ItemGroup>
 	<!-- Remove all sln files globbed by arcade so far and add only MSBuild.sln to the build.
 	Without this, arcade tries to build all three MSBuild solution at once, which leads to


### PR DESCRIPTION
This has been available in Arcade for a while now (dotnet/arcade#5056), and it's dogfood-y so we should have it on for our own repo.