### PR TITLE
Propertly report HasLoggedErrors when converting errors into warnings

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -940,16 +940,7 @@ namespace Microsoft.Build.BackEnd
                 IBuildEngine be = host.TaskInstance.BuildEngine;
                 if (taskReturned && !taskResult && !taskLoggingContext.HasLoggedErrors && (be is TaskHost th ? th.BuildRequestsSucceeded : false) && (be is IBuildEngine7 be7 ? !be7.AllowFailureWithoutError : true))
                 {
-                    if (_continueOnError == ContinueOnError.WarnAndContinue)
-                    {
-                        taskLoggingContext.LogWarning(null,
-                            new BuildEventFileInfo(_targetChildInstance.Location),
-                            "TaskReturnedFalseButDidNotLogError",
-                            _taskNode.Name);
-
-                        taskLoggingContext.LogComment(MessageImportance.Normal, "ErrorConvertedIntoWarning");
-                    }
-                    else
+                    if (_continueOnError != ContinueOnError.WarnAndContinue)
                     {
                         taskLoggingContext.LogError(new BuildEventFileInfo(_targetChildInstance.Location),
                             "TaskReturnedFalseButDidNotLogError",

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -455,8 +455,8 @@ namespace Microsoft.Build.BackEnd
                 {
                     e.BuildEventContext = _taskLoggingContext.BuildEventContext;
                     _taskLoggingContext.LoggingService.LogBuildEvent(e);
-                    _taskLoggingContext.HasLoggedErrors = true;
                 }
+                    _taskLoggingContext.HasLoggedErrors = true;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6275

### Context
When a task logs an error, its logging helper properly realizes that it logged an error. The overall build, however, converts that error into a warning. This leads to very confusing scenarios where a task can return "I logged an error" that the TaskBuilder recognizes, but doesn't see that an error was logged because it was turned into a warning.

### Changes Made
When a taskhost logs an error, even if it was converted into a warning, it understands that an error was logged but _does not fail the build_.

### Testing


### Notes
We're hoping that errors being reported properly AND preventing MSB4141 from being reported is sufficient to prevent the following: A task logs an error and reports as much, but the TaskBuilder that executed the task doesn't see the error so we log MSB4141.