### PR TITLE
Fix underbuild with ref assemblies in Visual Studio

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.11.1</VersionPrefix>
+    <VersionPrefix>16.11.2</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4700,9 +4700,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          input to projects that reference this one. -->
     <Touch Files="@(CopyUpToDateMarker)"
            AlwaysCreate="true"
-           Condition="'@(ReferencesCopiedInThisBuild)' != '' and '$(WroteAtLeastOneFile)' == 'true'">
-        <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
-    </Touch>
+           Condition="'@(ReferencesCopiedInThisBuild)' != '' and '$(WroteAtLeastOneFile)' == 'true'" />
+
+    <ItemGroup>
+      <FileWrites Include="@(CopyUpToDateMarker)" />
+    </ItemGroup>
 
   </Target>
 


### PR DESCRIPTION
Fixes #6917 by ensuring that the copy-marker file is _always_ added
to the FileWrites item if the copy-referenced-assemblies target runs
so that IncrementalClean never sees it as an 'orphan' file and then
deletes it.

Work item (Internal use): [AB#1417029](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1417029)

### Summary

In some common situations, Visual Studio will not build a project that should build. 

### Customer Impact

This can result in debugging or unit test execution running against stale binaries that don't have the user's latest changes. That's a baffling and intensely frustrating user experience.

### Regression?

Yes, in Visual Studio 16.11.4 and 17.0-preview3.

The bug is longstanding (since 15.6), but was masked by #6576 which caused Visual Studio overbuild.

### Testing

Private patching shows expected behavior; users experiencing the problem who applied a roughly-equivalent workaround have reported that it fixes their issues and not reported new ones.

### Risk

Low. Adds a file to the list of files that would be written to the output directory. We validated that adding nonexistent files to that list is harmless, so even if the file doesn't get written (for some reason) builds will still succeed.

However, this target is run in basically all builds, so unexpected impacts would potentially have wide scope.
