### PR TITLE
Don't flow self contained command-line option to referenced projects

### DIFF
--- a/src/Shared/ConversionUtilities.cs
+++ b/src/Shared/ConversionUtilities.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Build.Shared
         /// Returns true if the string represents a valid MSBuild boolean false value,
         /// such as "!on" "off" "no" "!true"
         /// </summary>
-        private static bool ValidBooleanFalse(string parameterValue)
+        internal static bool ValidBooleanFalse(string parameterValue)
         {
             return String.Equals(parameterValue, "false", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "off", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\FileSystemSources.proj" />
   <Import Project="..\Shared\DebuggingSources.proj" />
@@ -329,6 +329,7 @@
     </Compile>
     <Compile Include="ResourceHandling\*.cs" />
     <Compile Include="GetCompatiblePlatform.cs" />
+    <Compile Include="SetRidAgnosticValueForProjects.cs" />
     <Compile Include="ResolveComReference.cs" />
     <Compile Include="BuildCacheDisposeWrapper.cs" />
     <Compile Include="DownloadFile.cs" />
@@ -966,8 +967,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" SetTargetFramework="TargetFramework=netstandard2.0" OutputItemType="NetstandardRefAssemblies" />
     <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" SetTargetFramework="TargetFramework=netstandard2.0" OutputItemType="NetstandardRefAssemblies" />
-    <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj"/>
-    <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj"/>
+    <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
+    <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" />
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -42,9 +42,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPlatformMonikers>@(_TargetFrameworkInfo->'%(TargetPlatformMonikers)')</TargetPlatformMonikers>
         <AdditionalPropertiesFromProject>$(_AdditionalPropertiesFromProject)</AdditionalPropertiesFromProject>
         <HasSingleTargetFramework>false</HasSingleTargetFramework>
-        <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
-        <IsRidAgnostic>false</IsRidAgnostic>
-        <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
+        <AcceptsRuntimeIdentifier>@(_TargetFrameworkInfo->'%(AcceptsRuntimeIdentifier)')</AcceptsRuntimeIdentifier>
         <!-- Extract necessary information for SetPlatform negotiation -->
         <!-- This target does not run for cpp projects. -->
         <IsVcxOrNativeProj>false</IsVcxOrNativeProj>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -42,7 +42,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPlatformMonikers>@(_TargetFrameworkInfo->'%(TargetPlatformMonikers)')</TargetPlatformMonikers>
         <AdditionalPropertiesFromProject>$(_AdditionalPropertiesFromProject)</AdditionalPropertiesFromProject>
         <HasSingleTargetFramework>false</HasSingleTargetFramework>
-        <AcceptsRuntimeIdentifier>@(_TargetFrameworkInfo->'%(AcceptsRuntimeIdentifier)')</AcceptsRuntimeIdentifier>
+        <IsRidAgnostic>@(_TargetFrameworkInfo->'%(IsRidAgnostic)')</IsRidAgnostic>
         <!-- Extract necessary information for SetPlatform negotiation -->
         <!-- This target does not run for cpp projects. -->
         <IsVcxOrNativeProj>false</IsVcxOrNativeProj>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 ***********************************************************************************************
 Microsoft.Common.CurrentVersion.targets
 
@@ -1779,7 +1779,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
         ContinueOnError="!$(BuildingProject)"
-        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier$(_GlobalPropertiesToRemoveFromProjectReferences)"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier;SelfContained;$(_GlobalPropertiesToRemoveFromProjectReferences)"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true' and '$(EnableDynamicPlatformResolution)' != 'true'"
         SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkPossibilities" />
@@ -1795,7 +1795,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Targets="GetTargetFrameworks"
         BuildInParallel="$(BuildInParallel)"
         ContinueOnError="!$(BuildingProject)"
-        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier;Platform;Configuration$(_GlobalPropertiesToRemoveFromProjectReferences)"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier;SelfContained;Platform;Configuration$(_GlobalPropertiesToRemoveFromProjectReferences)"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true' and '$(EnableDynamicPlatformResolution)' == 'true'"
         SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkPossibilities" />
@@ -1866,6 +1866,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <!-- If the project is RID agnostic, undefine the RuntimeIdentifier property to avoid another evaluation. -->
       <AnnotatedProjects Condition="'@(AnnotatedProjects)' == '%(Identity)' and '%(AnnotatedProjects.IsRidAgnostic)' == 'true'">
         <UndefineProperties>%(AnnotatedProjects.UndefineProperties);RuntimeIdentifier</UndefineProperties>
+
+        <!-- Also undefine SelfContained property if it was defined on the command line.  Otherwise a command such as
+             "dotnet build -r win-x64 -/-self-contained" would fail to build referenced projects, as they would have
+             SelfContained defined but no RuntimeIdentifier.
+             We only undefine this if the specific command-line option was used, in order to avoid breaking projects
+             that were passing /p:SelfContained=true on the command-line and relying on it flowing acress projects
+             (they were then setting the RuntimeIdentifier if SelfContained was true in their props files) -->
+        <UndefineProperties Condition="'$(_CommandLineDefinedSelfContained)' == 'true'">%(AnnotatedProjects.UndefineProperties);SelfContained</UndefineProperties>
       </AnnotatedProjects>
 
       <!--

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1867,7 +1867,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
            unless the project is expecting those properties to flow.
            We include SelfContained together with RuntimeIdentifier, because otherwise a referenced project could try to build with
            SelfContained set to true but no RuntimeIdentifier set, which causes an error (for Exe projects). -->
-      <AnnotatedProjects Condition="'@(AnnotatedProjects)' == '%(Identity)' and '%(AnnotatedProjects.AcceptsRuntimeIdentifier)' != 'true'">
+      <AnnotatedProjects Condition="'@(AnnotatedProjects)' == '%(Identity)' and '%(AnnotatedProjects.IsRidAgnostic)' != 'false'">
         <UndefineProperties>%(AnnotatedProjects.UndefineProperties);RuntimeIdentifier;SelfContained</UndefineProperties>
       </AnnotatedProjects>
 
@@ -1901,7 +1901,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPlatformMonikers>@(_TargetFrameworkInfo->'%(TargetPlatformMonikers)')</TargetPlatformMonikers>
         <AdditionalPropertiesFromProject>$(_AdditionalPropertiesFromProject)</AdditionalPropertiesFromProject>
         <HasSingleTargetFramework>true</HasSingleTargetFramework>
-        <AcceptsRuntimeIdentifier>@(_TargetFrameworkInfo->'%(AcceptsRuntimeIdentifier)')</AcceptsRuntimeIdentifier>
+        <IsRidAgnostic>@(_TargetFrameworkInfo->'%(IsRidAgnostic)')</IsRidAgnostic>
         <!-- Extract necessary information for SetPlatform negotiation -->
         <IsVcxOrNativeProj Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.nativeproj'">true</IsVcxOrNativeProj>
         <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.4'))">$(Platform)</Platform>
@@ -1943,15 +1943,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPlatformMonikers Condition="'$(TargetPlatformMoniker)' == ''">None</TargetPlatformMonikers>
         <AdditionalPropertiesFromProject>$(_AdditionalTargetFrameworkInfoProperties)</AdditionalPropertiesFromProject>
 
-        <!-- Determine whether a global RuntimeIdentifier property should flow to this project across project references.
-             We will let the property flow if any of the following are true:
-             - The AcceptsRuntimeIdentifier property is set to true (or really, any non-empty value except "false")
-             - The RuntimeIdentifier is set
-             - The RuntimeIdentifiers property is set
-             Otherwise, we will include RuntimeIdentifier (and SelfContained) in the list of global properties to remove across project references-->
-        <AcceptsRuntimeIdentifier>$(AcceptsRuntimeIdentifier)</AcceptsRuntimeIdentifier>
-        <AcceptsRuntimeIdentifier Condition=" '$(AcceptsRuntimeIdentifier)' == ''">true</AcceptsRuntimeIdentifier>
-        <AcceptsRuntimeIdentifier Condition=" '$(AcceptsRuntimeIdentifier)' == '' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">false</AcceptsRuntimeIdentifier>
+        <!-- Determine whether a project is "RID agnostic" for each TargetFramework.  "RID agnostic" means that global properties such as SelfContained and RuntimeIdentifier should
+             not flow across project references.
+
+             Generally this value will come from the IsRidAgnostic property set by the .NET SDK.  If that's not set, then the fallback logic here will be that the project
+             is RID agnostic if it doesn't have RuntimeIdentifier or RuntimeIdentifiers properties set. -->
+        <IsRidAgnostic>$(IsRidAgnostic)</IsRidAgnostic>
+        <IsRidAgnostic Condition=" '$(IsRidAgnostic)' == '' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">false</IsRidAgnostic>
+        <IsRidAgnostic Condition=" '$(IsRidAgnostic)' == ''">true</IsRidAgnostic>
 
       </_TargetFrameworkInfo>
     </ItemGroup>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1863,17 +1863,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <UndefineProperties>%(AnnotatedProjects.UndefineProperties);TargetFramework</UndefineProperties>
       </AnnotatedProjects>
 
-      <!-- If the project is RID agnostic, undefine the RuntimeIdentifier property to avoid another evaluation. -->
-      <AnnotatedProjects Condition="'@(AnnotatedProjects)' == '%(Identity)' and '%(AnnotatedProjects.IsRidAgnostic)' == 'true'">
-        <UndefineProperties>%(AnnotatedProjects.UndefineProperties);RuntimeIdentifier</UndefineProperties>
-
-        <!-- Also undefine SelfContained property if it was defined on the command line.  Otherwise a command such as
-             "dotnet build -r win-x64 -/-self-contained" would fail to build referenced projects, as they would have
-             SelfContained defined but no RuntimeIdentifier.
-             We only undefine this if the specific command-line option was used, in order to avoid breaking projects
-             that were passing /p:SelfContained=true on the command-line and relying on it flowing acress projects
-             (they were then setting the RuntimeIdentifier if SelfContained was true in their props files) -->
-        <UndefineProperties Condition="'$(_CommandLineDefinedSelfContained)' == 'true'">%(AnnotatedProjects.UndefineProperties);SelfContained</UndefineProperties>
+      <!-- Add RuntimeIdentifier and SelfContained to the list of global properties that should not flow to the referenced project,
+           unless the project is expecting those properties to flow.
+           We include SelfContained together with RuntimeIdentifier, because otherwise a referenced project could try to build with
+           SelfContained set to true but no RuntimeIdentifier set, which causes an error (for Exe projects). -->
+      <AnnotatedProjects Condition="'@(AnnotatedProjects)' == '%(Identity)' and '%(AnnotatedProjects.AcceptsRuntimeIdentifier)' != 'true'">
+        <UndefineProperties>%(AnnotatedProjects.UndefineProperties);RuntimeIdentifier;SelfContained</UndefineProperties>
       </AnnotatedProjects>
 
       <!--
@@ -1906,9 +1901,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPlatformMonikers>@(_TargetFrameworkInfo->'%(TargetPlatformMonikers)')</TargetPlatformMonikers>
         <AdditionalPropertiesFromProject>$(_AdditionalPropertiesFromProject)</AdditionalPropertiesFromProject>
         <HasSingleTargetFramework>true</HasSingleTargetFramework>
-        <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
-        <IsRidAgnostic>false</IsRidAgnostic>
-        <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
+        <AcceptsRuntimeIdentifier>@(_TargetFrameworkInfo->'%(AcceptsRuntimeIdentifier)')</AcceptsRuntimeIdentifier>
         <!-- Extract necessary information for SetPlatform negotiation -->
         <IsVcxOrNativeProj Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.nativeproj'">true</IsVcxOrNativeProj>
         <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.4'))">$(Platform)</Platform>
@@ -1949,6 +1942,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPlatformMonikers>$(TargetPlatformMoniker)</TargetPlatformMonikers>
         <TargetPlatformMonikers Condition="'$(TargetPlatformMoniker)' == ''">None</TargetPlatformMonikers>
         <AdditionalPropertiesFromProject>$(_AdditionalTargetFrameworkInfoProperties)</AdditionalPropertiesFromProject>
+
+        <!-- Determine whether a global RuntimeIdentifier property should flow to this project across project references.
+             We will let the property flow if any of the following are true:
+             - The AcceptsRuntimeIdentifier property is set to true (or really, any non-empty value except "false")
+             - The RuntimeIdentifier is set
+             - The RuntimeIdentifiers property is set
+             Otherwise, we will include RuntimeIdentifier (and SelfContained) in the list of global properties to remove across project references-->
+        <AcceptsRuntimeIdentifier>$(AcceptsRuntimeIdentifier)</AcceptsRuntimeIdentifier>
+        <AcceptsRuntimeIdentifier Condition=" '$(AcceptsRuntimeIdentifier)' == ''">true</AcceptsRuntimeIdentifier>
+        <AcceptsRuntimeIdentifier Condition=" '$(AcceptsRuntimeIdentifier)' == '' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">false</AcceptsRuntimeIdentifier>
+
       </_TargetFrameworkInfo>
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1850,6 +1850,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                          Condition="'$(ReferringTargetFrameworkForProjectReferences)' == '' or
                                     ('$(EnableDynamicPlatformResolution)' == 'true' and '%(_ProjectReferenceTargetFrameworkPossibilities.IsVcxOrNativeProj)' == 'true')" />
 
+    </ItemGroup>
+
+    <!-- IsRidAgnostic metadata is used to determine whether global properties such as RuntimeIdentifier and SelfContained flow to a referenced project.
+         However, for multi-targeted projects there may be a different IsRidAgnostic value for each TargetFramework.  In that case, this task selects
+         the IsRidAgnostic value for the NearestTargetFramework for the project. -->
+    <SetRidAgnosticValueForProjects Projects="@(AnnotatedProjects)">
+      <Output ItemName="UpdatedAnnotatedProjects" TaskParameter="UpdatedProjects" />
+    </SetRidAgnosticValueForProjects>
+    
+    <ItemGroup>
+      <AnnotatedProjects Remove="@(AnnotatedProjects)" />
+      <AnnotatedProjects Include="@(UpdatedAnnotatedProjects)" />
+      <UpdatedAnnotatedProjects Remove="@(UpdatedAnnotatedProjects)" />
+
       <!-- If the NearestTargetFramework property was set and the project multi-targets, SetTargetFramework must be set. -->
       <AnnotatedProjects Condition="'@(AnnotatedProjects)' == '%(Identity)' and '%(AnnotatedProjects.NearestTargetFramework)' != '' and '%(AnnotatedProjects.HasSingleTargetFramework)' != 'true'">
         <SetTargetFramework>TargetFramework=%(AnnotatedProjects.NearestTargetFramework)</SetTargetFramework>
@@ -1864,9 +1878,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </AnnotatedProjects>
 
       <!-- Add RuntimeIdentifier and SelfContained to the list of global properties that should not flow to the referenced project,
-           unless the project is expecting those properties to flow.
-           We include SelfContained together with RuntimeIdentifier, because otherwise a referenced project could try to build with
-           SelfContained set to true but no RuntimeIdentifier set, which causes an error (for Exe projects). -->
+           unless the project is expecting those properties to flow. -->
       <AnnotatedProjects Condition="'@(AnnotatedProjects)' == '%(Identity)' and '%(AnnotatedProjects.IsRidAgnostic)' != 'false'">
         <UndefineProperties>%(AnnotatedProjects.UndefineProperties);RuntimeIdentifier;SelfContained</UndefineProperties>
       </AnnotatedProjects>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1795,7 +1795,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Targets="GetTargetFrameworks"
         BuildInParallel="$(BuildInParallel)"
         ContinueOnError="!$(BuildingProject)"
-        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier;SelfContained;Platform;Configuration$(_GlobalPropertiesToRemoveFromProjectReferences)"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier;SelfContained;Platform;Configuration;$(_GlobalPropertiesToRemoveFromProjectReferences)"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true' and '$(EnableDynamicPlatformResolution)' == 'true'"
         SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkPossibilities" />
@@ -1961,8 +1961,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
              Generally this value will come from the IsRidAgnostic property set by the .NET SDK.  If that's not set, then the fallback logic here will be that the project
              is RID agnostic if it doesn't have RuntimeIdentifier or RuntimeIdentifiers properties set. -->
         <IsRidAgnostic>$(IsRidAgnostic)</IsRidAgnostic>
-        <IsRidAgnostic Condition=" '$(IsRidAgnostic)' == '' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">false</IsRidAgnostic>
-        <IsRidAgnostic Condition=" '$(IsRidAgnostic)' == ''">true</IsRidAgnostic>
+        <IsRidAgnostic Condition=" '$(IsRidAgnostic)' == '' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
+        <IsRidAgnostic Condition=" '$(IsRidAgnostic)' == ''">false</IsRidAgnostic>
 
       </_TargetFrameworkInfo>
     </ItemGroup>

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -54,6 +54,7 @@
   <UsingTask TaskName="Microsoft.Build.Tasks.GetFrameworkPath"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <UsingTask TaskName="Microsoft.Build.Tasks.GetFrameworkSdkPath"                   AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <UsingTask TaskName="Microsoft.Build.Tasks.GetReferenceAssemblyPaths"             AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.SetRidAgnosticValueForProjects"        AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <UsingTask TaskName="Microsoft.Build.Tasks.Hash"                                  AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <UsingTask TaskName="Microsoft.Build.Tasks.LC"                                    AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <UsingTask TaskName="Microsoft.Build.Tasks.MakeDir"                               AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/src/Tasks/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Tasks/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,2 +1,9 @@
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.Projects.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.Projects.set -> void
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.SetRidAgnosticValueForProjects() -> void
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.UpdatedProjects.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.UpdatedProjects.set -> void
+override Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.Execute() -> bool
 Microsoft.Build.Tasks.XslTransformation.PreserveWhitespace.get -> bool
 Microsoft.Build.Tasks.XslTransformation.PreserveWhitespace.set -> void

--- a/src/Tasks/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Tasks/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,2 +1,9 @@
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.Projects.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.Projects.set -> void
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.SetRidAgnosticValueForProjects() -> void
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.UpdatedProjects.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.UpdatedProjects.set -> void
 Microsoft.Build.Tasks.XslTransformation.PreserveWhitespace.get -> bool
 Microsoft.Build.Tasks.XslTransformation.PreserveWhitespace.set -> void
+override Microsoft.Build.Tasks.SetRidAgnosticValueForProjects.Execute() -> bool

--- a/src/Tasks/SetRidAgnosticValueForProjects.cs
+++ b/src/Tasks/SetRidAgnosticValueForProjects.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.Tasks
+{
+    public sealed class SetRidAgnosticValueForProjects : TaskExtension
+    {
+        public ITaskItem[] Projects { get; set; } = Array.Empty<ITaskItem>();
+
+        [Output]
+        public ITaskItem[] UpdatedProjects { get; set; } = Array.Empty<ITaskItem>();
+
+        public override bool Execute()
+        {
+            UpdatedProjects = Projects
+                .Select(p =>
+                {
+                    var hasSingleTargetFrameworkString = p.GetMetadata("HasSingleTargetFramework");
+                    if (!ConversionUtilities.ValidBooleanFalse(hasSingleTargetFrameworkString))
+                    {
+                        // No change to item, it should already have a single-valued IsRidAgnostic value
+                        return p;
+                    }
+                    var updatedItem = new TaskItem(p);
+
+                    var nearestTargetFramework = p.GetMetadata("NearestTargetFramework");
+                    if (string.IsNullOrEmpty(nearestTargetFramework))
+                    {
+                        return p;
+                    }
+
+                    var targetFrameworksArray = p.GetMetadata("TargetFrameworks").Split(';');
+
+                    int targetFrameworkIndex = Array.IndexOf(targetFrameworksArray, nearestTargetFramework);
+                    if (targetFrameworkIndex < 0)
+                    {
+                        return p;
+                    }
+
+                    var isRidAgnosticArray = p.GetMetadata("IsRidAgnostic").Split(';');
+                    if (isRidAgnosticArray.Length != targetFrameworksArray.Length)
+                    {
+                        return p;
+                    }
+
+                    updatedItem.SetMetadata("IsRidAgnostic", isRidAgnosticArray[targetFrameworkIndex]);
+                    
+                    return updatedItem;
+                })
+                .ToArray();
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes dotnet/sdk#21677

### Context

In .NET 6, if you run a command such as `dotnet build -r win-x64`, you will get the following error:

> C:\Program Files\dotnet\sdk\6.0.100-rtm.21474.29\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(1105,5): warning NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used. [C:\git\repro\ConsoleTest\ConsoleTest.csproj]

However, if you follow the suggestion and change it to `dotnet build -r win-x64 --self-contained`, then you will likely get an error such as the following if there are any referenced projects:

> C:\Program Files\dotnet\sdk\6.0.100-rc.2.21501.4\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(150,5): error NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false. [C:\Users\brady\source\TodoApp\TodoApp.API\TodoApp.API.csproj]

This happens because

- Global properties (ie those specified on the command line) flow to referenced projects by default
- We normally stop the `RuntimeIdentifier` from flowing to referenced projects
- We don't currently stop the `SelfContained` property from flowing to referenced projects
- So the referenced project gets built with `SelfContained` set to true but no `RuntimeIdentifier`, which is an error

### Changes Made

If `--self-contained` is specified on the command-line, and the `RuntimeIdentifier` is blocked from flowing to referenced projects, then we also block the `SelfContained` property from flowing to referenced projects.

Note that this treats `--self-contained` differently from `/p:SelfContained=true`, as there is at least one project that relies on `/p:SelfContained=true` flowing across project references, and they set `RuntimeIdentifier` in their .props files if `SelfContained` is true.

### Testing

I will add automated tests to the SDK repo for this scenario, and test locally with those tests and the changes in this PR before merging.

### Notes

FYI @richlander @sfoslund @marcpopMSFT, I think we should take this for 17.0 GA