### PR TITLE
Fix EngineServices version bump check

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -158,9 +158,14 @@ function Check-EditedFiles() {
 
 function Check-RequiredVersionBumps() {
   # Log VSTS errors for missing required version bumps
-  if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
+  $targetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+  if ($targetBranch) {
+    # Prepend remote reference if the branch is not local
+    if (!$targetBranch.StartsWith("refs/head/")) {
+      $targetBranch = "refs/remotes/origin/" + $targetBranch
+    }
     $versionLineChanged = $false
-    git --no-pager diff --unified --no-color --exit-code -w $env:SYSTEM_PULLREQUEST_TARGETBRANCH HEAD src\Framework\EngineServices.cs `
+    git --no-pager diff --unified --no-color --exit-code -w $targetBranch HEAD src\Framework\EngineServices.cs `
       | Select-String -Pattern "int Version =" | ForEach-Object -process { $versionLineChanged = $true }
     if (($LASTEXITCODE -ne 0) -and (-not $versionLineChanged)) {
       throw "##vso[task.logissue type=error] Detected changes in Framework\EngineServices.cs without a version bump.  " +


### PR DESCRIPTION
### Context

The check is failing for loc PRs where `SYSTEM_PULLREQUEST_TARGETBRANCH` is set to `refs/head/main` because `origin/refs/head/main` is not a valid revision spec.

### Changes Made

Made the script add the `origin` remote reference only if the branch is not local.

### Testing

Tested by this PR and by #6929 after this PR is merged.
