### PR TITLE
Fix EngineServices version bump check follow-up

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -161,7 +161,7 @@ function Check-RequiredVersionBumps() {
   $targetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
   if ($targetBranch) {
     # Prepend remote reference if the branch is not local
-    if (!$targetBranch.StartsWith("refs/head/")) {
+    if (!$targetBranch.StartsWith("refs/heads/")) {
       $targetBranch = "refs/remotes/origin/" + $targetBranch
     }
     $versionLineChanged = $false


### PR DESCRIPTION
### Context

#6939 had a typo and didn't solve the problem with loc PRs.

### Changes Made

Fixed the revision spec prefix to `refs/heads` instead of `refs/head`.

### Testing

This PR and #6929 after this PR is merged.
