### PR TITLE
Fix files kept in use in XslTransformation

### DIFF
--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -334,9 +334,9 @@ namespace Microsoft.Build.Tasks
             {
                 if (XmlMode == XmlModes.XmlFile)
                 {
-                    return XmlReader.Create(new StreamReader(_data[itemPos]), null, _data[itemPos]);
+                    return XmlReader.Create(new StreamReader(_data[itemPos]), new XmlReaderSettings { CloseInput = true }, _data[itemPos]);
                 }
-                else // xmlModes.Xml 
+                else // xmlModes.Xml
                 {
                     return XmlReader.Create(new StringReader(_data[itemPos]));
                 }
@@ -459,7 +459,10 @@ namespace Microsoft.Build.Tasks
                             _log.LogMessageFromResources(MessageImportance.Low, "XslTransform.UseTrustedSettings", _data);
                         }
 
-                        xslct.Load(new XPathDocument(XmlReader.Create(new StreamReader(_data), null, _data)), settings, new XmlUrlResolver());
+                        using (XmlReader reader = XmlReader.Create(new StreamReader(_data), new XmlReaderSettings { CloseInput = true }, _data))
+                        {
+                            xslct.Load(new XPathDocument(reader), settings, new XmlUrlResolver());
+                        }
                         break;
                     case XslModes.XsltCompiledDll:
 #if FEATURE_COMPILED_XSL


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6962

Work item (Internal use): https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1417029

### Summary
The XslTransformation now holds a lock on its input xml file.

### Customer Impact
Customers that expect to modify/use the input files to the `XslTransformation` task are unable to due to a lock on the file.

### Regression?
Yes, in VS 17.0 P5+

### Testing
Added regression test & customer verified the fix.

### Risk
Low: makes use of a parameter that was previously passed null. This parameter now tells the xmlreader to drop its lock on the file as soon as it's done.

### Original Post
Following #6863, the created `XmlReader` is no longer responsible for its
underlying stream. This can cause the build process to hold on to the
processed file, preventing its removal. This can especially be a problem
when the transformation is in fact aimed at the input file itself, where
we want to create the transformed file, then move it to the original.
