### PR TITLE
C++ CodeAnalysis assemblies to v17

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -127,15 +127,15 @@
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
         <dependentAssembly>
           <assemblyIdentity name="FxCopTask" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="16.0.0.0" href="..\..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\FxCopTask.dll" />
+          <codeBase version="17.0.0.0" href="..\..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\FxCopTask.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="16.0.0.0" href="..\..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
+          <codeBase version="17.0.0.0" href="..\..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="16.0.0.0" href="..\..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
+          <codeBase version="17.0.0.0" href="..\..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
       </assemblyBinding>
     </runtime>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -119,15 +119,15 @@
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
         <dependentAssembly>
           <assemblyIdentity name="FxCopTask" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="16.0.0.0" href="..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\FxCopTask.dll" />
+          <codeBase version="17.0.0.0" href="..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\FxCopTask.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="16.0.0.0" href="..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
+          <codeBase version="17.0.0.0" href="..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="16.0.0.0" href="..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
+          <codeBase version="17.0.0.0" href="..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
       </assemblyBinding>
     </runtime>


### PR DESCRIPTION
These assemblies have moved and versioned in Visual Studio 2022.

Update of the workaround for dotnet#1675 in dotnet#4139.

Fixes #6952

Work item (Internal use): [AB#1420314](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1420314)

### Summary

As a workaround for an assembly load issue, these assemblies must have an explicit codebase in MSBuild.

### Customer Impact

Builds that run C++ code analysis can fail with MSBuild internal errors.

### Regression?

Yes, against 16.x which had the correct `codeBase` for C++ code analysis assemblies.

### Testing

Manual testing against repro project from #1675.

### Risk

Low. Changes a codebase for an assembly version that should never be referenced to point to the version and location of the extant assembly.

We could further reduce risk by leaving the `16.0.0.0` `codeBase` entry if that's desired; I don't think it's necessary and I don't know how that assembly could ever get in place in VS2022.