### PR TITLE
Expander shortcut for string.LastIndexOfAny()

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3980,6 +3980,12 @@ $(
         }
 
         [Fact]
+        public void PropertyFunctionStringLastIndexOfAny()
+        {
+            TestPropertyFunction("$(prop.LastIndexOfAny('xy'))", "prop", "x-x-y-y-y-z", "8");
+        }
+
+        [Fact]
         public void PropertyFunctionStringCopy()
         {
             string propertyFunction = @"$([System.String]::Copy($(X)).LastIndexOf(

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -3665,6 +3665,14 @@ namespace Microsoft.Build.Evaluation
                         else if (TryGetArgs(args, out arg0, out StringComparison arg1))
                         {
                             returnVal = text.LastIndexOf(arg0, arg1);
+                            return true;
+                        }
+                    }
+                    else if (string.Equals(_methodMethodName, nameof(string.LastIndexOfAny), StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (TryGetArg(args, out string arg0))
+                        {
+                            returnVal = text.LastIndexOfAny(arg0.ToCharArray());
                             return true;
                         }
                     }


### PR DESCRIPTION
Allowing a string as a char array to call string.LastIndexOfAny(char[]) seems like a sensible thing to do.

However the other two overloads expecting a
startIndex and count seem to be too exotic to support.

I'm honestly not even sure how to pass a char array to a function in MSBuild, and I saw people using strings, so I guess makes sense to support that?