### PR TITLE
Remove jnm2.ReferenceAssemblies.net35 to remove it as a prebuilt dependency for source-build

### DIFF
--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -20,16 +20,11 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
     <AssemblyName>Microsoft.NET.StringTools.net35</AssemblyName>
-    <!-- Disable Fx install checks as we're building against jnm2's 3.5 reference assemblies -->
-    <BypassFrameworkInstallChecks>true</BypassFrameworkInstallChecks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net35'">
     <PackageReference Include="System.Memory" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="jnm2.ReferenceAssemblies.net35" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">


### PR DESCRIPTION
* For https://github.com/dotnet/source-build/issues/2417

This prebuilt package filled a gap in the official 1.0 version of the .NET Framework reference assembly packages. The gap has been fixed in later versions of the official packages. Removal fixes a prebuilt dependency by letting the repo use the official version of the packages, which are produced by SBRP.

I removed `<BypassFrameworkInstallChecks>true</BypassFrameworkInstallChecks>` because the comment essentially says that it shouldn't be necessary anymore and it sounds like a good idea to enable checks when I can, but I'm not actually familiar with what the checks do. 😄 

Fixes https://github.com/dotnet/msbuild/issues/6935