### PR TITLE
Disable BannedApiAnalyzers during source-build to avoid a prebuilt dependency

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -46,11 +46,11 @@
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(MicrosoftCodeAnalysisBannedApiAnalyzersVersion)" />
   </ItemGroup>
 
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" PrivateAssets="All" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
-    <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(MicrosoftCodeAnalysisBannedApiAnalyzersVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6961

### Context

> BannedApiAnalyzers has some intentional old dependencies and it's not feasible to build it during source-build. It's already been removed from source-build and we need to remove usages. https://github.com/dotnet/roslyn-analyzers/issues/5619
> 
> BannedApiAnalyzers isn't one of the analyzers that ends up in the SDK product, so the only reason for source-build to build it is for code validation parity when building MSBuild's C# source code. That would help source-build developers write upstreamable code if the MSBuild C# code needs to be patched, but dev flows aren't the primary goal of source-build right now.

### Changes Made

Moved `GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers"` into an item group that is excluded during source-build, so the analyzer isn't referenced or used.
