### PR TITLE
Add missing match on metadata location translation

### DIFF
--- a/src/Build.UnitTests/TestComparers/ProjectInstanceModelTestComparers.cs
+++ b/src/Build.UnitTests/TestComparers/ProjectInstanceModelTestComparers.cs
@@ -183,6 +183,12 @@ namespace Microsoft.Build.Engine.UnitTests.TestComparers
                 Assert.Equal(x.RemoveMetadataLocation, y.RemoveMetadataLocation, new Helpers.ElementLocationComparerIgnoringType());
                 Assert.Equal(x.ConditionLocation, y.ConditionLocation, new Helpers.ElementLocationComparerIgnoringType());
 
+                Assert.Equal(x.MatchOnMetadata, y.MatchOnMetadata);
+                Assert.Equal(x.MatchOnMetadataLocation, y.MatchOnMetadataLocation, new Helpers.ElementLocationComparerIgnoringType());
+
+                Assert.Equal(x.MatchOnMetadataOptions, y.MatchOnMetadataOptions);
+                Assert.Equal(x.MatchOnMetadataOptionsLocation, y.MatchOnMetadataOptionsLocation, new Helpers.ElementLocationComparerIgnoringType());
+
                 Assert.Equal(x.Metadata, y.Metadata, new TargetItemMetadataComparer());
 
                 return true;

--- a/src/Build/Instance/ProjectItemGroupTaskItemInstance.cs
+++ b/src/Build/Instance/ProjectItemGroupTaskItemInstance.cs
@@ -459,6 +459,8 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _keepMetadataLocation, ElementLocation.FactoryForDeserialization);
             translator.Translate(ref _removeMetadataLocation, ElementLocation.FactoryForDeserialization);
             translator.Translate(ref _keepDuplicatesLocation, ElementLocation.FactoryForDeserialization);
+            translator.Translate(ref _matchOnMetadataLocation, ElementLocation.FactoryForDeserialization);
+            translator.Translate(ref _matchOnMetadataOptionsLocation, ElementLocation.FactoryForDeserialization);
             translator.Translate(ref _conditionLocation, ElementLocation.FactoryForDeserialization);
             translator.Translate(ref _metadata, ProjectItemGroupTaskMetadataInstance.FactoryForDeserialization);
         }


### PR DESCRIPTION
### Context
Project cache usage forces all projects to be evaluated on the main node. When a project gets a cache miss, it gets built. When that build gets scheduled on an out of proc node, the project instance gets serialized to that node. Some recent change in msbuild turns on full project instance translation, and a bug in item element translation (incomplete translation) makes the task builder crash with a null pointer for metadata location.

This could also crash for all other VS scenarios that end up triggering full project instance translation.

### Changes Made
Added missing translation of match on metadata attribute locations

### Testing
Updated incomplete unit test
