### PR TITLE
Spurious Windows test failure in FindOnPathSucceeds

### DIFF
--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -681,18 +681,19 @@ namespace Microsoft.Build.UnitTests
         {
             string[] expectedCmdPath;
             string shellName;
+            string cmdPath;
             if (NativeMethodsShared.IsWindows)
             {
                 expectedCmdPath = new[] { Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe").ToUpperInvariant() };
                 shellName = "cmd.exe";
+                cmdPath = ToolTask.FindOnPath(shellName).ToUpperInvariant();
             }
             else
             {
-                expectedCmdPath = new[] { "/bin/sh".ToUpperInvariant(), "/usr/bin/sh".ToUpperInvariant() };
+                expectedCmdPath = new[] { "/bin/sh", "/usr/bin/sh" };
                 shellName = "sh";
+                cmdPath = ToolTask.FindOnPath(shellName);
             }
-
-            string cmdPath = ToolTask.FindOnPath(shellName).ToUpperInvariant();
 
             cmdPath.ShouldBeOneOf(expectedCmdPath);
         }


### PR DESCRIPTION
Fixes #6869

### Context

`cmd.exe` full path retrieval from PATH environment variable and comparison in unit test was case sensitive.

### Changes Made

Converted `cmd.exe` full path to lowercase to repair case sensitivity for flaky unit test fact `FindOnPathSucceeds()` at `ToolTask_Tests.cs`

### Testing

Debugging, unit test run and code compiling.

### Notes
