### PR TITLE
Minor allocation optimizations / cleanup

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             else
             {
                 // Get the dictionary for the specified submission if one is already added otherwise create a new dictionary for the submission.
-                ConcurrentDictionary<string, Lazy<SdkResult>> cached = _cache.GetOrAdd(submissionId, new ConcurrentDictionary<string, Lazy<SdkResult>>(MSBuildNameIgnoreCaseComparer.Default));
+                ConcurrentDictionary<string, Lazy<SdkResult>> cached = _cache.GetOrAdd(
+                    submissionId,
+                    _ => new ConcurrentDictionary<string, Lazy<SdkResult>>(MSBuildNameIgnoreCaseComparer.Default));
 
                 /*
                  * Get a Lazy<SdkResult> if available, otherwise create a Lazy<SdkResult> which will resolve the SDK with the SdkResolverService.Instance.  If multiple projects are attempting to resolve

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -247,7 +247,9 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             // Do not set state for resolution requests that are not associated with a valid build submission ID
             if (submissionId != BuildEventContext.InvalidSubmissionId)
             {
-                ConcurrentDictionary<SdkResolver, object> resolverState = _resolverStateBySubmission.GetOrAdd(submissionId, new ConcurrentDictionary<SdkResolver, object>(NativeMethodsShared.GetLogicalCoreCount(), _resolvers.Count));
+                ConcurrentDictionary<SdkResolver, object> resolverState = _resolverStateBySubmission.GetOrAdd(
+                    submissionId,
+                    _ => new ConcurrentDictionary<SdkResolver, object>(NativeMethodsShared.GetLogicalCoreCount(), _resolvers.Count));
 
                 resolverState.AddOrUpdate(resolver, state, (sdkResolver, obj) => state);
             }

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -236,18 +236,13 @@ namespace Microsoft.Build.Internal
             return file => matchers.Any(m => m.Value.IsMatch(file));
         }
 
-        internal class IOCache
+        internal sealed class IOCache
         {
             private readonly Lazy<ConcurrentDictionary<string, bool>> existenceCache = new Lazy<ConcurrentDictionary<string, bool>>(() => new ConcurrentDictionary<string, bool>(), true);
 
-            public virtual bool DirectoryExists(string directory)
+            public bool DirectoryExists(string directory)
             {
-                return existenceCache.Value.GetOrAdd(directory, Directory.Exists);
-            }
-
-            public virtual bool FileExists(string file)
-            {
-                return existenceCache.Value.GetOrAdd(file, File.Exists);
+                return existenceCache.Value.GetOrAdd(directory, directory => Directory.Exists(directory));
             }
         }
     }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -903,7 +903,7 @@ namespace Microsoft.Build.Shared
                 fileSystem ??= DefaultFileSystem;
 
                 return Traits.Instance.CacheFileExistence
-                    ? FileExistenceCache.GetOrAdd(fullPath, fileSystem.DirectoryExists)
+                    ? FileExistenceCache.GetOrAdd(fullPath, fullPath => fileSystem.DirectoryExists(fullPath))
                     : fileSystem.DirectoryExists(fullPath);
             }
             catch
@@ -927,7 +927,7 @@ namespace Microsoft.Build.Shared
                 fileSystem ??= DefaultFileSystem;
 
                 return Traits.Instance.CacheFileExistence
-                    ? FileExistenceCache.GetOrAdd(fullPath, fileSystem.FileExists)
+                    ? FileExistenceCache.GetOrAdd(fullPath, fullPath => fileSystem.FileExists(fullPath))
                     : fileSystem.FileExists(fullPath);
             }
             catch
@@ -951,7 +951,7 @@ namespace Microsoft.Build.Shared
                 fileSystem ??= DefaultFileSystem;
 
                 return Traits.Instance.CacheFileExistence
-                    ? FileExistenceCache.GetOrAdd(fullPath, fileSystem.FileOrDirectoryExists)
+                    ? FileExistenceCache.GetOrAdd(fullPath, fullPath => fileSystem.FileOrDirectoryExists(fullPath))
                     : fileSystem.FileOrDirectoryExists(fullPath);
             }
             catch


### PR DESCRIPTION
### Context

Fixing a few places where we allocated objects unnecessarily. This is by no means exhaustive.

### Changes Made

- `GetOrAdd` should be given a delegate to a method that creates a new object, not the new object itself. Otherwise we allocate and throw away the object in the "Get" case.
- When passing a callbacks to a method, a lambda expression should be used even if all arguments are passed-through. Otherwise a new delegate object is allocated on each invocation. Lambdas are cached in static fields by the compiler.

### Testing

Existing unit tests.