### PR TITLE
Remove pinned .NET Framework ref assembly package: let SDK provide it

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -44,10 +44,6 @@
     <PackageReference Update="xunit.core" Version="$(XUnitVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
-  </ItemGroup>
-
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" PrivateAssets="All" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(MicrosoftCodeAnalysisBannedApiAnalyzersVersion)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6935

### Context
See https://github.com/dotnet/msbuild/pull/6966#issuecomment-949888555

### Changes Made
Remove the package reference on `Microsoft.NETFramework.ReferenceAssemblies/1.0.0`, which should let the SDK provide a `Microsoft.NETFramework.ReferenceAssemblies/1.0.2` (or higher) reference.

### Testing
Built on Fedora 33 Linux with `./build.sh`.

@KirillOsenkov Can you give this a shot?