### PR TITLE
Simplify property/item type requirements Fixes #6985

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.Evaluation
                 _matchOnMetadata = builder.MatchOnMetadata.ToImmutable();
 
                 ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(
-                    _matchOnMetadata.IsEmpty || _itemSpec.Fragments.All(f => f is ItemSpec<ProjectProperty, ProjectItem>.ItemExpressionFragment),
+                    _matchOnMetadata.IsEmpty || _itemSpec.Fragments.All(f => f is ItemSpec<P, I>.ItemExpressionFragment),
                     new BuildEventFileInfo(string.Empty),
                     "OM_MatchOnMetadataIsRestrictedToReferencedItems");
 


### PR DESCRIPTION
Fixes #6985

### Context
RemoveOperation currently requires either not MatchOnMetadata or that the fragments are ItemSpec<ProjectProperty, ProjectItem>.ItemExpressionFragments. The latter is how we do it in tests, but in the wild, we use ProjectPropertyInstance and ProjectItemInstance. It sounds like those two should extend the other two, but they don't. I think it would be valid to make them do so, but this is a minimal change that resolves the issue such that it passes both tests and the repro case in #6985 by essentially letting how Remove is invoked dictate what the type has to be.

### Changes Made
Switch to generic P and I.

### Testing
Unit tests + verified the repro case no longer repros.