### PR TITLE
Check if Documentis null before creating elementlocation object

### DIFF
--- a/src/Build/ElementLocation/XmlAttributeWithLocation.cs
+++ b/src/Build/ElementLocation/XmlAttributeWithLocation.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Build.Construction
             {
                 // Caching the element location object saves significant memory
                 XmlDocumentWithLocation ownerDocumentWithLocation = (XmlDocumentWithLocation)OwnerDocument;
-                if (!String.Equals(_elementLocation.File, ownerDocumentWithLocation.FullPath, StringComparison.OrdinalIgnoreCase))
+                if (!string.IsNullOrEmpty(ownerDocumentWithLocation.FullPath) && !String.Equals(_elementLocation.File, ownerDocumentWithLocation.FullPath, StringComparison.OrdinalIgnoreCase))
                 {
                     _elementLocation = ElementLocation.Create(ownerDocumentWithLocation.FullPath, _elementLocation.Line, _elementLocation.Column);
                 }

--- a/src/Build/ElementLocation/XmlAttributeWithLocation.cs
+++ b/src/Build/ElementLocation/XmlAttributeWithLocation.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Build.Construction
             {
                 // Caching the element location object saves significant memory
                 XmlDocumentWithLocation ownerDocumentWithLocation = (XmlDocumentWithLocation)OwnerDocument;
-                if (!string.IsNullOrEmpty(ownerDocumentWithLocation.FullPath) && !String.Equals(_elementLocation.File, ownerDocumentWithLocation.FullPath, StringComparison.OrdinalIgnoreCase))
+                if (!String.Equals(_elementLocation.File, ownerDocumentWithLocation.FullPath ?? String.Empty, StringComparison.OrdinalIgnoreCase))
                 {
                     _elementLocation = ElementLocation.Create(ownerDocumentWithLocation.FullPath, _elementLocation.Line, _elementLocation.Column);
                 }

--- a/src/Build/ElementLocation/XmlElementWithLocation.cs
+++ b/src/Build/ElementLocation/XmlElementWithLocation.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Build.Construction
             {
                 // Caching the element location object saves significant memory
                 XmlDocumentWithLocation ownerDocumentWithLocation = (XmlDocumentWithLocation)OwnerDocument;
-                if (!string.IsNullOrEmpty(ownerDocumentWithLocation.FullPath) && !String.Equals(_elementLocation.File, ownerDocumentWithLocation.FullPath, StringComparison.OrdinalIgnoreCase))
+                if (!String.Equals(_elementLocation.File, ownerDocumentWithLocation.FullPath ?? String.Empty, StringComparison.OrdinalIgnoreCase))
                 {
                     _elementLocation = ElementLocation.Create(ownerDocumentWithLocation.FullPath, _elementLocation.Line, _elementLocation.Column);
                 }

--- a/src/Build/ElementLocation/XmlElementWithLocation.cs
+++ b/src/Build/ElementLocation/XmlElementWithLocation.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Build.Construction
             {
                 // Caching the element location object saves significant memory
                 XmlDocumentWithLocation ownerDocumentWithLocation = (XmlDocumentWithLocation)OwnerDocument;
-                if (!String.Equals(_elementLocation.File, ownerDocumentWithLocation.FullPath, StringComparison.OrdinalIgnoreCase))
+                if (!string.IsNullOrEmpty(ownerDocumentWithLocation.FullPath) && !String.Equals(_elementLocation.File, ownerDocumentWithLocation.FullPath, StringComparison.OrdinalIgnoreCase))
                 {
                     _elementLocation = ElementLocation.Create(ownerDocumentWithLocation.FullPath, _elementLocation.Line, _elementLocation.Column);
                 }


### PR DESCRIPTION
### Context
When ownerDocumentWithLocation.FullPath is null, then ElementLocation is always created.  This is because ElementLocation.Empty.File is " " (empty not null).
This can occurs when a project is created from memory or loaded from a stream which loses all file information.  

### Changes Made
Add null check.

### Testing
Standard unittest

### Notes
