### PR TITLE
Attempt to prevent node explosions with parallel node creation

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Build.BackEnd
         {
             ErrorUtilities.VerifyThrowArgumentNull(factory, nameof(factory));
 
-            if (_nodeContexts.Count == ComponentHost.BuildParameters.MaxNodeCount)
+            if (_nodeContexts.Count >= ComponentHost.BuildParameters.MaxNodeCount)
             {
                 ErrorUtilities.ThrowInternalError("All allowable nodes already created ({0}).", _nodeContexts.Count);
                 return false;

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -498,7 +498,7 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrowArgumentNull(factory, nameof(factory));
             ErrorUtilities.VerifyThrow(!_nodeIdToPacketFactory.ContainsKey((int)hostContext), "We should not already have a factory for this context!  Did we forget to call DisconnectFromHost somewhere?");
 
-            if (AvailableNodes == 0)
+            if (AvailableNodes <= 0)
             {
                 ErrorUtilities.ThrowInternalError("All allowable nodes already created ({0}).", _nodeContexts.Count);
                 return false;


### PR DESCRIPTION
### Context
A long time ago, I was struggling with a bug in which we created thousands of MSBuild nodes. ~~Looking at our code for creating nodes, we fail early in NodeProviderOutOfProc if (_nodeContexts.Count == ComponentHost.BuildParameters.MaxNodeCount). We have an equivalent check in NodeProviderOutOfProcTaskHost. We don't in NodeProviderInProc, presumably because we shouldn't ever have > 1 in proc node.~~

Actually, I don't think this is true because _nodeContexts aren't shared between providers. That said, rainersigwald pointed out this is still helpful if we parallelize this.

I'm wondering if the explosion might be avertable by changing the ​==​ to ​>=​. If we haven't used the in-proc node for whatever reason and we use MaxNodeCount nodes, and then we create an in-proc node, we'd have MaxNodeCount + 1 nodes, and we could spiral out of control because the `==` checks would no longer be valid.

### Changes Made
Switched equality to >= or <= as appropriate.

### Testing
None. I'm not exactly sure how to set up a situation in which the in-proc node isn't there until MaxNodeCount has been exhausted, then decides to be used. Could happen also if the in-proc node dies for some reason, but I think that would kill the build.

### Notes
Maybe not useful; not sure, but it seemed like an easy and possibly impactful change. Computer deaths can be really frustrating.