### PR TITLE
Permit individually settable search paths

### DIFF
--- a/documentation/wiki/ResolveAssemblyReference.md
+++ b/documentation/wiki/ResolveAssemblyReference.md
@@ -145,6 +145,21 @@ There were recent fixes made to RAR to alleviate the situation. You can control 
     DoNotCopyLocalIfInGac="$(DoNotCopyLocalIfInGac)"
 ```
 
+## AssemblySearchPaths
+There are two ways to customize the list of paths RAR will search in attempting to locate an assembly. To fully customize the list, the property `AssemblySearchPaths` can be set ahead of time. Note that the order matters; if an assembly is in two locations, RAR will stop after it finds it at the first location.
+
+By default, there are ten locations RAR will search (four if using the .NET SDK), and each can be disabled by setting the relevant flag to false:
+1. Searching files from the current project is disabled by setting the `AssemblySearchPathUseCandidateAssemblyFiles` property to false.
+2. Searching the reference path property (from a .user file) is disabled by setting the `AssemblySearchPathUseReferencePath` property to false.
+3. Using the hint path from the item is disabled by setting the `AssemblySearchPathUseHintPathFromItem` property to false.
+4. Using the directory with MSBuild's target runtime is disabled by setting the `AssemblySearchPathUseTargetFrameworkDirectory` property to false.
+5. Searching assembly folders from AssemblyFolders.config is disabled by setting the `AssemblySearchPathUseAssemblyFoldersConfigFileSearchPath` property to false.
+6. Searching the registry is disabled by setting the `AssemblySearchPathUseRegistry` property to false.
+7. Searching legacy registered assembly folders is disabled by setting the `AssemblySearchPathUseAssemblyFolders` property to false.
+8. Looking in the GAC is disabled by setting the `AssemblySearchPathUseGAC` property to false.
+9. Treating the reference's Include as a real file name is disabled by setting the `AssemblySearchPathUseRawFileName` property to false.
+10. Checking the application's output folder is disabled by setting the `AssemblySearchPathUseOutDir` property to false.
+
 ## There was a conflict
 
 A common situation is MSBuild gives a warning about different versions of the same assembly being used by different references. The solution often involves adding a binding redirect to the app.config file. 

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -3020,6 +3020,33 @@ elementFormDefault="qualified">
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
+    <xs:element name="AssemblySearchPaths" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation>
+                Semicolon-delimited ordered list of paths to search when the ResolveAssemblyReference task looks for an assembly. Some non-path locations like the Global Assembly Cache can also be searched using curly braces: {GAC}.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseCandidateAssemblyFiles" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseReferencePath" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseHintPathFromItem" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseTargetFrameworkDirectory" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseAssemblyFoldersConfigFileSearchPath" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseRegistry" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseAssemblyFolders" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseGAC" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseRawFileName" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
+    <xs:element name="AssemblySearchPathUseOutDir" type="msb:boolean" substitutionGroup="msb:Property">
+    </xs:element>
     <xs:element name="ResolveAssemblyReference" substitutionGroup="msb:Task">
         <xs:complexType>
             <xs:complexContent>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -575,33 +575,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <TargetPlatformRegistryBase Condition="'$(TargetPlatformRegistryBase)' == ''">Software\Microsoft\Microsoft SDKs\$(TargetPlatformIdentifier)</TargetPlatformRegistryBase>
     <AssemblyFoldersConfigFile Condition="'$(AssemblyFoldersConfigFile)' == ''">$([MSBuild]::GetToolsDirectory32())\AssemblyFolders.config</AssemblyFoldersConfigFile>
     <AssemblyFoldersConfigFileSearchPath Condition="Exists('$(AssemblyFoldersConfigFile)')">{AssemblyFoldersFromConfig:$(AssemblyFoldersConfigFile),$(TargetFrameworkVersion)};</AssemblyFoldersConfigFileSearchPath>
-    <!--
-        The SearchPaths property is set to find assemblies in the following order:
-
-            (1) Files from current project - indicated by {CandidateAssemblyFiles}
-            (2) $(ReferencePath) - the reference path property, which comes from the .USER file.
-            (3) The hintpath from the referenced item itself, indicated by {HintPathFromItem}.
-            (4) The directory of MSBuild's "target" runtime from GetFrameworkPath.
-                The "target" runtime folder is the folder of the runtime that MSBuild is a part of.
-            (5) Registered assembly folders, indicated by {Registry:*,*,*}
-            (6) Assembly folders from AssemblyFolders.config file (provided by Visual Studio Dev15+).
-            (7) Legacy registered assembly folders, indicated by {AssemblyFolders}
-            (8) Resolve to the GAC.
-            (9) Treat the reference's Include as if it were a real file name.
-            (10) Look in the application's output folder (like bin\debug)
-        -->
-    <AssemblySearchPaths Condition=" '$(AssemblySearchPaths)' == ''">
-      {CandidateAssemblyFiles};
-      $(ReferencePath);
-      {HintPathFromItem};
-      {TargetFrameworkDirectory};
-      $(AssemblyFoldersConfigFileSearchPath)
-      {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
-      {AssemblyFolders};
-      {GAC};
-      {RawFileName};
-      $(OutDir)
-    </AssemblySearchPaths>
 
     <!--
         These are the extensions that assembly reference resolution will consider for resolution.
@@ -632,6 +605,34 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         For example :   Full;Complete;AllThere
         -->
     <FullReferenceAssemblyNames Condition="'$(FullReferenceAssemblyNames)' == ''">Full</FullReferenceAssemblyNames>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(AssemblySearchPaths) == ''">
+    <!--
+        The SearchPaths property is set to find assemblies in the following order:
+
+            (1) Files from current project - indicated by {CandidateAssemblyFiles}
+            (2) $(ReferencePath) - the reference path property, which comes from the .USER file.
+            (3) The hintpath from the referenced item itself, indicated by {HintPathFromItem}.
+            (4) The directory of MSBuild's "target" runtime from GetFrameworkPath.
+                The "target" runtime folder is the folder of the runtime that MSBuild is a part of.
+            (5) Registered assembly folders, indicated by {Registry:*,*,*}
+            (6) Assembly folders from AssemblyFolders.config file (provided by Visual Studio Dev15+).
+            (7) Legacy registered assembly folders, indicated by {AssemblyFolders}
+            (8) Resolve to the GAC.
+            (9) Treat the reference's Include as if it were a real file name.
+            (10) Look in the application's output folder (like bin\debug)
+        -->
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseCandidateAssemblyFiles) != 'false'">{CandidateAssemblyFiles}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseReferencePath) != 'false'">$(AssemblySearchPaths);$(ReferencePath)</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseHintPathFromItem) != 'false'">$(AssemblySearchPaths);{HintPathFromItem}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseTargetFrameworkDirectory) != 'false'">$(AssemblySearchPaths);{TargetFrameworkDirectory}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseAssemblyFoldersConfigFileSearchPath) != 'false'">$(AssemblySearchPaths);$(AssemblyFoldersConfigFileSearchPath)</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseRegistry) != 'false'">$(AssemblySearchPaths);{Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseAssemblyFolders) != 'false'">$(AssemblySearchPaths);{AssemblyFolders}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseGAC) != 'false'">$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseRawFileName) != 'false'">$(AssemblySearchPaths);{RawFileName}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="$(AssemblySearchPathUseOutDir) != 'false'">$(AssemblySearchPaths);$(OutDir)</AssemblySearchPaths>
   </PropertyGroup>
 
   <!-- ContinueOnError takes 3 values:  WarnAndContinue (true), ErrorAndStop (false), and ErrorAndContinue.

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -616,8 +616,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             (3) The hintpath from the referenced item itself, indicated by {HintPathFromItem}.
             (4) The directory of MSBuild's "target" runtime from GetFrameworkPath.
                 The "target" runtime folder is the folder of the runtime that MSBuild is a part of.
-            (5) Registered assembly folders, indicated by {Registry:*,*,*}
-            (6) Assembly folders from AssemblyFolders.config file (provided by Visual Studio Dev15+).
+            (5) Assembly folders from AssemblyFolders.config file (provided by Visual Studio Dev15+).
+            (6) Registered assembly folders, indicated by {Registry:*,*,*}
             (7) Legacy registered assembly folders, indicated by {AssemblyFolders}
             (8) Resolve to the GAC.
             (9) Treat the reference's Include as if it were a real file name.


### PR DESCRIPTION
Fixes #3784

### Context
AssemblySearchPaths are currently set using a property (not an item because order often matters) in which either the user sets all of them or the user accepts the default. This allows the user to accept some or most of the default without accepting all of it.

It may also be reasonable to add:

```XML
<AssemblySearchPaths Condition="'$(CustomAssemblySearchPaths)' != ''">$(AssemblySearchPaths);$(CustomAssemblySearchPaths)</AssemblySearchPaths>
```

though that would only allow users to add custom paths at the predefined spot, so it may not be too helpful. I'm also unsure if it would be most likely to be used if it's first, last, or just before OutDir.