### PR TITLE
Preventing warning in bootstrapper package self contained scenario

### DIFF
--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -2091,7 +2091,10 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                     }
 
                     // If the public key in the file doesn't match the public key on disk, issue a build warning
-                    if (publicKey?.Equals(publicKeyAttribute.Value, StringComparison.OrdinalIgnoreCase) == false)
+                    // Skip this check if the public key attribute is "0", as this means we're expecting the public key
+                    // comparison to be skipped at install time because the file is signed by an MS trusted cert.
+                    if (publicKeyAttribute.Value.Equals("0", StringComparison.OrdinalIgnoreCase) == false &&
+                        publicKey?.Equals(publicKeyAttribute.Value, StringComparison.OrdinalIgnoreCase) == false)
                     {
                         results?.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Warning, "GenerateBootstrapper.DifferingPublicKeys", PUBLICKEY_ATTRIBUTE, builder.Name, fileSource));
                     }


### PR DESCRIPTION
For 16.9 we made a change where bootstrapper packages can specify "0" for the public key value of a downloaded file and this will cause the bootstrapper to skip the public key comparison as long as the file is signed with a trusted MS cert.  However, we didn't account for the scenario where a user wants to create a self contained bootstrapper, meaning it will include a copy of the package's installer.  In this scenario we still perform the public key comparison and give a build warning when they don't match.  This change skips this check when the package specifies 0 for the public key of the file in question.

### Context
See the following thread: https://docs.microsoft.com/en-us/answers/questions/583383/publickey-token-warning-building-net-core-50-insta.html?childToView=602746#comment-602746

### Changes Made
Skipping a check when a package's PublicKey value is set to "0".

### Testing
Verified we no longer give this warning in this scenario, and that we still give it when the public key is non-zero and doesn't match the file on disk.
