### PR TITLE
Use cached StringBuilder in CreateManifestResourceName

### DIFF
--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.IO;
-using System.Text;
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
@@ -114,7 +113,7 @@ namespace Microsoft.Build.Tasks
                 info.culture = culture;
             }
 
-            var manifestName = new StringBuilder();
+            var manifestName = StringBuilderCache.Acquire();
             if (binaryStream != null)
             {
                 // Resource depends on a form. Now, get the form's class name fully 
@@ -212,7 +211,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            return manifestName.ToString();
+            return StringBuilderCache.GetStringAndRelease(manifestName);
         }
 
         /// <summary>

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.IO;
-using System.Text;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -111,7 +111,7 @@ namespace Microsoft.Build.Tasks
                 info.culture = culture;
             }
 
-            var manifestName = new StringBuilder();
+            var manifestName = StringBuilderCache.Acquire();
             if (binaryStream != null)
             {
                 // Resource depends on a form. Now, get the form's class name fully 
@@ -192,7 +192,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            return manifestName.ToString();
+            return StringBuilderCache.GetStringAndRelease(manifestName);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #5551

### Context

Addressing a small inefficiency pointed out in #5551. If the task is given multiple resource files it wastefully creates a new `StringBuilder` for each.

### Changes Made

Reuse a cached `StringBuilder` when creating resource names.

### Testing

Existing unit tests.

### Notes

- The `StringBuilder` is not used "append-only" so this is *not* a good fit for `SpanBasedStringBuilder`.
- I did not put the release call inside a finally block because if the code throws an exception "leaking" a `StringBuilder` is not a big deal with very minor perf impact compared to the exception handling machinery.