### PR TITLE
CurrentHost was not properly set when DisableInProcNode = false

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -590,7 +590,7 @@ namespace Microsoft.Build.BackEnd
 #if RUNTIME_TYPE_NETCORE || MONO
             if (CurrentHost == null)
             {
-                string dotnetExe = Path.Combine(FileUtilities.GetFolderAbove(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, 2),
+                string dotnetExe = Path.Combine(FileUtilities.GetFolderAbove(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, 2),
                     NativeMethodsShared.IsWindows ? "dotnet.exe" : "dotnet");
                 if (File.Exists(dotnetExe))
                 {


### PR DESCRIPTION
Fixes #6782
Follow-up of #6890

### Context
Tried `DisableInProcNode = false` and couldn't make it work.
After some investigations, it turns out the code in `NodeProviderOutOfProcBase.GetCurrentHost()` has some issues:

https://github.com/dotnet/msbuild/blob/24b33188f385cee07804cc63ec805216b3f8b72f/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs#L593

In my case, `CurrentMSBuildToolsDirectory` returns `C:\Program Files\dotnet\sdk\6.0.100\MSBuild.dll`.
`FileUtilities.GetFolderAbove()` 2 levels makes it try to resolve `dotnet.exe` from `C:\Program Files\dotnet\sdk\dotnet.exe` instead of `C:\Program Files\dotnet\dotnet.exe`.
I believe this is because the filename itself was not taken into account (it counts as 1 extra step for `FileUtilities.GetFolderAbove()`)

### Changes Made
Used `CurrentMSBuildToolsDirectory` rather than `CurrentMSBuildExePath`.
Another option would be to use 3 for `FileUtilities.GetFolderAbove`, but since the function explicitely contains "folder" in its name, I preferred to avoid the case where it is later changed to ignore the top-level file rather than considering it as a folder.

### Testing
I tested with a simple console app.
(Note: without being careful it could quickly crash the PC as mentioned in #6782 because it calls itself in infinite loop (instead of `dotnet.exe`), unless you add some check on `args.Length` as done in this test code)

```C#
using Microsoft.Build.Execution;
using Microsoft.Build.Locator;

// Avoid infinite loop => system crash (until MSBuild bug to properly resolve dotnet.exe is fixed)
if (args.Length > 0) return;

var projectPath = @"C:\dev\ConsoleApp8\ConsoleApp8.csproj";

MSBuildLocator.RegisterDefaults();
RunTest();

void RunTest()
{
    var mainBuildManager = new BuildManager();
    var pc = new Microsoft.Build.Evaluation.ProjectCollection();
    var parameters = new BuildParameters(pc) { DisableInProcNode = true };

    // Run a MSBuild /t:Restore <projectfile>
    var request = new BuildRequestData(projectPath, new Dictionary<string, string>(), null, new[] { "Restore" }, null, BuildRequestDataFlags.None);
    mainBuildManager.Build(parameters, request);
}
```

### Notes
