### PR TITLE
Add enumeration values for CopyToOutputDirectory in XSD

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -738,6 +738,16 @@ elementFormDefault="qualified">
                             <xs:documentation><!-- _locID_text="Compile_Include" _locComment="" -->Semi-colon separated list of source files (wildcards are allowed)</xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
+                    <!-- metadata may be defined as nested elements (as above) or as attributes (as below), so we duplicate these entries -->
+                    <xs:attribute name="CopyToOutputDirectory">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="Never" />
+                                <xs:enumeration value="Always" />
+                                <xs:enumeration value="PreserveNewest" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>
@@ -795,6 +805,16 @@ elementFormDefault="qualified">
                         <xs:annotation>
                             <xs:documentation><!-- _locID_text="EmbeddedResource_Include" _locComment="" -->Semi-colon separated list of resource files (wildcards are allowed)</xs:documentation>
                         </xs:annotation>
+                    </xs:attribute>
+                    <!-- metadata may be defined as nested elements (as above) or as attributes (as below), so we duplicate these entries -->
+                    <xs:attribute name="CopyToOutputDirectory">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="Never" />
+                                <xs:enumeration value="Always" />
+                                <xs:enumeration value="PreserveNewest" />
+                            </xs:restriction>
+                        </xs:simpleType>
                     </xs:attribute>
                 </xs:extension>
             </xs:complexContent>
@@ -867,6 +887,16 @@ elementFormDefault="qualified">
                             <xs:documentation><!-- _locID_text="Content_Include" _locComment="" -->Semi-colon separated list of content files (wildcards are allowed)</xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
+                    <!-- metadata may be defined as nested elements (as above) or as attributes (as below), so we duplicate these entries -->
+                    <xs:attribute name="CopyToOutputDirectory">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="Never" />
+                                <xs:enumeration value="Always" />
+                                <xs:enumeration value="PreserveNewest" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>
@@ -914,6 +944,16 @@ elementFormDefault="qualified">
                         <xs:annotation>
                             <xs:documentation><!-- _locID_text="Page_Include" _locComment="" -->Semi-colon separated list of XAML files (wildcards are allowed)</xs:documentation>
                         </xs:annotation>
+                    </xs:attribute>
+                    <!-- metadata may be defined as nested elements (as above) or as attributes (as below), so we duplicate these entries -->
+                    <xs:attribute name="CopyToOutputDirectory">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="Never" />
+                                <xs:enumeration value="Always" />
+                                <xs:enumeration value="PreserveNewest" />
+                            </xs:restriction>
+                        </xs:simpleType>
                     </xs:attribute>
                 </xs:extension>
             </xs:complexContent>
@@ -963,6 +1003,16 @@ elementFormDefault="qualified">
                             <xs:documentation><!-- _locID_text="Resource_Include" _locComment="" -->Semi-colon separated list of files (wildcards are allowed)</xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
+                    <!-- metadata may be defined as nested elements (as above) or as attributes (as below), so we duplicate these entries -->
+                    <xs:attribute name="CopyToOutputDirectory">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="Never" />
+                                <xs:enumeration value="Always" />
+                                <xs:enumeration value="PreserveNewest" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>
@@ -1005,6 +1055,16 @@ elementFormDefault="qualified">
                             </xs:element>
                         </xs:choice>
                     </xs:sequence>
+                    <!-- metadata may be defined as nested elements (as above) or as attributes (as below), so we duplicate these entries -->
+                    <xs:attribute name="CopyToOutputDirectory">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="Never" />
+                                <xs:enumeration value="Always" />
+                                <xs:enumeration value="PreserveNewest" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -720,7 +720,15 @@ elementFormDefault="qualified">
                                     <xs:documentation><!-- _locID_text="Compile_InProject" _locComment="" -->Display in user interface (optional, boolean)</xs:documentation>
                                 </xs:annotation>
                             </xs:element>
-                            <xs:element name="CopyToOutputDirectory"/>
+                            <xs:element name="CopyToOutputDirectory">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Never" />
+                                        <xs:enumeration value="Always" />
+                                        <xs:enumeration value="PreserveNewest" />
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
                             <xs:element name="VBMyExtensionTemplateID"/>
                         </xs:choice>
                     </xs:sequence>
@@ -770,7 +778,15 @@ elementFormDefault="qualified">
                                 </xs:annotation>
                             </xs:element>
                             <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory"/>
+                            <xs:element name="CopyToOutputDirectory">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Never" />
+                                        <xs:enumeration value="Always" />
+                                        <xs:enumeration value="PreserveNewest" />
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
                             <xs:element name="LogicalName"/>
                         </xs:choice>
                     </xs:sequence>
@@ -819,15 +835,29 @@ elementFormDefault="qualified">
                                 </xs:annotation>
                             </xs:element>
                             <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory" type="msb:boolean">
+                            <xs:element name="CopyToOutputDirectory">
                                 <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Content_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)</xs:documentation>
+                                    <xs:documentation><!-- _locID_text="Content_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, default Never)</xs:documentation>
                                 </xs:annotation>
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Never" />
+                                        <xs:enumeration value="Always" />
+                                        <xs:enumeration value="PreserveNewest" />
+                                    </xs:restriction>
+                                </xs:simpleType>
                             </xs:element>
-                            <xs:element name="CopyToPublishDirectory" type="msb:boolean">
+                            <xs:element name="CopyToPublishDirectory">
                                 <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Content_CopyToPublishDirectory" _locComment="" -->Copy file to publish directory (optional, boolean, default false)</xs:documentation>
+                                    <xs:documentation><!-- _locID_text="Content_CopyToPublishDirectory" _locComment="" -->Copy file to publish directory (optional, default Never)</xs:documentation>
                                 </xs:annotation>
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Never" />
+                                        <xs:enumeration value="Always" />
+                                        <xs:enumeration value="PreserveNewest" />
+                                    </xs:restriction>
+                                </xs:simpleType>
                             </xs:element>
                         </xs:choice>
                     </xs:sequence>
@@ -865,10 +895,17 @@ elementFormDefault="qualified">
                             </xs:element>
                             <xs:element name="Group"/>
                             <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory" type="msb:boolean">
+                            <xs:element name="CopyToOutputDirectory">
                                 <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Page_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)</xs:documentation>
+                                    <xs:documentation><!-- _locID_text="Page_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, Never, PreserveNewest or Always, default Never)</xs:documentation>
                                 </xs:annotation>
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Never" />
+                                        <xs:enumeration value="Always" />
+                                        <xs:enumeration value="PreserveNewest" />
+                                    </xs:restriction>
+                                </xs:simpleType>
                             </xs:element>
                         </xs:choice>
                     </xs:sequence>
@@ -906,10 +943,17 @@ elementFormDefault="qualified">
                             </xs:element>
                             <xs:element name="Group"/>
                             <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory" type="msb:boolean">
+                            <xs:element name="CopyToOutputDirectory">
                                 <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Resource_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)</xs:documentation>
+                                    <xs:documentation><!-- _locID_text="Resource_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, default Never)</xs:documentation>
                                 </xs:annotation>
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Never" />
+                                        <xs:enumeration value="Always" />
+                                        <xs:enumeration value="PreserveNewest" />
+                                    </xs:restriction>
+                                </xs:simpleType>
                             </xs:element>
                         </xs:choice>
                     </xs:sequence>
@@ -947,10 +991,17 @@ elementFormDefault="qualified">
                             </xs:element>
                             <xs:element name="Group"/>
                             <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory" type="msb:boolean">
+                            <xs:element name="CopyToOutputDirectory">
                                 <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="ApplicationDefinition_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)</xs:documentation>
+                                    <xs:documentation><!-- _locID_text="ApplicationDefinition_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, default Never)</xs:documentation>
                                 </xs:annotation>
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Never" />
+                                        <xs:enumeration value="Always" />
+                                        <xs:enumeration value="PreserveNewest" />
+                                    </xs:restriction>
+                                </xs:simpleType>
                             </xs:element>
                         </xs:choice>
                     </xs:sequence>
@@ -985,7 +1036,15 @@ elementFormDefault="qualified">
                                     <xs:documentation><!-- _locID_text="None_InProject" _locComment="" -->Display in user interface (optional, boolean)</xs:documentation>
                                 </xs:annotation>
                             </xs:element>
-                            <xs:element name="CopyToOutputDirectory"/>
+                            <xs:element name="CopyToOutputDirectory">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Never" />
+                                        <xs:enumeration value="Always" />
+                                        <xs:enumeration value="PreserveNewest" />
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
                         </xs:choice>
                     </xs:sequence>
                 </xs:extension>


### PR DESCRIPTION
### Context

The `CopyToOutputDirectory` property only supports values `Never`, `Always` or `PreserveNewest`.

MSBuild provides an XSD file that drives IntelliSense in VS when editing project XML.

Earlier today we were debugging a broken incremental build related to the use of `Always`. It wasn't obvious what the correct value should be, as no IntelliSense was provided in VS.

### Changes Made

This change allows VS and other consumers of the XSD to suggest and validate that the provided value is valid.

The property on some item types was previously declared incorrectly as being a boolean.

### Testing

None.
