### PR TITLE
Remove reference to .NET Core 2.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,11 +4,6 @@
   },
   "tools": {
     "dotnet": "6.0.100-rc.1.21458.32",
-    "runtimes": {
-      "dotnet/x64": [
-        "2.1.7"
-      ]
-    },
     "vs": {
       "version": "16.0"
     }


### PR DESCRIPTION
We no longer target or use .NET Core 2.1 for tests so no point in downloading the runtime.