### PR TITLE
Add VS Code tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,80 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "dotnet msbuild MSBuild.Dev.slnf",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "msbuild",
+                // Ask MSBuild to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary",
+                "${workspaceFolder}/MSBuild.Dev.slnf"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "revealProblems": "onProblem"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "full build",
+            "command": "${workspaceFolder}/build.sh",
+            "type": "shell",
+            "windows": {
+                "command": "cmd.exe",
+                "type": "process",
+                "args": [
+                    "/d",
+                    "/c",
+                    "${workspaceFolder}/build.cmd"
+                ]
+            },
+            "args": [
+                "-bl",
+                "/property:CreateBootstrap=true",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "revealProblems": "onProblem"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build -test",
+            "command": "${workspaceFolder}/build.sh",
+            "type": "shell",
+            "windows": {
+                "command": "cmd.exe",
+                "type": "process",
+                "args": [
+                    "/d",
+                    "/c",
+                    "${workspaceFolder}/build.cmd"
+                ]
+            },
+            "args": [
+                "-test",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "revealProblems": "onProblem"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
These are the main scenarios I want quick access to.

This came in handy when iterating with a bajillion errors across the whole codebase in #7016.