### PR TITLE
Update mac version for CI

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -197,7 +197,7 @@ jobs:
 - job: CoreOnMac
   displayName: "macOS Core"
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build


### PR DESCRIPTION
macOS-10.14 is being deprecated December 2021.

https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/