### PR TITLE
Improve globbing performance

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1560,10 +1560,10 @@ namespace Microsoft.Build.Globbing
         public static Microsoft.Build.Globbing.MSBuildGlob Parse(string fileSpec) { throw null; }
         public static Microsoft.Build.Globbing.MSBuildGlob Parse(string globRoot, string fileSpec) { throw null; }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct MatchInfoResult
+        public readonly partial struct MatchInfoResult
         {
-            private object _dummy;
-            private int _dummyPrimitive;
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
             public string FilenamePartMatchGroup { get { throw null; } }
             public string FixedDirectoryPartMatchGroup { get { throw null; } }
             public bool IsMatch { get { throw null; } }

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1542,6 +1542,7 @@ namespace Microsoft.Build.Globbing
         public CompositeGlob(params Microsoft.Build.Globbing.IMSBuildGlob[] globs) { }
         public CompositeGlob(System.Collections.Generic.IEnumerable<Microsoft.Build.Globbing.IMSBuildGlob> globs) { }
         public System.Collections.Generic.IEnumerable<Microsoft.Build.Globbing.IMSBuildGlob> Globs { get { throw null; } }
+        public static Microsoft.Build.Globbing.IMSBuildGlob Create(System.Collections.Generic.IEnumerable<Microsoft.Build.Globbing.IMSBuildGlob> globs) { throw null; }
         public bool IsMatch(string stringToMatch) { throw null; }
     }
     public partial interface IMSBuildGlob

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1554,10 +1554,10 @@ namespace Microsoft.Build.Globbing
         public static Microsoft.Build.Globbing.MSBuildGlob Parse(string fileSpec) { throw null; }
         public static Microsoft.Build.Globbing.MSBuildGlob Parse(string globRoot, string fileSpec) { throw null; }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct MatchInfoResult
+        public readonly partial struct MatchInfoResult
         {
-            private object _dummy;
-            private int _dummyPrimitive;
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
             public string FilenamePartMatchGroup { get { throw null; } }
             public string FixedDirectoryPartMatchGroup { get { throw null; } }
             public bool IsMatch { get { throw null; } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1536,6 +1536,7 @@ namespace Microsoft.Build.Globbing
         public CompositeGlob(params Microsoft.Build.Globbing.IMSBuildGlob[] globs) { }
         public CompositeGlob(System.Collections.Generic.IEnumerable<Microsoft.Build.Globbing.IMSBuildGlob> globs) { }
         public System.Collections.Generic.IEnumerable<Microsoft.Build.Globbing.IMSBuildGlob> Globs { get { throw null; } }
+        public static Microsoft.Build.Globbing.IMSBuildGlob Create(System.Collections.Generic.IEnumerable<Microsoft.Build.Globbing.IMSBuildGlob> globs) { throw null; }
         public bool IsMatch(string stringToMatch) { throw null; }
     }
     public partial interface IMSBuildGlob

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -3733,7 +3733,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var getAllGlobsResult = ObjectModelHelpers.CreateInMemoryProject(projectContents).GetAllGlobs();
 
-            var uberGlob = new CompositeGlob(getAllGlobsResult.Select(r => r.MsBuildGlob).ToImmutableArray());
+            var uberGlob = CompositeGlob.Create(getAllGlobsResult.Select(r => r.MsBuildGlob));
 
             foreach (var matchingString in stringsThatShouldMatch)
             {

--- a/src/Build.UnitTests/Globbing/CompositeGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/CompositeGlob_Tests.cs
@@ -138,5 +138,37 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
                 Assert.Contains(expectedGlob, leafGlobs);
             }
         }
+
+        [Fact]
+        public void CreateShouldHandleZeroChildren()
+        {
+            IMSBuildGlob composite = CompositeGlob.Create(Enumerable.Empty<IMSBuildGlob>());
+
+            Assert.False(composite.IsMatch(""));
+        }
+
+        [Fact]
+        public void CreateShouldReturnSingleChildUnchanged()
+        {
+            var glob = MSBuildGlob.Parse("");
+
+            IMSBuildGlob composite = CompositeGlob.Create(new[] { glob });
+
+            Assert.Same(glob, composite);
+        }
+
+        [Fact]
+        public void CreateShouldReturnNewCompositeWhenMultipleProvided()
+        {
+            var glob1 = MSBuildGlob.Parse("");
+            var glob2 = MSBuildGlob.Parse("");
+
+            IMSBuildGlob result = CompositeGlob.Create(new[] { glob1, glob2 });
+
+            var composite = Assert.IsType<CompositeGlob>(result);
+            Assert.Same(glob1, composite.Globs.First());
+            Assert.Same(glob2, composite.Globs.Skip(1).First());
+            Assert.Equal(2, composite.Globs.Count());
+        }
     }
 }

--- a/src/Build.UnitTests/Globbing/MSBuildGlobWithGaps_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlobWithGaps_Tests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
     public class MSBuildGlobWithGaps_Tests
     {
         [Fact]
-        public void GlobWithGapsShoulWorkWithNoGaps()
+        public void GlobWithGapsShouldWorkWithNoGaps()
         {
             var glob = new MSBuildGlobWithGaps(MSBuildGlob.Parse("a*"), Enumerable.Empty<IMSBuildGlob>());
 
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
         }
 
         [Fact]
-        public void GlobWithGapsShoulMatchIfNoGapsMatch()
+        public void GlobWithGapsShouldMatchIfNoGapsMatch()
         {
             var glob = new MSBuildGlobWithGaps(MSBuildGlob.Parse("a*"), MSBuildGlob.Parse("b*"));
 
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
         }
 
         [Fact]
-        public void GlobWithGapsShoulNotMatchIfGapsMatch()
+        public void GlobWithGapsShouldNotMatchIfGapsMatch()
         {
             var glob = new MSBuildGlobWithGaps(MSBuildGlob.Parse("a*"), MSBuildGlob.Parse("*b"));
 

--- a/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
             "../d/e/**",
             "a/b/d/e"
             )]
-        public void GlobWithRelativeFixedDirectoryPartShouldMissmatchTheGlobRoot(string globRoot, string filespec, string expectedFixedDirectoryPart)
+        public void GlobWithRelativeFixedDirectoryPartShouldMismatchTheGlobRoot(string globRoot, string filespec, string expectedFixedDirectoryPart)
         {
             var glob = MSBuildGlob.Parse(globRoot, filespec);
 

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -768,7 +768,7 @@ namespace Microsoft.Build.BackEnd
                     }
 
                     var fragments = items.SelectMany(i => ExpressionShredder.SplitSemiColonSeparatedList(i.EvaluatedInclude));
-                    var glob = new CompositeGlob(
+                    var glob = CompositeGlob.Create(
                         fragments
                             .Select(s => MSBuildGlob.Parse(Project.Directory, s)));
 

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2575,7 +2575,7 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 ImmutableArray<string> includeGlobStrings = includeGlobFragments.Select(f => f.TextFragment).ToImmutableArray();
-                var includeGlob = new CompositeGlob(includeGlobFragments.Select(f => f.ToMSBuildGlob()));
+                var includeGlob = CompositeGlob.Create(includeGlobFragments.Select(f => f.ToMSBuildGlob()));
 
                 IEnumerable<string> excludeFragmentStrings = Enumerable.Empty<string>();
                 IMSBuildGlob excludeGlob = null;
@@ -2594,7 +2594,7 @@ namespace Microsoft.Build.Evaluation
                 if (removeElementCache.TryGetValue(itemElement.ItemType, out CumulativeRemoveElementData removeItemElement))
                 {
                     removeFragmentStrings = removeItemElement.FragmentStrings;
-                    removeGlob = new CompositeGlob(removeItemElement.Globs);
+                    removeGlob = CompositeGlob.Create(removeItemElement.Globs);
                 }
 
                 var includeGlobWithGaps = CreateIncludeGlobWithGaps(includeGlob, excludeGlob, removeGlob);

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2604,17 +2604,13 @@ namespace Microsoft.Build.Evaluation
 
             private static IMSBuildGlob CreateIncludeGlobWithGaps(IMSBuildGlob includeGlob, IMSBuildGlob excludeGlob, IMSBuildGlob removeGlob)
             {
-                if (excludeGlob == null)
+                return (excludeGlob, removeGlob) switch
                 {
-                    return removeGlob == null ? includeGlob :
-                        new MSBuildGlobWithGaps(includeGlob, removeGlob);
-                }
-                else
-                {
-                    return new MSBuildGlobWithGaps(includeGlob,
-                        removeGlob == null ? excludeGlob :
-                        new CompositeGlob(excludeGlob, removeGlob));
-                }
+                    (null,     null)     => includeGlob,
+                    (not null, null)     => new MSBuildGlobWithGaps(includeGlob, excludeGlob),
+                    (null,     not null) => new MSBuildGlobWithGaps(includeGlob, removeGlob),
+                    (not null, not null) => new MSBuildGlobWithGaps(includeGlob, new CompositeGlob(excludeGlob, removeGlob))
+                };
             }
 
             private void CacheInformationFromRemoveItem(ProjectItemElement itemElement, Dictionary<string, CumulativeRemoveElementData> removeElementCache)

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Build.Evaluation
 
             protected override IMSBuildGlob CreateMsBuildGlob()
             {
-                return new CompositeGlob(ReferencedItems.Select(i => i.ItemAsValueFragment.ToMSBuildGlob()));
+                return CompositeGlob.Create(ReferencedItems.Select(i => i.ItemAsValueFragment.ToMSBuildGlob()));
             }
 
             private bool InitReferencedItemsIfNecessary()
@@ -368,7 +368,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public IMSBuildGlob ToMSBuildGlob()
         {
-            return new CompositeGlob(Fragments.Select(f => f.ToMSBuildGlob()));
+            return CompositeGlob.Create(Fragments.Select(f => f.ToMSBuildGlob()));
         }
 
         /// <summary>

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -97,6 +97,12 @@ namespace Microsoft.Build.Evaluation
 
             protected override IMSBuildGlob CreateMsBuildGlob()
             {
+                if (ReferencedItems.Count == 1)
+                {
+                    // Optimize the common case, avoiding allocation of enumerable/enumerator.
+                    return ReferencedItems[0].ItemAsValueFragment.ToMSBuildGlob();
+                }
+
                 return CompositeGlob.Create(ReferencedItems.Select(i => i.ItemAsValueFragment.ToMSBuildGlob()));
             }
 
@@ -368,6 +374,12 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public IMSBuildGlob ToMSBuildGlob()
         {
+            if (Fragments.Count == 1)
+            {
+                // Optimize the common case, avoiding allocation of enumerable/enumerator.
+                return Fragments[0].ToMSBuildGlob();
+            }
+
             return CompositeGlob.Create(Fragments.Select(f => f.ToMSBuildGlob()));
         }
 

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Build.Globbing
         public CompositeGlob(IEnumerable<IMSBuildGlob> globs)
         {
             // ImmutableArray also does this check, but copied it here just in case they remove it
-            if (globs is ImmutableArray<IMSBuildGlob>)
+            if (globs is ImmutableArray<IMSBuildGlob> immutableGlobs)
             {
-                Globs = (ImmutableArray<IMSBuildGlob>)globs;
+                Globs = immutableGlobs;
             }
 
             Globs = globs.ToImmutableArray();

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -13,27 +13,20 @@ namespace Microsoft.Build.Globbing
     /// </summary>
     public class CompositeGlob : IMSBuildGlob
     {
+        private readonly ImmutableArray<IMSBuildGlob> _globs;
+
         /// <summary>
         /// The direct children of this composite
         /// </summary>
-        public IEnumerable<IMSBuildGlob> Globs { get; }
+        public IEnumerable<IMSBuildGlob> Globs => _globs;
 
         /// <summary>
         ///     Constructor
         /// </summary>
         /// <param name="globs">Children globs. Input gets shallow cloned</param>
         public CompositeGlob(IEnumerable<IMSBuildGlob> globs)
-        {
-            // ImmutableArray also does this check, but copied it here just in case they remove it
-            if (globs is ImmutableArray<IMSBuildGlob> immutableGlobs)
-            {
-                Globs = immutableGlobs;
-            }
-            else
-            {
-                Globs = globs.ToImmutableArray();
-            }
-        }
+            : this(globs is ImmutableArray<IMSBuildGlob> immutableGlobs ? immutableGlobs : globs.ToImmutableArray())
+        {}
 
         /// <summary>
         ///     Constructor
@@ -42,13 +35,22 @@ namespace Microsoft.Build.Globbing
         public CompositeGlob(params IMSBuildGlob[] globs) : this(globs.ToImmutableArray())
         {}
 
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="globs">Children globs.</param>
+        private CompositeGlob(ImmutableArray<IMSBuildGlob> globs)
+        {
+            _globs = globs;
+        }
+
         /// <inheritdoc />
         public bool IsMatch(string stringToMatch)
         {
             // Threadpools are a scarce resource in Visual Studio, do not use them.
             //return Globs.AsParallel().Any(g => g.IsMatch(stringToMatch));
 
-            return Globs.Any(g => g.IsMatch(stringToMatch));
+            return _globs.Any(g => g.IsMatch(stringToMatch));
         }
     }
 }

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -10,7 +10,8 @@ using Microsoft.Build.Shared;
 namespace Microsoft.Build.Globbing
 {
     /// <summary>
-    ///     A Composite glob
+    ///     A composite glob that returns a match for an input if any of its
+    ///     inner globs match the input (disjunction).
     /// </summary>
     public class CompositeGlob : IMSBuildGlob
     {

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Globbing
 {
@@ -60,6 +61,89 @@ namespace Microsoft.Build.Globbing
             //return Globs.AsParallel().Any(g => g.IsMatch(stringToMatch));
 
             return _globs.Any(g => g.IsMatch(stringToMatch));
+        }
+
+        /// <summary>
+        ///     Creates an <see cref="IMSBuildGlob"/> that aggregates multiple other globs
+        ///     such that the resulting glob matches when any inner glob matches (disjunction).
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         When <paramref name="globs"/> contains no elements, a singleton glob is
+        ///         returned that never matches, regardless of input.
+        ///     </para>
+        ///     <para>
+        ///         When <paramref name="globs"/> contains one element, that single element is
+        ///         returned directly. This avoids allocating a redundant wrapper instance.
+        ///     </para>
+        /// </remarks>
+        /// <param name="globs">An enumeration of globs to compose.</param>
+        /// <returns>The logical disjunction of the input globs.</returns>
+        public static IMSBuildGlob Create(IEnumerable<IMSBuildGlob> globs)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(globs, nameof(globs));
+
+            if (globs is ImmutableArray<IMSBuildGlob> immutableGlobs)
+            {
+                // Avoid allocations in the case that the input is an ImmutableArray
+                return immutableGlobs.Length switch
+                {
+                    0 => NeverMatchingGlob.Instance,
+                    1 => immutableGlobs[0],
+                    _ => new CompositeGlob(immutableGlobs)
+                };
+            }
+
+            // Use explicit enumeration so we can do minimal work in the case
+            // that the input set of globs is either empty or only contains a
+            // single item.
+
+            using var enumerator = globs.GetEnumerator();
+
+            if (!enumerator.MoveNext())
+            {
+                // The input is empty, so return our singleton that doesn't
+                // match anything.
+                return NeverMatchingGlob.Instance;
+            }
+
+            var first = enumerator.Current;
+
+            if (!enumerator.MoveNext())
+            {
+                // The input contains only a single glob. Disjunction has no
+                // effect on a single input, so return it directly and avoid
+                // allocating a CompositeGlob instance.
+                return first;
+            }
+
+            // We have more than one input glob, to add them all to a builder
+            // and create a new CompositeGlob.
+
+            var builder = ImmutableArray.CreateBuilder<IMSBuildGlob>();
+
+            builder.Add(first);
+            builder.Add(enumerator.Current);
+
+            while (enumerator.MoveNext())
+            {
+                builder.Add(enumerator.Current);
+            }
+
+            return new CompositeGlob(builder.ToImmutable());
+        }
+
+        /// <summary>
+        ///    A glob that never returns a match.
+        /// </summary>
+        private sealed class NeverMatchingGlob : IMSBuildGlob
+        {
+            /// <summary>
+            ///    Singleton instance of this type.
+            /// </summary>
+            public static NeverMatchingGlob Instance { get; } = new();
+
+            public bool IsMatch(string stringToMatch) => false;
         }
     }
 }

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -38,6 +38,15 @@ namespace Microsoft.Build.Globbing
         /// <summary>
         ///     Constructor
         /// </summary>
+        /// <param name="glob1">First child glob.</param>
+        /// <param name="glob2">Second child glob.</param>
+        internal CompositeGlob(IMSBuildGlob glob1, IMSBuildGlob glob2)
+            : this(ImmutableArray.Create(glob1, glob2))
+        {}
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
         /// <param name="globs">Children globs.</param>
         private CompositeGlob(ImmutableArray<IMSBuildGlob> globs)
         {

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -29,8 +29,10 @@ namespace Microsoft.Build.Globbing
             {
                 Globs = immutableGlobs;
             }
-
-            Globs = globs.ToImmutableArray();
+            else
+            {
+                Globs = globs.ToImmutableArray();
+            }
         }
 
         /// <summary>

--- a/src/Build/Globbing/IMSBuildGlob.cs
+++ b/src/Build/Globbing/IMSBuildGlob.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Globbing
         ///     - arguments representing relative paths are normalized against the glob's root.
         ///     For example, the glob **/*.cs does not match ../a.cs, since ../a.cs points outside of the glob root.
         /// 
-        ///     Returns false if <paramref name="stringToMatch" /> contains invalid path or file characters>
+        ///     Returns false if <paramref name="stringToMatch" /> contains invalid path or file characters.
         /// </summary>
         /// <param name="stringToMatch">The string to match. If the string represents a relative path, it will get normalized against the glob's root. Cannot be null.</param>
         /// <returns></returns>

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Build.Globbing
         /// <summary>
         ///     Return type of <see cref="MSBuildGlob.MatchInfo" />
         /// </summary>
-        public struct MatchInfoResult
+        public readonly struct MatchInfoResult
         {
             /// <summary>
             ///     Whether the <see cref="MSBuildGlob.MatchInfo" /> argument was matched against the glob

--- a/src/Build/Globbing/MSBuildGlobWithGaps.cs
+++ b/src/Build/Globbing/MSBuildGlobWithGaps.cs
@@ -37,6 +37,20 @@ namespace Microsoft.Build.Globbing
         /// </summary>
         /// <param name="mainGlob">The main glob</param>
         /// <param name="gaps">The gap glob</param>
+        internal MSBuildGlobWithGaps(IMSBuildGlob mainGlob, IMSBuildGlob gaps)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(mainGlob, nameof(mainGlob));
+            ErrorUtilities.VerifyThrowArgumentNull(gaps, nameof(gaps));
+
+            MainGlob = mainGlob;
+            Gaps = gaps;
+        }
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="mainGlob">The main glob</param>
+        /// <param name="gaps">The gap glob</param>
         public MSBuildGlobWithGaps(IMSBuildGlob mainGlob, IEnumerable<IMSBuildGlob> gaps)
         {
             ErrorUtilities.VerifyThrowArgumentNull(mainGlob, nameof(mainGlob));

--- a/src/Build/Globbing/MSBuildGlobWithGaps.cs
+++ b/src/Build/Globbing/MSBuildGlobWithGaps.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Build.Globbing
             ErrorUtilities.VerifyThrowArgumentNull(gaps, nameof(gaps));
 
             MainGlob = mainGlob;
-            Gaps = new CompositeGlob(gaps);
+            Gaps = CompositeGlob.Create(gaps);
         }
 
         /// <summary>

--- a/src/Build/Globbing/Visitor/GlobVisitor.cs
+++ b/src/Build/Globbing/Visitor/GlobVisitor.cs
@@ -7,14 +7,12 @@ namespace Microsoft.Build.Globbing.Visitor
     {
         public void Visit(IMSBuildGlob glob)
         {
-            var msbuildGlob = glob as MSBuildGlob;
-            if (msbuildGlob != null)
+            if (glob is MSBuildGlob msbuildGlob)
             {
                 VisitMSBuildGlob(msbuildGlob);
             }
 
-            var compositGlob = glob as CompositeGlob;
-            if (compositGlob != null)
+            if (glob is CompositeGlob compositGlob)
             {
                 VisitCompositeGlob(compositGlob);
 
@@ -24,8 +22,7 @@ namespace Microsoft.Build.Globbing.Visitor
                 }
             }
 
-            var globWithGaps = glob as MSBuildGlobWithGaps;
-            if (globWithGaps != null)
+            if (glob is MSBuildGlobWithGaps globWithGaps)
             {
                 VisitGlobWithGaps(globWithGaps);
 

--- a/src/Build/Globbing/Visitor/GlobVisitor.cs
+++ b/src/Build/Globbing/Visitor/GlobVisitor.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Build.Globbing.Visitor
                 VisitMSBuildGlob(msbuildGlob);
             }
 
-            if (glob is CompositeGlob compositGlob)
+            if (glob is CompositeGlob compositeGlob)
             {
-                VisitCompositeGlob(compositGlob);
+                VisitCompositeGlob(compositeGlob);
 
-                foreach (var globPart in compositGlob.Globs)
+                foreach (var globPart in compositeGlob.Globs)
                 {
                     Visit(globPart);
                 }
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Globbing.Visitor
         {
         }
 
-        protected virtual void VisitCompositeGlob(CompositeGlob compositGlob)
+        protected virtual void VisitCompositeGlob(CompositeGlob compositeGlob)
         {
         }
 


### PR DESCRIPTION
### Context

Traces of devenv during build showed a lot of CPS activity related to glob evaluation. Investigation of the code showed a few opportunities to eliminate some allocations and reduce work during construction and matching.

### Changes Made

- Eliminate allocation of `CompositeGlob` wrapper for zero or one child (seems very common)
- Eliminate enumerator allocation in `CompositeGlob.IsMatch`
- Eliminate array allocation when constructing `CompositeGlob`
- Eliminate array allocation when constructing `MSBuildGlobWithGaps`
- Fix `CompositeGlob(IEnumerable<>)` ctor optimisation (missing `else` block)
- Make struct readonly
- Use pattern matching
- Typos & documentation

### Testing

- Unit tests

### Notes

This is probably easiest to review one commit at a time.