### PR TITLE
Loosen version comparisons in loading assemblies

### DIFF
--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -164,12 +164,10 @@ namespace Microsoft.Build.Shared
                     }
 
                     AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
-                    if (candidateAssemblyName.Version != assemblyName.Version)
+                    if (candidateAssemblyName.Version >= assemblyName.Version)
                     {
-                        continue;
+                        return LoadAndCache(context, candidatePath);
                     }
-
-                    return LoadAndCache(context, candidatePath);
                 }
             }
 

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -53,22 +53,20 @@ namespace Microsoft.Build.Shared
                 // bare search directory if that fails.
                 : new[] { assemblyName.CultureName, string.Empty })
             {
-                    var candidatePath = Path.Combine(_directory,
-                        cultureSubfolder,
-                        $"{assemblyName.Name}.dll");
+                var candidatePath = Path.Combine(_directory,
+                    cultureSubfolder,
+                    $"{assemblyName.Name}.dll");
 
-                    if (!FileSystems.Default.FileExists(candidatePath))
-                    {
-                        continue;
-                    }
+                if (!FileSystems.Default.FileExists(candidatePath))
+                {
+                    continue;
+                }
 
-                    AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
-                    if (candidateAssemblyName.Version != assemblyName.Version)
-                    {
-                        continue;
-                    }
-
+                AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
+                if (candidateAssemblyName.Version >= assemblyName.Version)
+                {
                     return LoadFromAssemblyPath(candidatePath);
+                }
             }
 
             // If the Assembly is provided via a file path, the following rules are used to load the assembly:


### PR DESCRIPTION
Fixes #6993

### Context
See issue.

### Changes Made
Switched to also load if the found assembly is greater than what was requested.

### Testing
CI? I had trouble repro'ing this.