### PR TITLE
Get Microsoft SDK paths from 32-bit registry

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -146,7 +146,7 @@
         <property name="MSBuildToolsPath32" value="$([MSBuild]::GetToolsDirectory32())" />
         <property name="MSBuildToolsPath64" value="$([MSBuild]::GetToolsDirectory64())" />
         <property name="MSBuildSDKsPath" value="$([MSBuild]::GetMSBuildSDKsPath())" />
-        <property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8@InstallationFolder)" />
+        <property name="FrameworkSDKRoot" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8', 'InstallationFolder', null, RegistryView.Registry32))" />
         <property name="MSBuildRuntimeVersion" value="4.0.30319" />
         <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsPath32" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
@@ -154,7 +154,7 @@
         <property name="MSBuildFrameworkToolsRoot" value="$(SystemRoot)\Microsoft.NET\Framework\" />
         <property name="SDK35ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
         <property name="SDK40ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8\WinSDK-NetFx40Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
-        <property name="WindowsSDK80Path" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)" />
+        <property name="WindowsSDK80Path" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1', 'InstallationFolder', null, RegistryView.Registry32))" />
         <property name="VsInstallRoot" value="$([MSBuild]::GetVsInstallRoot())" />
         <property name="MSBuildToolsRoot" value="$(VsInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -138,7 +138,7 @@
         <property name="MSBuildToolsPath32" value="$([MSBuild]::GetToolsDirectory32())" />
         <property name="MSBuildToolsPath64" value="$([MSBuild]::GetToolsDirectory64())" />
         <property name="MSBuildSDKsPath" value="$([MSBuild]::GetMSBuildSDKsPath())" />
-        <property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8@InstallationFolder)" />
+        <property name="FrameworkSDKRoot" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8', 'InstallationFolder', null, RegistryView.Registry32))" />
         <property name="MSBuildRuntimeVersion" value="4.0.30319" />
         <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsPath32" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
@@ -146,7 +146,7 @@
         <property name="MSBuildFrameworkToolsRoot" value="$(SystemRoot)\Microsoft.NET\Framework\" />
         <property name="SDK35ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
         <property name="SDK40ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8\WinSDK-NetFx40Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
-        <property name="WindowsSDK80Path" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)" />
+        <property name="WindowsSDK80Path" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1', 'InstallationFolder', null, RegistryView.Registry32))" />
         <property name="VsInstallRoot" value="$([MSBuild]::GetVsInstallRoot())" />
         <property name="MSBuildToolsRoot" value="$(VsInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())" />


### PR DESCRIPTION
Fixes #7047.

These worked in 32-bit MSBuild because the values are placed only in the
32-bit registry.

```sh-session
❯ reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8" /s
ERROR: The system was unable to find the specified registry key or value.

msbuild on frameworkpath-reg-wow [$+] via .NET v6.0.100
❯ reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8" /s /reg:32

HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8
    InstallationFolder    REG_SZ    C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\
    ProductVersion    REG_SZ    4.8.03928
    ProductName    REG_SZ    Microsoft .NET Framework 4.8 SDK
    KitsInstallationFolder    REG_SZ    C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\

HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8\WinSDK-NetFx40Tools
    ProductVersion    REG_SZ    4.8.03928
    ComponentName    REG_SZ    Microsoft .NET Framework 4.8 SDK
    InstallationFolder    REG_SZ    C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\

HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8\WinSDK-NetFx40Tools-x64
    ProductVersion    REG_SZ    4.8.03928
    ComponentName    REG_SZ    Microsoft .NET Framework 4.8 SDK
    InstallationFolder    REG_SZ    C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\

HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8\WinSDK-NetFx40Tools-x86
    ProductVersion    REG_SZ    4.8.03928
    ComponentName    REG_SZ    Microsoft .NET Framework 4.8 SDK
    InstallationFolder    REG_SZ    C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\
```
