### PR TITLE
Remove closure allocation in CompositeGlob.IsMatch

### DIFF
--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Globbing
         /// </summary>
         /// <param name="globs">Children globs. Input gets shallow cloned</param>
         public CompositeGlob(IEnumerable<IMSBuildGlob> globs)
-            : this(globs is ImmutableArray<IMSBuildGlob> immutableGlobs ? immutableGlobs : globs.ToImmutableArray())
+            : this(globs.ToImmutableArray())
         {}
 
         /// <summary>

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Globbing
             // Threadpools are a scarce resource in Visual Studio, do not use them.
             //return Globs.AsParallel().Any(g => g.IsMatch(stringToMatch));
 
-            return _globs.Any(g => g.IsMatch(stringToMatch));
+            return _globs.Any(static (glob, str) => glob.IsMatch(str), stringToMatch);
         }
 
         /// <summary>

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -34,7 +34,8 @@ namespace Microsoft.Build.Globbing
         ///     Constructor
         /// </summary>
         /// <param name="globs">Children globs. Input gets shallow cloned</param>
-        public CompositeGlob(params IMSBuildGlob[] globs) : this(globs.ToImmutableArray())
+        public CompositeGlob(params IMSBuildGlob[] globs)
+            : this(ImmutableArray.Create(globs))
         {}
 
         /// <summary>

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -162,6 +162,7 @@
     <Compile Include="BackEnd\Components\SdkResolution\SdkResolverException.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\TranslationHelpers.cs" />
     <Compile Include="FileSystem\*.cs" />
+    <Compile Include="Utilities\ImmutableCollectionsExtensions.cs" />
     <Compile Include="Utilities\NuGetFrameworkWrapper.cs" />
     <Compile Include="ObjectModelRemoting\ConstructionObjectLinks\ProjectUsingTaskParameterElementLink.cs" />
     <Compile Include="ObjectModelRemoting\ExternalProjectsProvider.cs" />

--- a/src/Build/Utilities/ImmutableCollectionsExtensions.cs
+++ b/src/Build/Utilities/ImmutableCollectionsExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+
+// Added to the System.Linq extension method as these extensions augment those
+// provided by Linq. The immutable collections library includes ImmutableArrayExtensions
+// which is also in this namespace.
+
+namespace System.Linq
+{
+    internal static class ImmutableCollectionsExtensions
+    {
+        /// <summary>
+        /// Gets a value indicating whether any elements are in this collection
+        /// that match a given condition.
+        /// </summary>
+        /// <remarks>
+        /// This extension method accepts an argument which is then passed, on the stack, to the predicate.
+        /// This allows using a static lambda, which can avoid a per-call allocation of a closure object.
+        /// </remarks>
+        /// <typeparam name="TElement">The type of element contained by the collection.</typeparam>
+        /// <typeparam name="TArg">The type of argument passed to <paramref name="predicate"/>.</typeparam>
+        /// <param name="immutableArray">The array to check.</param>
+        /// <param name="predicate">The predicate.</param>
+        /// <param name="arg">The argument to pass to <paramref name="predicate"/>.</param>
+        public static bool Any<TElement, TArg>(this ImmutableArray<TElement> immutableArray, Func<TElement, TArg, bool> predicate, TArg arg)
+        {
+            foreach (TElement element in immutableArray)
+            {
+                if (predicate(element, arg))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Context

@Therzok provided some additional feedback on PR #7040 after it was merged. This PR addresses that feedback.

### Changes Made

- Avoid allocating a closure object for each call to `CompositeGlob.IsMatch` by adding an overload of `Any` that allows passing state on the stack.
- Other API substitutions for better run time, though these code paths are not used in product code (they would be removed if not public).

### Testing

Unit tests.