### PR TITLE
Fix stackoverflowexception

### DIFF
--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -79,6 +79,17 @@ namespace Microsoft.Build.Graph.UnitTests
         }
 
         [Fact]
+        public void CycleInGraphDoesNotThrowStackOverflowException()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                TransientTestFile entryProject = CreateProjectFile(env, 1, new[] { 2 });
+                CreateProjectFile(env, 2, new[] { 2 }, extraContent: @"<PropertyGroup><UsingMicrosoftNETSdk>true</UsingMicrosoftNETSdk></PropertyGroup>");
+                Should.Throw<CircularDependencyException>(() => new ProjectGraph(entryProject.Path));
+            }
+        }
+
+        [Fact]
         public void ConstructWithSingleNodeWithProjectInstanceFactory()
         {
             using (var env = TestEnvironment.Create())

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -178,21 +178,17 @@ namespace Microsoft.Build.Graph
                     HashSet<ProjectGraphNode> toCache = new();
                     foreach (ProjectInterpretation.ReferenceInfo referenceInfo in parsedProject.ReferenceInfos)
                     {
-                        if (transitiveReferences.Contains(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode))
+                        if (transitiveReferences.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode))
                         {
-                            if (transitiveReferenceCache.TryGetValue(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode, out cachedTransitiveReferences))
-                            {
-                                toCache = toCache.Concat(cachedTransitiveReferences).ToHashSet();
-                            }
-                            else
-                            {
-                                toCache.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
-                            }
+                            GetTransitiveProjectReferencesExcludingSelfHelper(allParsedProjects[referenceInfo.ReferenceConfiguration], transitiveReferences, toCache);
+                        }
+                        else if (transitiveReferenceCache.TryGetValue(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode, out cachedTransitiveReferences))
+                        {
+                            toCache = toCache.Concat(cachedTransitiveReferences).ToHashSet();
                         }
                         else
                         {
-                            transitiveReferences.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
-                            GetTransitiveProjectReferencesExcludingSelfHelper(allParsedProjects[referenceInfo.ReferenceConfiguration], transitiveReferences, toCache);
+                            toCache.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
                         }
                     }
 

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -162,27 +162,45 @@ namespace Microsoft.Build.Graph
 
             HashSet<ProjectGraphNode> GetTransitiveProjectReferencesExcludingSelf(ParsedProject parsedProject)
             {
+                HashSet<ProjectGraphNode> references = new();
+                GetTransitiveProjectReferencesExcludingSelfHelper(parsedProject, references, null);
+                return references;
+            }
+
+            void GetTransitiveProjectReferencesExcludingSelfHelper(ParsedProject parsedProject, HashSet<ProjectGraphNode> transitiveReferences, HashSet<ProjectGraphNode> referencesFromHere)
+            {
                 if (transitiveReferenceCache.TryGetValue(parsedProject.GraphNode, out HashSet<ProjectGraphNode> cachedTransitiveReferences))
                 {
-                    return cachedTransitiveReferences;
+                    transitiveReferences = transitiveReferences.Concat(cachedTransitiveReferences).ToHashSet();
                 }
                 else
                 {
-                    var transitiveReferences = new HashSet<ProjectGraphNode>();
-
-                    foreach (var referenceInfo in parsedProject.ReferenceInfos)
+                    HashSet<ProjectGraphNode> toCache = new();
+                    foreach (ProjectInterpretation.ReferenceInfo referenceInfo in parsedProject.ReferenceInfos)
                     {
-                        transitiveReferences.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
-
-                        foreach (var transitiveReference in GetTransitiveProjectReferencesExcludingSelf(allParsedProjects[referenceInfo.ReferenceConfiguration]))
+                        if (transitiveReferences.Contains(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode))
                         {
-                            transitiveReferences.Add(transitiveReference);
+                            if (transitiveReferenceCache.TryGetValue(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode, out cachedTransitiveReferences))
+                            {
+                                toCache = toCache.Concat(cachedTransitiveReferences).ToHashSet();
+                            }
+                            else
+                            {
+                                toCache.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
+                            }
+                        }
+                        else
+                        {
+                            transitiveReferences.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
+                            GetTransitiveProjectReferencesExcludingSelfHelper(allParsedProjects[referenceInfo.ReferenceConfiguration], transitiveReferences, toCache);
                         }
                     }
 
-                    transitiveReferenceCache.Add(parsedProject.GraphNode, transitiveReferences);
-
-                    return transitiveReferences;
+                    transitiveReferenceCache[parsedProject.GraphNode] = transitiveReferences;
+                    if (referencesFromHere is not null)
+                    {
+                        referencesFromHere = referencesFromHere.Concat(toCache).ToHashSet();
+                    }
                 }
             }
         }

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -169,38 +169,42 @@ namespace Microsoft.Build.Graph
 
             // transitiveReferences contains all of the references we've found so far from the initial GetTransitiveProjectReferencesExcludingSelf call.
             // referencesFromHere is essentially "reset" at each level of the recursion.
-            // The first is important because if we find a cycle at some point, we need to know not to keep recursing. We wouldn't have added to a cache yet, since we haven't finished
+            // The first is important because if we find a cycle at some point, we need to know not to keep recursing. We wouldn't have added to transitiveReferenceCache yet, since we haven't finished
             // finding all the transitive references yet.
             // On the other hand, the second is important to help us fill that cache afterwards. The cache is from a particular node to all of its references, including transitive references
             // but not including itself, which means we can't include parents as we would if we used transitiveReferences. You can see that for any particular call, it creates a new "toCache"
             // HashSet that we fill with direct references and pass as referencesFromHere in recursive calls to fill it with transitive references. It is then used to populate the cache.
             // Meanwhile, we avoid going into the recursive step at all if transitiveReferences already includes a particular node to avoid a StackOverflowException if there's a loop.
-            void GetTransitiveProjectReferencesExcludingSelfHelper(ParsedProject parsedProject, HashSet<ProjectGraphNode> transitiveReferences, HashSet<ProjectGraphNode> referencesFromHere)
+            void GetTransitiveProjectReferencesExcludingSelfHelper(ParsedProject parsedProject, HashSet<ProjectGraphNode> traversedReferences, HashSet<ProjectGraphNode> incompleteReferencesOfDirectlyReferencingNode)
             {
                 if (transitiveReferenceCache.TryGetValue(parsedProject.GraphNode, out HashSet<ProjectGraphNode> cachedTransitiveReferences))
                 {
-                    transitiveReferences.UnionWith(cachedTransitiveReferences);
+                    traversedReferences.UnionWith(cachedTransitiveReferences);
                 }
                 else
                 {
-                    HashSet<ProjectGraphNode> toCache = new();
+                    HashSet<ProjectGraphNode> referencesFromThisNode = new();
                     foreach (ProjectInterpretation.ReferenceInfo referenceInfo in parsedProject.ReferenceInfos)
                     {
-                        if (transitiveReferences.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode))
+                        if (traversedReferences.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode))
                         {
-                            GetTransitiveProjectReferencesExcludingSelfHelper(allParsedProjects[referenceInfo.ReferenceConfiguration], transitiveReferences, toCache);
+                            GetTransitiveProjectReferencesExcludingSelfHelper(allParsedProjects[referenceInfo.ReferenceConfiguration], traversedReferences, referencesFromThisNode);
                         }
                         else if (transitiveReferenceCache.TryGetValue(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode, out cachedTransitiveReferences))
                         {
-                            toCache.UnionWith(cachedTransitiveReferences);
+                            referencesFromThisNode.UnionWith(cachedTransitiveReferences);
                         }
-                        toCache.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
+                        referencesFromThisNode.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
                     }
 
-                    transitiveReferenceCache[parsedProject.GraphNode] = toCache;
-                    if (referencesFromHere is not null)
+                    // We've returned from recursing through all transitive references
+                    // of this node, so add that set to the cache
+                    transitiveReferenceCache[parsedProject.GraphNode] = referencesFromThisNode;
+                    if (incompleteReferencesOfDirectlyReferencingNode is not null)
                     {
-                        referencesFromHere.UnionWith(toCache);
+                        // Also add it to the set of transitive dependencies of
+                        // the referencing node (which are probably still incomplete)
+                        incompleteReferencesOfDirectlyReferencingNode.UnionWith(referencesFromThisNode);
                     }
                 }
             }

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -167,6 +167,14 @@ namespace Microsoft.Build.Graph
                 return references;
             }
 
+            // transitiveReferences contains all of the references we've found so far from the initial GetTransitiveProjectReferencesExcludingSelf call.
+            // referencesFromHere is essentially "reset" at each level of the recursion.
+            // The first is important because if we find a cycle at some point, we need to know not to keep recursing. We wouldn't have added to a cache yet, since we haven't finished
+            // finding all the transitive references yet.
+            // On the other hand, the second is important to help us fill that cache afterwards. The cache is from a particular node to all of its references, including transitive references
+            // but not including itself, which means we can't include parents as we would if we used transitiveReferences. You can see that for any particular call, it creates a new "toCache"
+            // HashSet that we fill with direct references and pass as referencesFromHere in recursive calls to fill it with transitive references. It is then used to populate the cache.
+            // Meanwhile, we avoid going into the recursive step at all if transitiveReferences already includes a particular node to avoid a StackOverflowException if there's a loop.
             void GetTransitiveProjectReferencesExcludingSelfHelper(ParsedProject parsedProject, HashSet<ProjectGraphNode> transitiveReferences, HashSet<ProjectGraphNode> referencesFromHere)
             {
                 if (transitiveReferenceCache.TryGetValue(parsedProject.GraphNode, out HashSet<ProjectGraphNode> cachedTransitiveReferences))

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Build.Graph
             {
                 if (transitiveReferenceCache.TryGetValue(parsedProject.GraphNode, out HashSet<ProjectGraphNode> cachedTransitiveReferences))
                 {
-                    transitiveReferences = transitiveReferences.Concat(cachedTransitiveReferences).ToHashSet();
+                    transitiveReferences.UnionWith(cachedTransitiveReferences);
                 }
                 else
                 {
@@ -184,7 +184,7 @@ namespace Microsoft.Build.Graph
                         }
                         else if (transitiveReferenceCache.TryGetValue(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode, out cachedTransitiveReferences))
                         {
-                            toCache = toCache.Concat(cachedTransitiveReferences).ToHashSet();
+                            toCache.UnionWith(cachedTransitiveReferences);
                         }
                         else
                         {
@@ -192,10 +192,10 @@ namespace Microsoft.Build.Graph
                         }
                     }
 
-                    transitiveReferenceCache[parsedProject.GraphNode] = transitiveReferences;
+                    transitiveReferenceCache[parsedProject.GraphNode] = toCache;
                     if (referencesFromHere is not null)
                     {
-                        referencesFromHere = referencesFromHere.Concat(toCache).ToHashSet();
+                        referencesFromHere.UnionWith(toCache);
                     }
                 }
             }

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -186,10 +186,7 @@ namespace Microsoft.Build.Graph
                         {
                             toCache.UnionWith(cachedTransitiveReferences);
                         }
-                        else
-                        {
-                            toCache.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
-                        }
+                        toCache.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
                     }
 
                     transitiveReferenceCache[parsedProject.GraphNode] = toCache;

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -186,15 +186,16 @@ namespace Microsoft.Build.Graph
                     HashSet<ProjectGraphNode> referencesFromThisNode = new();
                     foreach (ProjectInterpretation.ReferenceInfo referenceInfo in parsedProject.ReferenceInfos)
                     {
-                        if (traversedReferences.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode))
+                        ParsedProject reference = allParsedProjects[referenceInfo.ReferenceConfiguration];
+                        if (traversedReferences.Add(reference.GraphNode))
                         {
-                            GetTransitiveProjectReferencesExcludingSelfHelper(allParsedProjects[referenceInfo.ReferenceConfiguration], traversedReferences, referencesFromThisNode);
+                            GetTransitiveProjectReferencesExcludingSelfHelper(reference, traversedReferences, referencesFromThisNode);
                         }
-                        else if (transitiveReferenceCache.TryGetValue(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode, out cachedTransitiveReferences))
+                        else if (transitiveReferenceCache.TryGetValue(reference.GraphNode, out cachedTransitiveReferences))
                         {
                             referencesFromThisNode.UnionWith(cachedTransitiveReferences);
                         }
-                        referencesFromThisNode.Add(allParsedProjects[referenceInfo.ReferenceConfiguration].GraphNode);
+                        referencesFromThisNode.Add(reference.GraphNode);
                     }
 
                     // We've returned from recursing through all transitive references


### PR DESCRIPTION
Fixes #6925

### Context
If you have a cycle in your ProjectReferences, that should be caught and marked as invalid with MSB4251. If you do a graph build, however, it turns into a StackOverflowException, which is much less clear. This handles circular dependencies, giving the nicer exception.

### Changes Made
Ensures that each project "marks" itself as not to be revisited before the recursive call so that you cannot get endless recursion.

### Testing
Tried with the original repro and got MSB4251 as desired.

### Notes
The first commit maintains the previous caching behavior. It isn't obvious to me how much benefit there really is here, and I have yet to test it. In particular, although it could save you a good bit of work, it costs creation and manipulation of a series of intermediate HashSets that are all stored in a Dictionary, so GC can't even get rid of any of them. Without having tested this, I would guess that the first commit would be more efficient for large projects, and the second commit would be more efficient for small projects. I'm happy to hear feedback before I test or just test that hypothesis as reviewers think best.