### PR TITLE
Replace O(N^2) with O(N)

### DIFF
--- a/src/Deprecated/Engine/Caching/BuildItemCacheEntry.cs
+++ b/src/Deprecated/Engine/Caching/BuildItemCacheEntry.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.Build.BuildEngine
@@ -100,7 +100,7 @@ namespace Microsoft.Build.BuildEngine
                     return false;
                 }
 
-                ArrayList otherEntryMetadataNames = new ArrayList(otherEntry.BuildItems[i].GetAllCustomMetadataNames());
+                HashSet<string> otherEntryMetadataNames = new HashSet<string>(otherEntry.BuildItems[i].GetAllCustomMetadataNames());
 
                 foreach (string metadataName in this.BuildItems[i].GetAllCustomMetadataNames())
                 {

--- a/src/Deprecated/Engine/Caching/BuildItemCacheEntry.cs
+++ b/src/Deprecated/Engine/Caching/BuildItemCacheEntry.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Build.BuildEngine
                     return false;
                 }
 
-                HashSet<string> otherEntryMetadataNames = new HashSet<string>(otherEntry.BuildItems[i].GetAllCustomMetadataNames());
+                HashSet<string> otherEntryMetadataNames = new HashSet<string>(otherEntry.BuildItems[i].GetAllCustomMetadataNames(), StringComparer.Ordinal);
 
                 foreach (string metadataName in this.BuildItems[i].GetAllCustomMetadataNames())
                 {


### PR DESCRIPTION
### Context

Noticed this while browsing code.

### Changes Made

This loop verifies all items in one list are present in another. Previously this involved `ArrayList.Contains`, which is O(N). As this happened in a loop, the time complexity comes out to O(N^2). Using a `HashSet<>.Contains` instead allows O(1) lookup within the loop, leading to an overall complexity of O(N).

### Testing

Unit tests.