### PR TITLE
Disable RestoreUseStaticGraphEvaluation for source-build

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -3,7 +3,7 @@
 <Project>
 
   <PropertyGroup>
-    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <RestoreUseStaticGraphEvaluation Condition="'$(DotNetBuildFromSource)' != 'true'">true</RestoreUseStaticGraphEvaluation>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Temporary workaround for https://github.com/dotnet/msbuild/issues/7058 to unblock source-build while it is being investigated.