### PR TITLE
Disable ValidateExecutableReferences

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -59,6 +59,9 @@
     <PackageIconUrl>https://go.microsoft.com/fwlink/?linkid=825694</PackageIconUrl>
 
     <DevDivPackagesDir>$(VisualStudioSetupOutputPath)DevDivPackages\</DevDivPackagesDir>
+
+    <!-- Work around issue with official builds using 6.0.100 GA SDK with older MSBuild. Remove after internal pools use 17.0 GA -->
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">


### PR DESCRIPTION
This works around an odd misconfiguration in the internal 1ES 2022 pools that they use the latest .NET SDK but a preview VS/MSBuild.
