### PR TITLE
Fix binding redirect for System.Threading.Tasks.Dataflow

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -99,7 +99,7 @@
           <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>
-          <assemblyIdentity name="Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
           <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -89,7 +89,7 @@
           <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>
-          <assemblyIdentity name="Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
           <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>


### PR DESCRIPTION
I observed a failure in NuGet restore because a NuGet task wasn't able to
access this assembly because we updated it. The binding redirect wasn't
working because it referred to a partial name.
