### PR TITLE
Revert "Disable ValidateExecutableReferences"

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -59,9 +59,6 @@
     <PackageIconUrl>https://go.microsoft.com/fwlink/?linkid=825694</PackageIconUrl>
 
     <DevDivPackagesDir>$(VisualStudioSetupOutputPath)DevDivPackages\</DevDivPackagesDir>
-
-    <!-- Work around issue with official builds using 6.0.100 GA SDK with older MSBuild. Remove after internal pools use 17.0 GA -->
-    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">


### PR DESCRIPTION
Reverts dotnet/msbuild#7065 since the official build machine image has now been updated (see passing internal build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=5474330&view=logs&j=834effc5-0088-5346-39e6-11e704da850d&t=dbe71018-a6bc-5bc7-ce4d-4aa6967c40a7&l=166).