### PR TITLE
Drop remaining jnm2.ReferenceAssemblies.net35 references

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -9,7 +9,6 @@
      -->
   <ItemGroup>
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Update="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
     <PackageReference Update="LargeAddressAware" Version="1.0.5" />
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3" />
     <PackageReference Update="Microsoft.CodeQuality.Analyzers" Version="3.3.0" PrivateAssets="all" />

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -212,7 +212,6 @@
     <PackageReference Include="PdbGit" /> -->
     <PackageReference Include="SourceLink.Create.CommandLine" />
     <PackageReference Include="LargeAddressAware" PrivateAssets="All" />
-    <PackageReference Include="jnm2.ReferenceAssemblies.net35" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->


### PR DESCRIPTION
Closes #6935.

These references were not removed by #6966, but could have been.