### PR TITLE
Remove unused 'capacity' parameter for COW dictionaries

### DIFF
--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -59,15 +59,6 @@ namespace Microsoft.Build.Collections
         }
 
         /// <summary>
-        /// Creates empty dictionary with specified initial capacity
-        /// </summary>
-        public CopyOnWritePropertyDictionary(int capacity)
-        {
-            // Tracing.Record("New COWD2");
-            _properties = new CopyOnWriteDictionary<T>(capacity, MSBuildNameIgnoreCaseComparer.Default);
-        }
-
-        /// <summary>
         /// Cloning constructor, with deferred cloning semantics
         /// </summary>
         private CopyOnWritePropertyDictionary(CopyOnWritePropertyDictionary<T> that)

--- a/src/Build/Construction/ProjectTaskElement.cs
+++ b/src/Build/Construction/ProjectTaskElement.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Build.Construction
         {
             if (_parameters == null)
             {
-                _parameters = new CopyOnWriteDictionary<(string, ElementLocation)>(XmlElement.Attributes.Count, StringComparer.OrdinalIgnoreCase);
+                _parameters = new CopyOnWriteDictionary<(string, ElementLocation)>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (XmlAttributeWithLocation attribute in XmlElement.Attributes)
                 {

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2909,7 +2909,7 @@ namespace Microsoft.Build.Execution
 
                 if (item.DirectMetadata != null)
                 {
-                    directMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(item.DirectMetadataCount);
+                    directMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
                     foreach (ProjectMetadata directMetadatum in item.DirectMetadata)
                     {
                         ProjectMetadataInstance directMetadatumInstance = new ProjectMetadataInstance(directMetadatum);

--- a/src/Build/Instance/ProjectItemDefinitionInstance.cs
+++ b/src/Build/Instance/ProjectItemDefinitionInstance.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Execution
         {
             if (itemDefinition.MetadataCount > 0)
             {
-                _metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(itemDefinition.MetadataCount);
+                _metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
             }
 
             foreach (ProjectMetadata originalMetadata in itemDefinition.Metadata)

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -15,7 +15,6 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Construction;
 using Microsoft.Build.BackEnd;
-using Microsoft.Build.Internal;
 using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Execution
@@ -113,7 +112,7 @@ namespace Microsoft.Build.Execution
 
             if (directMetadata?.GetEnumerator().MoveNext() == true)
             {
-                metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(directMetadata.FastCountOrZero());
+                metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
                 foreach (KeyValuePair<string, string> metadatum in directMetadata)
                 {
                     metadata.Set(new ProjectMetadataInstance(metadatum.Key, metadatum.Value));
@@ -600,7 +599,7 @@ namespace Microsoft.Build.Execution
         internal static void SetMetadata(IEnumerable<KeyValuePair<string, string>> metadataList, IEnumerable<ProjectItemInstance> items)
         {
             // Set up a single dictionary that can be applied to all the items
-            CopyOnWritePropertyDictionary<ProjectMetadataInstance> metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(metadataList.FastCountOrZero());
+            CopyOnWritePropertyDictionary<ProjectMetadataInstance> metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
             foreach (KeyValuePair<string, string> metadatum in metadataList)
             {
                 metadata.Set(new ProjectMetadataInstance(metadatum.Key, metadatum.Value));
@@ -1143,7 +1142,7 @@ namespace Microsoft.Build.Execution
                         return (_directMetadata == null) ? new CopyOnWritePropertyDictionary<ProjectMetadataInstance>() : _directMetadata.DeepClone(); // copy on write!
                     }
 
-                    CopyOnWritePropertyDictionary<ProjectMetadataInstance> allMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(_itemDefinitions.Count + (_directMetadata?.Count ?? 0));
+                    CopyOnWritePropertyDictionary<ProjectMetadataInstance> allMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
 
                     // Next, any inherited item definitions. Front of the list is highest priority,
                     // so walk backwards.
@@ -1716,7 +1715,7 @@ namespace Microsoft.Build.Execution
                     if (translator.TranslateNullable(_directMetadata))
                     {
                         int count = translator.Reader.ReadInt32();
-                        _directMetadata = (count == 0) ? null : new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(count);
+                        _directMetadata = (count == 0) ? null : new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
                         for (int i = 0; i < count; i++)
                         {
                             int key = translator.Reader.ReadInt32();
@@ -1971,7 +1970,7 @@ namespace Microsoft.Build.Execution
                 public void SetMetadata(IEnumerable<Pair<ProjectMetadataElement, string>> metadataList, IEnumerable<ProjectItemInstance> destinationItems)
                 {
                     // Set up a single dictionary that can be applied to all the items
-                    CopyOnWritePropertyDictionary<ProjectMetadataInstance> metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(metadataList.FastCountOrZero());
+                    CopyOnWritePropertyDictionary<ProjectMetadataInstance> metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
                     foreach (Pair<ProjectMetadataElement, string> metadatum in metadataList)
                     {
                         metadata.Set(new ProjectMetadataInstance(metadatum.Key.Name, metadatum.Value));

--- a/src/Build/Instance/ProjectTaskInstance.cs
+++ b/src/Build/Instance/ProjectTaskInstance.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Build.Execution
             continueOnError,
             msbuildRuntime,
             msbuildArchitecture,
-            new CopyOnWriteDictionary<(string, ElementLocation)>(8, StringComparer.OrdinalIgnoreCase),
+            new CopyOnWriteDictionary<(string, ElementLocation)>(StringComparer.OrdinalIgnoreCase),
             new List<ProjectTaskInstanceChild>(),
             location,
             condition == string.Empty ? null : ElementLocation.EmptyLocation,
@@ -382,7 +382,7 @@ namespace Microsoft.Build.Execution
                 ref localParameters,
                 ParametersKeyTranslator,
                 ParametersValueTranslator,
-                count => new CopyOnWriteDictionary<(string, ElementLocation)>(count));
+                count => new CopyOnWriteDictionary<(string, ElementLocation)>());
 
             if (translator.Mode == TranslationDirection.ReadFromStream && localParameters != null)
             {

--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -36,14 +36,14 @@ namespace Microsoft.Build.Collections
         /// used as the basis of new dictionaries with that comparer to avoid
         /// allocating new comparers objects.
         /// </summary>
-        private readonly static ImmutableDictionary<string, V> NameComparerDictionaryPrototype = ImmutableDictionary.Create<string, V>((IEqualityComparer<string>)MSBuildNameIgnoreCaseComparer.Default);
+        private readonly static ImmutableDictionary<string, V> NameComparerDictionaryPrototype = ImmutableDictionary.Create<string, V>(MSBuildNameIgnoreCaseComparer.Default);
 
         /// <summary>
         /// Empty dictionary with <see cref="StringComparer.OrdinalIgnoreCase" />,
         /// used as the basis of new dictionaries with that comparer to avoid
         /// allocating new comparers objects.
         /// </summary>
-        private readonly static ImmutableDictionary<string, V> OrdinalIgnoreCaseComparerDictionaryPrototype = ImmutableDictionary.Create<string, V>((IEqualityComparer<string>)StringComparer.OrdinalIgnoreCase);
+        private readonly static ImmutableDictionary<string, V> OrdinalIgnoreCaseComparerDictionaryPrototype = ImmutableDictionary.Create<string, V>(StringComparer.OrdinalIgnoreCase);
 #endif
 
 
@@ -62,25 +62,9 @@ namespace Microsoft.Build.Collections
         }
 
         /// <summary>
-        /// Constructor taking an initial capacity
-        /// </summary>
-        internal CopyOnWriteDictionary(int capacity)
-            : this(capacity, null)
-        {
-        }
-
-        /// <summary>
         /// Constructor taking a specified comparer for the keys
         /// </summary>
-        internal CopyOnWriteDictionary(IEqualityComparer<string> keyComparer)
-            : this(0, keyComparer)
-        {
-        }
-
-        /// <summary>
-        /// Constructor taking a specified comparer for the keys and an initial capacity
-        /// </summary>
-        internal CopyOnWriteDictionary(int capacity, IEqualityComparer<string>? keyComparer)
+        internal CopyOnWriteDictionary(IEqualityComparer<string>? keyComparer)
         {
             _backing = GetInitialDictionary(keyComparer);
         }


### PR DESCRIPTION
Context

The underlying immutable dictionaries are implemented as trees and as such the concept of 'capacity' does not apply.

Removing these parameters and their arguments from call sites can avoid some redundant work.

### Changes Made

- Remove `capacity` parameters from constructors.
- Resolve conflicts between then-identical constructors.
- Update call sites.

### Testing

Unit tests.