### PR TITLE
Fixing bug detected by DDRIT

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -508,7 +508,7 @@ namespace Microsoft.Build.Shared
             VisualStudioInstallRootDirectory = visualStudioPath;
 
 #if !NO_FRAMEWORK_IVT
-            Framework.BuildEnvironmentState.s_runningTests = true;
+            Framework.BuildEnvironmentState.s_runningTests = runningTests;
             Framework.BuildEnvironmentState.s_runningInVisualStudio = runningInVisualStudio;
 #endif
 


### PR DESCRIPTION
Fixes: VS Insertion PR nr: 366256

### Context
DDRIT detected memory regression. It was caused by wrongly initialize `Traits` as `running unit tests` so It allocates new `Traits` instance as oppose to use singleton.

### Changes Made
Simple fix.

### Testing
Locally
