### PR TITLE
Remove locking and indirection from CopyOnWritePropertyDictionary

### DIFF
--- a/src/Build.UnitTests/Collections/CopyOnWritePropertyDictionary_Tests.cs
+++ b/src/Build.UnitTests/Collections/CopyOnWritePropertyDictionary_Tests.cs
@@ -3,6 +3,9 @@
 
 using System;
 using Microsoft.Build.Collections;
+
+using Shouldly;
+
 using Xunit;
 
 namespace Microsoft.Build.UnitTests.OM.Collections
@@ -17,23 +20,23 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         {
             var dic = CreateInstance();
 
-            Assert.Equal(0, dic.Count);
+            dic.Count.ShouldBe(0);
 
             dic.Set(new("a"));
 
-            Assert.Equal(1, dic.Count);
+            dic.Count.ShouldBe(1);
 
             dic.Set(new("b"));
 
-            Assert.Equal(2, dic.Count);
+            dic.Count.ShouldBe(2);
 
             dic.Set(new("c"));
 
-            Assert.Equal(3, dic.Count);
+            dic.Count.ShouldBe(3);
 
             dic.Clear();
 
-            Assert.Equal(0, dic.Count);
+            dic.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -44,18 +47,18 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             MockValue a = new("a");
             MockValue b = new("b");
 
-            Assert.Null(dic["a"]);
-            Assert.Null(dic["b"]);
+            dic["a"].ShouldBeNull();
+            dic["b"].ShouldBeNull();
 
             dic["a"] = a;
 
-            Assert.Same(a, dic["a"]);
-            Assert.Null(dic["b"]);
+            dic["a"].ShouldBeSameAs(a);
+            dic["b"].ShouldBeNull();
 
             dic["b"] = b;
 
-            Assert.Same(a, dic["a"]);
-            Assert.Same(b, dic["b"]);
+            dic["a"].ShouldBeSameAs(a);
+            dic["b"].ShouldBeSameAs(b);
 
             // Cannot set a null value
             Assert.ThrowsAny<Exception>(() => dic["a"] = null);
@@ -72,18 +75,18 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             MockValue a = new("a");
             MockValue b = new("b");
 
-            Assert.False(dic.Contains("a"));
-            Assert.False(dic.Contains("b"));
+            dic.Contains("a").ShouldBeFalse();
+            dic.Contains("b").ShouldBeFalse();
 
             dic["a"] = a;
 
-            Assert.True(dic.Contains("a"));
-            Assert.False(dic.Contains("b"));
+            dic.Contains("a").ShouldBeTrue();
+            dic.Contains("b").ShouldBeFalse();
 
             dic["b"] = b;
 
-            Assert.True(dic.Contains("a"));
-            Assert.True(dic.Contains("b"));
+            dic.Contains("a").ShouldBeTrue();
+            dic.Contains("b").ShouldBeTrue();
         }
 
         [Fact]
@@ -91,11 +94,11 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         {
             var dic = CreateInstance("a", "b", "c");
 
-            Assert.Equal(3, dic.Count);
+            dic.Count.ShouldBe(3);
 
             dic.Clear();
 
-            Assert.Equal(0, dic.Count);
+            dic.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -133,14 +136,14 @@ namespace Microsoft.Build.UnitTests.OM.Collections
                 if (expected)
                 {
                     // Test equality in both directions
-                    Assert.Equal(a, b);
-                    Assert.Equal(b, a);
+                    a.ShouldBe(b);
+                    b.ShouldBe(a);
                 }
                 else
                 {
                     // Test equality in both directions
-                    Assert.NotEqual(a, b);
-                    Assert.NotEqual(b, a);
+                    a.ShouldNotBe(b);
+                    b.ShouldNotBe(a);
                 }
             }
         }
@@ -150,14 +153,14 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         {
             var dic = CreateInstance("a", "b", "c");
 
-            Assert.False(dic.Remove("ZZZ"));
+            dic.Remove("ZZZ").ShouldBeFalse();
 
-            Assert.True(dic.Remove("a"));
-            Assert.False(dic.Remove("a"));
-            Assert.True(dic.Remove("b"));
-            Assert.True(dic.Remove("c"));
+            dic.Remove("a").ShouldBeTrue();
+            dic.Remove("a").ShouldBeFalse();
+            dic.Remove("b").ShouldBeTrue();
+            dic.Remove("c").ShouldBeTrue();
 
-            Assert.Equal(0, dic.Count);
+            dic.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -179,8 +182,8 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             CopyOnWritePropertyDictionary<MockValue> source = CreateInstance("a", "b", "c");
             CopyOnWritePropertyDictionary<MockValue> clone = source.DeepClone();
 
-            Assert.Equal(source, clone);
-            Assert.NotSame(source, clone);
+            source.ShouldBe(clone);
+            source.ShouldNotBeSameAs(clone);
         }
 
         private static CopyOnWritePropertyDictionary<MockValue> CreateInstance(params string[] values)

--- a/src/Build.UnitTests/Collections/CopyOnWritePropertyDictionary_Tests.cs
+++ b/src/Build.UnitTests/Collections/CopyOnWritePropertyDictionary_Tests.cs
@@ -1,0 +1,212 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Collections;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.OM.Collections
+{
+    /// <summary>
+    /// Tests for <see cref="CopyOnWritePropertyDictionary{T}"/>.
+    /// </summary>
+    public class CopyOnWritePropertyDictionary_Tests
+    {
+        [Fact]
+        public void Count()
+        {
+            var dic = CreateInstance();
+
+            Assert.Equal(0, dic.Count);
+
+            dic.Set(new("a"));
+
+            Assert.Equal(1, dic.Count);
+
+            dic.Set(new("b"));
+
+            Assert.Equal(2, dic.Count);
+
+            dic.Set(new("c"));
+
+            Assert.Equal(3, dic.Count);
+
+            dic.Clear();
+
+            Assert.Equal(0, dic.Count);
+        }
+
+        [Fact]
+        public void Indexer()
+        {
+            var dic = CreateInstance();
+
+            MockValue a = new("a");
+            MockValue b = new("b");
+
+            Assert.Null(dic["a"]);
+            Assert.Null(dic["b"]);
+
+            dic["a"] = a;
+
+            Assert.Same(a, dic["a"]);
+            Assert.Null(dic["b"]);
+
+            dic["b"] = b;
+
+            Assert.Same(a, dic["a"]);
+            Assert.Same(b, dic["b"]);
+
+            // Cannot set a null value
+            Assert.ThrowsAny<Exception>(() => dic["a"] = null);
+
+            // Value's key must match the specified key
+            Assert.ThrowsAny<Exception>(() => dic["a"] = b);
+        }
+
+        [Fact]
+        public void Contains()
+        {
+            var dic = CreateInstance();
+
+            MockValue a = new("a");
+            MockValue b = new("b");
+
+            Assert.False(dic.Contains("a"));
+            Assert.False(dic.Contains("b"));
+
+            dic["a"] = a;
+
+            Assert.True(dic.Contains("a"));
+            Assert.False(dic.Contains("b"));
+
+            dic["b"] = b;
+
+            Assert.True(dic.Contains("a"));
+            Assert.True(dic.Contains("b"));
+        }
+
+        [Fact]
+        public void Clear()
+        {
+            var dic = CreateInstance("a", "b", "c");
+
+            Assert.Equal(3, dic.Count);
+
+            dic.Clear();
+
+            Assert.Equal(0, dic.Count);
+        }
+
+        [Fact]
+        public void Enumeration()
+        {
+            var dic = CreateInstance();
+
+            MockValue a = new("a");
+            MockValue b = new("b");
+
+            dic.Set(a);
+            dic.Set(b);
+
+            dic.ShouldBeSetEquivalentTo(new[] { a, b });
+        }
+
+        [Fact]
+        public void Equal()
+        {
+            var dic1 = CreateInstance("a", "b", "c");
+            var dic2 = CreateInstance("a", "b", "c");
+            var dic3 = CreateInstance("c", "b", "a");      // reversed order
+            var dic4 = CreateInstance("a", "b");           // missing item
+            var dic5 = CreateInstance("a", "b", "c", "d"); // extra item
+
+            Test(dic1, dic1, true);
+            Test(dic1, dic2, true);
+            Test(dic1, dic3, true);
+
+            Test(dic1, dic4, false);
+            Test(dic1, dic5, false);
+
+            static void Test(CopyOnWritePropertyDictionary<MockValue> a, CopyOnWritePropertyDictionary<MockValue> b, bool expected)
+            {
+                if (expected)
+                {
+                    // Test equality in both directions
+                    Assert.Equal(a, b);
+                    Assert.Equal(b, a);
+                }
+                else
+                {
+                    // Test equality in both directions
+                    Assert.NotEqual(a, b);
+                    Assert.NotEqual(b, a);
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove()
+        {
+            var dic = CreateInstance("a", "b", "c");
+
+            Assert.False(dic.Remove("ZZZ"));
+
+            Assert.True(dic.Remove("a"));
+            Assert.False(dic.Remove("a"));
+            Assert.True(dic.Remove("b"));
+            Assert.True(dic.Remove("c"));
+
+            Assert.Equal(0, dic.Count);
+        }
+
+        [Fact]
+        public void ImportProperties()
+        {
+            var dic = CreateInstance();
+
+            MockValue a = new("a");
+            MockValue b = new("b");
+
+            dic.ImportProperties(new[] { a, b });
+
+            dic.ShouldBeSetEquivalentTo(new[] { a, b });
+        }
+
+        [Fact]
+        public void DeepClone()
+        {
+            CopyOnWritePropertyDictionary<MockValue> source = CreateInstance("a", "b", "c");
+            CopyOnWritePropertyDictionary<MockValue> clone = source.DeepClone();
+
+            Assert.Equal(source, clone);
+            Assert.NotSame(source, clone);
+        }
+
+        private static CopyOnWritePropertyDictionary<MockValue> CreateInstance(params string[] values)
+        {
+            CopyOnWritePropertyDictionary<MockValue> dic = new CopyOnWritePropertyDictionary<MockValue>();
+
+            foreach (string value in values)
+            {
+                dic.Set(new(value));
+            }
+
+            return dic;
+        }
+
+        private sealed class MockValue : IKeyed, IValued, IEquatable<MockValue>, IImmutable
+        {
+            public MockValue(string s) => Key = s;
+
+            public string Key { get; }
+
+            public string EscapedValue => Key;
+
+            public bool Equals(MockValue other)
+            {
+                return other != null && Key == other.Key;
+            }
+        }
+    }
+}

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -109,12 +109,14 @@
       <Link>TaskParameter_Tests.cs</Link>
     </Compile>
     <Compile Include="..\Shared\UnitTests\ObjectModelHelpers.cs" />
-    <Compile Include="..\Shared\UnitTests\CopyOnWriteDictionary_Tests.cs" />
+    <Compile Include="..\Shared\UnitTests\CopyOnWriteDictionary_Tests.cs">
+      <Link>Collections\CopyOnWriteDictionary_Tests.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\UnitTests\TestData\GlobbingTestData.cs">
       <Link>TestData\GlobbingTestData.cs</Link>
     </Compile>
     <Compile Include="..\Shared\UnitTests\ImmutableDictionary_Tests.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(MSBuildRuntimeType)' == 'Full' and '$(MonoBuild)' != 'true'">
-      <Link>ImmutableDictionary_Tests.cs</Link>
+      <Link>Collections\ImmutableDictionary_Tests.cs</Link>
     </Compile>
 
     <None Include="..\Shared\UnitTests\App.config">

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -374,25 +374,11 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal bool Remove(string name)
         {
-            return Remove(name, clearIfEmpty: false);
-        }
-
-        /// <summary>
-        /// Removes any property with the specified name.
-        /// Returns true if the property was in the collection, otherwise false.
-        /// </summary>
-        internal bool Remove(string name, bool clearIfEmpty)
-        {
             ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
 
             lock (_properties)
             {
-                bool result = _properties.Remove(name);
-                if (clearIfEmpty && _properties.Count == 0)
-                {
-                    _properties.Clear();
-                }
-                return result;
+                return _properties.Remove(name);
             }
         }
 

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
+
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Collections
@@ -19,43 +21,35 @@ namespace Microsoft.Build.Collections
     /// </summary>
     /// <remarks>
     /// The value that this adds over IDictionary&lt;string, T&gt; is:
+    ///     - supports copy on write
     ///     - enforces that key = T.Name
     ///     - default enumerator is over values
     ///     - (marginal) enforces the correct key comparer
-    ///     - potentially makes copy on write possible
     /// 
     /// Really a Dictionary&lt;string, T&gt; where the key (the name) is obtained from IKeyed.Key.
     /// Is not observable, so if clients wish to observe modifications they must mediate them themselves and 
     /// either not expose this collection or expose it through a readonly wrapper.
     ///
-    /// At various places in this class locks are taken on the backing collection.  The reason for this is to allow
-    /// this class to be asynchronously enumerated.  This is accomplished by the CopyOnReadEnumerable which will 
-    /// lock the backing collection when it does its deep cloning.  This prevents asynchronous access from corrupting
-    /// the state of the enumeration until the collection has been fully copied.
-    ///
-    /// The use of a CopyOnWriteDictionary does not reduce the concurrency of this collection, because CopyOnWriteDictionary
-    /// offers the same concurrency guarantees (concurrent readers OR single writer) for EACH user of the dictionary.
-    /// 
-    /// Since we use the mutable ignore case comparer we need to make sure that we lock our self before we call the comparer since the comparer can call back 
-    /// into this dictionary which could cause a deadlock if another thread is also accessing another method in the dictionary.
+    /// This collection is safe for concurrent readers and a single writer.
     /// </remarks>
     /// <typeparam name="T">Property or Metadata class type to store</typeparam>
     [DebuggerDisplay("#Entries={Count}")]
     internal sealed class CopyOnWritePropertyDictionary<T> : IEnumerable<T>, IEquatable<CopyOnWritePropertyDictionary<T>>, IDictionary<string, T>
         where T : class, IKeyed, IValued, IEquatable<T>, IImmutable
     {
+        private static readonly ImmutableDictionary<string, T> NameComparerDictionaryPrototype = ImmutableDictionary.Create<string, T>(MSBuildNameIgnoreCaseComparer.Default);
+
         /// <summary>
         /// Backing dictionary
         /// </summary>
-        private readonly CopyOnWriteDictionary<T> _properties;
+        private ImmutableDictionary<string, T> _backing;
 
         /// <summary>
         /// Creates empty dictionary
         /// </summary>
         public CopyOnWritePropertyDictionary()
         {
-            // Tracing.Record("New COWD1");
-            _properties = new CopyOnWriteDictionary<T>(MSBuildNameIgnoreCaseComparer.Default);
+            _backing = NameComparerDictionaryPrototype;
         }
 
         /// <summary>
@@ -63,36 +57,18 @@ namespace Microsoft.Build.Collections
         /// </summary>
         private CopyOnWritePropertyDictionary(CopyOnWritePropertyDictionary<T> that)
         {
-            _properties = that._properties.Clone(); // copy on write!
+            _backing = that._backing;
         }
 
         /// <summary>
         /// Accessor for the list of property names
         /// </summary>
-        ICollection<string> IDictionary<string, T>.Keys
-        {
-            get
-            {
-                lock (_properties)
-                {
-                    return _properties.Keys;
-                }
-            }
-        }
+        ICollection<string> IDictionary<string, T>.Keys => ((IDictionary<string, T>)_backing).Keys;
 
         /// <summary>
         /// Accessor for the list of properties
         /// </summary>
-        ICollection<T> IDictionary<string, T>.Values
-        {
-            get
-            {
-                lock (_properties)
-                {
-                    return _properties.Values;
-                }
-            }
-        }
+        ICollection<T> IDictionary<string, T>.Values => ((IDictionary<string, T>)_backing).Values;
 
         /// <summary>
         /// Whether the collection is read-only.
@@ -102,16 +78,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Returns the number of properties in the collection.
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                lock (_properties)
-                {
-                    return _properties.Count;
-                }
-            }
-        }
+        public int Count => _backing.Count;
 
         /// <summary>
         /// Get the property with the specified name, or null if none exists.
@@ -128,12 +95,7 @@ namespace Microsoft.Build.Collections
             {
                 // We don't want to check for a zero length name here, since that is a valid name
                 // and should return a null instance which will be interpreted as blank
-                T projectProperty;
-                lock (_properties)
-                {
-                    _properties.TryGetValue(name, out projectProperty);
-                }
-
+                _backing.TryGetValue(name, out T projectProperty);
                 return projectProperty;
             }
 
@@ -149,44 +111,26 @@ namespace Microsoft.Build.Collections
         /// Returns true if a property with the specified name is present in the collection,
         /// otherwise false.
         /// </summary>
-        public bool Contains(string name)
-        {
-            return ((IDictionary<string, T>)this).ContainsKey(name);
-        }
+        public bool Contains(string name) => _backing.ContainsKey(name);
 
         /// <summary>
         /// Empties the collection
         /// </summary>
         public void Clear()
         {
-            lock (_properties)
-            {
-                _properties.Clear();
-            }
+            _backing = _backing.Clear();
         }
 
         /// <summary>
         /// Gets an enumerator over all the properties in the collection
         /// Enumeration is in undefined order
         /// </summary>
-        public IEnumerator<T> GetEnumerator()
-        {
-            lock (_properties)
-            {
-                return _properties.Values.GetEnumerator();
-            }
-        }
+        public IEnumerator<T> GetEnumerator() => _backing.Values.GetEnumerator();
 
         /// <summary>
         /// Get an enumerator over entries
         /// </summary>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            lock (_properties)
-            {
-                return ((IEnumerable)_properties.Values).GetEnumerator();
-            }
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         #region IEquatable<PropertyDictionary<T>> Members
 
@@ -203,25 +147,29 @@ namespace Microsoft.Build.Collections
                 return false;
             }
 
-            if (ReferenceEquals(this, other))
+            // Copy both backing collections to locals 
+            ImmutableDictionary<string, T> thisBacking = _backing;
+            ImmutableDictionary<string, T> thatBacking = other._backing;
+
+            // If the backing collections are the same, we are equal.
+            // Note that with this check, we intentionally avoid the common reference
+            // comparison between 'this' and 'other'.
+            if (ReferenceEquals(thisBacking, thatBacking))
             {
                 return true;
             }
 
-            if (Count != other.Count)
+            if (thisBacking.Count != thatBacking.Count)
             {
                 return false;
             }
 
-            lock (_properties)
+            foreach (T thisProp in thisBacking.Values)
             {
-                foreach (T leftProp in this)
+                if (!thatBacking.TryGetValue(thisProp.Key, out T thatProp) ||
+                    !EqualityComparer<T>.Default.Equals(thisProp, thatProp))
                 {
-                    T rightProp = other[leftProp.Key];
-                    if (rightProp == null || !EqualityComparer<T>.Default.Equals(leftProp, rightProp))
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
 
@@ -237,6 +185,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         void IDictionary<string, T>.Add(string key, T value)
         {
+            ErrorUtilities.VerifyThrowInternalNull(value, "Properties can't have null value");
             ErrorUtilities.VerifyThrow(key == value.Key, "Key must match value's key");
             Set(value);
         }
@@ -244,20 +193,12 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Returns true if the dictionary contains the key
         /// </summary>
-        bool IDictionary<string, T>.ContainsKey(string key)
-        {
-            return _properties.ContainsKey(key);
-        }
+        bool IDictionary<string, T>.ContainsKey(string key) => _backing.ContainsKey(key);
 
         /// <summary>
         /// Attempts to retrieve the a property.
         /// </summary>
-        bool IDictionary<string, T>.TryGetValue(string key, out T value)
-        {
-            value = this[key];
-
-            return value != null;
-        }
+        bool IDictionary<string, T>.TryGetValue(string key, out T value) => _backing.TryGetValue(key, out value);
 
         #endregion
 
@@ -276,12 +217,9 @@ namespace Microsoft.Build.Collections
         /// </summary>
         bool ICollection<KeyValuePair<string, T>>.Contains(KeyValuePair<string, T> item)
         {
-            lock (_properties)
+            if (_backing.TryGetValue(item.Key, out T value))
             {
-                if (_properties.TryGetValue(item.Key, out T value))
-                {
-                    return EqualityComparer<T>.Default.Equals(value, item.Value);
-                }
+                return EqualityComparer<T>.Default.Equals(value, item.Value);
             }
 
             return false;
@@ -313,10 +251,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         IEnumerator<KeyValuePair<string, T>> IEnumerable<KeyValuePair<string, T>>.GetEnumerator()
         {
-            lock (_properties)
-            {
-                return _properties.GetEnumerator();
-            }
+            return _backing.GetEnumerator();
         }
 
         #endregion
@@ -329,10 +264,7 @@ namespace Microsoft.Build.Collections
         {
             ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
 
-            lock (_properties)
-            {
-                return _properties.Remove(name);
-            }
+            return ImmutableInterlocked.TryRemove(ref _backing, name, out _);
         }
 
         /// <summary>
@@ -344,10 +276,7 @@ namespace Microsoft.Build.Collections
         {
             ErrorUtilities.VerifyThrowArgumentNull(projectProperty, nameof(projectProperty));
 
-            lock (_properties)
-            {
-                _properties[projectProperty.Key] = projectProperty;
-            }
+            _backing = _backing.SetItem(projectProperty.Key, projectProperty);
         }
 
         /// <summary>
@@ -356,10 +285,14 @@ namespace Microsoft.Build.Collections
         /// <param name="other">An enumerator over the properties to add.</param>
         internal void ImportProperties(IEnumerable<T> other)
         {
-            // Properties are locked in the set method
-            foreach (T property in other)
+            _backing = _backing.SetItems(Items());
+
+            IEnumerable<KeyValuePair<string, T>> Items()
             {
-                Set(property);
+                foreach (T property in other)
+                {
+                    yield return new(property.Key, property);
+                }
             }
         }
 

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -69,7 +69,16 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Accessor for the list of property names
         /// </summary>
-        ICollection<string> IDictionary<string, T>.Keys => PropertyNames;
+        ICollection<string> IDictionary<string, T>.Keys
+        {
+            get
+            {
+                lock (_properties)
+                {
+                    return _properties.Keys;
+                }
+            }
+        }
 
         /// <summary>
         /// Accessor for the list of properties
@@ -114,20 +123,6 @@ namespace Microsoft.Build.Collections
                 lock (_properties)
                 {
                     return _properties.Count;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Retrieves a collection containing the names of all the properties present in the dictionary.
-        /// </summary>
-        internal ICollection<string> PropertyNames
-        {
-            get
-            {
-                lock (_properties)
-                {
-                    return _properties.Keys;
                 }
             }
         }
@@ -178,15 +173,6 @@ namespace Microsoft.Build.Collections
                 ErrorUtilities.VerifyThrow(String.Equals(name, value.Key, StringComparison.OrdinalIgnoreCase), "Key must match value's key");
                 Set(value);
             }
-        }
-
-        /// <summary>
-        /// Returns an enumerable which clones the properties 
-        /// </summary>
-        /// <returns>Returns a cloning enumerable.</returns>
-        public IEnumerable<T> GetCopyOnReadEnumerable()
-        {
-            return new CopyOnReadEnumerable<T>(this, _properties);
         }
 
         /// <summary>
@@ -436,38 +422,6 @@ namespace Microsoft.Build.Collections
             {
                 Set(property);
             }
-        }
-
-        /// <summary>
-        /// Removes the specified properties from this dictionary
-        /// </summary>
-        /// <param name="other">An enumerator over the properties to remove.</param>
-        internal void RemoveProperties(IEnumerable<T> other)
-        {
-            // Properties are locked in the remove method
-            foreach (T property in other)
-            {
-                Remove(property.Key);
-            }
-        }
-
-        /// <summary>
-        /// Helper to convert into a read-only dictionary of string, string.
-        /// </summary>
-        internal IDictionary<string, string> ToDictionary()
-        {
-            Dictionary<string, string> dictionary;
-
-            lock (_properties)
-            {
-                dictionary = new Dictionary<string, string>(_properties.Count, StringComparer.OrdinalIgnoreCase);
-                foreach (T property in this)
-                {
-                    dictionary[property.Key] = property.EscapedValue;
-                }
-            }
-
-            return dictionary;
         }
 
         /// <summary>

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -95,28 +95,14 @@ namespace Microsoft.Build.Collections
         }
 
         /// <summary>
-        /// Returns the number of properties in the collection
-        /// </summary>
-        int ICollection<KeyValuePair<string, T>>.Count
-        {
-            get
-            {
-                lock (_properties)
-                {
-                    return _properties.Count;
-                }
-            }
-        }
-
-        /// <summary>
         /// Whether the collection is read-only.
         /// </summary>
         bool ICollection<KeyValuePair<string, T>>.IsReadOnly => false;
 
         /// <summary>
-        /// Returns the number of property in the collection.
+        /// Returns the number of properties in the collection.
         /// </summary>
-        internal int Count
+        public int Count
         {
             get
             {
@@ -136,23 +122,7 @@ namespace Microsoft.Build.Collections
         /// This better matches the semantics of property, which are considered to have a blank value if they
         /// are not defined.
         /// </remarks>
-        T IDictionary<string, T>.this[string name]
-        {
-            // The backing properties dictionary is locked in the indexor
-            get => this[name];
-            set => this[name] = value;
-        }
-
-        /// <summary>
-        /// Get the property with the specified name, or null if none exists.
-        /// Sets the property with the specified name, overwriting it if already exists.
-        /// </summary>
-        /// <remarks>
-        /// Unlike Dictionary&lt;K,V&gt;[K], the getter returns null instead of throwing if the key does not exist.
-        /// This better matches the semantics of property, which are considered to have a blank value if they
-        /// are not defined.
-        /// </remarks>
-        internal T this[string name]
+        public T this[string name]
         {
             get
             {
@@ -280,15 +250,6 @@ namespace Microsoft.Build.Collections
         }
 
         /// <summary>
-        /// Removes a property
-        /// </summary>
-        bool IDictionary<string, T>.Remove(string key)
-        {
-            // Backing properties are locked in the remove method
-            return Remove(key);
-        }
-
-        /// <summary>
         /// Attempts to retrieve the a property.
         /// </summary>
         bool IDictionary<string, T>.TryGetValue(string key, out T value)
@@ -308,14 +269,6 @@ namespace Microsoft.Build.Collections
         void ICollection<KeyValuePair<string, T>>.Add(KeyValuePair<string, T> item)
         {
             ((IDictionary<string, T>)this).Add(item.Key, item.Value);
-        }
-
-        /// <summary>
-        /// Clears the property collection
-        /// </summary>
-        void ICollection<KeyValuePair<string, T>>.Clear()
-        {
-            Clear();
         }
 
         /// <summary>
@@ -348,7 +301,7 @@ namespace Microsoft.Build.Collections
         bool ICollection<KeyValuePair<string, T>>.Remove(KeyValuePair<string, T> item)
         {
             ErrorUtilities.VerifyThrow(item.Key == item.Value.Key, "Key must match value's key");
-            return ((IDictionary<string, T>)this).Remove(item.Key);
+            return Remove(item.Key);
         }
 
         #endregion
@@ -372,7 +325,7 @@ namespace Microsoft.Build.Collections
         /// Removes any property with the specified name.
         /// Returns true if the property was in the collection, otherwise false.
         /// </summary>
-        internal bool Remove(string name)
+        public bool Remove(string name)
         {
             ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
 

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1376,8 +1376,7 @@ namespace Microsoft.Build.Execution
             {
                 ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
 
-                // If the metadata was all removed, toss the dictionary
-                _directMetadata?.Remove(metadataName, clearIfEmpty: true);
+                _directMetadata?.Remove(metadataName);
             }
 
             /// <summary>


### PR DESCRIPTION
### Context

Some more optimisation of collection types, focussing on  `CopyOnWritePropertyDictionary<>`.

### Changes Made

Previously, `CopyOnWritePropertyDictionary<>` wrapped a  `CopyOnWriteDictionary<>` which in turn wrapped an `ImmutableDictionary<>`.

That middle layer is redundant. Removing it reduces allocations, reduces indirection, replaces virtual calls with non-virtual ones, and allows for more optimal construction of the inner data structures.

By using `ImmutableDictionary<>` directly in `CopyOnWritePropertyDictionary<>` it's possible to remove all locking from the class entirely.

Other changes:

- Remove unused and obsolete members
- Add unit tests (which pass both before and after the core change here)

It may be easiest to review this PR commit by commit.

### Testing

Unit tests.