### PR TITLE
Fixed test that is dependent on current regional settings

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4205,7 +4205,7 @@ $(
         [Fact]
         public void PropertyFunctionMSBuildDivide()
         {
-            TestPropertyFunction("$([MSBuild]::Divide($(X), 10000))", "X", "65536", "6.5536");
+            TestPropertyFunction("$([MSBuild]::Divide($(X), 10000))", "X", "65536", (6.5536).ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #7027

### Context
String result of the `PropertyFunctionMSBuildDivide` test depends on the regional settings, but the `expected` value assumes US decimal symbol, so the test is failing for regional settings with different decimal symbol.

### Changes Made
`ToString` is called on constant double value to respect current formatting. 

### Testing


### Notes
