### PR TITLE
Minor refactor around project cache logging

### DIFF
--- a/src/Build/BackEnd/Components/ProjectCache/PluginLoggerBase.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/PluginLoggerBase.cs
@@ -11,16 +11,6 @@ namespace Microsoft.Build.Experimental.ProjectCache
     /// </summary>
     public abstract class PluginLoggerBase
     {
-        protected PluginLoggerBase(LoggerVerbosity verbosity)
-        {
-            Verbosity = verbosity;
-        }
-
-        /// <summary>
-        ///     See <see cref="ILogger.Verbosity" />
-        /// </summary>
-        private LoggerVerbosity Verbosity { get; }
-
         public abstract bool HasLoggedErrors { get; protected set; }
 
         public abstract void LogMessage(string message, MessageImportance? messageImportance = null);

--- a/src/Build/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Shipped.txt
@@ -1320,7 +1320,6 @@ Microsoft.Build.Experimental.ProjectCache.CacheResultType.CacheMiss = 2 -> Micro
 Microsoft.Build.Experimental.ProjectCache.CacheResultType.CacheNotApplicable = 3 -> Microsoft.Build.Experimental.ProjectCache.CacheResultType
 Microsoft.Build.Experimental.ProjectCache.CacheResultType.None = 0 -> Microsoft.Build.Experimental.ProjectCache.CacheResultType
 Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase
-Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase(Microsoft.Build.Framework.LoggerVerbosity verbosity) -> void
 Microsoft.Build.Experimental.ProjectCache.PluginTargetResult
 Microsoft.Build.Experimental.ProjectCache.PluginTargetResult.PluginTargetResult() -> void
 Microsoft.Build.Experimental.ProjectCache.PluginTargetResult.PluginTargetResult(string targetName, System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Framework.ITaskItem2> taskItems, Microsoft.Build.Execution.BuildResultCode resultCode) -> void

--- a/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.get -> Microsoft.Build.FileSystem.IDirectoryCacheFactory
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.set -> void
+Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase() -> void
 Microsoft.Build.FileSystem.FindPredicate
 Microsoft.Build.FileSystem.FindTransform<TResult>
 Microsoft.Build.FileSystem.IDirectoryCache

--- a/src/Build/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Build/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -1317,7 +1317,6 @@ Microsoft.Build.Experimental.ProjectCache.CacheResultType.CacheMiss = 2 -> Micro
 Microsoft.Build.Experimental.ProjectCache.CacheResultType.CacheNotApplicable = 3 -> Microsoft.Build.Experimental.ProjectCache.CacheResultType
 Microsoft.Build.Experimental.ProjectCache.CacheResultType.None = 0 -> Microsoft.Build.Experimental.ProjectCache.CacheResultType
 Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase
-Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase(Microsoft.Build.Framework.LoggerVerbosity verbosity) -> void
 Microsoft.Build.Experimental.ProjectCache.PluginTargetResult
 Microsoft.Build.Experimental.ProjectCache.PluginTargetResult.PluginTargetResult() -> void
 Microsoft.Build.Experimental.ProjectCache.PluginTargetResult.PluginTargetResult(string targetName, System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Framework.ITaskItem2> taskItems, Microsoft.Build.Execution.BuildResultCode resultCode) -> void

--- a/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.get -> Microsoft.Build.FileSystem.IDirectoryCacheFactory
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.set -> void
+Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase() -> void
 Microsoft.Build.FileSystem.FindPredicate
 Microsoft.Build.FileSystem.FindTransform<TResult>
 Microsoft.Build.FileSystem.IDirectoryCache


### PR DESCRIPTION
The overall goal I'm trying to achieve is general logging cleanup of the project cache code. Currently it looks nothing like regular MSBuild logging, isn't associated with projects, and various other quirks.

This specific change is a light refactor of how the `PluginLoggerBase` provided to plugins is created. It allows for eventually providing the `BuildEventContext`.

It also removes an unused Verbosity provided to the logger. This is technically a breaking change to the public API, although a) `PluginLoggerBase` is in the experimental namespace, b) project cache is new and not likely to be widely used, and c) callers have no way currently to provide their own instance of `PluginLoggerBase`, so subclassing it in the first place makes no sense and thus is very likely not done outside of maybe unit tests.