### PR TITLE
Prevent null reference exception with null Platform when using AL task

### DIFF
--- a/src/Tasks/Al.cs
+++ b/src/Tasks/Al.cs
@@ -306,8 +306,9 @@ namespace Microsoft.Build.Tasks
             if (String.IsNullOrEmpty(pathToTool) || !FileSystems.Default.FileExists(pathToTool))
             {
                 // The bitness of al.exe should match the platform being built
-                string archToLookFor =  Platform.Equals("x86", StringComparison.OrdinalIgnoreCase) ? Platform :
-                                        Platform.Equals("x64", StringComparison.OrdinalIgnoreCase) ? ProcessorArchitecture.AMD64 : // x64 maps to AMD64 in GeneratePathToTool
+                // Yoda condition prevents null reference exception if Platform is null.
+                string archToLookFor =  "x86".Equals(Platform, StringComparison.OrdinalIgnoreCase) ? Platform :
+                                        "x64".Equals(Platform, StringComparison.OrdinalIgnoreCase) ? ProcessorArchitecture.AMD64 : // x64 maps to AMD64 in GeneratePathToTool
                                         ProcessorArchitecture.CurrentProcessArchitecture;
 
                 pathToTool = SdkToolsPathUtility.GeneratePathToTool(f => SdkToolsPathUtility.FileInfoExists(f), archToLookFor, SdkToolsPath, ToolExe, Log, true);


### PR DESCRIPTION
Fixes #7101

### Context
The AL task's Platform property is used to find the architecture, but it can be null. If it is, we should just use the current process architecture. Instead, we were throwing a null reference exception after #7051.

### Changes Made
Switch to yoda condition. Prevents NRE.

### Testing
None