### PR TITLE
Minor cleanup of ProjectLoggingContext

### DIFF
--- a/src/Build.UnitTests/BackEnd/TargetBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetBuilder_Tests.cs
@@ -1632,7 +1632,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
         /// <returns>The context</returns>
         private ProjectLoggingContext GetProjectLoggingContext(BuildRequestEntry entry)
         {
-            return new ProjectLoggingContext(new NodeLoggingContext(_host, 1, false), entry, null);
+            return new ProjectLoggingContext(new NodeLoggingContext(_host, 1, false), entry);
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/TargetEntry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetEntry_Tests.cs
@@ -1190,7 +1190,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <returns>The project logging context.</returns>
         private ProjectLoggingContext GetProjectLoggingContext(BuildRequestEntry entry)
         {
-            return new ProjectLoggingContext(new NodeLoggingContext(_host, 1, false), entry, null);
+            return new ProjectLoggingContext(new NodeLoggingContext(_host, 1, false), entry);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.BackEnd.Logging
         internal ProjectLoggingContext LogProjectStarted(BuildRequestEntry requestEntry)
         {
             ErrorUtilities.VerifyThrow(this.IsValid, "Build not started.");
-            return new ProjectLoggingContext(this, requestEntry, requestEntry.Request.ParentBuildEventContext);
+            return new ProjectLoggingContext(this, requestEntry);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Microsoft.Build.BackEnd.Logging
             // Order is important here because the Project getter will throw if IsCached.
             int evaluationId = (configuration != null && !configuration.IsCached && configuration.Project != null) ? configuration.Project.EvaluationId : BuildEventContext.InvalidEvaluationId;
 
-            return new ProjectLoggingContext(this, request, configuration.ProjectFullPath, configuration.ToolsVersion, request.ParentBuildEventContext, evaluationId);
+            return new ProjectLoggingContext(this, request, configuration.ProjectFullPath, configuration.ToolsVersion, evaluationId);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Constructs a project logging context.
         /// </summary>
-        internal ProjectLoggingContext(NodeLoggingContext nodeLoggingContext, BuildRequestEntry requestEntry, BuildEventContext parentBuildEventContext)
+        internal ProjectLoggingContext(NodeLoggingContext nodeLoggingContext, BuildRequestEntry requestEntry)
             : this
             (
             nodeLoggingContext,
@@ -42,7 +42,7 @@ namespace Microsoft.Build.BackEnd.Logging
             requestEntry.RequestConfiguration.ToolsVersion,
             requestEntry.RequestConfiguration.Project.PropertiesToBuildWith,
             requestEntry.RequestConfiguration.Project.ItemsToBuildWith,
-            parentBuildEventContext,
+            requestEntry.Request.ParentBuildEventContext,
             requestEntry.RequestConfiguration.Project.EvaluationId
             )
         {
@@ -51,7 +51,12 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Constructs a project logging context.
         /// </summary>
-        internal ProjectLoggingContext(NodeLoggingContext nodeLoggingContext, BuildRequest request, string projectFullPath, string toolsVersion, BuildEventContext parentBuildEventContext, int evaluationId = BuildEventContext.InvalidEvaluationId)
+        internal ProjectLoggingContext(
+            NodeLoggingContext nodeLoggingContext,
+            BuildRequest request,
+            string projectFullPath,
+            string toolsVersion,
+            int evaluationId = BuildEventContext.InvalidEvaluationId)
             : this
             (
             nodeLoggingContext,
@@ -60,9 +65,9 @@ namespace Microsoft.Build.BackEnd.Logging
             projectFullPath,
             request.Targets,
             toolsVersion,
-            null,
-            null,
-            parentBuildEventContext,
+            projectProperties: null,
+            projectItems: null,
+            request.ParentBuildEventContext,
             evaluationId
             )
         {

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -24,11 +24,6 @@ namespace Microsoft.Build.BackEnd.Logging
         private string _projectFullPath;
 
         /// <summary>
-        /// The parent node logging context this context was derived from.
-        /// </summary>
-        private NodeLoggingContext _nodeLoggingContext;
-
-        /// <summary>
         /// Constructs a project logging context.
         /// </summary>
         internal ProjectLoggingContext(NodeLoggingContext nodeLoggingContext, BuildRequestEntry requestEntry)
@@ -79,7 +74,6 @@ namespace Microsoft.Build.BackEnd.Logging
         private ProjectLoggingContext(NodeLoggingContext nodeLoggingContext, int submissionId, int configurationId, string projectFullPath, List<string> targets, string toolsVersion, PropertyDictionary<ProjectPropertyInstance> projectProperties, ItemDictionary<ProjectItemInstance> projectItems, BuildEventContext parentBuildEventContext, int evaluationId = BuildEventContext.InvalidEvaluationId)
             : base(nodeLoggingContext)
         {
-            _nodeLoggingContext = nodeLoggingContext;
             _projectFullPath = projectFullPath;
 
             ProjectPropertyInstanceEnumeratorProxy properties = null;
@@ -148,17 +142,6 @@ namespace Microsoft.Build.BackEnd.Logging
             }
 
             this.IsValid = true;
-        }
-
-        /// <summary>
-        /// Retrieves the node logging context.
-        /// </summary>
-        internal NodeLoggingContext NodeLoggingContext
-        {
-            get
-            {
-                return _nodeLoggingContext;
-            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1131,8 +1131,7 @@ namespace Microsoft.Build.BackEnd
                     _nodeLoggingContext,
                     _requestEntry.Request,
                     _requestEntry.RequestConfiguration.ProjectFullPath,
-                    _requestEntry.RequestConfiguration.ToolsVersion,
-                    _requestEntry.Request.ParentBuildEventContext
+                    _requestEntry.RequestConfiguration.ToolsVersion
                     );
 
                 throw;


### PR DESCRIPTION
Just a small cleanup of `ProjectLoggingContext`. 

Specifically:
* Removed the `NodeLoggingContext` property. It was unused
* Removed some ctor params which could be retrieved from sub-objects of other params and which callers *always* provided those values form the sub-objects already