### PR TITLE
Associate Project Cache log messages with the project execution

### DIFF
--- a/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -19,6 +19,7 @@ using System.Xml;
 
 using MockHost = Microsoft.Build.UnitTests.BackEnd.MockHost;
 using Xunit;
+using Shouldly;
 
 namespace Microsoft.Build.UnitTests.Logging
 {
@@ -810,26 +811,149 @@ namespace Microsoft.Build.UnitTests.Logging
         /// Test the case where ProjectFile is good and TargetNames is null.
         /// Expect an event to be logged
         /// </summary>
-        [Fact]
-        public void ProjectStartedEventTests()
+        [Theory]
+        [InlineData("ProjectFile", null)] // Good project File and null target names
+        [InlineData("ProjectFile", "")] // Good project File and empty target names
+        [InlineData(null, null)] // Null project file and null target names
+        [InlineData("", null)] // // Empty project file null target Names
+        [InlineData("", "")] // Empty project File and Empty target Names
+        [InlineData("ProjectFile", "TargetNames")] // Good inputs
+        public void ProjectStartedEventTests(string projectFile, string targetNames)
         {
-            // Good project File and null target names
-            LogProjectStartedTestHelper("ProjectFile", null);
+            string message;
+            if (!String.IsNullOrEmpty(targetNames))
+            {
+                message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ProjectStartedPrefixForTopLevelProjectWithTargetNames", Path.GetFileName(projectFile), targetNames);
+            }
+            else
+            {
+                message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ProjectStartedPrefixForTopLevelProjectWithDefaultTargets", Path.GetFileName(projectFile));
+            }
 
-            // Good project File and empty target names
-            LogProjectStartedTestHelper("ProjectFile", string.Empty);
+            MockHost componentHost = new MockHost();
+            ProcessBuildEventHelper service = (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1, componentHost);
+            ConfigCache cache = (ConfigCache)componentHost.GetComponent(BuildComponentType.ConfigCache);
 
-            // Null project file and null target names
-            LogProjectStartedTestHelper(null, null);
+            BuildRequestData data = new BuildRequestData("file", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), "toolsVersion", new string[0], null);
+            BuildRequestConfiguration config = new BuildRequestConfiguration(2, data, "4.0");
+            cache.AddConfiguration(config);
 
-            // Empty project file null target Names
-            LogProjectStartedTestHelper(string.Empty, null);
+            BuildEventContext context = service.LogProjectStarted(s_buildEventContext, 1, 2, s_buildEventContext, projectFile, targetNames, null, null);
+            BuildEventContext parentBuildEventContext = s_buildEventContext;
+            VerifyProjectStartedEventArgs(service, context.ProjectContextId, message, projectFile, targetNames, parentBuildEventContext, context);
 
-            // Empty project File and Empty target Names
-            LogProjectStartedTestHelper(string.Empty, string.Empty);
+            service.ResetProcessedBuildEvent();
+        }
+        /// <summary>
+        /// Expect the returned BuildEventContext to have the provided ProjectContextId
+        /// </summary>
+        [Fact]
+        public void ProjectStartedProvidedProjectContextId()
+        {
+            const int SubmissionId = 1;
+            const int EvaluationId = 2;
+            const int ConfigurationId = 3;
+            const string ProjectFile = "SomeProjectFile";
 
-            // TestGoodInputs
-            LogProjectStartedTestHelper("ProjectFile", "TargetNames");
+            MockHost componentHost = new MockHost();
+            ProcessBuildEventHelper service = (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1, componentHost);
+            ConfigCache cache = (ConfigCache)componentHost.GetComponent(BuildComponentType.ConfigCache);
+
+            BuildRequestData data = new BuildRequestData(ProjectFile, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), "toolsVersion", Array.Empty<string>(), null);
+            BuildRequestConfiguration config = new BuildRequestConfiguration(ConfigurationId, data, "4.0");
+            cache.AddConfiguration(config);
+
+            BuildEventContext projectCacheBuildEventContext = service.CreateProjectCacheBuildEventContext(SubmissionId, EvaluationId, ConfigurationId, ProjectFile);
+            projectCacheBuildEventContext.NodeId.ShouldBe(Scheduler.InProcNodeId);
+            projectCacheBuildEventContext.ProjectContextId.ShouldNotBe(BuildEventContext.InvalidProjectContextId);
+
+            BuildEventContext nodeBuildEventContext = new BuildEventContext(Scheduler.InProcNodeId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
+            BuildEventContext projectStartedBuildEventContext = service.LogProjectStarted(
+                nodeBuildEventContext,
+                submissionId: SubmissionId,
+                configurationId: ConfigurationId,
+                parentBuildEventContext: BuildEventContext.Invalid,
+                projectFile: ProjectFile,
+                targetNames: "TargetNames",
+                properties: null,
+                items: null,
+                evaluationId: EvaluationId,
+                projectContextId: projectCacheBuildEventContext.ProjectContextId);
+            projectStartedBuildEventContext.ProjectContextId.ShouldBe(projectCacheBuildEventContext.ProjectContextId);
+        }
+        /// <summary>
+        /// Expect an exception to be thrown if an unknown project context id is passed in for the in-proc node
+        /// </summary>
+        [Fact]
+        public void ProjectStartedProvidedUnknownProjectContextIdInProcNode()
+        {
+            const int SubmissionId = 1;
+            const int EvaluationId = 2;
+            const int ConfigurationId = 3;
+            const string ProjectFile = "SomeProjectFile";
+            const int ProjectContextId = 123;
+
+            MockHost componentHost = new MockHost();
+            ProcessBuildEventHelper service = (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1, componentHost);
+            ConfigCache cache = (ConfigCache)componentHost.GetComponent(BuildComponentType.ConfigCache);
+
+            BuildRequestData data = new BuildRequestData(ProjectFile, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), "toolsVersion", Array.Empty<string>(), null);
+            BuildRequestConfiguration config = new BuildRequestConfiguration(ConfigurationId, data, "4.0");
+            cache.AddConfiguration(config);
+
+            BuildEventContext nodeBuildEventContext = new BuildEventContext(Scheduler.InProcNodeId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
+            Assert.Throws<InternalErrorException>(() =>
+            {
+                service.LogProjectStarted(
+                    nodeBuildEventContext,
+                    submissionId: SubmissionId,
+                    configurationId: ConfigurationId,
+                    parentBuildEventContext: BuildEventContext.Invalid,
+                    projectFile: ProjectFile,
+                    targetNames: "TargetNames",
+                    properties: null,
+                    items: null,
+                    evaluationId: EvaluationId,
+                    projectContextId: ProjectContextId);
+            });
+        }
+        /// <summary>
+        /// Expect an unknown project context id to be accepted on an out-of-proc node.
+        /// </summary>
+        [Fact]
+        public void ProjectStartedProvidedUnknownProjectContextIdOutOfProcNode()
+        {
+            const int SubmissionId = 1;
+            const int EvaluationId = 2;
+            const int ConfigurationId = 3;
+            const string ProjectFile = "SomeProjectFile";
+            const int NodeId = 2;
+            const int ProjectContextId = 123;
+
+            // Ensure we didn't pick the one bad const value
+            NodeId.ShouldNotBe(Scheduler.InProcNodeId);
+
+            MockHost componentHost = new MockHost();
+            ProcessBuildEventHelper service = (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1, componentHost);
+            ConfigCache cache = (ConfigCache)componentHost.GetComponent(BuildComponentType.ConfigCache);
+
+            BuildRequestData data = new BuildRequestData(ProjectFile, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), "toolsVersion", Array.Empty<string>(), null);
+            BuildRequestConfiguration config = new BuildRequestConfiguration(ConfigurationId, data, "4.0");
+            cache.AddConfiguration(config);
+
+            BuildEventContext nodeBuildEventContext = new BuildEventContext(NodeId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
+            BuildEventContext projectStartedBuildEventContext = service.LogProjectStarted(
+                nodeBuildEventContext,
+                submissionId: SubmissionId,
+                configurationId: ConfigurationId,
+                parentBuildEventContext: BuildEventContext.Invalid,
+                projectFile: ProjectFile,
+                targetNames: "TargetNames",
+                properties: null,
+                items: null,
+                evaluationId: EvaluationId,
+                projectContextId: ProjectContextId);
+            projectStartedBuildEventContext.ProjectContextId.ShouldBe(ProjectContextId);
         }
 
         #endregion
@@ -1425,36 +1549,6 @@ namespace Microsoft.Build.UnitTests.Logging
             service.OnlyLogCriticalEvents = true;
             service.LogTargetStarted(s_targetBuildEventContext, targetName, projectFile, projectFileOfTarget, parentTargetName, TargetBuiltReason.BeforeTargets);
             Assert.Null(service.ProcessedBuildEvent);
-        }
-
-        /// <summary>
-        /// Test LogProjectStarted
-        /// </summary>
-        private void LogProjectStartedTestHelper(string projectFile, string targetNames)
-        {
-            string message;
-            if (!String.IsNullOrEmpty(targetNames))
-            {
-                message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ProjectStartedPrefixForTopLevelProjectWithTargetNames", Path.GetFileName(projectFile), targetNames);
-            }
-            else
-            {
-                message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ProjectStartedPrefixForTopLevelProjectWithDefaultTargets", Path.GetFileName(projectFile));
-            }
-
-            MockHost componentHost = new MockHost();
-            ProcessBuildEventHelper service = (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1, componentHost);
-            ConfigCache cache = (ConfigCache)componentHost.GetComponent(BuildComponentType.ConfigCache);
-
-            BuildRequestData data = new BuildRequestData("file", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), "toolsVersion", new string[0], null);
-            BuildRequestConfiguration config = new BuildRequestConfiguration(2, data, "4.0");
-            cache.AddConfiguration(config);
-
-            BuildEventContext context = service.LogProjectStarted(s_buildEventContext, 1, 2, s_buildEventContext, projectFile, targetNames, null, null);
-            BuildEventContext parentBuildEventContext = s_buildEventContext;
-            VerifyProjectStartedEventArgs(service, context.ProjectContextId, message, projectFile, targetNames, parentBuildEventContext, context);
-
-            service.ResetProcessedBuildEvent();
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Test LogBuildevent by logging a number of events with both OnlyLogCriticalEvents On and Off
         /// </summary>
@@ -105,6 +106,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an InternlErrorException is thrown when an empty MessageResourceName is passed in.
         /// </summary>
@@ -118,6 +120,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify a message is logged when all of the parameters are filled out correctly.
         /// </summary>
@@ -155,6 +158,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an exception is thrown when a null Invalid ProjectFile exception is passed in
         /// </summary>
@@ -168,6 +172,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify a message is logged when both parameters are good and
         /// the exception has not been logged yet. Verify with and without OnlyLogCriticalEvents.
@@ -216,6 +221,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an InternalErrorException is thrown when fileInfo is null
         /// </summary>
@@ -229,6 +235,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify a error message is correctly logged when  the exception is null.
         /// </summary>
@@ -261,6 +268,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an InternalErrorException is thrown when messageResourceName is empty
         /// </summary>
@@ -275,6 +283,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify a error message is correctly logged when all of the inputs are valid.
         /// </summary>
@@ -335,6 +344,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify a error message is correctly logged when all of the inputs are valid.
         /// </summary>
@@ -375,6 +385,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an InternalErrorException when a null FileInfo is passed in
         /// </summary>
@@ -388,6 +399,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an InternalErrorException is thrown when a null message is passed in
         /// </summary>
@@ -401,6 +413,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Test LogErrorFromText with a number of different inputs
         /// </summary>
@@ -510,6 +523,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an InternalErrorException is thrown when taskName is empty
         /// </summary>
@@ -524,6 +538,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify a LogTaskWarningFromException with a null exception and a non null exception
         /// with all of the other fields properly filled out.
@@ -567,6 +582,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an exception is when a empty MessageResourceName is passed in.
         /// </summary>
@@ -580,6 +596,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify a message is logged when all of the parameters are filled out
         /// </summary>
@@ -607,6 +624,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an InternalErrorException is thrown when a null fileInfo is passed in
         /// </summary>
@@ -620,6 +638,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an InternalErrorException is thrown when a null message is passed in
         /// </summary>
@@ -633,6 +652,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Test LogWarningFromText with a number of different inputs
         /// </summary>
@@ -677,6 +697,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify an InternalErrorException is thrown when a empty messageResource name is passed in
         /// </summary>
@@ -690,6 +711,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify LogComment by testing it with OnlyLogCriticalEvents On and Off when the rest of the fields are
         /// valid inputs.
@@ -730,6 +752,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Verify a message is logged when an empty message is passed in
         /// </summary>
@@ -753,6 +776,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Make sure we can log a comment when everything should be working correctly
         /// </summary>
@@ -793,6 +817,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Expect an exception to be thrown if a null build event context is passed in
         /// and OnlyLogCriticalEvents is false
@@ -807,6 +832,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Test the case where ProjectFile is good and TargetNames is null.
         /// Expect an event to be logged
@@ -844,6 +870,7 @@ namespace Microsoft.Build.UnitTests.Logging
 
             service.ResetProcessedBuildEvent();
         }
+
         /// <summary>
         /// Expect the returned BuildEventContext to have the provided ProjectContextId
         /// </summary>
@@ -881,6 +908,7 @@ namespace Microsoft.Build.UnitTests.Logging
                 projectContextId: projectCacheBuildEventContext.ProjectContextId);
             projectStartedBuildEventContext.ProjectContextId.ShouldBe(projectCacheBuildEventContext.ProjectContextId);
         }
+
         /// <summary>
         /// Expect an exception to be thrown if an unknown project context id is passed in for the in-proc node
         /// </summary>
@@ -917,6 +945,7 @@ namespace Microsoft.Build.UnitTests.Logging
                     projectContextId: ProjectContextId);
             });
         }
+
         /// <summary>
         /// Expect an unknown project context id to be accepted on an out-of-proc node.
         /// </summary>
@@ -973,6 +1002,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Test the project finished event
         /// </summary>
@@ -998,7 +1028,7 @@ namespace Microsoft.Build.UnitTests.Logging
         public void LogBuildStarted()
         {
             ProcessBuildEventHelper service =
-                (ProcessBuildEventHelper) ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1);
+                (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1);
 
             service.LogBuildStarted();
 
@@ -1009,7 +1039,7 @@ namespace Microsoft.Build.UnitTests.Logging
                     service.ProcessedBuildEvent.Timestamp);
 
             Assert.IsType<BuildStartedEventArgs>(service.ProcessedBuildEvent);
-            Assert.Equal(buildEvent, (BuildStartedEventArgs) service.ProcessedBuildEvent,
+            Assert.Equal(buildEvent, (BuildStartedEventArgs)service.ProcessedBuildEvent,
                 new EventArgsEqualityComparer<BuildStartedEventArgs>());
         }
 
@@ -1020,7 +1050,7 @@ namespace Microsoft.Build.UnitTests.Logging
         public void LogBuildStartedCriticalOnly()
         {
             ProcessBuildEventHelper service =
-                (ProcessBuildEventHelper) ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1);
+                (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1);
             service.OnlyLogCriticalEvents = true;
             service.LogBuildStarted();
 
@@ -1030,7 +1060,7 @@ namespace Microsoft.Build.UnitTests.Logging
                     null /* no help keyword */);
 
             Assert.IsType<BuildStartedEventArgs>(service.ProcessedBuildEvent);
-            Assert.Equal(buildEvent, (BuildStartedEventArgs) service.ProcessedBuildEvent,
+            Assert.Equal(buildEvent, (BuildStartedEventArgs)service.ProcessedBuildEvent,
                 new EventArgsEqualityComparer<BuildStartedEventArgs>());
         }
 
@@ -1089,6 +1119,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Test the case where TaskName
         /// </summary>
@@ -1124,6 +1155,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Test the case where TaskName is null.
         /// </summary>
@@ -1164,6 +1196,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Test the target started event with a null target name.
         /// </summary>
@@ -1212,6 +1245,7 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
+
         /// <summary>
         /// Test the case where TargetName is null.
         /// </summary>

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -477,7 +477,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             => new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
 
         /// <inheritdoc />
-        public BuildEventContext CreateProjectCacheBuildEventContext(int submissionId, int evaluationId, int projectInstanceId)
+        public BuildEventContext CreateProjectCacheBuildEventContext(int submissionId, int evaluationId, int projectInstanceId, string projectFile)
             => new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
 
         /// <inheritdoc />

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -474,9 +474,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         /// <inheritdoc />
         public BuildEventContext CreateEvaluationBuildEventContext(int nodeId, int submissionId)
-        {
-            return new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
-        }
+            => new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
+
+        /// <inheritdoc />
+        public BuildEventContext CreateProjectCacheBuildEventContext(int nodeId, int submissionId, int evaluationId, int projectInstanceId)
+            => new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
 
         /// <inheritdoc />
         public void LogProjectEvaluationStarted(BuildEventContext eventContext, string projectFile)
@@ -499,7 +501,17 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <summary>
         /// Logs a project started event
         /// </summary>
-        public BuildEventContext LogProjectStarted(BuildEventContext nodeBuildEventContext, int submissionId, int projectId, BuildEventContext parentBuildEventContext, string projectFile, string targetNames, IEnumerable<DictionaryEntry> properties, IEnumerable<DictionaryEntry> items, int evaluationId = BuildEventContext.InvalidEvaluationId)
+        public BuildEventContext LogProjectStarted(
+            BuildEventContext nodeBuildEventContext,
+            int submissionId,
+            int configurationId,
+            BuildEventContext parentBuildEventContext,
+            string projectFile,
+            string targetNames,
+            IEnumerable<DictionaryEntry> properties,
+            IEnumerable<DictionaryEntry> items,
+            int evaluationId = BuildEventContext.InvalidEvaluationId,
+            int projectContextId = BuildEventContext.InvalidProjectContextId)
         {
             return new BuildEventContext(0, 0, 0, 0);
         }

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -477,7 +477,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             => new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
 
         /// <inheritdoc />
-        public BuildEventContext CreateProjectCacheBuildEventContext(int nodeId, int submissionId, int evaluationId, int projectInstanceId)
+        public BuildEventContext CreateProjectCacheBuildEventContext(int submissionId, int evaluationId, int projectInstanceId)
             => new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
 
         /// <inheritdoc />

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -477,15 +477,26 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         /// <param name="nodeBuildEventContext">The logging context of the node which is building this project.</param>
         /// <param name="submissionId">The id of the build submission.</param>
-        /// <param name="projectId">The id of the project instance which is about to start</param>
+        /// <param name="configurationId">The id of the project configuration which is about to start</param>
         /// <param name="parentBuildEventContext">The build context of the parent project which asked this project to build</param>
         /// <param name="projectFile">The project file path of the project about to be built</param>
         /// <param name="targetNames">The entrypoint target names for this project</param>
         /// <param name="properties">The initial properties of the project</param>
         /// <param name="items">The initial items of the project</param>
         /// <param name="evaluationId">EvaluationId of the project instance</param>
+        /// <param name="projectContextId">The project context id</param>
         /// <returns>The BuildEventContext to use for this project.</returns>
-        BuildEventContext LogProjectStarted(BuildEventContext nodeBuildEventContext, int submissionId, int projectId, BuildEventContext parentBuildEventContext, string projectFile, string targetNames, IEnumerable<DictionaryEntry> properties, IEnumerable<DictionaryEntry> items, int evaluationId = BuildEventContext.InvalidEvaluationId);
+        BuildEventContext LogProjectStarted(
+            BuildEventContext nodeBuildEventContext,
+            int submissionId,
+            int configurationId,
+            BuildEventContext parentBuildEventContext,
+            string projectFile,
+            string targetNames,
+            IEnumerable<DictionaryEntry> properties,
+            IEnumerable<DictionaryEntry> items,
+            int evaluationId = BuildEventContext.InvalidEvaluationId,
+            int projectContextId = BuildEventContext.InvalidProjectContextId);
 
         /// <summary>
         /// Log that the project has finished

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -447,6 +447,15 @@ namespace Microsoft.Build.BackEnd.Logging
         BuildEventContext CreateEvaluationBuildEventContext(int nodeId, int submissionId);
 
         /// <summary>
+        /// Create a project cache context, by generating a new project context id.
+        /// </summary>
+        /// <param name="submissionId">The submission id</param>
+        /// <param name="evaluationId">The evaluation id</param>
+        /// <param name="projectInstanceId">The project instance id</param>
+        /// <returns></returns>
+        BuildEventContext CreateProjectCacheBuildEventContext(int submissionId, int evaluationId, int projectInstanceId);
+
+        /// <summary>
         /// Logs that a project evaluation has started
         /// </summary>
         /// <param name="eventContext">The event context to use for logging</param>

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -452,8 +452,9 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="submissionId">The submission id</param>
         /// <param name="evaluationId">The evaluation id</param>
         /// <param name="projectInstanceId">The project instance id</param>
+        /// <param name="projectFile">Project file being built</param>
         /// <returns></returns>
-        BuildEventContext CreateProjectCacheBuildEventContext(int submissionId, int evaluationId, int projectInstanceId);
+        BuildEventContext CreateProjectCacheBuildEventContext(int submissionId, int evaluationId, int projectInstanceId, string projectFile);
 
         /// <summary>
         /// Logs that a project evaluation has started

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -483,9 +483,13 @@ namespace Microsoft.Build.BackEnd.Logging
 
         /// <inheritdoc />
         public BuildEventContext CreateEvaluationBuildEventContext(int nodeId, int submissionId)
-        {
-            return new BuildEventContext(submissionId, nodeId, NextEvaluationId, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-        }
+            => new BuildEventContext(submissionId, nodeId, NextEvaluationId, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+
+        /// <inheritdoc />
+        public BuildEventContext CreateProjectCacheBuildEventContext(int submissionId, int evaluationId, int projectInstanceId)
+            // Because the project cache runs in the BuildManager, it makes some sense to associate logging with the in-proc node.
+            // If a invalid node id is used the messages become deferred in the console logger and spit out at the end.
+            => new BuildEventContext(submissionId, Scheduler.InProcNodeId, evaluationId, projectInstanceId, NextProjectId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
 
         /// <inheritdoc />
         public void LogProjectEvaluationStarted(BuildEventContext projectEvaluationEventContext, string projectFile)

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -492,16 +492,19 @@ namespace Microsoft.Build.BackEnd.Logging
             int projectInstanceId,
             string projectFile)
         {
-            int projectContextId = NextProjectId;
+            lock (_lockObject)
+            {
+                int projectContextId = NextProjectId;
 
-            // In the future if some LogProjectCacheStarted event is created, move this there to align with evaluation and build execution.
-            _projectFileMap[projectContextId] = projectFile;
+                // In the future if some LogProjectCacheStarted event is created, move this there to align with evaluation and build execution.
+                _projectFileMap[projectContextId] = projectFile;
 
-            // Because the project cache runs in the BuildManager, it makes some sense to associate logging with the in-proc node.
-            // If a invalid node id is used the messages become deferred in the console logger and spit out at the end.
-            int nodeId = Scheduler.InProcNodeId;
+                // Because the project cache runs in the BuildManager, it makes some sense to associate logging with the in-proc node.
+                // If a invalid node id is used the messages become deferred in the console logger and spit out at the end.
+                int nodeId = Scheduler.InProcNodeId;
 
-            return new BuildEventContext(submissionId, nodeId, evaluationId, projectInstanceId, projectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+                return new BuildEventContext(submissionId, nodeId, evaluationId, projectInstanceId, projectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+            }
         }
 
         /// <inheritdoc />

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.BackEnd.Logging
             requestEntry.RequestConfiguration.Project.ItemsToBuildWith,
             requestEntry.Request.ParentBuildEventContext,
             requestEntry.RequestConfiguration.Project.EvaluationId,
-            requestEntry.Request.BuildEventContext.ProjectContextId // TODO: Bad
+            requestEntry.Request.ProjectContextId
             )
         {
         }
@@ -51,8 +51,7 @@ namespace Microsoft.Build.BackEnd.Logging
             BuildRequest request,
             string projectFullPath,
             string toolsVersion,
-            int evaluationId = BuildEventContext.InvalidEvaluationId,
-            int projectContextId = BuildEventContext.InvalidProjectContextId)
+            int evaluationId = BuildEventContext.InvalidEvaluationId)
             : this
             (
             nodeLoggingContext,
@@ -65,7 +64,7 @@ namespace Microsoft.Build.BackEnd.Logging
             projectItems: null,
             request.ParentBuildEventContext,
             evaluationId,
-            projectContextId
+            request.ProjectContextId
             )
         {
         }

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Build.Framework;
-using Microsoft.Build.Execution;
 using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
-using Microsoft.Build.Collections;
-using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.BackEnd.Logging
 {
@@ -38,7 +37,8 @@ namespace Microsoft.Build.BackEnd.Logging
             requestEntry.RequestConfiguration.Project.PropertiesToBuildWith,
             requestEntry.RequestConfiguration.Project.ItemsToBuildWith,
             requestEntry.Request.ParentBuildEventContext,
-            requestEntry.RequestConfiguration.Project.EvaluationId
+            requestEntry.RequestConfiguration.Project.EvaluationId,
+            requestEntry.Request.BuildEventContext.ProjectContextId // TODO: Bad
             )
         {
         }
@@ -51,7 +51,8 @@ namespace Microsoft.Build.BackEnd.Logging
             BuildRequest request,
             string projectFullPath,
             string toolsVersion,
-            int evaluationId = BuildEventContext.InvalidEvaluationId)
+            int evaluationId = BuildEventContext.InvalidEvaluationId,
+            int projectContextId = BuildEventContext.InvalidProjectContextId)
             : this
             (
             nodeLoggingContext,
@@ -63,7 +64,8 @@ namespace Microsoft.Build.BackEnd.Logging
             projectProperties: null,
             projectItems: null,
             request.ParentBuildEventContext,
-            evaluationId
+            evaluationId,
+            projectContextId
             )
         {
         }
@@ -71,7 +73,18 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Constructs a project logging contexts.
         /// </summary>
-        private ProjectLoggingContext(NodeLoggingContext nodeLoggingContext, int submissionId, int configurationId, string projectFullPath, List<string> targets, string toolsVersion, PropertyDictionary<ProjectPropertyInstance> projectProperties, ItemDictionary<ProjectItemInstance> projectItems, BuildEventContext parentBuildEventContext, int evaluationId = BuildEventContext.InvalidEvaluationId)
+        private ProjectLoggingContext(
+            NodeLoggingContext nodeLoggingContext,
+            int submissionId,
+            int configurationId,
+            string projectFullPath,
+            List<string> targets,
+            string toolsVersion,
+            PropertyDictionary<ProjectPropertyInstance> projectProperties,
+            ItemDictionary<ProjectItemInstance> projectItems,
+            BuildEventContext parentBuildEventContext,
+            int evaluationId,
+            int projectContextId)
             : base(nodeLoggingContext)
         {
             _projectFullPath = projectFullPath;
@@ -130,10 +143,12 @@ namespace Microsoft.Build.BackEnd.Logging
                 configurationId,
                 parentBuildEventContext,
                 projectFullPath,
-                String.Join(";", targets),
+                string.Join(";", targets),
                 properties,
                 items,
-                evaluationId);
+                evaluationId,
+                projectContextId
+                );
 
             // No need to log a redundant message in the common case
             if (toolsVersion != "Current")

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -217,18 +217,23 @@ namespace Microsoft.Build.Experimental.ProjectCache
         {
             Task.Run(async () =>
             {
+                var buildEventContext = _loggingService.CreateProjectCacheBuildEventContext(
+                    cacheRequest.Submission.SubmissionId,
+                    evaluationId: cacheRequest.Configuration.Project.EvaluationId,
+                    projectInstanceId: cacheRequest.Configuration.ConfigurationId);
+
                 try
                 {
-                    var cacheResult = await ProcessCacheRequest(cacheRequest);
-                    _buildManager.PostCacheResult(cacheRequest, cacheResult);
+                    var cacheResult = await ProcessCacheRequest(cacheRequest, buildEventContext);
+                    _buildManager.PostCacheResult(cacheRequest, cacheResult, buildEventContext.ProjectContextId);
                 }
                 catch (Exception e)
                 {
-                    _buildManager.PostCacheResult(cacheRequest, CacheResult.IndicateException(e));
+                    _buildManager.PostCacheResult(cacheRequest, CacheResult.IndicateException(e), buildEventContext.ProjectContextId);
                 }
             }, _cancellationToken);
 
-            async Task<CacheResult> ProcessCacheRequest(CacheRequest request)
+            async Task<CacheResult> ProcessCacheRequest(CacheRequest request, BuildEventContext buildEventContext)
             {
                 // Prevent needless evaluation if design time builds detected.
                 if (_projectCacheDescriptor.VsWorkaround && DesignTimeBuildsDetected)
@@ -286,10 +291,10 @@ namespace Microsoft.Build.Experimental.ProjectCache
                     _projectCacheDescriptor.VsWorkaround && LateInitializationForVSWorkaroundCompleted.Task.IsCompleted,
                     "Completion source should be null when this is not the VS workaround");
 
-                return await GetCacheResultAsync(
-                    new BuildRequestData(
-                        request.Configuration.Project,
-                        request.Submission.BuildRequestData.TargetNames.ToArray()));
+                BuildRequestData buildRequest = new BuildRequestData(
+                    cacheRequest.Configuration.Project,
+                    cacheRequest.Submission.BuildRequestData.TargetNames.ToArray());
+                return await GetCacheResultAsync(buildRequest, buildEventContext);
             }
 
             static bool IsDesignTimeBuild(ProjectInstance project)
@@ -448,7 +453,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 ConversionUtilities.ConvertStringToBool(msbuildString, nullOrWhitespaceIsFalse: true);
         }
 
-        private async Task<CacheResult> GetCacheResultAsync(BuildRequestData buildRequest)
+        private async Task<CacheResult> GetCacheResultAsync(BuildRequestData buildRequest, BuildEventContext buildEventContext)
         {
             lock (this)
             {
@@ -467,8 +472,6 @@ namespace Microsoft.Build.Experimental.ProjectCache
                                    $"\n\tTargets:[{string.Join(", ", buildRequest.TargetNames)}]" +
                                    $"\n\tGlobal Properties: {{{string.Join(",", buildRequest.GlobalProperties.Select(kvp => $"{kvp.Name}={kvp.EvaluatedValue}"))}}}";
 
-            // TODO: Get a valid BuildEventContext to correcctly associate cache-related log events with the build
-            var buildEventContext = BuildEventContext.Invalid;
             var buildEventFileInfo = new BuildEventFileInfo(buildRequest.ProjectFullPath);
             var logger = new LoggingServiceToPluginLoggerAdapter(
                 _loggingService,

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Build.BackEnd
         private int _configurationId;
 
         /// <summary>
+        /// The project context id, if already determined.
+        /// </summary>
+        private int _projectContextId;
+
+        /// <summary>
         /// The global build request id, assigned by the Build Manager
         /// </summary>
         private int _globalRequestId;
@@ -98,11 +103,13 @@ namespace Microsoft.Build.BackEnd
             int nodeRequestId,
             int configurationId,
             HostServices hostServices,
-            BuildRequestDataFlags buildRequestDataFlags = BuildRequestDataFlags.None,
-            RequestedProjectState requestedProjectState = null)
+            BuildRequestDataFlags buildRequestDataFlags,
+            RequestedProjectState requestedProjectState,
+            int projectContextId)
         {
             _submissionId = submissionId;
             _configurationId = configurationId;
+            _projectContextId = projectContextId;
 
             HostServices = hostServices;
             _buildEventContext = BuildEventContext.Invalid;
@@ -123,6 +130,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="hostServices">Host services if any. May be null.</param>
         /// <param name="buildRequestDataFlags">Additional flags for the request.</param>
         /// <param name="requestedProjectState">Filter for desired build results.</param>
+        /// <param name="projectContextId">The project context id</param>
         public BuildRequest(
             int submissionId,
             int nodeRequestId,
@@ -130,9 +138,9 @@ namespace Microsoft.Build.BackEnd
             ProxyTargets proxyTargets,
             HostServices hostServices,
             BuildRequestDataFlags buildRequestDataFlags = BuildRequestDataFlags.None,
-            RequestedProjectState requestedProjectState = null)
-            : this(submissionId, nodeRequestId, configurationId, hostServices, buildRequestDataFlags,
-                requestedProjectState)
+            RequestedProjectState requestedProjectState = null,
+            int projectContextId = BuildEventContext.InvalidProjectContextId)
+            : this(submissionId, nodeRequestId, configurationId, hostServices, buildRequestDataFlags, requestedProjectState, projectContextId)
         {
             _proxyTargets = proxyTargets;
             _targets = proxyTargets.ProxyTargetToRealTargetMap.Keys.ToList();
@@ -155,6 +163,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="skipStaticGraphIsolationConstraints"></param>
         /// <param name="buildRequestDataFlags">Additional flags for the request.</param>
         /// <param name="requestedProjectState">Filter for desired build results.</param>
+        /// <param name="projectContextId">The project context id</param>
         public BuildRequest(
             int submissionId,
             int nodeRequestId,
@@ -165,8 +174,9 @@ namespace Microsoft.Build.BackEnd
             BuildRequest parentRequest,
             BuildRequestDataFlags buildRequestDataFlags = BuildRequestDataFlags.None,
             RequestedProjectState requestedProjectState = null,
-            bool skipStaticGraphIsolationConstraints = false)
-        : this(submissionId, nodeRequestId, configurationId, hostServices, buildRequestDataFlags, requestedProjectState)
+            bool skipStaticGraphIsolationConstraints = false,
+            int projectContextId = BuildEventContext.InvalidProjectContextId)
+        : this(submissionId, nodeRequestId, configurationId, hostServices, buildRequestDataFlags, requestedProjectState, projectContextId)
         {
             ErrorUtilities.VerifyThrowArgumentNull(escapedTargets, "targets");
             ErrorUtilities.VerifyThrowArgumentNull(parentBuildEventContext, nameof(parentBuildEventContext));
@@ -220,6 +230,16 @@ namespace Microsoft.Build.BackEnd
             [DebuggerStepThrough]
             get
             { return _configurationId; }
+        }
+
+        /// <summary>
+        /// Returns the project context id
+        /// </summary>
+        public int ProjectContextId
+        {
+            [DebuggerStepThrough]
+            get
+            { return _projectContextId; }
         }
 
         /// <summary>
@@ -406,6 +426,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _requestedProjectState);
             translator.Translate(ref _hostServices);
             translator.Translate(ref _proxyTargets, ProxyTargets.FactoryForDeserialization);
+            translator.Translate(ref _projectContextId);
 
             // UNDONE: (Compat) Serialize the host object.
         }

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Initializes a build request with a parent context.
+        /// Initializes a build request with proxy targets.
         /// </summary>
         /// <param name="submissionId">The id of the build submission.</param>
         /// <param name="nodeRequestId">The id of the node issuing the request</param>


### PR DESCRIPTION
This change creates a `projectContextId` during project cache execution to use for logging. Then that same `projectContextId` is used for the build execution (if needed) so that the cache-related log messages are structured under the build execution for that project.

Although the cache-related log messages come before the "project started" event, the somehow still get nested under it, both in console logging(!?) and binary logging. This is what we want anyway though, so I won't question it.

Example of the change in structure. Left is current, right is new:
![image](https://user-images.githubusercontent.com/6445614/144328069-622665be-bf0c-42db-bdf4-ecc7fac309d8.png)

In a future change I plan to clean up the hard-coded log messages that the `ProjectCacheService` uses in favor of properly localized string which also look more "MSBuild-y".

Note that commits are broken down to perhaps make reviewing more bite-sized. Feel free to review each commit as opposed to the whole PR at once.