### PR TITLE
Don't reference PublicApiAnalyzers in sourcebuild

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -85,7 +85,7 @@
 
   <ItemGroup Condition="'$(GenerateReferenceAssemblySource)' == 'true'">
     <!-- Ensure API stability for shipping packages -->
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(DotNetBuildFromSource)' != 'true'" />
 
     <AdditionalFiles Include="PublicAPI/$(PublicApiTfm)/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/$(PublicApiTfm)/PublicAPI.Unshipped.txt" />


### PR DESCRIPTION
This package is only super relevant at PR-build time so it should
be fine to drop it from source-build scenarios. Fixes #7115.

cc @MichaelSimons 