### PR TITLE
Parse SolutionItems from the Solution File

### DIFF
--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -110,6 +110,12 @@ namespace Microsoft.Build.Construction
         private readonly Dictionary<string, ProjectConfigurationInSolution> _projectConfigurations;
         private IReadOnlyDictionary<string, ProjectConfigurationInSolution> _projectConfigurationsReadOnly;
 
+        /// <summary>
+        /// A list of strings representing relative paths from the solution file to loose items.
+        /// </summary>
+        private readonly List<string> _solutionItems;
+        private IReadOnlyList<string> _solutionItemsAsReadOnly;
+
         #endregion
 
         #region Constructors
@@ -132,6 +138,7 @@ namespace Microsoft.Build.Construction
             AspNetConfigurations = new Hashtable(StringComparer.OrdinalIgnoreCase);
 
             _projectConfigurations = new Dictionary<string, ProjectConfigurationInSolution>(StringComparer.OrdinalIgnoreCase);
+            _solutionItems = new List<string>();
         }
 
         #endregion
@@ -214,6 +221,15 @@ namespace Microsoft.Build.Construction
         public IReadOnlyList<string> Dependencies => _dependenciesAsReadonly ?? (_dependenciesAsReadonly = _dependencies.AsReadOnly());
 
         /// <summary>
+        /// List of relative paths mapping to loose folders or files, as defined in the solution file.
+        /// </summary>
+        /// <remarks>
+        /// There is no grouping or ordering inherent in this list (nor is there in the solution file itself), so callers
+        /// should enforce their own grouping or ordering before using this.
+        /// </remarks>
+        public IReadOnlyList<string> SolutionItems => _solutionItemsAsReadOnly ?? (_solutionItemsAsReadOnly = _solutionItems.AsReadOnly());
+
+        /// <summary>
         /// Configurations for this project, keyed off the configuration's full name, e.g. "Debug|x86"
         /// They contain only the project configurations from the solution file that fully matched (configuration and platform) against the solution configurations.
         /// </summary>
@@ -261,6 +277,15 @@ namespace Microsoft.Build.Construction
         {
             _dependencies.Add(referencedProjectGuid);
             _dependenciesAsReadonly = null;
+        }
+
+        /// <summary>
+        /// Add the relative path to the solution item to our solution items list.
+        /// </summary>
+        internal void AddSolutionItem(string relativeFilePath)
+        {
+            _solutionItems.Add(relativeFilePath);
+            _solutionItemsAsReadOnly = null;
         }
 
         /// <summary>

--- a/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.Build.Construction.ProjectInSolution.SolutionItems.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.get -> Microsoft.Build.FileSystem.IDirectoryCacheFactory
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.set -> void
 Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase() -> void

--- a/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.Build.Construction.ProjectInSolution.SolutionItems.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.get -> Microsoft.Build.FileSystem.IDirectoryCacheFactory
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.set -> void
 Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase() -> void


### PR DESCRIPTION
Fixes #1708

### Context

The solution file can contain a list of loose folders and files in a dedicated project section that are encoded as key/value lines, where the key and value are both the relative path from the solution file to the item.  This change adds a simple parser for these lines to the existing SolutionFile parser, following the established conventions of the surrounding code.

### Changes Made

A new section-parser was added to the ParseProject method in SolutionFile.
A new backing List and public ReadOnlyList was added to the ProjectInSolution type, with an associated internal helper method to be used by the parser.

### Testing

This logic has been in active use in the ionide/proj-info project for solution file parsing for several years now, and powers our solution explorer view:

![image](https://user-images.githubusercontent.com/573979/144634976-f0c3b98c-f49b-44f3-a7f0-02ccc606fd81.png)

In the above image, you can see the `SolutionItems` virtual folder at the top of the solution tree, and it contains the two items from the MSBuild.sln's Project Section.  This is all extracted using this logic.

This is a very simple example, but it's been bulletproof for years now.  I couldn't find any existing testing for the solution file parser in this repo, but I'd be glad to add it if desired.
