### PR TITLE
Add ProjectCollectionRootElementCache

### DIFF
--- a/src/Build/Definition/ProjectCollectionRootElementCache.cs
+++ b/src/Build/Definition/ProjectCollectionRootElementCache.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Construction;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Evaluation;
+
+/// <summary>
+/// ProjectCollectionRootElementCache represents the cache used by a <see cref="ProjectCollection"/> for <see cref="ProjectRootElement"/>.
+/// </summary>
+public class ProjectCollectionRootElementCache
+{
+    internal readonly ProjectRootElementCacheBase ProjectRootElementCache;
+
+    /// <summary>
+    /// Initialize a ProjectCollectionRootElementCache instance.
+    /// </summary>
+    /// <param name="loadProjectsReadOnly">If set to true, load all projects as read-only.</param>
+    /// <param name="autoReloadFromDisk">If set to true, Whether the cache should check the timestamp of the file on disk whenever it is requested, and update with the latest content of that file if it has changed.</param>
+    public ProjectCollectionRootElementCache(bool loadProjectsReadOnly, bool autoReloadFromDisk = false)
+    {
+        if (Traits.Instance.UseSimpleProjectRootElementCacheConcurrency)
+        {
+            ProjectRootElementCache = new SimpleProjectRootElementCache();
+        }
+        else
+        {
+            ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk: autoReloadFromDisk, loadProjectsReadOnly);
+        }
+    }
+}

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -149,6 +149,7 @@
     <Compile Include="BackEnd\Components\SdkResolution\SdkResolverException.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\TranslationHelpers.cs" />
     <Compile Include="FileSystem\*.cs" />
+    <Compile Include="Definition\ProjectCollectionRootElementCache.cs" />
     <Compile Include="Utilities\ImmutableCollectionsExtensions.cs" />
     <Compile Include="Utilities\NuGetFrameworkWrapper.cs" />
     <Compile Include="ObjectModelRemoting\ConstructionObjectLinks\ProjectUsingTaskParameterElementLink.cs" />

--- a/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.get -> Microsoft.Build.FileSystem.IDirectoryCacheFactory
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.set -> void
+Microsoft.Build.Evaluation.ProjectCollection.ProjectCollection(System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, Microsoft.Build.Evaluation.ProjectCollectionRootElementCache projectCollectionRootElementCache) -> void
+Microsoft.Build.Evaluation.ProjectCollection.ProjectCollectionRootElementCache.get -> Microsoft.Build.Evaluation.ProjectCollectionRootElementCache
+Microsoft.Build.Evaluation.ProjectCollectionRootElementCache
+Microsoft.Build.Evaluation.ProjectCollectionRootElementCache.ProjectCollectionRootElementCache(bool loadProjectsReadOnly, bool autoReloadFromDisk = false) -> void
 Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase() -> void
 Microsoft.Build.FileSystem.FindPredicate
 Microsoft.Build.FileSystem.FindTransform<TResult>


### PR DESCRIPTION
Fixes #7107

### Context

Loading ProjectRootElement can be a costly operation. Today, we cannot share the `ProjectRootElementCacheBase` that is used by a ProjectCollection. This PR is attempting to fix this issue.

### Changes Made

- Add a new class `ProjectCollectionRootElementCache` that is holding a `ProjectRootElementCacheBase`.
- Add a new constructor to `ProjectCollection` that allows to pass this cache around.
- Allow the `ProjectCollectionRootElementCache` to specify `autoReloadFromDisk`. It was not possible previously, but it is important for scenarios where you want to create a server that maintains a life sync state with the disk.

### Testing

- I haven't added a test, but let me know where it would be best to add them.

### Notes

- Added the new API to `PublicAPI.Unshipped.txt`, but not sure if it is the right place to add them.
- The parameters `loadProjectsReadOnly` and `autoReloadFromDisk` of `ProjectCollectionRootElementCache` ctor are not added as readonly properties. They could be added.