### PR TITLE
Avoid loading Framework/Utilities in CodeTaskFactory

### DIFF
--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -683,18 +683,24 @@ namespace Microsoft.Build.Tasks
 
                 try
                 {
+                    // Framework and Utilities are default references but are often
+                    // specified in the UsingTask anyway; if so just ignore them.
+                    //
+                    // Do this with an explicit upfront check rather than loading the
+                    // assembly and then checking its name, because that can cause
+                    // the loader to have multiple copies of these assemblies as in
+                    // https://github.com/dotnet/msbuild/issues/7108.
+
+                    string name = AssemblyName.GetAssemblyName(assemblyFile).FullName;
+                    if (name == _msbuildFrameworkName ||
+                        name == _msbuildUtilitiesName)
+                    {
+                        return false;
+                    }
+
                     Assembly candidateAssembly = Assembly.UnsafeLoadFrom(assemblyFile);
                     if (candidateAssembly != null)
                     {
-                        string name = candidateAssembly.FullName;
-                        if (name == _msbuildFrameworkName ||
-                            name == _msbuildUtilitiesName)
-                        {
-                            // Framework and Utilities are default references but are often
-                            // specified in the UsingTask anyway; if so just ignore them.
-                            return false;
-                        }
-
                         candidateAssemblyLocation = candidateAssembly.Location;
                         s_knownReferenceAssemblies[candidateAssembly.FullName] = candidateAssembly;
                     }


### PR DESCRIPTION
Fixes #7108 by moving the check of whether a given assembly is one of
the ones we'll provide by default to occur before the assembly is
loaded. This should prevent loading the amd64 copy of either assembly
side-by-side with the bin copy, and thus keep downstream consumers
from getting type definitions from the wrong assembly.
