### PR TITLE
Fix possible race condition in ProjectRootElementCache.Get

### DIFF
--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2124,11 +2124,7 @@ namespace Microsoft.Build.Evaluation
                         // clearing the weak cache (and therefore setting explicitload=false) for projects the project system never
                         // was directly interested in (i.e. the ones that were reached for purposes of building a P2P.)
                         bool explicitlyLoaded = importElement.ContainingProject.IsExplicitlyLoaded;
-                        importedProjectElement = _projectRootElementCache.Get(
-                            importFileUnescaped,
-                            (p, c) =>
-                            {
-                                return ProjectRootElement.OpenProjectOrSolution(
+                        importedProjectElement = ProjectRootElement.OpenProjectOrSolution(
                                     importFileUnescaped,
                                     new ReadOnlyConvertingDictionary<string, ProjectPropertyInstance, string>(
                                         _data.GlobalPropertiesDictionary,
@@ -2136,10 +2132,6 @@ namespace Microsoft.Build.Evaluation
                                     _data.ExplicitToolsVersion,
                                     _projectRootElementCache,
                                     explicitlyLoaded);
-                            },
-                            explicitlyLoaded,
-                            // don't care about formatting, reuse whatever is there
-                            preserveFormatting: null);
 
                         if (duplicateImport)
                         {

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -15,10 +15,6 @@ using System.Globalization;
 using Microsoft.Build.Internal;
 using OutOfProcNode = Microsoft.Build.Execution.OutOfProcNode;
 
-#if DEBUG
-using System.Threading;
-#endif
-
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
@@ -231,7 +227,7 @@ namespace Microsoft.Build.Evaluation
         {
 #if DEBUG
             // Verify that loadProjectRootElement delegate does not call ProjectRootElementCache.Get().
-            Interlocked.Increment(ref s_getEntriesNumber);
+            s_getEntriesNumber++;
             ErrorUtilities.VerifyThrow(
                 s_getEntriesNumber == 1,
                 "Reentrance to the ProjectRootElementCache.Get function detected."
@@ -328,7 +324,7 @@ namespace Microsoft.Build.Evaluation
             }
             finally
             {
-                Interlocked.Decrement(ref s_getEntriesNumber);
+                s_getEntriesNumber--;
             }
 #endif
         }

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -275,7 +275,12 @@ namespace Microsoft.Build.Evaluation
 
                 projectRootElement = openProjectRootElement(projectFile, this);
                 ErrorUtilities.VerifyThrowInternalNull(projectRootElement, "projectRootElement");
-                ErrorUtilities.VerifyThrow(projectRootElement.FullPath == projectFile, "Got project back with incorrect path");
+                ErrorUtilities.VerifyThrow(
+                    projectRootElement.FullPath.Equals(projectFile, StringComparison.OrdinalIgnoreCase),
+                    "Got project back with incorrect path. Expected path: {0}, received path: {1}.",
+                    projectFile,
+                    projectRootElement.FullPath
+                );
 
                 // An implicit load will never reset the explicit flag.
                 if (isExplicitlyLoaded)

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -236,101 +236,101 @@ namespace Microsoft.Build.Evaluation
                 s_getEntriesNumber == 1,
                 "Reentrance to the ProjectRootElementCache.Get function detected."
             );
+
+            try {
 #endif
+                // Should already have been canonicalized
+                ErrorUtilities.VerifyThrowInternalRooted(projectFile);
 
-            // Should already have been canonicalized
-            ErrorUtilities.VerifyThrowInternalRooted(projectFile);
-
-            ProjectRootElement projectRootElement;
-            lock (_locker)
-            {
-                _weakCache.TryGetValue(projectFile, out projectRootElement);
-
-                if (projectRootElement != null)
+                ProjectRootElement projectRootElement;
+                lock (_locker)
                 {
-                    BoostEntryInStrongCache(projectRootElement);
+                    _weakCache.TryGetValue(projectFile, out projectRootElement);
+
+                    if (projectRootElement != null)
+                    {
+                        BoostEntryInStrongCache(projectRootElement);
+
+                        // An implicit load will never reset the explicit flag.
+                        if (isExplicitlyLoaded)
+                        {
+                            projectRootElement.MarkAsExplicitlyLoaded();
+                        }
+                    }
+                    else
+                    {
+                        DebugTraceCache("Not found in cache: ", projectFile);
+                    }
+
+                    if (preserveFormatting != null && projectRootElement != null && projectRootElement.XmlDocument.PreserveWhitespace != preserveFormatting)
+                    {
+                        //  Cached project doesn't match preserveFormatting setting, so reload it
+                        projectRootElement.Reload(true, preserveFormatting);
+                    }
+                }
+
+                bool projectRootElementIsInvalid = IsInvalidEntry(projectFile, projectRootElement);
+                if (projectRootElementIsInvalid)
+                {
+                    DebugTraceCache("Not satisfied from cache: ", projectFile);
+                    ForgetEntryIfExists(projectRootElement);
+                }
+
+                if (loadProjectRootElement == null)
+                {
+                    if (projectRootElement == null || projectRootElementIsInvalid)
+                    {
+                        return null;
+                    }
+                    else
+                    {
+                        DebugTraceCache("Satisfied from XML cache: ", projectFile);
+                        return projectRootElement;
+                    }
+                }
+
+                // Use openProjectRootElement to reload the element if the cache element does not exist or need to be reloaded.
+                if (projectRootElement == null || projectRootElementIsInvalid)
+                {
+                    // We do not lock loading with common _locker of the cache, to avoid lock contention.
+                    // Decided also not to lock this section with the key specific locker to avoid the overhead and code overcomplication, as
+                    // it is not likely that two threads would use Get function for the same project simultaneously and it is not a big deal if in some cases we load the same project twice.
+
+                    projectRootElement = loadProjectRootElement(projectFile, this);
+                    ErrorUtilities.VerifyThrowInternalNull(projectRootElement, "projectRootElement");
+                    ErrorUtilities.VerifyThrow(
+                        projectRootElement.FullPath.Equals(projectFile, StringComparison.OrdinalIgnoreCase),
+                        "Got project back with incorrect path. Expected path: {0}, received path: {1}.",
+                        projectFile,
+                        projectRootElement.FullPath
+                    );
 
                     // An implicit load will never reset the explicit flag.
                     if (isExplicitlyLoaded)
                     {
                         projectRootElement.MarkAsExplicitlyLoaded();
                     }
-                }
-                else
-                {
-                    DebugTraceCache("Not found in cache: ", projectFile);
-                }
 
-                if (preserveFormatting != null && projectRootElement != null && projectRootElement.XmlDocument.PreserveWhitespace != preserveFormatting)
-                {
-                    //  Cached project doesn't match preserveFormatting setting, so reload it
-                    projectRootElement.Reload(true, preserveFormatting);
-                }
-            }
-
-            bool projectRootElementIsInvalid = IsInvalidEntry(projectFile, projectRootElement);
-            if (projectRootElementIsInvalid)
-            {
-                DebugTraceCache("Not satisfied from cache: ", projectFile);
-                ForgetEntryIfExists(projectRootElement);
-            }
-
-            if (loadProjectRootElement == null)
-            {
-                if (projectRootElement == null || projectRootElementIsInvalid)
-                {
-#if DEBUG
-                    Interlocked.Decrement(ref s_getEntriesNumber);
-#endif
-                    return null;
+                    // Update cache element.
+                    // It is unlikely, but it might be that while without the lock, the projectRootElement in cache was updated by another thread.
+                    // And here its entry will be replaced with the loaded projectRootElement. This is fine:
+                    // if loaded projectRootElement is out of date (so, it changed since the time we loaded it), it will be updated the next time some thread calls Get function.
+                    AddEntry(projectRootElement);
                 }
                 else
                 {
                     DebugTraceCache("Satisfied from XML cache: ", projectFile);
-#if DEBUG
-                    Interlocked.Decrement(ref s_getEntriesNumber);
-#endif
-                    return projectRootElement;
-                }
-            }
-
-            // Use openProjectRootElement to reload the element if the cache element does not exist or need to be reloaded.
-            if (projectRootElement == null || projectRootElementIsInvalid)
-            {
-                // We do not lock loading with common _locker of the cache, to avoid lock contention.
-                // Decided also not to lock this section with the key specific locker to avoid the overhead and code overcomplication, as
-                // it is not likely that two threads would use Get function for the same project simultaneously and it is not a big deal if in some cases we load the same project twice.
-
-                projectRootElement = loadProjectRootElement(projectFile, this);
-                ErrorUtilities.VerifyThrowInternalNull(projectRootElement, "projectRootElement");
-                ErrorUtilities.VerifyThrow(
-                    projectRootElement.FullPath.Equals(projectFile, StringComparison.OrdinalIgnoreCase),
-                    "Got project back with incorrect path. Expected path: {0}, received path: {1}.",
-                    projectFile,
-                    projectRootElement.FullPath
-                );
-
-                // An implicit load will never reset the explicit flag.
-                if (isExplicitlyLoaded)
-                {
-                    projectRootElement.MarkAsExplicitlyLoaded();
                 }
 
-                // Update cache element.
-                // It is unlikely, but it might be that while without the lock, the projectRootElement in cache was updated by another thread.
-                // And here its entry will be replaced with the loaded projectRootElement. This is fine:
-                // if loaded projectRootElement is out of date (so, it changed since the time we loaded it), it will be updated the next time some thread calls Get function.
-                AddEntry(projectRootElement);
-            }
-            else
-            {
-                DebugTraceCache("Satisfied from XML cache: ", projectFile);
-            }
 
+                return projectRootElement;
 #if DEBUG
-            Interlocked.Decrement(ref s_getEntriesNumber);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref s_getEntriesNumber);
+            }
 #endif
-            return projectRootElement;
         }
 
         /// <summary>

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal event EventHandler<ProjectChangedEventArgs> ProjectDirtied;
 
-        internal abstract ProjectRootElement Get(string projectFile, OpenProjectRootElement openProjectRootElement,
+        internal abstract ProjectRootElement Get(string projectFile, OpenProjectRootElement loadProjectRootElement,
             bool isExplicitlyLoaded,
             bool? preserveFormatting);
 

--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -61,8 +61,12 @@ namespace Microsoft.Build.Evaluation
             {
                 ProjectRootElement rootElement = openFunc(key, this);
                 ErrorUtilities.VerifyThrowInternalNull(rootElement, "projectRootElement");
-                ErrorUtilities.VerifyThrow(rootElement.FullPath.Equals(key, StringComparison.OrdinalIgnoreCase),
-                    "Got project back with incorrect path");
+                ErrorUtilities.VerifyThrow(
+                    rootElement.FullPath.Equals(key, StringComparison.OrdinalIgnoreCase),
+                    "Got project back with incorrect path. Expected path: {0}, received path: {1}.",
+                    key,
+                    rootElement.FullPath
+                );
 
                 AddEntry(rootElement);
 

--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -33,16 +33,16 @@ namespace Microsoft.Build.Evaluation
 
         internal override ProjectRootElement Get(
             string projectFile,
-            OpenProjectRootElement openProjectRootElement,
+            OpenProjectRootElement loadProjectRootElement,
             bool isExplicitlyLoaded,
             bool? preserveFormatting)
         {
             // Should already have been canonicalized
             ErrorUtilities.VerifyThrowInternalRooted(projectFile);
 
-            return openProjectRootElement == null
+            return loadProjectRootElement == null
                 ? GetFromCache(projectFile)
-                : GetFromOrAddToCache(projectFile, openProjectRootElement);
+                : GetFromOrAddToCache(projectFile, loadProjectRootElement);
         }
 
         private ProjectRootElement GetFromCache(string projectFile)
@@ -55,11 +55,11 @@ namespace Microsoft.Build.Evaluation
             return null;
         }
 
-        private ProjectRootElement GetFromOrAddToCache(string projectFile, OpenProjectRootElement openFunc)
+        private ProjectRootElement GetFromOrAddToCache(string projectFile, OpenProjectRootElement loadFunc)
         {
             return _cache.GetOrAdd(projectFile, key =>
             {
-                ProjectRootElement rootElement = openFunc(key, this);
+                ProjectRootElement rootElement = loadFunc(key, this);
                 ErrorUtilities.VerifyThrowInternalNull(rootElement, "projectRootElement");
                 ErrorUtilities.VerifyThrow(
                     rootElement.FullPath.Equals(key, StringComparison.OrdinalIgnoreCase),


### PR DESCRIPTION
Fixes possible race condition in `ProjectRootElementCache.Get` supposedly introduced in #6680.

### Context
Passing a load function that uses `ProjectRootElementCache.Get` to `ProjectRootElementCache.Get` function could lead to failure (to verify a path in the loaded ProjectRootElement), due to a race condition. We eliminate calling `ProjectRootElementCache.Get` inside the load function, eliminating an unnecessary double entry to `ProjectRootElementCache.Get` function.

### Changes Made
- Remove double entry to `ProjectRootElementCache.Get` function that could cause race condition.
- Adjust path verification in `ProjectRootElementCache` and `SimpleProjectRootElementCache` to be more safe and to have more information.

### Testing
Unit tests + manual testing

### Notes
The stack trace of failure:

```
> ##[error]C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.RestoreEx.targets(19,5): Error : MSB0001: Internal MSBuild Error: Got project back with incorrect path 
> at Microsoft.Build.Shared.ErrorUtilities.ThrowInternalError(String message, Exception innerException, Object[] args) 
> at Microsoft.Build.Evaluation.ProjectRootElementCache.Get(String projectFile, OpenProjectRootElement openProjectRootElement, Boolean isExplicitlyLoaded, Nullable1 preserveFormatting) 
> at Microsoft.Build.Evaluation.Evaluator4.ExpandAndLoadImportsFromUnescapedImportExpression(String directoryOfImportingFile, ProjectImportElement importElement, String unescapedExpression, Boolean throwOnFileNotExistsError, List1& imports) 
> at Microsoft.Build.Evaluation.Evaluator4.ExpandAndLoadImportsFromUnescapedImportExpressionConditioned(String directoryOfImportingFile, ProjectImportElement importElement, List1& projects, SdkResult& sdkResult, Boolean throwOnFileNotExistsError) 
> at Microsoft.Build.Evaluation.Evaluator4.ExpandAndLoadImports(String directoryOfImportingFile, ProjectImportElement importElement, SdkResult& sdkResult) 
> at Microsoft.Build.Evaluation.Evaluator4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement) 
> at Microsoft.Build.Evaluation.Evaluator4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport) 
> at Microsoft.Build.Evaluation.Evaluator4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement) 
> at Microsoft.Build.Evaluation.Evaluator4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport) 
> at Microsoft.Build.Evaluation.Evaluator4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement) 
> at Microsoft.Build.Evaluation.Evaluator4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport) 
> at Microsoft.Build.Evaluation.Evaluator4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement) 
> at Microsoft.Build.Evaluation.Evaluator4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport) 
> at Microsoft.Build.Evaluation.Evaluator4.Evaluate() 

```
