### PR TITLE
Add more SdkResolverService events and allow SdkResolvers to log events

### DIFF
--- a/documentation/specs/event-source.md
+++ b/documentation/specs/event-source.md
@@ -5,23 +5,30 @@
 ## EventSource in MSBuild
 EventSource is primarily used to profile code. For MSBuild specifically, a major goal is to reduce the time it takes to run, as measured (among other metrics) by the Regression Prevention System (RPS), i.e., running specific scenarios. To find which code segments were likely candidates for improvement, EventSources were added around a mix of code segments. Larger segments that encompass several steps within a build occur nearly every time MSBuild is run and take a long time. They generally run relatively few times. Smaller methods with well-defined purposes may occur numerous times. Profiling both types of events provides both broad strokes to identify large code segments that underperform and, more specifically, which parts of them. Profiled functions include:
 
-* MSBuildExe: Executes MSBuild from the command line.
-* Build: Sets up a BuildManager to receive build requests.
-* BuildProject: Builds a project file.
-* RequestThreadProc: A function to requesting a new builder thread.
-* LoadDocument: Loads an XMLDocumentWithLocation from a path.
-* RarRemoveReferencesMarkedForExclusion: Removes blacklisted references from the reference table, putting primary and dependency references in invalid file lists.
-* RarComputeClosure: Resolves references from, for example, properties to explicit values. Used in resolving assembly references (RAR).
-* EvaluateCondition: Checks whether a condition is true and removes false conditionals.
-* Parse: Parses an XML document into a ProjectRootElement.
-* Evaluate: Evaluates a project, running several other parts of MSBuild in the process.
-* GenerateResourceOverall: Uses resource APIs to transform resource files into strongly-typed resource classes.
-* ExpandGlob: Identifies a list of files that correspond to an item, potentially with a wildcard.
-* ApplyLazyItemOperations: Collects a set of items, mutates them in a specified way, and saves the results in a lazy way.
-* RarOverall: Initiates the process of resolving assembly references (RAR).
-* Save: Saves a project to the file system if dirty, creating directories as necessary.
-* Target: Executes a target.
-* RarLogResults: Logs the results from having resolved assembly references (RAR).
+| Event | Description |
+| ------| ------------|
+| MSBuildExe | Executes MSBuild from the command line. |
+| Build | Sets up a BuildManager to receive build requests. |
+| BuildProject | Builds a project file. |
+| RequestThreadProc | A function to requesting a new builder thread. |
+| LoadDocument | Loads an XMLDocumentWithLocation from a path.
+| RarRemoveReferencesMarkedForExclusion | Removes blacklisted references from the reference table, putting primary and dependency references in invalid file lists. |
+| RarComputeClosure | Resolves references from, for example, properties to explicit values. Used in resolving assembly references (RAR). |
+| EvaluateCondition | Checks whether a condition is true and removes false conditionals. |
+| Parse | Parses an XML document into a ProjectRootElement. |
+| Evaluate | Evaluates a project, running several other parts of MSBuild in the process. |
+| GenerateResourceOverall | Uses resource APIs to transform resource files into strongly-typed resource classes. |
+| ExpandGlob | Identifies a list of files that correspond to an item, potentially with a wildcard. |
+| ApplyLazyItemOperations | Collects a set of items, mutates them in a specified way, and saves the results in a lazy way. |
+| RarOverall | Initiates the process of resolving assembly references (RAR). |
+| Save | Saves a project to the file system if dirty, creating directories as necessary. |
+| Target | Executes a target. |
+| RarLogResults | Logs the results from having resolved assembly references (RAR). |
+| SdkResolverServiceInitialize | Initializes SDK resolvers. |
+| SdkResolverResolveSdk | A single SDK resolver is called. |
+| CachedSdkResolverServiceResolveSdk | The caching SDK resolver service is resolving an SDK. |
+| SdkResolverEvent | An SDK resolver logs an event. |
+| OutOfProcSdkResolverServiceRequestSdkPathFromMainNode | An out-of-proc node requests an SDK be resolved from the main node. |
 
 One can run MSBuild with eventing using the following command:
 

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         {
             SdkResult result;
 
-            bool wasResultCached = false;
+            bool wasResultCached = true;
 
             MSBuildEventSource.Log.CachedSdkResolverServiceResolveSdkStart(sdk.Name, solutionPath, projectPath);
 
@@ -59,9 +59,12 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                  */
                 Lazy<SdkResult> resultLazy = cached.GetOrAdd(
                     sdk.Name,
-                    key => new Lazy<SdkResult>(() => base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio)));
+                    key => new Lazy<SdkResult>(() =>
+                    {
+                        wasResultCached = false;
 
-                wasResultCached = resultLazy.IsValueCreated;
+                        return base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
+                    }));
 
                 // Get the lazy value which will block all waiting threads until the SDK is resolved at least once while subsequent calls get cached results.
                 result = resultLazy.Value;

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -64,16 +64,19 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
         public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
-            bool wasResultCached = false;
+            bool wasResultCached = true;
 
             MSBuildEventSource.Log.OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStart(submissionId, sdk.Name, solutionPath, projectPath);
 
             // Get a cached response if possible, otherwise send the request
             Lazy<SdkResult> sdkResultLazy = _responseCache.GetOrAdd(
                 sdk.Name,
-                key => new Lazy<SdkResult>(() => RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio)));
+                key => new Lazy<SdkResult>(() =>
+                {
+                    wasResultCached = false;
 
-            wasResultCached = sdkResultLazy.IsValueCreated;
+                    return RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
+                }));
 
             SdkResult sdkResult = sdkResultLazy.Value;
 

--- a/src/Build/BackEnd/Components/SdkResolution/SdkLogger.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkLogger.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Eventing;
 using Microsoft.Build.Framework;
 
 using SdkLoggerBase = Microsoft.Build.Framework.SdkLogger;
@@ -18,6 +19,21 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         public SdkLogger(LoggingContext loggingContext)
         {
             _loggingContext = loggingContext;
+        }
+
+        public override void LogEvent(params object[] args)
+        {
+            MSBuildEventSource.Log.SdkResolverEvent(args);
+        }
+
+        public override void LogEventStart(params object[] args)
+        {
+            MSBuildEventSource.Log.SdkResolverEventStart(args);
+        }
+
+        public override void LogEventStop(params object[] args)
+        {
+            MSBuildEventSource.Log.SdkResolverEventStop(args);
         }
 
         public override void LogMessage(string message, MessageImportance messageImportance = MessageImportance.Low)

--- a/src/Build/BackEnd/Components/SdkResolution/SdkLogger.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkLogger.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.BackEnd.Logging;
-using Microsoft.Build.Eventing;
 using Microsoft.Build.Framework;
 
 using SdkLoggerBase = Microsoft.Build.Framework.SdkLogger;
@@ -19,21 +18,6 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         public SdkLogger(LoggingContext loggingContext)
         {
             _loggingContext = loggingContext;
-        }
-
-        public override void LogEvent(params object[] args)
-        {
-            MSBuildEventSource.Log.SdkResolverEvent(args);
-        }
-
-        public override void LogEventStart(params object[] args)
-        {
-            MSBuildEventSource.Log.SdkResolverEventStart(args);
-        }
-
-        public override void LogEventStop(params object[] args)
-        {
-            MSBuildEventSource.Log.SdkResolverEventStop(args);
         }
 
         public override void LogMessage(string message, MessageImportance messageImportance = MessageImportance.Low)

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -485,9 +485,9 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(67, Keywords = Keywords.All)]
-        public void CachedSdkResolverServiceResolveSdkStop(string sdkName, string solutionPath, string projectPath, bool success)
+        public void CachedSdkResolverServiceResolveSdkStop(string sdkName, string solutionPath, string projectPath, bool success, bool wasResultCached)
         {
-            WriteEvent(67, sdkName, solutionPath, projectPath, success);
+            WriteEvent(67, sdkName, solutionPath, projectPath, success, wasResultCached);
         }
 
         /// <remarks>
@@ -538,27 +538,15 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(74, Keywords = Keywords.All)]
-        public void CachedSdkResolverServiceResolveSdkFromCache(string sdkName, string solutionPath, string projectPath, bool success)
+        public void OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStart(int submissionId, string sdkName, string solutionPath, string projectPath)
         {
-            WriteEvent(74, sdkName, solutionPath, projectPath, success);
+            WriteEvent(74, submissionId, sdkName, solutionPath, projectPath);
         }
 
         [Event(75, Keywords = Keywords.All)]
-        public void OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStart(int submissionId, string sdkName, string solutionPath, string projectPath)
+        public void OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStop(int submissionId, string sdkName, string solutionPath, string projectPath, bool success, bool wasResultCached)
         {
-            WriteEvent(75, submissionId, sdkName, solutionPath, projectPath);
-        }
-
-        [Event(76, Keywords = Keywords.All)]
-        public void OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStop(int submissionId, string sdkName, string solutionPath, string projectPath, bool success)
-        {
-            WriteEvent(76, submissionId, sdkName, solutionPath, projectPath, success);
-        }
-
-        [Event(77, Keywords = Keywords.All)]
-        public void OutOfProcSdkResolverServiceResolveSdkFromCache(int submissionId, string sdkName, string solutionPath, string projectPath, bool success)
-        {
-            WriteEvent(77, submissionId, sdkName, solutionPath, projectPath, success);
+            WriteEvent(75, submissionId, sdkName, solutionPath, projectPath, success, wasResultCached);
         }
 
         #endregion

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -519,6 +519,48 @@ namespace Microsoft.Build.Eventing
             WriteEvent(70, oldHash, newHash);
         }
 
-#endregion
+        [Event(71, Keywords = Keywords.All)]
+        public void SdkResolverEvent(params object[] args)
+        {
+            WriteEvent(71, args);
+        }
+
+        [Event(72, Keywords = Keywords.All)]
+        public void SdkResolverEventStart(params object[] args)
+        {
+            WriteEvent(72, args);
+        }
+
+        [Event(73, Keywords = Keywords.All)]
+        public void SdkResolverEventStop(params object[] args)
+        {
+            WriteEvent(73, args);
+        }
+
+        [Event(74, Keywords = Keywords.All)]
+        public void CachedSdkResolverServiceResolveSdkFromCache(string sdkName, string solutionPath, string projectPath, bool success)
+        {
+            WriteEvent(74, sdkName, solutionPath, projectPath, success);
+        }
+
+        [Event(75, Keywords = Keywords.All)]
+        public void OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStart(int submissionId, string sdkName, string solutionPath, string projectPath)
+        {
+            WriteEvent(75, submissionId, sdkName, solutionPath, projectPath);
+        }
+
+        [Event(76, Keywords = Keywords.All)]
+        public void OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStop(int submissionId, string sdkName, string solutionPath, string projectPath, bool success)
+        {
+            WriteEvent(76, submissionId, sdkName, solutionPath, projectPath, success);
+        }
+
+        [Event(77, Keywords = Keywords.All)]
+        public void OutOfProcSdkResolverServiceResolveSdkFromCache(int submissionId, string sdkName, string solutionPath, string projectPath, bool success)
+        {
+            WriteEvent(77, submissionId, sdkName, solutionPath, projectPath, success);
+        }
+
+        #endregion
     }
 }

--- a/src/Framework/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Framework/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+abstract Microsoft.Build.Framework.SdkLogger.LogEvent(params object[] args) -> void
+abstract Microsoft.Build.Framework.SdkLogger.LogEventStart(params object[] args) -> void
+abstract Microsoft.Build.Framework.SdkLogger.LogEventStop(params object[] args) -> void

--- a/src/Framework/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Framework/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
-abstract Microsoft.Build.Framework.SdkLogger.LogEvent(params object[] args) -> void
-abstract Microsoft.Build.Framework.SdkLogger.LogEventStart(params object[] args) -> void
-abstract Microsoft.Build.Framework.SdkLogger.LogEventStop(params object[] args) -> void
+virtual Microsoft.Build.Framework.SdkLogger.LogEvent(params object[] args) -> void
+virtual Microsoft.Build.Framework.SdkLogger.LogEventStart(params object[] args) -> void
+virtual Microsoft.Build.Framework.SdkLogger.LogEventStop(params object[] args) -> void

--- a/src/Framework/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Framework/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+abstract Microsoft.Build.Framework.SdkLogger.LogEvent(params object[] args) -> void
+abstract Microsoft.Build.Framework.SdkLogger.LogEventStart(params object[] args) -> void
+abstract Microsoft.Build.Framework.SdkLogger.LogEventStop(params object[] args) -> void

--- a/src/Framework/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Framework/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
-abstract Microsoft.Build.Framework.SdkLogger.LogEvent(params object[] args) -> void
-abstract Microsoft.Build.Framework.SdkLogger.LogEventStart(params object[] args) -> void
-abstract Microsoft.Build.Framework.SdkLogger.LogEventStop(params object[] args) -> void
+virtual Microsoft.Build.Framework.SdkLogger.LogEvent(params object[] args) -> void
+virtual Microsoft.Build.Framework.SdkLogger.LogEventStart(params object[] args) -> void
+virtual Microsoft.Build.Framework.SdkLogger.LogEventStop(params object[] args) -> void

--- a/src/Framework/Sdk/SdkLogger.cs
+++ b/src/Framework/Sdk/SdkLogger.cs
@@ -15,5 +15,23 @@ namespace Microsoft.Build.Framework
         /// <param name="message">Message string.</param>
         /// <param name="messageImportance">Optional message importances. Default to low.</param>
         public abstract void LogMessage(string message, MessageImportance messageImportance = MessageImportance.Low);
+
+        /// <summary>
+        /// Logs that an event.
+        /// </summary>
+        /// <param name="args">An array of arguments to log with the event.</param>
+        public abstract void LogEvent(params object[] args);
+
+        /// <summary>
+        /// Logs that an event when an operation has started.
+        /// </summary>
+        /// <param name="args">An array of arguments to log with the event.</param>
+        public abstract void LogEventStart(params object[] args);
+
+        /// <summary>
+        /// Logs that an event when an operation has completed.
+        /// </summary>
+        /// <param name="args">An array of arguments to log with the event.</param>
+        public abstract void LogEventStop(params object[] args);
     }
 }

--- a/src/Framework/Sdk/SdkLogger.cs
+++ b/src/Framework/Sdk/SdkLogger.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Build.Eventing;
+
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -20,18 +22,27 @@ namespace Microsoft.Build.Framework
         /// Logs that an event.
         /// </summary>
         /// <param name="args">An array of arguments to log with the event.</param>
-        public abstract void LogEvent(params object[] args);
+        public virtual void LogEvent(params object[] args)
+        {
+            MSBuildEventSource.Log.SdkResolverEvent(args);
+        }
 
         /// <summary>
         /// Logs that an event when an operation has started.
         /// </summary>
         /// <param name="args">An array of arguments to log with the event.</param>
-        public abstract void LogEventStart(params object[] args);
+        public virtual void LogEventStart(params object[] args)
+        {
+            MSBuildEventSource.Log.SdkResolverEventStart(args);
+        }
 
         /// <summary>
         /// Logs that an event when an operation has completed.
         /// </summary>
         /// <param name="args">An array of arguments to log with the event.</param>
-        public abstract void LogEventStop(params object[] args);
+        public virtual void LogEventStop(params object[] args)
+        {
+            MSBuildEventSource.Log.SdkResolverEventStop(args);
+        }
     }
 }


### PR DESCRIPTION
Fixes #7136

### Context
Adding on to https://github.com/dotnet/msbuild/pull/6876, this change adds more events to SDK resolution.

### Changes Made
1. Add boolean to `CachedSdkResolverServiceResolveSdkStop` so we can differentiate cached and non-cached calls
4. Add `OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStart` and `OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStop` events to track how long it takes to send/receive an SDK result from the main node
5. Add `SdkResolverEvent`, `SdkResolverEventStart`, and `SdkResolverEventStop` methods to `Microsoft.Build.Framework.SdkLogger` so that SDK resolvers can contribute to the events in SDK resolution.

### Testing


### Notes
