### PR TITLE
Fix bug in CacheSerialization.SerializeCaches

### DIFF
--- a/src/Build/BackEnd/BuildManager/CacheSerialization.cs
+++ b/src/Build/BackEnd/BuildManager/CacheSerialization.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Build.Execution
 
                 Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
 
-                using (var fileStream = File.OpenWrite(fullPath))
+                // Use FileStream constructor (File.OpenWrite should not be used as it doesn't reset the length of the file!)
+                using (var fileStream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
                     var translator = BinaryTranslator.GetWriteTranslator(fileStream);
 

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -3347,13 +3347,13 @@ namespace Microsoft.Build.Tasks
         {
             if (_usePreserializedResources && HaveSystemResourcesExtensionsReference)
             {
-                WriteResources(reader, new PreserializedResourceWriter(File.OpenWrite(filename))); // closes writer for us
+                WriteResources(reader, new PreserializedResourceWriter(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None))); // closes writer for us
                 return;
             }
 
             try
             {
-                WriteResources(reader, new ResourceWriter(File.OpenWrite(filename))); // closes writer for us
+                WriteResources(reader, new ResourceWriter(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None))); // closes writer for us
             }
             catch (PreserializedResourceWriterRequiredException)
             {


### PR DESCRIPTION
### Context

The method `CacheSerialization.SerializeCaches` was using `File.OpenWrite(fullPath)` which is pretty confusing if a file already exists, as it will write to it without truncating it. So if a cache file was 10MB and we then write a file that is just 5KB, the file will still be 10MB.

### Changes Made

- Use `FileStream` constructor instead with a more adequate behavior.