### PR TITLE
Add ProjectImportInstance to ProjectInstance

### DIFF
--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -857,6 +857,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                     : expectedImportPaths;
 
                 Helpers.AssertListsValueEqual(expectedImportPaths, projectInstance.ImportPaths.ToList());
+                var expectedImports = expectedImportPaths.Select(x => new ProjectImportInstance(x, File.GetLastWriteTime(x))).ToList();
+                Helpers.AssertListsValueEqual(expectedImports, projectInstance.Imports.ToList());
                 Helpers.AssertListsValueEqual(expectedImportPathsIncludingDuplicates, projectInstance.ImportPathsIncludingDuplicates.ToList());
             }
             finally

--- a/src/Build/Instance/ProjectImportInstance.cs
+++ b/src/Build/Instance/ProjectImportInstance.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Execution;
 /// <summary>
 /// Defines an import from a specific path and that was read at a specified time.
 /// </summary>
-public struct ProjectImportInstance
+public record struct ProjectImportInstance
 {
     /// <summary>
     /// Constructor of this instance.

--- a/src/Build/Instance/ProjectImportInstance.cs
+++ b/src/Build/Instance/ProjectImportInstance.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Execution;
+
+/// <summary>
+/// Defines an import from a specific path and that was read at a specified time.
+/// </summary>
+public struct ProjectImportInstance
+{
+    /// <summary>
+    /// Constructor of this instance.
+    /// </summary>
+    /// <param name="fullPath">The full path to the import.</param>
+    /// <param name="lastWriteTimeWhenRead">The last-write-time of the file that was read, when it was read.</param>
+    public ProjectImportInstance(string fullPath, DateTime lastWriteTimeWhenRead)
+    {
+        ErrorUtilities.VerifyThrowArgumentNull(fullPath, nameof(fullPath));
+        FullPath = fullPath;
+        LastWriteTimeWhenRead = lastWriteTimeWhenRead;
+    }
+
+    /// <summary>
+    /// The full path to the import.
+    /// </summary>
+    public string FullPath { get; }
+
+    /// <summary>
+    /// The last-write-time of the file that was read, when it was read.
+    /// This can be used to see whether the file has been changed on disk
+    /// by an external means.
+    /// </summary>
+    public DateTime LastWriteTimeWhenRead { get; }
+}

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -909,9 +909,12 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public IReadOnlyList<string> ImportPaths { get; private set; }
 
-
+        /// <summary>
+        /// The full list of <see cref="ProjectImportInstance"/> of all the files that during evaluation contributed to this project instance.
+        /// This does not include projects that were never imported because a condition on an Import element was false.
+        /// The outer ProjectRootElement that maps to this project instance itself is not included.
+        /// </summary>
         public IReadOnlyList<ProjectImportInstance> Imports { get; private set; }
-
 
         /// <summary>
         /// This list will contain duplicate imports if an import is imported multiple times. However, only the first import was used in evaluation.

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -149,6 +149,7 @@
     <Compile Include="BackEnd\Components\SdkResolution\SdkResolverException.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\TranslationHelpers.cs" />
     <Compile Include="FileSystem\*.cs" />
+    <Compile Include="Instance\ProjectImportInstance.cs" />
     <Compile Include="Utilities\ImmutableCollectionsExtensions.cs" />
     <Compile Include="Utilities\NuGetFrameworkWrapper.cs" />
     <Compile Include="ObjectModelRemoting\ConstructionObjectLinks\ProjectUsingTaskParameterElementLink.cs" />

--- a/src/Build/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Shipped.txt
@@ -1115,11 +1115,6 @@ Microsoft.Build.Execution.OutOfProcNode.OutOfProcNode() -> void
 Microsoft.Build.Execution.OutOfProcNode.Run(bool enableReuse, bool lowPriority, out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
 Microsoft.Build.Execution.OutOfProcNode.Run(bool enableReuse, out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
 Microsoft.Build.Execution.OutOfProcNode.Run(out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
-Microsoft.Build.Execution.ProjectImportInstance
-Microsoft.Build.Execution.ProjectImportInstance.ProjectImportInstance() -> void
-Microsoft.Build.Execution.ProjectImportInstance.ProjectImportInstance(string fullPath, System.DateTime lastWriteTimeWhenRead) -> void
-Microsoft.Build.Execution.ProjectImportInstance.FullPath.get -> string
-Microsoft.Build.Execution.ProjectImportInstance.LastWriteTimeWhenRead.get -> System.DateTime
 Microsoft.Build.Execution.ProjectInstance
 Microsoft.Build.Execution.ProjectInstance.AddItem(string itemType, string evaluatedInclude) -> Microsoft.Build.Execution.ProjectItemInstance
 Microsoft.Build.Execution.ProjectInstance.AddItem(string itemType, string evaluatedInclude, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadata) -> Microsoft.Build.Execution.ProjectItemInstance
@@ -1149,7 +1144,6 @@ Microsoft.Build.Execution.ProjectInstance.GetProperty(string name) -> Microsoft.
 Microsoft.Build.Execution.ProjectInstance.GetPropertyValue(string name) -> string
 Microsoft.Build.Execution.ProjectInstance.GlobalProperties.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.Build.Execution.ProjectInstance.ImportPaths.get -> System.Collections.Generic.IReadOnlyList<string>
-Microsoft.Build.Execution.ProjectInstance.Imports.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Build.Execution.ProjectImportInstance>
 Microsoft.Build.Execution.ProjectInstance.ImportPathsIncludingDuplicates.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Build.Execution.ProjectInstance.InitialTargets.get -> System.Collections.Generic.List<string>
 Microsoft.Build.Execution.ProjectInstance.IsImmutable.get -> bool

--- a/src/Build/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Shipped.txt
@@ -1115,6 +1115,11 @@ Microsoft.Build.Execution.OutOfProcNode.OutOfProcNode() -> void
 Microsoft.Build.Execution.OutOfProcNode.Run(bool enableReuse, bool lowPriority, out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
 Microsoft.Build.Execution.OutOfProcNode.Run(bool enableReuse, out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
 Microsoft.Build.Execution.OutOfProcNode.Run(out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
+Microsoft.Build.Execution.ProjectImportInstance
+Microsoft.Build.Execution.ProjectImportInstance.ProjectImportInstance() -> void
+Microsoft.Build.Execution.ProjectImportInstance.ProjectImportInstance(string fullPath, System.DateTime lastWriteTimeWhenRead) -> void
+Microsoft.Build.Execution.ProjectImportInstance.FullPath.get -> string
+Microsoft.Build.Execution.ProjectImportInstance.LastWriteTimeWhenRead.get -> System.DateTime
 Microsoft.Build.Execution.ProjectInstance
 Microsoft.Build.Execution.ProjectInstance.AddItem(string itemType, string evaluatedInclude) -> Microsoft.Build.Execution.ProjectItemInstance
 Microsoft.Build.Execution.ProjectInstance.AddItem(string itemType, string evaluatedInclude, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadata) -> Microsoft.Build.Execution.ProjectItemInstance
@@ -1144,6 +1149,7 @@ Microsoft.Build.Execution.ProjectInstance.GetProperty(string name) -> Microsoft.
 Microsoft.Build.Execution.ProjectInstance.GetPropertyValue(string name) -> string
 Microsoft.Build.Execution.ProjectInstance.GlobalProperties.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.Build.Execution.ProjectInstance.ImportPaths.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Build.Execution.ProjectInstance.Imports.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Build.Execution.ProjectImportInstance>
 Microsoft.Build.Execution.ProjectInstance.ImportPathsIncludingDuplicates.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Build.Execution.ProjectInstance.InitialTargets.get -> System.Collections.Generic.List<string>
 Microsoft.Build.Execution.ProjectInstance.IsImmutable.get -> bool

--- a/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.get -> Microsoft.Build.FileSystem.IDirectoryCacheFactory
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.set -> void
+Microsoft.Build.Execution.ProjectImportInstance
+Microsoft.Build.Execution.ProjectImportInstance.FullPath.get -> string
+Microsoft.Build.Execution.ProjectImportInstance.LastWriteTimeWhenRead.get -> System.DateTime
+Microsoft.Build.Execution.ProjectImportInstance.ProjectImportInstance() -> void
+Microsoft.Build.Execution.ProjectImportInstance.ProjectImportInstance(string fullPath, System.DateTime lastWriteTimeWhenRead) -> void
+Microsoft.Build.Execution.ProjectInstance.Imports.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Build.Execution.ProjectImportInstance>
 Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase() -> void
 Microsoft.Build.FileSystem.FindPredicate
 Microsoft.Build.FileSystem.FindTransform<TResult>

--- a/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.get -> Microsoft.Build.FileSystem.IDirectoryCacheFactory
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.set -> void
+Microsoft.Build.Execution.ProjectImportInstance
+Microsoft.Build.Execution.ProjectImportInstance.FullPath.get -> string
+Microsoft.Build.Execution.ProjectImportInstance.LastWriteTimeWhenRead.get -> System.DateTime
+Microsoft.Build.Execution.ProjectImportInstance.ProjectImportInstance() -> void
+Microsoft.Build.Execution.ProjectImportInstance.ProjectImportInstance(string fullPath, System.DateTime lastWriteTimeWhenRead) -> void
+Microsoft.Build.Execution.ProjectInstance.Imports.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Build.Execution.ProjectImportInstance>
 Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase() -> void
 Microsoft.Build.FileSystem.FindPredicate
 Microsoft.Build.FileSystem.FindTransform<TResult>


### PR DESCRIPTION
This is PR for API design discussion.

### Context

Currently, It is not possible with a `ProjectInstance` to infer what were the timestamps of the imports, while the information is known and can be valuable for a build server.

### Changes Made

- Added `ProjectImportInstance` that has a `FullPath` to the import file and a `LastWriteTimeWhenRead`
- Added `ProjectInstance.Imports` that return a list of `ProjectImportInstance`

### Notes

This PR is missing:
- Shipped API txt changes (not sure how to make them work)
- Some comments missing
- Tests (best place to add them?)