### PR TITLE
Update up-to-date check items/properties in XSD 

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1691,7 +1691,7 @@ elementFormDefault="qualified">
     <xs:element name="DeployDirSuffix" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="DisableFastUpToDateCheck" type="msb:boolean" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="DisableFastUpToDateCheck" _locComment="" -->Whether Visual Studio should do its own faster up-to-date check before Building, rather than invoke MSBuild to do a possibly more accurate one. You would set this to false if you have a heavily customized build process and builds in Visual Studio are not occurring when they should.</xs:documentation>
+            <xs:documentation><!-- _locID_text="DisableFastUpToDateCheck" _locComment="" -->Whether Visual Studio should do its own faster up-to-date check before Building, rather than invoke MSBuild to do a possibly more accurate one. You would set this to true if you have a heavily customized build process and builds in Visual Studio are not occurring when they should.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="DocumentationFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -5381,6 +5381,81 @@ elementFormDefault="qualified">
         </xs:complexType>
     </xs:element>
 
+    <!-- ============================ -->
+    <!-- Fast up-to-date check items. -->
+    <!-- ============================ -->
+
+    <xs:element name="UpToDateCheckInput" substitutionGroup="msb:Item">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="UpToDateCheckInputDescription" _locComment="" -->Defines an item to be considered an input to the project for the fast up-to-date check.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="msb:SimpleItemType">
+                    <xs:attribute name="Set">
+                        <xs:annotation>
+                            <xs:documentation><!-- _locID_text="UpToDateCheckInput_Set" _locComment="" -->Optional group(s) of inputs and outputs that should be considered in isolation during build. Useful when a build involves multiple discrete compilation/transpilation steps. Semicolon-delimited when multiple sets are required.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="Kind">
+                        <xs:annotation>
+                            <xs:documentation><!-- _locID_text="UpToDateCheckInput_Kind" _locComment="" -->Optional identifier for this item that allows it to be omitted from the fast up-to-date check via a global property.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="UpToDateCheckOutput" substitutionGroup="msb:Item">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="UpToDateCheckOutputDescription" _locComment="" -->Defines an item to be considered an output of the project for the fast up-to-date check.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="msb:SimpleItemType">
+                    <xs:attribute name="Set">
+                        <xs:annotation>
+                            <xs:documentation><!-- _locID_text="UpToDateCheckOutput_Set" _locComment="" -->Optional group(s) of inputs and outputs that should be considered in isolation during build. Useful when a build involves multiple discrete compilation/transpilation steps. Semicolon-delimited when multiple sets are required.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="Kind">
+                        <xs:annotation>
+                            <xs:documentation><!-- _locID_text="UpToDateCheckOutput_Kind" _locComment="" -->Optional identifier for this item that allows it to be omitted from the fast up-to-date check via a global property.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="UpToDateCheckBuilt" substitutionGroup="msb:Item">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="UpToDateCheckBuiltDescription" _locComment="" -->Defines an item to be considered an output of the project for the fast up-to-date check, with optional corresponding input via 'Original' metadata. When 'Original' metadata is specified, the input and output are considered in isolation. Useful when a single file will be copied (and potentially transformed in doing so) during build.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="msb:SimpleItemType">
+                    <xs:attribute name="Set">
+                        <xs:annotation>
+                            <xs:documentation><!-- _locID_text="UpToDateCheckBuilt_Set" _locComment="" -->Optional group(s) of inputs and outputs that should be considered in isolation during build. Useful when a build involves multiple discrete compilation/transpilation steps. Semicolon-delimited when multiple sets are required.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="Kind">
+                        <xs:annotation>
+                            <xs:documentation><!-- _locID_text="UpToDateCheckBuilt_Kind" _locComment="" -->Optional identifier for this item that allows it to be omitted from the fast up-to-date check via a global property.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="Original">
+                        <xs:annotation>
+                            <xs:documentation><!-- _locID_text="UpToDateCheckBuilt_Original" _locComment="" -->Optional location of the input item that produces this output. Useful when a file is copied (and potentially transformed in doing so) during build. If multiple inputs and/or outputs are involved, use 'Set' metadata instead.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
     <!-- ================ -->
     <!-- Packaging tasks. -->
     <!-- ================ -->


### PR DESCRIPTION
### Changes Made

- Fix an incorrect comment on the `DisableFastUpToDateCheck` property
- Add items for `UpToDateCheckInput`, `UpToDateCheckOutput` and `UpToDateCheckBuilt`

### Testing

CI

### Notes

- I added new `locID_text` entries in the XML comments. Is anything else needed here?