### PR TITLE
Fix nuget targets and dll loading

### DIFF
--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Build.Evaluation
                 BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
             try
             {
-                var NuGetAssembly = Assembly.LoadFile(Path.Combine(assemblyDirectory, "NuGet.Frameworks.dll"));
+                var NuGetAsssemblyFilePath = Path.Combine(assemblyDirectory, "NuGet.Frameworks.dll");
+                var NuGetAssembly = File.Exists(NuGetAsssemblyFilePath)
+                    ? Assembly.LoadFile(NuGetAsssemblyFilePath)
+                    : Assembly.Load("NuGet.Frameworks");
+
                 var NuGetFramework = NuGetAssembly.GetType("NuGet.Frameworks.NuGetFramework");
                 var NuGetFrameworkCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.CompatibilityProvider");
                 var NuGetFrameworkDefaultCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.DefaultCompatibilityProvider");

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -170,7 +170,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <MSBuildUseVisualStudioDirectoryLayout Condition="'$(MSBuildUseVisualStudioDirectoryLayout)'==''">$([MSBuild]::IsRunningFromVisualStudio())</MSBuildUseVisualStudioDirectoryLayout>
     <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'=='' and '$(MSBuildUseVisualStudioDirectoryLayout)'=='true'">$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets</NuGetRestoreTargets>
-    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildToolsPath)\NuGet.targets</NuGetRestoreTargets>
+    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildExtensionsPath)\NuGet.targets</NuGetRestoreTargets>
   </PropertyGroup>
 
   <Import Project="$(NuGetRestoreTargets)" />

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6657,7 +6657,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <MSBuildUseVisualStudioDirectoryLayout Condition="'$(MSBuildUseVisualStudioDirectoryLayout)'==''">$([MSBuild]::IsRunningFromVisualStudio())</MSBuildUseVisualStudioDirectoryLayout>
     <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'=='' and '$(MSBuildUseVisualStudioDirectoryLayout)'=='true'">$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets</NuGetRestoreTargets>
-    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildToolsPath)\NuGet.targets</NuGetRestoreTargets>
+    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildExtensionsPath)\NuGet.targets</NuGetRestoreTargets>
   </PropertyGroup>
 
   <Import Condition="'$(IsRestoreTargetsFileLoaded)' != 'true' and Exists('$(NuGetRestoreTargets)')" Project="$(NuGetRestoreTargets)" />


### PR DESCRIPTION
This PR is meant to simplify using msbuild built from this repo on top on an existing SDK without relying on implicit dependencies to NuGet that cannot be resolved.

### Context

When developing with a branch of msbuild on top of an existing public SDK (e.g 6.0.100), msbuild is currently referencing 2 parts of NuGet that are making impossible to test it without grabbing these NuGet files into the folder of msbuild outputs binaries.

### Changes Made

- In `src/Build/Utilities/NuGetFrameworkWrapper.cs`, tries to load from a fixed path while it should try to load also from the current context so that an AssemblyLoadContext correctly configured can honor the `Assembly.Load(...)` if `Assembly.LoadFile` is failing.
- Loading of `NuGet.targets` is relying on `MSBuildToolsPath` while it should rely on `MSBuildExtensionsPath`. I assume that files in msbuild repo should never try to depend on props/targets files from `MSBuildToolsPath` that are not delivered by this build itself.