### PR TITLE
Remove unnecessary allocations in Hash task.

### DIFF
--- a/src/Tasks.UnitTests/Hash_Tests.cs
+++ b/src/Tasks.UnitTests/Hash_Tests.cs
@@ -86,35 +86,32 @@ namespace Microsoft.Build.Tasks.UnitTests
             string input = "";
             using (var sha1 = System.Security.Cryptography.SHA1.Create())
             {
-                using (var stringBuilder = new ReuseableStringBuilder(sha1.HashSize))
+                var stringBuilder = new System.Text.StringBuilder(sha1.HashSize);
+                MockEngine mockEngine = new();
+                for (int i = 0; i < maxInputSize; i++)
                 {
-                    MockEngine mockEngine = new();
-                    for (int i = 0; i < maxInputSize; i++)
+                    input += "a";
+
+                    Hash hashTask = new()
                     {
-                        input += "a";
+                        BuildEngine = mockEngine,
+                        ItemsToHash = new ITaskItem[] { new TaskItem(input) },
+                        IgnoreCase = false
+                    };
+                    Assert.True(hashTask.Execute());
+                    string actualHash = hashTask.HashResult;
 
-                        Hash hashTask = new()
-                        {
-                            BuildEngine = mockEngine,
-                            ItemsToHash = new ITaskItem[] { new TaskItem(input) },
-                            IgnoreCase = false
-                        };
-                        Assert.True(hashTask.Execute());
-                        string actualHash = hashTask.HashResult;
-
-                        byte[] hash = sha1.ComputeHash(System.Text.Encoding.UTF8.GetBytes(input + '\u2028'));
-                        stringBuilder.Clear();
-                        foreach (var b in hash)
-                        {
-                            stringBuilder.Append(b.ToString("x2"));
-                        }
-                        string expectedHash = stringBuilder.ToString();
-
-                        Assert.Equal(expectedHash, actualHash);
+                    byte[] hash = sha1.ComputeHash(System.Text.Encoding.UTF8.GetBytes(input + '\u2028'));
+                    stringBuilder.Clear();
+                    foreach (var b in hash)
+                    {
+                        stringBuilder.Append(b.ToString("x2"));
                     }
+                    string expectedHash = stringBuilder.ToString();
+
+                    Assert.Equal(expectedHash, actualHash);
                 }
             }
-
         }
 #pragma warning restore CA5350
 
@@ -163,6 +160,5 @@ namespace Microsoft.Build.Tasks.UnitTests
 
             return hashTask.HashResult;
         }
-
     }
 }

--- a/src/Tasks.UnitTests/Hash_Tests.cs
+++ b/src/Tasks.UnitTests/Hash_Tests.cs
@@ -105,6 +105,8 @@ namespace Microsoft.Build.Tasks.UnitTests
         }
 
 #pragma warning disable CA5350
+        // This test verifies that hash computes correctly for various numbers of characters.
+        // We would like to process edge of the buffer use cases regardless on the size of the buffer.
         [Fact]
         public void HashTaskDifferentInputSizesTest()
         {

--- a/src/Tasks.UnitTests/Hash_Tests.cs
+++ b/src/Tasks.UnitTests/Hash_Tests.cs
@@ -44,6 +44,100 @@ namespace Microsoft.Build.Tasks.UnitTests
         }
 
         [Fact]
+        public void HashTaskLargeInputCountTest()
+        {
+            // This hash was pre-computed. If the implementation changes it may need to be adjusted.
+            var expectedHash = "8a996bbcb5e481981c2fba7ac408e20d0b4360a5";
+
+            ITaskItem[] itemsToHash = new ITaskItem[1000];
+            for (int i = 0; i < itemsToHash.Length; i++)
+            {
+                itemsToHash[i] = new TaskItem($"Item{i}");
+            }
+
+            var actualHash = ExecuteHashTask(itemsToHash);
+            Assert.Equal(expectedHash, actualHash);
+        }
+
+        [Fact]
+        public void HashTaskLargeInputSizeTest()
+        {
+            // This hash was pre-computed. If the implementation changes it may need to be adjusted.
+            var expectedHash = "0509142dd3d3a733f30a52a0eec37cd727d46122";
+
+            string[] array = new string[1000];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = $"Item{i}";
+            }
+            ITaskItem[] itemsToHash = new ITaskItem[] { new TaskItem(string.Join("", array)) };
+
+            var actualHash = ExecuteHashTask(itemsToHash);
+            Assert.Equal(expectedHash, actualHash);
+        }
+
+        [Fact]
+        public void HashTaskLargeInputCountAndSizeTest()
+        {
+            // This hash was pre-computed. If the implementation changes it may need to be adjusted.
+            var expectedHash = "be23ae7b09f1e14fa5a17de87ddae2c3ec62f967";
+
+            int inputSize = 1000;
+            string[][] array = new string[inputSize][];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new string[inputSize];
+                for (int j = 0; j < array[i].Length; j++)
+                {
+                    array[i][j] = $"Item{i}{j}";
+                }
+            }
+
+            ITaskItem[] itemsToHash = new ITaskItem[inputSize];
+            for (int i = 0; i < itemsToHash.Length; i++)
+            {
+                itemsToHash[i] = new TaskItem(string.Join("", array[i]));
+            }
+
+            var actualHash = ExecuteHashTask(itemsToHash);
+
+            Assert.Equal(expectedHash, actualHash);
+        }
+
+#pragma warning disable CA5350
+        [Fact]
+        public void HashTaskDifferentInputSizesTest()
+        {
+            int maxInputSize = 2000;
+            string input = "";
+            using (var sha1 = System.Security.Cryptography.SHA1.Create())
+            {
+                using (var stringBuilder = new ReuseableStringBuilder(sha1.HashSize))
+                {
+                    for (int i = 0; i < maxInputSize; i++)
+                    {
+                        input += "a";
+                        ITaskItem[] itemsToHash = new ITaskItem[] { new TaskItem(input) };
+
+                        var actualHash = ExecuteHashTask(itemsToHash);
+
+                        byte[] hash = sha1.ComputeHash(System.Text.Encoding.UTF8.GetBytes(input+'\u2028'));
+                        stringBuilder.Clear();
+                        foreach (var b in hash)
+                        {
+                            stringBuilder.Append(b.ToString("x2"));
+                        }
+                        string expectedHash = stringBuilder.ToString();
+
+                        Assert.Equal(expectedHash, actualHash);
+                    }
+                }
+            }
+
+        }
+#pragma warning restore CA5350
+
+        [Fact]
         public void HashTaskIgnoreCaseTest()
         {
             var uppercaseHash =
@@ -88,5 +182,6 @@ namespace Microsoft.Build.Tasks.UnitTests
 
             return hashTask.HashResult;
         }
+
     }
 }

--- a/src/Tasks.UnitTests/Hash_Tests.cs
+++ b/src/Tasks.UnitTests/Hash_Tests.cs
@@ -76,34 +76,6 @@ namespace Microsoft.Build.Tasks.UnitTests
             Assert.Equal(expectedHash, actualHash);
         }
 
-        [Fact]
-        public void HashTaskLargeInputCountAndSizeTest()
-        {
-            // This hash was pre-computed. If the implementation changes it may need to be adjusted.
-            var expectedHash = "be23ae7b09f1e14fa5a17de87ddae2c3ec62f967";
-
-            int inputSize = 1000;
-            string[][] array = new string[inputSize][];
-            for (int i = 0; i < array.Length; i++)
-            {
-                array[i] = new string[inputSize];
-                for (int j = 0; j < array[i].Length; j++)
-                {
-                    array[i][j] = $"Item{i}{j}";
-                }
-            }
-
-            ITaskItem[] itemsToHash = new ITaskItem[inputSize];
-            for (int i = 0; i < itemsToHash.Length; i++)
-            {
-                itemsToHash[i] = new TaskItem(string.Join("", array[i]));
-            }
-
-            var actualHash = ExecuteHashTask(itemsToHash);
-
-            Assert.Equal(expectedHash, actualHash);
-        }
-
 #pragma warning disable CA5350
         // This test verifies that hash computes correctly for various numbers of characters.
         // We would like to process edge of the buffer use cases regardless on the size of the buffer.
@@ -116,14 +88,21 @@ namespace Microsoft.Build.Tasks.UnitTests
             {
                 using (var stringBuilder = new ReuseableStringBuilder(sha1.HashSize))
                 {
+                    MockEngine mockEngine = new();
                     for (int i = 0; i < maxInputSize; i++)
                     {
                         input += "a";
-                        ITaskItem[] itemsToHash = new ITaskItem[] { new TaskItem(input) };
 
-                        var actualHash = ExecuteHashTask(itemsToHash);
+                        Hash hashTask = new()
+                        {
+                            BuildEngine = mockEngine,
+                            ItemsToHash = new ITaskItem[] { new TaskItem(input) },
+                            IgnoreCase = false
+                        };
+                        Assert.True(hashTask.Execute());
+                        string actualHash = hashTask.HashResult;
 
-                        byte[] hash = sha1.ComputeHash(System.Text.Encoding.UTF8.GetBytes(input+'\u2028'));
+                        byte[] hash = sha1.ComputeHash(System.Text.Encoding.UTF8.GetBytes(input + '\u2028'));
                         stringBuilder.Clear();
                         foreach (var b in hash)
                         {

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -5,7 +5,6 @@ using System;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Tasks
 {
@@ -18,19 +17,17 @@ namespace Microsoft.Build.Tasks
     /// </remarks>
     public class Hash : TaskExtension
     {
-        private const char s_itemSeparatorCharacter = '\u2028';
-
+        private const char ItemSeparatorCharacter = '\u2028';
         private static readonly Encoding s_encoding = Encoding.UTF8;
-
-        private static readonly byte[] s_itemSeparatorCharacterBytes = s_encoding.GetBytes(new char[] { s_itemSeparatorCharacter });
+        private static readonly byte[] s_itemSeparatorCharacterBytes = s_encoding.GetBytes(new char[] { ItemSeparatorCharacter });
 
         // Size of buffer where bytes of the strings are stored until sha1.TransformBlock is be run on them.
         // It is needed to get a balance between amount of costly sha1.TransformBlock calls and amount of allocated memory.
-        private const int sha1BufferSize = 512;
+        private const int Sha1BufferSize = 512;
 
         // Size of chunks in which ItemSpecs would be cut.
-        // String of size 169 gives no more than ~512 bytes in utf8 encoding.
-        private const int maxInputChunkLength = 169;
+        // We have chosen this length so itemSpecChunkByteBuffer rented from ArrayPool will be close but not bigger than 512.
+        private const int MaxInputChunkLength = 169;
 
         /// <summary>
         /// Items from which to generate a hash.
@@ -63,12 +60,12 @@ namespace Microsoft.Build.Tasks
                     byte[] sha1Buffer = null;
 
                     // Buffer in which bytes of items' ItemSpec are to be stored.
-                    byte[] byteBuffer = null;
+                    byte[] itemSpecChunkByteBuffer = null;
 
                     try
                     {
-                        sha1Buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(sha1BufferSize);
-                        byteBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(s_encoding.GetMaxByteCount(maxInputChunkLength));
+                        sha1Buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(Sha1BufferSize);
+                        itemSpecChunkByteBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(s_encoding.GetMaxByteCount(MaxInputChunkLength));
 
                         int sha1BufferPosition = 0;
                         for (int i = 0; i < ItemsToHash.Length; i++)
@@ -76,15 +73,15 @@ namespace Microsoft.Build.Tasks
                             string itemSpec = IgnoreCase ? ItemsToHash[i].ItemSpec.ToUpperInvariant() : ItemsToHash[i].ItemSpec;
 
                             // Slice the itemSpec string into chunks of reasonable size and add them to sha1 buffer.
-                            for (int itemSpecPosition = 0; itemSpecPosition < itemSpec.Length; itemSpecPosition += maxInputChunkLength)
+                            for (int itemSpecPosition = 0; itemSpecPosition < itemSpec.Length; itemSpecPosition += MaxInputChunkLength)
                             {
-                                int charsToProcess = Math.Min(itemSpec.Length - itemSpecPosition, maxInputChunkLength);
-                                int byteCount = s_encoding.GetBytes(itemSpec, itemSpecPosition, charsToProcess, byteBuffer, 0);
+                                int charsToProcess = Math.Min(itemSpec.Length - itemSpecPosition, MaxInputChunkLength);
+                                int byteCount = s_encoding.GetBytes(itemSpec, itemSpecPosition, charsToProcess, itemSpecChunkByteBuffer, 0);
 
-                                AddBytesToSha1Buffer(sha1, sha1Buffer, ref sha1BufferPosition, sha1BufferSize, byteBuffer, byteCount);
+                                sha1BufferPosition = AddBytesToSha1Buffer(sha1, sha1Buffer, sha1BufferPosition, Sha1BufferSize, itemSpecChunkByteBuffer, byteCount);
                             }
 
-                            AddBytesToSha1Buffer(sha1, sha1Buffer, ref sha1BufferPosition, sha1BufferSize, s_itemSeparatorCharacterBytes, s_itemSeparatorCharacterBytes.Length);
+                            sha1BufferPosition = AddBytesToSha1Buffer(sha1, sha1Buffer, sha1BufferPosition, Sha1BufferSize, s_itemSeparatorCharacterBytes, s_itemSeparatorCharacterBytes.Length);
                         }
 
                         sha1.TransformFinalBlock(sha1Buffer, 0, sha1BufferPosition);
@@ -104,9 +101,9 @@ namespace Microsoft.Build.Tasks
                         {
                             System.Buffers.ArrayPool<byte>.Shared.Return(sha1Buffer);
                         }
-                        if (byteBuffer != null)
+                        if (itemSpecChunkByteBuffer != null)
                         {
-                            System.Buffers.ArrayPool<byte>.Shared.Return(byteBuffer);
+                            System.Buffers.ArrayPool<byte>.Shared.Return(itemSpecChunkByteBuffer);
                         }
                     }
                 }
@@ -123,9 +120,10 @@ namespace Microsoft.Build.Tasks
         /// <param name="sha1BufferSize">The size of sha1 buffer.</param>
         /// <param name="byteBuffer">Bytes buffer which contains bytes to be written to sha1 buffer.</param>
         /// <param name="byteCount">Amount of bytes that are to be added to sha1 buffer.</param>
-        private void AddBytesToSha1Buffer(SHA1 sha1, byte[] sha1Buffer, ref int sha1BufferPosition, int sha1BufferSize, byte[] byteBuffer, int byteCount)
+        /// <returns>Updated sha1BufferPosition.</returns>
+        private int AddBytesToSha1Buffer(SHA1 sha1, byte[] sha1Buffer, int sha1BufferPosition, int sha1BufferSize, byte[] byteBuffer, int byteCount)
         {
-            int bytesProcessedNumber = 0;
+            int bytesProcessed = 0;
             while (sha1BufferPosition + byteCount >= sha1BufferSize)
             {
                 int sha1BufferFreeSpace = sha1BufferSize - sha1BufferPosition;
@@ -134,21 +132,23 @@ namespace Microsoft.Build.Tasks
                 {
                     // If sha1 buffer is empty and bytes number is big enough there is no need to copy bytes to sha1 buffer.
                     // Pass the bytes to TransformBlock right away.
-                    sha1.TransformBlock(byteBuffer, bytesProcessedNumber, sha1BufferSize, null, 0);
+                    sha1.TransformBlock(byteBuffer, bytesProcessed, sha1BufferSize, null, 0);
                 }
                 else
                 {
-                    Array.Copy(byteBuffer, bytesProcessedNumber, sha1Buffer, sha1BufferPosition, sha1BufferFreeSpace);
+                    Array.Copy(byteBuffer, bytesProcessed, sha1Buffer, sha1BufferPosition, sha1BufferFreeSpace);
                     sha1.TransformBlock(sha1Buffer, 0, sha1BufferSize, null, 0);
                     sha1BufferPosition = 0;
                 }
 
-                bytesProcessedNumber += sha1BufferFreeSpace;
+                bytesProcessed += sha1BufferFreeSpace;
                 byteCount -= sha1BufferFreeSpace;
             }
 
-            Array.Copy(byteBuffer, bytesProcessedNumber, sha1Buffer, sha1BufferPosition, byteCount);
+            Array.Copy(byteBuffer, bytesProcessed, sha1Buffer, sha1BufferPosition, byteCount);
             sha1BufferPosition += byteCount;
+
+            return sha1BufferPosition;
         }
     }
 }

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -58,8 +58,7 @@ namespace Microsoft.Build.Tasks
                     // Once the limit is reached, the sha1.TransformBlock is be run on all the bytes of this buffer.
                     byte[] sha1Buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(sha1BufferSize);
 
-                    int maxItemStringSize = encoding.GetMaxByteCount(Math.Min(ComputeMaxItemSpecLength(ItemsToHash), maxInputChunkLength));
-                    byte[] bytesBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(maxItemStringSize);
+                    byte[] bytesBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(encoding.GetMaxByteCount(maxInputChunkLength));
 
                     int bufferLength = 0;
                     for (int i = 0; i < ItemsToHash.Length; i++)
@@ -106,8 +105,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="sha1BufferSize">The size of sha1 buffer.</param>
         /// <param name="bytesBuffer">Bytes buffer which contains bytes to be written to sha1 buffer.</param>
         /// <param name="bytesNumber">Amount of bytes that are to be added to sha1 buffer.</param>
-        /// <returns></returns>
-        private bool AddBytesToSha1Buffer(SHA1 sha1, byte[] sha1Buffer, ref int sha1BufferLength, int sha1BufferSize, byte[] bytesBuffer, int bytesNumber)
+        private void AddBytesToSha1Buffer(SHA1 sha1, byte[] sha1Buffer, ref int sha1BufferLength, int sha1BufferSize, byte[] bytesBuffer, int bytesNumber)
         {
             int bytesProcessedNumber = 0;
             while (sha1BufferLength + bytesNumber >= sha1BufferSize)
@@ -133,22 +131,6 @@ namespace Microsoft.Build.Tasks
 
             Array.Copy(bytesBuffer, bytesProcessedNumber, sha1Buffer, sha1BufferLength, bytesNumber);
             sha1BufferLength += bytesNumber;
-
-            return true;
-        }
-
-        private int ComputeMaxItemSpecLength(ITaskItem[] itemsToHash)
-        {
-            int maxItemSpecLength = 0;
-            foreach (var item in itemsToHash)
-            {
-                if (item.ItemSpec.Length > maxItemSpecLength)
-                {
-                    maxItemSpecLength = item.ItemSpec.Length;
-                }
-            }
-
-            return maxItemSpecLength;
         }
     }
 }

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -18,6 +18,20 @@ namespace Microsoft.Build.Tasks
     /// </remarks>
     public class Hash : TaskExtension
     {
+        private static readonly char s_itemSeparatorCharacter = '\u2028';
+
+        private static readonly Encoding s_encoding = Encoding.UTF8;
+
+        private static readonly byte[] s_itemSeparatorCharacterBytes = s_encoding.GetBytes(new char[] { s_itemSeparatorCharacter });
+
+        // Size of buffer where bytes of the strings are stored until sha1.TransformBlock is be run on them.
+        // It is needed to get a balance between amount of costly sha1.TransformBlock calls and amount of allocated memory.
+        private const int sha1BufferSize = 512;
+
+        // Size of chunks in which ItemSpecs would be cut.
+        // String of size 169 gives no more than ~512 bytes in utf8 encoding.
+        private const int maxInputChunkLength = 169;
+
         /// <summary>
         /// Items from which to generate a hash.
         /// </summary>
@@ -35,16 +49,6 @@ namespace Microsoft.Build.Tasks
         [Output]
         public string HashResult { get; set; }
 
-        private static readonly char s_itemSeparatorCharacter = '\u2028';
-
-        private static readonly Encoding s_encoding = Encoding.UTF8;
-
-        private static readonly byte[] s_itemSeparatorCharacterBytes = s_encoding.GetBytes(new char[] { s_itemSeparatorCharacter });
-
-        private const int sha1BufferSize = 512;
-
-        private const int maxInputChunkLength = 256;
-
         /// <summary>
         /// Execute the task.
         /// </summary>
@@ -56,36 +60,54 @@ namespace Microsoft.Build.Tasks
                 {
                     // Buffer in which bytes of the strings are to be stored until their number reaches the limit size.
                     // Once the limit is reached, the sha1.TransformBlock is be run on all the bytes of this buffer.
-                    byte[] sha1Buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(sha1BufferSize);
+                    byte[] sha1Buffer = null;
 
-                    byte[] byteBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(s_encoding.GetMaxByteCount(maxInputChunkLength));
+                    // Buffer in which bytes of items' ItemSpec are to be stored.
+                    byte[] byteBuffer = null;
 
-                    int sha1BufferPosition = 0;
-                    for (int i = 0; i < ItemsToHash.Length; i++)
+                    try
                     {
-                        string itemSpec = IgnoreCase ? ItemsToHash[i].ItemSpec.ToUpperInvariant() : ItemsToHash[i].ItemSpec;
+                        sha1Buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(sha1BufferSize);
+                        byteBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(s_encoding.GetMaxByteCount(maxInputChunkLength));
 
-                        // Slice the itemSpec string into chunks of reasonable size and add them to sha1 buffer.
-                        for (int itemSpecPosition = 0; itemSpecPosition < itemSpec.Length; itemSpecPosition += maxInputChunkLength)
+                        int sha1BufferPosition = 0;
+                        for (int i = 0; i < ItemsToHash.Length; i++)
                         {
-                            int charsToProcess = Math.Min(itemSpec.Length - itemSpecPosition, maxInputChunkLength);
-                            int byteCount = s_encoding.GetBytes(itemSpec, itemSpecPosition, charsToProcess, byteBuffer, 0);
+                            string itemSpec = IgnoreCase ? ItemsToHash[i].ItemSpec.ToUpperInvariant() : ItemsToHash[i].ItemSpec;
 
-                            AddBytesToSha1Buffer(sha1, sha1Buffer, ref sha1BufferPosition, sha1BufferSize, byteBuffer, byteCount);
+                            // Slice the itemSpec string into chunks of reasonable size and add them to sha1 buffer.
+                            for (int itemSpecPosition = 0; itemSpecPosition < itemSpec.Length; itemSpecPosition += maxInputChunkLength)
+                            {
+                                int charsToProcess = Math.Min(itemSpec.Length - itemSpecPosition, maxInputChunkLength);
+                                int byteCount = s_encoding.GetBytes(itemSpec, itemSpecPosition, charsToProcess, byteBuffer, 0);
+
+                                AddBytesToSha1Buffer(sha1, sha1Buffer, ref sha1BufferPosition, sha1BufferSize, byteBuffer, byteCount);
+                            }
+
+                            AddBytesToSha1Buffer(sha1, sha1Buffer, ref sha1BufferPosition, sha1BufferSize, s_itemSeparatorCharacterBytes, s_itemSeparatorCharacterBytes.Length);
                         }
 
-                        AddBytesToSha1Buffer(sha1, sha1Buffer, ref sha1BufferPosition, sha1BufferSize, s_itemSeparatorCharacterBytes, s_itemSeparatorCharacterBytes.Length);
+                        sha1.TransformFinalBlock(sha1Buffer, 0, sha1BufferPosition);
+
+                        using (var stringBuilder = new ReuseableStringBuilder(sha1.HashSize))
+                        {
+                            foreach (var b in sha1.Hash)
+                            {
+                                stringBuilder.Append(b.ToString("x2"));
+                            }
+                            HashResult = stringBuilder.ToString();
+                        }
                     }
-
-                    sha1.TransformFinalBlock(sha1Buffer, 0, sha1BufferPosition);
-
-                    using (var stringBuilder = new ReuseableStringBuilder(sha1.HashSize))
+                    finally
                     {
-                        foreach (var b in sha1.Hash)
+                        if (sha1Buffer != null)
                         {
-                            stringBuilder.Append(b.ToString("x2"));
+                            System.Buffers.ArrayPool<byte>.Shared.Return(sha1Buffer);
                         }
-                        HashResult = stringBuilder.ToString();
+                        if (byteBuffer != null)
+                        {
+                            System.Buffers.ArrayPool<byte>.Shared.Return(byteBuffer);
+                        }
                     }
                 }
             }

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Tasks
     /// </remarks>
     public class Hash : TaskExtension
     {
-        private static readonly char s_itemSeparatorCharacter = '\u2028';
+        private const char s_itemSeparatorCharacter = '\u2028';
 
         private static readonly Encoding s_encoding = Encoding.UTF8;
 

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Build.Tasks
 
                     byte[] byteBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(s_encoding.GetMaxByteCount(maxInputChunkLength));
 
-                    int bufferLength = 0;
+                    int sha1BufferPosition = 0;
                     for (int i = 0; i < ItemsToHash.Length; i++)
                     {
                         string itemSpec = IgnoreCase ? ItemsToHash[i].ItemSpec.ToUpperInvariant() : ItemsToHash[i].ItemSpec;
@@ -71,13 +71,13 @@ namespace Microsoft.Build.Tasks
                             int charsToProcess = Math.Min(itemSpec.Length - itemSpecPosition, maxInputChunkLength);
                             int byteCount = s_encoding.GetBytes(itemSpec, itemSpecPosition, charsToProcess, byteBuffer, 0);
 
-                            AddBytesToSha1Buffer(sha1, sha1Buffer, ref bufferLength, sha1BufferSize, byteBuffer, byteCount);
+                            AddBytesToSha1Buffer(sha1, sha1Buffer, ref sha1BufferPosition, sha1BufferSize, byteBuffer, byteCount);
                         }
 
-                        AddBytesToSha1Buffer(sha1, sha1Buffer, ref bufferLength, sha1BufferSize, s_itemSeparatorCharacterBytes, s_itemSeparatorCharacterBytes.Length);
+                        AddBytesToSha1Buffer(sha1, sha1Buffer, ref sha1BufferPosition, sha1BufferSize, s_itemSeparatorCharacterBytes, s_itemSeparatorCharacterBytes.Length);
                     }
 
-                    sha1.TransformFinalBlock(sha1Buffer, 0, bufferLength);
+                    sha1.TransformFinalBlock(sha1Buffer, 0, sha1BufferPosition);
 
                     using (var stringBuilder = new ReuseableStringBuilder(sha1.HashSize))
                     {

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Build.Tasks
         [Output]
         public string HashResult { get; set; }
 
-        private static readonly char ItemSeparatorCharacter = '\u2028';
+        private static readonly char s_itemSeparatorCharacter = '\u2028';
 
-        private static readonly Encoding encoding = Encoding.UTF8;
+        private static readonly Encoding s_encoding = Encoding.UTF8;
 
-        private static readonly byte[] ItemSeparatorCharacterBytes = encoding.GetBytes(new char[] { ItemSeparatorCharacter });
+        private static readonly byte[] s_itemSeparatorCharacterBytes = s_encoding.GetBytes(new char[] { s_itemSeparatorCharacter });
 
         private const int sha1BufferSize = 512;
 
@@ -50,15 +50,15 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public override bool Execute()
         {
-            if (ItemsToHash != null && ItemsToHash.Length > 0)
+            if (ItemsToHash?.Length > 0)
             {
                 using (var sha1 = SHA1.Create())
                 {
-                    // Buffer in which bytes of the strings are to be stored until their number reachs the limit size.
+                    // Buffer in which bytes of the strings are to be stored until their number reaches the limit size.
                     // Once the limit is reached, the sha1.TransformBlock is be run on all the bytes of this buffer.
                     byte[] sha1Buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(sha1BufferSize);
 
-                    byte[] bytesBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(encoding.GetMaxByteCount(maxInputChunkLength));
+                    byte[] byteBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(s_encoding.GetMaxByteCount(maxInputChunkLength));
 
                     int bufferLength = 0;
                     for (int i = 0; i < ItemsToHash.Length; i++)
@@ -66,19 +66,15 @@ namespace Microsoft.Build.Tasks
                         string itemSpec = IgnoreCase ? ItemsToHash[i].ItemSpec.ToUpperInvariant() : ItemsToHash[i].ItemSpec;
 
                         // Slice the itemSpec string into chunks of reasonable size and add them to sha1 buffer.
-                        int itemSpecLength = itemSpec.Length;
-                        int itemSpecPosition = 0;
-                        while (itemSpecLength > 0)
+                        for (int itemSpecPosition = 0; itemSpecPosition < itemSpec.Length; itemSpecPosition += maxInputChunkLength)
                         {
-                            int charsToProcess = Math.Min(itemSpecLength, maxInputChunkLength);
-                            int bytesNumber = encoding.GetBytes(itemSpec, itemSpecPosition, charsToProcess, bytesBuffer, 0);
-                            itemSpecPosition += charsToProcess;
-                            itemSpecLength -= charsToProcess;
+                            int charsToProcess = Math.Min(itemSpec.Length - itemSpecPosition, maxInputChunkLength);
+                            int byteCount = s_encoding.GetBytes(itemSpec, itemSpecPosition, charsToProcess, byteBuffer, 0);
 
-                            AddBytesToSha1Buffer(sha1, sha1Buffer, ref bufferLength, sha1BufferSize, bytesBuffer, bytesNumber);
+                            AddBytesToSha1Buffer(sha1, sha1Buffer, ref bufferLength, sha1BufferSize, byteBuffer, byteCount);
                         }
 
-                        AddBytesToSha1Buffer(sha1, sha1Buffer, ref bufferLength, sha1BufferSize, ItemSeparatorCharacterBytes, ItemSeparatorCharacterBytes.Length);
+                        AddBytesToSha1Buffer(sha1, sha1Buffer, ref bufferLength, sha1BufferSize, s_itemSeparatorCharacterBytes, s_itemSeparatorCharacterBytes.Length);
                     }
 
                     sha1.TransformFinalBlock(sha1Buffer, 0, bufferLength);
@@ -101,36 +97,36 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         /// <param name="sha1">Hashing algorithm sha1.</param>
         /// <param name="sha1Buffer">The sha1 buffer which stores bytes of the strings. Bytes should be added to this buffer.</param>
-        /// <param name="sha1BufferLength">Number of used bytes of the sha1 buffer.</param>
+        /// <param name="sha1BufferPosition">Number of used bytes of the sha1 buffer.</param>
         /// <param name="sha1BufferSize">The size of sha1 buffer.</param>
-        /// <param name="bytesBuffer">Bytes buffer which contains bytes to be written to sha1 buffer.</param>
-        /// <param name="bytesNumber">Amount of bytes that are to be added to sha1 buffer.</param>
-        private void AddBytesToSha1Buffer(SHA1 sha1, byte[] sha1Buffer, ref int sha1BufferLength, int sha1BufferSize, byte[] bytesBuffer, int bytesNumber)
+        /// <param name="byteBuffer">Bytes buffer which contains bytes to be written to sha1 buffer.</param>
+        /// <param name="byteCount">Amount of bytes that are to be added to sha1 buffer.</param>
+        private void AddBytesToSha1Buffer(SHA1 sha1, byte[] sha1Buffer, ref int sha1BufferPosition, int sha1BufferSize, byte[] byteBuffer, int byteCount)
         {
             int bytesProcessedNumber = 0;
-            while (sha1BufferLength + bytesNumber >= sha1BufferSize)
+            while (sha1BufferPosition + byteCount >= sha1BufferSize)
             {
-                int sha1BufferFreeSpace = sha1BufferSize - sha1BufferLength;
+                int sha1BufferFreeSpace = sha1BufferSize - sha1BufferPosition;
 
-                if (sha1BufferLength == 0)
+                if (sha1BufferPosition == 0)
                 {
                     // If sha1 buffer is empty and bytes number is big enough there is no need to copy bytes to sha1 buffer.
                     // Pass the bytes to TransformBlock right away.
-                    sha1.TransformBlock(bytesBuffer, bytesProcessedNumber, sha1BufferSize, null, 0);
+                    sha1.TransformBlock(byteBuffer, bytesProcessedNumber, sha1BufferSize, null, 0);
                 }
                 else
                 {
-                    Array.Copy(bytesBuffer, bytesProcessedNumber, sha1Buffer, sha1BufferLength, sha1BufferFreeSpace);
+                    Array.Copy(byteBuffer, bytesProcessedNumber, sha1Buffer, sha1BufferPosition, sha1BufferFreeSpace);
                     sha1.TransformBlock(sha1Buffer, 0, sha1BufferSize, null, 0);
-                    sha1BufferLength = 0;
+                    sha1BufferPosition = 0;
                 }
 
                 bytesProcessedNumber += sha1BufferFreeSpace;
-                bytesNumber -= sha1BufferFreeSpace;
+                byteCount -= sha1BufferFreeSpace;
             }
 
-            Array.Copy(bytesBuffer, bytesProcessedNumber, sha1Buffer, sha1BufferLength, bytesNumber);
-            sha1BufferLength += bytesNumber;
+            Array.Copy(byteBuffer, bytesProcessedNumber, sha1Buffer, sha1BufferPosition, byteCount);
+            sha1BufferPosition += byteCount;
         }
     }
 }

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Build.Tasks
     /// </remarks>
     public class Hash : TaskExtension
     {
-        private const char ItemSeparatorCharacter = '\u2028';
-
         /// <summary>
         /// Items from which to generate a hash.
         /// </summary>
@@ -37,61 +35,120 @@ namespace Microsoft.Build.Tasks
         [Output]
         public string HashResult { get; set; }
 
+        private static readonly char ItemSeparatorCharacter = '\u2028';
+
+        private static readonly Encoding encoding = Encoding.UTF8;
+
+        private static readonly byte[] ItemSeparatorCharacterBytes = encoding.GetBytes(new char[] { ItemSeparatorCharacter });
+
+        private const int sha1BufferSize = 512;
+
+        private const int maxInputChunkLength = 256;
+
         /// <summary>
         /// Execute the task.
         /// </summary>
         public override bool Execute()
         {
-            if (ItemsToHash?.Length > 0)
+            if (ItemsToHash != null && ItemsToHash.Length > 0)
             {
                 using (var sha1 = SHA1.Create())
                 {
-                    var concatenatedItemStringSize = ComputeStringSize(ItemsToHash);
+                    // Buffer in which bytes of the strings are to be stored until their number reachs the limit size.
+                    // Once the limit is reached, the sha1.TransformBlock is be run on all the bytes of this buffer.
+                    byte[] sha1Buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(sha1BufferSize);
 
-                    var hashStringSize = sha1.HashSize;
+                    int maxItemStringSize = encoding.GetMaxByteCount(Math.Min(ComputeMaxItemSpecLength(ItemsToHash), maxInputChunkLength));
+                    byte[] bytesBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(maxItemStringSize);
 
-                    using (var stringBuilder = new ReuseableStringBuilder(Math.Max(concatenatedItemStringSize, hashStringSize)))
+                    int bufferLength = 0;
+                    for (int i = 0; i < ItemsToHash.Length; i++)
                     {
-                        foreach (var item in ItemsToHash)
+                        string itemSpec = IgnoreCase ? ItemsToHash[i].ItemSpec.ToUpperInvariant() : ItemsToHash[i].ItemSpec;
+
+                        // Slice the itemSpec string into chunks of reasonable size and add them to sha1 buffer.
+                        int itemSpecLength = itemSpec.Length;
+                        int itemSpecPosition = 0;
+                        while (itemSpecLength > 0)
                         {
-                            string itemSpec = item.ItemSpec;
-                            stringBuilder.Append(IgnoreCase ? itemSpec.ToUpperInvariant() : itemSpec);
-                            stringBuilder.Append(ItemSeparatorCharacter);
+                            int charsToProcess = Math.Min(itemSpecLength, maxInputChunkLength);
+                            int bytesNumber = encoding.GetBytes(itemSpec, itemSpecPosition, charsToProcess, bytesBuffer, 0);
+                            itemSpecPosition += charsToProcess;
+                            itemSpecLength -= charsToProcess;
+
+                            AddBytesToSha1Buffer(sha1, sha1Buffer, ref bufferLength, sha1BufferSize, bytesBuffer, bytesNumber);
                         }
 
-                        var hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(stringBuilder.ToString()));
+                        AddBytesToSha1Buffer(sha1, sha1Buffer, ref bufferLength, sha1BufferSize, ItemSeparatorCharacterBytes, ItemSeparatorCharacterBytes.Length);
+                    }
 
-                        stringBuilder.Clear();
+                    sha1.TransformFinalBlock(sha1Buffer, 0, bufferLength);
 
-                        foreach (var b in hash)
+                    using (var stringBuilder = new ReuseableStringBuilder(sha1.HashSize))
+                    {
+                        foreach (var b in sha1.Hash)
                         {
                             stringBuilder.Append(b.ToString("x2"));
                         }
-
                         HashResult = stringBuilder.ToString();
                     }
                 }
             }
+            return true;
+        }
+
+        /// <summary>
+        /// Add bytes to the sha1 buffer. Once the limit size is reached, sha1.TransformBlock is called and the buffer is flushed.
+        /// </summary>
+        /// <param name="sha1">Hashing algorithm sha1.</param>
+        /// <param name="sha1Buffer">The sha1 buffer which stores bytes of the strings. Bytes should be added to this buffer.</param>
+        /// <param name="sha1BufferLength">Number of used bytes of the sha1 buffer.</param>
+        /// <param name="sha1BufferSize">The size of sha1 buffer.</param>
+        /// <param name="bytesBuffer">Bytes buffer which contains bytes to be written to sha1 buffer.</param>
+        /// <param name="bytesNumber">Amount of bytes that are to be added to sha1 buffer.</param>
+        /// <returns></returns>
+        private bool AddBytesToSha1Buffer(SHA1 sha1, byte[] sha1Buffer, ref int sha1BufferLength, int sha1BufferSize, byte[] bytesBuffer, int bytesNumber)
+        {
+            int bytesProcessedNumber = 0;
+            while (sha1BufferLength + bytesNumber >= sha1BufferSize)
+            {
+                int sha1BufferFreeSpace = sha1BufferSize - sha1BufferLength;
+
+                if (sha1BufferLength == 0)
+                {
+                    // If sha1 buffer is empty and bytes number is big enough there is no need to copy bytes to sha1 buffer.
+                    // Pass the bytes to TransformBlock right away.
+                    sha1.TransformBlock(bytesBuffer, 0, sha1BufferSize, null, 0);
+                }
+                else
+                {
+                    Array.Copy(bytesBuffer, bytesProcessedNumber, sha1Buffer, sha1BufferLength, sha1BufferFreeSpace);
+                    sha1.TransformBlock(sha1Buffer, 0, sha1BufferSize, null, 0);
+                    sha1BufferLength = 0;
+                }
+
+                bytesProcessedNumber += sha1BufferFreeSpace;
+                bytesNumber -= sha1BufferFreeSpace;
+            }
+
+            Array.Copy(bytesBuffer, bytesProcessedNumber, sha1Buffer, sha1BufferLength, bytesNumber);
+            sha1BufferLength += bytesNumber;
 
             return true;
         }
 
-        private int ComputeStringSize(ITaskItem[] itemsToHash)
+        private int ComputeMaxItemSpecLength(ITaskItem[] itemsToHash)
         {
-            if (itemsToHash.Length == 0)
-            {
-                return 0;
-            }
-
-            var totalItemSize = 0;
-
+            int maxItemSpecLength = 0;
             foreach (var item in itemsToHash)
             {
-                totalItemSize += item.ItemSpec.Length;
+                if (item.ItemSpec.Length > maxItemSpecLength)
+                {
+                    maxItemSpecLength = item.ItemSpec.Length;
+                }
             }
 
-            // Add one ItemSeparatorCharacter per item
-            return totalItemSize + itemsToHash.Length;
+            return maxItemSpecLength;
         }
     }
 }

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Tasks
                 {
                     // If sha1 buffer is empty and bytes number is big enough there is no need to copy bytes to sha1 buffer.
                     // Pass the bytes to TransformBlock right away.
-                    sha1.TransformBlock(bytesBuffer, 0, sha1BufferSize, null, 0);
+                    sha1.TransformBlock(bytesBuffer, bytesProcessedNumber, sha1BufferSize, null, 0);
                 }
                 else
                 {

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Tasks
         private static readonly Encoding s_encoding = Encoding.UTF8;
         private static readonly byte[] s_itemSeparatorCharacterBytes = s_encoding.GetBytes(new char[] { ItemSeparatorCharacter });
 
-        // Size of buffer where bytes of the strings are stored until sha1.TransformBlock is be run on them.
+        // Size of buffer where bytes of the strings are stored until sha1.TransformBlock is to be run on them.
         // It is needed to get a balance between amount of costly sha1.TransformBlock calls and amount of allocated memory.
         private const int Sha1BufferSize = 512;
 
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Tasks
                 using (var sha1 = SHA1.Create())
                 {
                     // Buffer in which bytes of the strings are to be stored until their number reaches the limit size.
-                    // Once the limit is reached, the sha1.TransformBlock is be run on all the bytes of this buffer.
+                    // Once the limit is reached, the sha1.TransformBlock is to be run on all the bytes of this buffer.
                     byte[] sha1Buffer = null;
 
                     // Buffer in which bytes of items' ItemSpec are to be stored.


### PR DESCRIPTION
Fixes #7086

### Context
`Hash.Execute()` allocates a string which gets to the large object heap. This could be avoided without changing the resulting hash function.

### Changes Made
Hash function is rewritten.

### Testing
Unit tests & manual testing
