### PR TITLE
Rename `AssemblySearchPathUseXXX` to `AssemblySearchPath_UseXXX` for better readability

### DIFF
--- a/documentation/wiki/ResolveAssemblyReference.md
+++ b/documentation/wiki/ResolveAssemblyReference.md
@@ -149,16 +149,16 @@ There were recent fixes made to RAR to alleviate the situation. You can control 
 There are two ways to customize the list of paths RAR will search in attempting to locate an assembly. To fully customize the list, the property `AssemblySearchPaths` can be set ahead of time. Note that the order matters; if an assembly is in two locations, RAR will stop after it finds it at the first location.
 
 By default, there are ten locations RAR will search (four if using the .NET SDK), and each can be disabled by setting the relevant flag to false:
-1. Searching files from the current project is disabled by setting the `AssemblySearchPathUseCandidateAssemblyFiles` property to false.
-2. Searching the reference path property (from a .user file) is disabled by setting the `AssemblySearchPathUseReferencePath` property to false.
-3. Using the hint path from the item is disabled by setting the `AssemblySearchPathUseHintPathFromItem` property to false.
-4. Using the directory with MSBuild's target runtime is disabled by setting the `AssemblySearchPathUseTargetFrameworkDirectory` property to false.
-5. Searching assembly folders from AssemblyFolders.config is disabled by setting the `AssemblySearchPathUseAssemblyFoldersConfigFileSearchPath` property to false.
-6. Searching the registry is disabled by setting the `AssemblySearchPathUseRegistry` property to false.
-7. Searching legacy registered assembly folders is disabled by setting the `AssemblySearchPathUseAssemblyFolders` property to false.
-8. Looking in the GAC is disabled by setting the `AssemblySearchPathUseGAC` property to false.
-9. Treating the reference's Include as a real file name is disabled by setting the `AssemblySearchPathUseRawFileName` property to false.
-10. Checking the application's output folder is disabled by setting the `AssemblySearchPathUseOutDir` property to false.
+1. Searching files from the current project is disabled by setting the `AssemblySearchPath_UseCandidateAssemblyFiles` property to false.
+2. Searching the reference path property (from a .user file) is disabled by setting the `AssemblySearchPath_UseReferencePath` property to false.
+3. Using the hint path from the item is disabled by setting the `AssemblySearchPath_UseHintPathFromItem` property to false.
+4. Using the directory with MSBuild's target runtime is disabled by setting the `AssemblySearchPath_UseTargetFrameworkDirectory` property to false.
+5. Searching assembly folders from AssemblyFolders.config is disabled by setting the `AssemblySearchPath_UseAssemblyFoldersConfigFileSearchPath` property to false.
+6. Searching the registry is disabled by setting the `AssemblySearchPath_UseRegistry` property to false.
+7. Searching legacy registered assembly folders is disabled by setting the `AssemblySearchPath_UseAssemblyFolders` property to false.
+8. Looking in the GAC is disabled by setting the `AssemblySearchPath_UseGAC` property to false.
+9. Treating the reference's Include as a real file name is disabled by setting the `AssemblySearchPath_UseRawFileName` property to false.
+10. Checking the application's output folder is disabled by setting the `AssemblySearchPath_UseOutDir` property to false.
 
 ## There was a conflict
 

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -3201,25 +3201,25 @@ elementFormDefault="qualified">
             </xs:documentation>
         </xs:annotation>
     </xs:element>
-    <xs:element name="AssemblySearchPathUseCandidateAssemblyFiles" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseCandidateAssemblyFiles" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
-    <xs:element name="AssemblySearchPathUseReferencePath" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseReferencePath" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
-    <xs:element name="AssemblySearchPathUseHintPathFromItem" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseHintPathFromItem" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
-    <xs:element name="AssemblySearchPathUseTargetFrameworkDirectory" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseTargetFrameworkDirectory" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
-    <xs:element name="AssemblySearchPathUseAssemblyFoldersConfigFileSearchPath" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseAssemblyFoldersConfigFileSearchPath" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
-    <xs:element name="AssemblySearchPathUseRegistry" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseRegistry" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
-    <xs:element name="AssemblySearchPathUseAssemblyFolders" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseAssemblyFolders" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
-    <xs:element name="AssemblySearchPathUseGAC" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseGAC" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
-    <xs:element name="AssemblySearchPathUseRawFileName" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseRawFileName" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
-    <xs:element name="AssemblySearchPathUseOutDir" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:element name="AssemblySearchPath_UseOutDir" type="msb:boolean" substitutionGroup="msb:Property">
     </xs:element>
     <xs:element name="ResolveAssemblyReference" substitutionGroup="msb:Task">
         <xs:complexType>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -625,16 +625,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             (9) Treat the reference's Include as if it were a real file name.
             (10) Look in the application's output folder (like bin\debug)
         -->
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseCandidateAssemblyFiles) != 'false'">{CandidateAssemblyFiles}</AssemblySearchPaths>
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseReferencePath) != 'false'">$(AssemblySearchPaths);$(ReferencePath)</AssemblySearchPaths>
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseHintPathFromItem) != 'false'">$(AssemblySearchPaths);{HintPathFromItem}</AssemblySearchPaths>
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseTargetFrameworkDirectory) != 'false'">$(AssemblySearchPaths);{TargetFrameworkDirectory}</AssemblySearchPaths>
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseAssemblyFoldersConfigFileSearchPath) != 'false'">$(AssemblySearchPaths);$(AssemblyFoldersConfigFileSearchPath)</AssemblySearchPaths>
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseRegistry) != 'false'">$(AssemblySearchPaths);{Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)}</AssemblySearchPaths>
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseAssemblyFolders) != 'false'">$(AssemblySearchPaths);{AssemblyFolders}</AssemblySearchPaths>
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseGAC) != 'false'">$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseRawFileName) != 'false'">$(AssemblySearchPaths);{RawFileName}</AssemblySearchPaths>
-    <AssemblySearchPaths Condition="$(AssemblySearchPathUseOutDir) != 'false'">$(AssemblySearchPaths);$(OutDir)</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseCandidateAssemblyFiles)' != 'false'">{CandidateAssemblyFiles}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseReferencePath)' != 'false'">$(AssemblySearchPaths);$(ReferencePath)</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseHintPathFromItem)' != 'false'">$(AssemblySearchPaths);{HintPathFromItem}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseTargetFrameworkDirectory)' != 'false'">$(AssemblySearchPaths);{TargetFrameworkDirectory}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseAssemblyFoldersConfigFileSearchPath)' != 'false'">$(AssemblySearchPaths);$(AssemblyFoldersConfigFileSearchPath)</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseRegistry)' != 'false'">$(AssemblySearchPaths);{Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseAssemblyFolders)' != 'false'">$(AssemblySearchPaths);{AssemblyFolders}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseGAC)' != 'false'">$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseRawFileName)' != 'false'">$(AssemblySearchPaths);{RawFileName}</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(AssemblySearchPath_UseOutDir)' != 'false'">$(AssemblySearchPaths);$(OutDir)</AssemblySearchPaths>
   </PropertyGroup>
 
   <!-- ContinueOnError takes 3 values:  WarnAndContinue (true), ErrorAndStop (false), and ErrorAndContinue.


### PR DESCRIPTION
Fixes #3784 and Updates #7008

Follow-ups from

1. https://github.com/dotnet/msbuild/pull/7008#pullrequestreview-836812544
2. https://github.com/dotnet/sdk/pull/22719#discussion_r773444947

### Context

For multi-level properties, follow the naming pattern similar to `BaseProperty_SubOption` with an `_`
underscore character acting as a separator to make these properties clearer. We already follow this
pattern in Common props where we have `DisableLogTaskParameter_ConvertToAbsolutePath_Path`and friends.

https://github.com/dotnet/msbuild/blob/14313d17e407e24ad80e113bd475d1dd7c698656/src/Tasks/Microsoft.Common.props#L181-L183

### Changes Made

So, Use `AssemblySearchPath_Use{Variant}` property format to control individual inclusion of different
variants of assembly search paths. By default, these properties will be opt-out to maintain back-compat.

### Notes

This change hasn't been shipped yet. So, it's technically not breaking and it's also not too late to change it.
I have changed all the references in targets, docs and schema. Let me know if there are any other places I should change.