### PR TITLE
Remove xmlns from props/targets and UTs

### DIFF
--- a/documentation/wiki/MSBuild-Tips-&-Tricks.md
+++ b/documentation/wiki/MSBuild-Tips-&-Tricks.md
@@ -39,7 +39,7 @@ See the [MSBuild Command-Line Reference](https://docs.microsoft.com/visualstudio
 If MSBuild.exe is passed properties on the command line, such as `/p:Platform=AnyCPU` then this value overrides whatever assignments you have to that property inside property groups. For instance, `<Platform>x86</Platform>` will be ignored. To make sure your local assignment to properties overrides whatever they pass on the command line, add the following at the top of your MSBuild project file:
 
 ```
-<Project TreatAsLocalProperty="Platform" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project TreatAsLocalProperty="Platform" DefaultTargets="Build">
 ```
 
 This will make sure that your local assignments to the `Platform` property are respected. You can specify multiple properties in `TreatAsLocalProperty` separated by semicolon.
@@ -59,11 +59,11 @@ Use this command-line to approximate what the design-time build does:
 See https://www.simple-talk.com/dotnet/.net-tools/extending-msbuild, "Extending all builds" section. Also read about [MSBuildUserExtensionsPath](http://referencesource.microsoft.com/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/Microsoft.Common.props,33), [CustomBeforeMicrosoftCommonProps](http://referencesource.microsoft.com/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/Microsoft.Common.props,68), [CustomBeforeMicrosoftCommonTargets](http://referencesource.microsoft.com/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/bin_/amd64/Microsoft.Common.targets,71), and CustomAfterMicrosoftCommonProps/CustomAfterMicrosoftCommonTargets.
 
 Example:
-Create this file (Custom.props) in `C:\Users\username\AppData\Local\Microsoft\MSBuild\14.0\Microsoft.Common.targets\ImportAfter`:
+Create this file (Custom.props) in `C:\Users\username\AppData\Local\Microsoft\MSBuild\Current\Microsoft.Common.targets\ImportAfter`:
 
 ```
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <PropertyGroup>
     <MyCustomProperty>Value!</MyCustomProperty>
   </PropertyGroup>

--- a/src/Build.OM.UnitTests/Construction/ElementLocationPublic_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ElementLocationPublic_Tests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.UnitTests.Construction
     public class ElementLocationPublic_Tests
     {
         /// <summary>
-        /// Check that we can get the file name off an element and attribute, even if 
+        /// Check that we can get the file name off an element and attribute, even if
         /// it wouldn't normally have got one because the project wasn't
         /// loaded from disk, or has been edited since.
         /// This is really a test of our XmlDocumentWithLocation.
@@ -84,7 +84,7 @@ namespace Microsoft.Build.UnitTests.Construction
         public void LocationStringsMedley()
         {
             string content = @"
-            <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+            <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <UsingTask TaskName='t' AssemblyName='a' Condition='true'/>
                     <UsingTask TaskName='t' AssemblyFile='a' Condition='true'/>
                     <ItemDefinitionGroup Condition='true' Label='l'>

--- a/src/Build.OM.UnitTests/Construction/ProjectChooseElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectChooseElement_Tests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose X='Y'/>
                     </Project>
                 ";
@@ -50,7 +50,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose Condition='true'/>
                     </Project>
                 ";
@@ -68,7 +68,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose>
                             <X/>
                         </Choose>
@@ -88,7 +88,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose>
                             <When>
                                 <PropertyGroup><x/></PropertyGroup>
@@ -113,7 +113,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose>
                             <Otherwise/>
                         </Choose>
@@ -133,7 +133,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose>
                             <Otherwise/>
                             <Otherwise/>
@@ -154,7 +154,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose>
                             <Otherwise/>
                             <When Condition='c'/>
@@ -178,7 +178,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose/>
                     </Project>
                 ";
@@ -197,7 +197,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadChooseOnlyWhen()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose>
                             <When Condition='c'/>
                         </Choose>
@@ -218,7 +218,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadChooseBothWhenOtherwise()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose>
                             <When Condition='c1'/>
                             <When Condition='c2'/>
@@ -254,7 +254,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     builder2.Append("</When></Choose>");
                 }
 
-                string content = "<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>";
+                string content = "<Project>";
                 content += builder1.ToString();
                 content += builder2.ToString();
                 content += @"</Project>";
@@ -270,13 +270,13 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void SettingWhenConditionDirties()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Choose>
                             <When Condition='true'>
                               <PropertyGroup>
                                 <p>v1</p>
-                              </PropertyGroup> 
-                            </When>      
+                              </PropertyGroup>
+                            </When>
                         </Choose>
                     </Project>
                 ";

--- a/src/Build.OM.UnitTests/Construction/ProjectExtensionsElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectExtensionsElement_Tests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void Read()
         {
             string content = @"
-                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                 <Project>
                    <ProjectExtensions>
                      <a/>
                    </ProjectExtensions>
@@ -36,7 +36,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
             ProjectExtensionsElement extensions = (ProjectExtensionsElement)Helpers.GetFirst(project.Children);
 
-            Assert.Equal(@"<a xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />", extensions.Content);
+            Assert.Equal(@"<a />", extensions.Content);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                 <Project>
                    <ProjectExtensions Condition='c'/>
                  </Project>
                 ";
@@ -66,7 +66,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                 <Project>
                    <ProjectExtensions/>
                    <Target Name='t'/>
                    <ProjectExtensions   />
@@ -88,7 +88,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             extensions.Content = "a<b/>c";
 
-            Assert.Equal(@"a<b xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />c", extensions.Content);
+            Assert.Equal(@"a<b />c", extensions.Content);
             Assert.True(extensions.ContainingProject.HasUnsavedChanges);
         }
 
@@ -107,13 +107,13 @@ namespace Microsoft.Build.UnitTests.OM.Construction
            );
         }
         /// <summary>
-        /// Delete by ID 
+        /// Delete by ID
         /// </summary>
         [Fact]
         public void DeleteById()
         {
             string content = @"
-                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                 <Project>
                    <ProjectExtensions>
                      <a>x</a>
                      <b>y</b>
@@ -132,13 +132,13 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         }
 
         /// <summary>
-        /// Get by ID 
+        /// Get by ID
         /// </summary>
         [Fact]
         public void GetById()
         {
             string content = @"
-                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                 <Project>
                    <ProjectExtensions>
                      <a>x</a>
                      <b>y</b>
@@ -163,7 +163,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void SetById()
         {
             string content = @"
-                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                 <Project>
                    <ProjectExtensions>
                      <a>x</a>
                      <b>y</b>
@@ -185,7 +185,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void SetByIdWhereItAlreadyExists()
         {
             string content = @"
-                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                 <Project>
                    <ProjectExtensions>
                      <a>x</a>
                      <b>y</b>
@@ -206,7 +206,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectExtensionsElement GetEmptyProjectExtensions()
         {
             string content = @"
-                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                 <Project>
                    <ProjectExtensions/>
                  </Project>
                 ";

--- a/src/Build.OM.UnitTests/Construction/ProjectImportElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectImportElement_Tests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import/>
                     </Project>
                 ";
@@ -60,7 +60,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project=''/>
                     </Project>
                 ";
@@ -78,7 +78,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='p' X='Y'/>
                     </Project>
                 ";
@@ -94,7 +94,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadBasic()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='i1.proj' />
                         <Import Project='i2.proj' Condition='c'/>
                     </Project>
@@ -117,7 +117,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void SetProjectValid()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='i1.proj' />
                     </Project>
                 ";
@@ -139,7 +139,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<ArgumentException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='i1.proj' />
                     </Project>
                 ";
@@ -175,7 +175,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
                 string content = String.Format
                     (
-    @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+    @"<Project>
     <Import Project='{0}'/>
 </Project>",
                     file1
@@ -215,7 +215,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
                 string content = String.Format
                     (
-    @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+    @"<Project>
     <Import Project='{0}'/>
 </Project>",
                     file
@@ -250,14 +250,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             string projectfileContent = String.Format
                 (
                 @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='{0}'/>
                     </Project>
                 ",
                  testTempPath + "\\..\\x.targets"
                  );
             string targetsfileContent = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                     </Project>
                 ";
             try

--- a/src/Build.OM.UnitTests/Construction/ProjectImportGroupElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectImportGroupElement_Tests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void AddImportWhenNoImportGroupExists()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='a.proj' />
                     </Project>
                 ";
@@ -37,7 +37,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             project.AddImport("b.proj");
 
             string expectedContent = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='a.proj' />
                         <Import Project='b.proj' />
                     </Project>
@@ -54,7 +54,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void AddImportToLastImportGroupWithNoCondition()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='a.proj' />
                         <ImportGroup>
                             <Import Project='b.proj' />
@@ -76,7 +76,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             project.AddImport("e.proj");
 
             string expectedContent = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='a.proj' />
                         <ImportGroup>
                             <Import Project='b.proj' />
@@ -105,7 +105,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void AddImportOnlyConditionedImportGroupsExist()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='a.proj' />
                         <ImportGroup Condition='c1'>
                             <Import Project='b.proj' />
@@ -121,7 +121,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             project.AddImport("d.proj");
 
             string expectedContent = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='a.proj' />
                         <ImportGroup Condition='c1'>
                             <Import Project='b.proj' />
@@ -154,7 +154,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadNoChild()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ImportGroup />
                     </Project>
                 ";
@@ -176,7 +176,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ImportGroup>
                             <Import/>
                         </ImportGroup>
@@ -197,7 +197,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ImportGroup>
                             <PropertyGroup />
                         </ImportGroup>
@@ -218,7 +218,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <ImportGroup />
                         </PropertyGroup>
@@ -238,7 +238,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ImportGroup X='Y'/>
                     </Project>
                 ";
@@ -254,7 +254,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadBasic()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ImportGroup>
                             <Import Project='i1.proj' />
                             <Import Project='i2.proj' Condition='c'/>
@@ -282,7 +282,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadMultipleImportGroups()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ImportGroup>
                             <Import Project='i1.proj' />
                             <Import Project='i2.proj' Condition='c'/>
@@ -317,7 +317,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void SetProjectValid()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ImportGroup>
                             <Import Project='i1.proj' />
                         </ImportGroup>
@@ -344,7 +344,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<ArgumentException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ImportGroup>
                             <Import Project='i1.proj' />
                         </ImportGroup>

--- a/src/Build.OM.UnitTests/Construction/ProjectItemDefinitionElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemDefinitionElement_Tests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadNoChildren()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i/>
                         </ItemDefinitionGroup>
@@ -45,7 +45,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadBasic()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i>
                                 <m1>v1</m1>
@@ -75,7 +75,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadBuiltInElementName()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <PropertyGroup/>
                         </ItemDefinitionGroup>
@@ -92,7 +92,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadMetadata()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1='v1'>
                                 <m2 Condition='c'>v2</m2>
@@ -124,63 +124,63 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i Include='inc' />
-                        </ItemDefinitionGroup> 
+                        </ItemDefinitionGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i Update='upd' />
                         </ItemDefinitionGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i Remove='rem' />
                         </ItemDefinitionGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i Exclude='excl' />
                         </ItemDefinitionGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i KeepMetadata='true' />
                         </ItemDefinitionGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i RemoveMetadata='true' />
                         </ItemDefinitionGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i KeepDuplicates='true' />
                         </ItemDefinitionGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i cOndiTion='true' />
                         </ItemDefinitionGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i LabeL='text' />
                         </ItemDefinitionGroup>

--- a/src/Build.OM.UnitTests/Construction/ProjectItemDefinitionGroupElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemDefinitionGroupElement_Tests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup X='Y'/>
                     </Project>
                 ";
@@ -54,7 +54,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadNoChildren()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup/>
                     </Project>
                 ";
@@ -72,7 +72,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadBasic()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup Condition='c'>
                             <i1/>
                         </ItemDefinitionGroup>

--- a/src/Build.OM.UnitTests/Construction/ProjectItemElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemElement_Tests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
     public class ProjectItemElement_Tests
     {
         private const string RemoveInTarget = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Remove='i'/>
@@ -32,21 +32,21 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 ";
 
         private const string RemoveOutsideTarget = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                             <ItemGroup>
                                 <i Remove='i'/>
                             </ItemGroup>
                     </Project>
                 ";
         private const string IncludeOutsideTarget = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i'/>
                         </ItemGroup>
                     </Project>
                 ";
         private const string IncludeInsideTarget = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Include='i'/>
@@ -55,14 +55,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ";
         private const string UpdateOutsideTarget = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                             <ItemGroup>
                                 <i Update='i'/>
                             </ItemGroup>
                     </Project>
                 ";
         private const string UpdateInTarget = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Update='i'/>
@@ -89,7 +89,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i/>
                         </ItemGroup>
@@ -97,7 +97,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 ")]
         // https://github.com/dotnet/msbuild/issues/900
         // [InlineData(@"
-        //            <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+        //            <Project>
         //                <Target Name='t'>
         //                    <ItemGroup>
         //                        <i/>
@@ -119,14 +119,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='a'>error text</i>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Include='a'>error text</i>
@@ -148,14 +148,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include=''/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Include=''/>
@@ -177,14 +177,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <PropertyGroup Include='i1'/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <PropertyGroup Include='i1'/>
@@ -208,7 +208,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadInvalidExcludeWithoutInclude()
         {
             var project = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Exclude='i1'/>
                         </ItemGroup>
@@ -219,10 +219,10 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 Assert.Throws<InvalidProjectFileException>(
                     () => { ProjectRootElement.Create(XmlReader.Create(new StringReader(project))); }
                     );
-            
+
             Assert.Contains("Items that are outside Target elements must have one of the following operations: Include, Update, or Remove.", exception.Message);
         }
-        
+
         /// <summary>
         /// Read item with Exclude without Include under a target
         /// </summary>
@@ -230,7 +230,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadInvalidExcludeWithoutIncludeUnderTarget()
         {
             var project = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Exclude='i1'/>
@@ -243,20 +243,20 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 Assert.Throws<InvalidProjectFileException>(
                     () => { ProjectRootElement.Create(XmlReader.Create(new StringReader(project))); }
                     );
-            
+
             Assert.Contains("The attribute \"Exclude\" in element <i> is unrecognized.", exception.Message);
         }
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i include='i1'/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i include='i1'/>
@@ -265,14 +265,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' exclude='i2' />
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Include='i1' exclude='i2' />
@@ -294,7 +294,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i'>
                                 <m1>v1</m1>
@@ -306,7 +306,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i'>
@@ -320,7 +320,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i' m1='v1' />
                             <i2 Include='i' Exclude='j' m2='v2' />
@@ -328,7 +328,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i' m1='v1' />
@@ -340,7 +340,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadBasic(string project)
         {
             ProjectRootElement projectElement = ProjectRootElement.Create(XmlReader.Create(new StringReader(project)));
-            ProjectItemGroupElement itemGroup = (ProjectItemGroupElement) projectElement.AllChildren.FirstOrDefault(c => c is ProjectItemGroupElement);
+            ProjectItemGroupElement itemGroup = (ProjectItemGroupElement)projectElement.AllChildren.FirstOrDefault(c => c is ProjectItemGroupElement);
 
             var items = Helpers.MakeList(itemGroup.Items);
 
@@ -366,7 +366,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i'>
                                 <m1>v1</m1>
@@ -377,7 +377,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i'>
@@ -408,14 +408,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' Update='i2'/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Include='i1' Update='i2'/>
@@ -434,14 +434,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' Exclude='i1' Update='i2'/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Include='i1' Exclude='i1' Update='i2'/>
@@ -460,14 +460,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Exclude='i1' Update='i2'/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Exclude='i1' Update='i2'/>
@@ -489,7 +489,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Remove='i1'>
                                     <m> </m>
@@ -498,7 +498,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Remove='i1'>
@@ -522,14 +522,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Exclude='i1' Remove='i1'/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Exclude='i1' Remove='i1'/>
@@ -551,14 +551,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' Remove='i1'/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Include='i1' Remove='i1'/>
@@ -606,14 +606,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' Exclude='i2'/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i Include='i1' Exclude='i2'/>
@@ -831,7 +831,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             }
            );
         }
-        
+
         /// <summary>
         /// Set Update when Remove is present
         /// </summary>
@@ -849,7 +849,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
            );
         }
 
-        /// 
+        ///
         /// <summary>
         /// Set the Update on an item
         /// </summary>

--- a/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadEmptyItemGroup()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup/>
                     </Project>
                 ";
@@ -52,7 +52,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadItemGroupTwoItems()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'/>
                             <i Include='i2'/>

--- a/src/Build.OM.UnitTests/Construction/ProjectMetadataElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectMetadataElement_Tests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m Condition='c' XX='YY'/>
@@ -72,7 +72,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <" + "\u03A3" + @"/>
@@ -88,14 +88,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' " + "\u03A3" + @"='v1' />
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i " + "\u03A3" + @"='v1' />
                         </ItemDefinitionGroup>
@@ -119,7 +119,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <Filename/>
@@ -135,14 +135,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' Filename='v1'/>
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i Filename='v1'/>
                         </ItemDefinitionGroup>
@@ -166,7 +166,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <PropertyGroup/>
@@ -185,14 +185,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' PropertyGroup='v1' />
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i PropertyGroup='v1' />
                         </ItemDefinitionGroup>
@@ -290,14 +290,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i' />
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i' />
@@ -326,7 +326,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void AddMetadataAsAttributeToItemDefinitionIllegalName()
         {
             string project = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1/>
                         </ItemDefinitionGroup>
@@ -383,7 +383,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i>
                                 <m1>@(x)</m1>
@@ -403,7 +403,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadValidItemExpressionInMetadata()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m1>@(x)</m1>
@@ -418,14 +418,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i' m1='v1' />
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i' m1='v1' />
@@ -453,7 +453,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadMetadataAsAttributeOnItemDefinition()
         {
             string project = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1='v1' />
                         </ItemDefinitionGroup>
@@ -475,14 +475,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i' m1='&lt;&amp;>""' />
                         </ItemGroup>
                     </Project>
                 ")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i' m1='&lt;&amp;>""' />
@@ -510,7 +510,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadMetadataAsAttributeOnItemDefinitionWithSpecialCharacters()
         {
             var project = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1='&lt;&amp;>""' />
                         </ItemDefinitionGroup>
@@ -532,19 +532,19 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                             <i1 Include=`i` m1=`v1` />
                         </ItemGroup>
                     </Project>",
                 @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemGroup>
                             <i1 Include=`i` m1=`v2` />
                         </ItemGroup>
                     </Project>")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include=`i` m1=`v1` />
@@ -552,7 +552,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </Target>
                     </Project>",
                 @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <Target Name=`t`>
                             <ItemGroup>
                                 <i1 Include=`i` m1=`v2` />
@@ -598,7 +598,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void UpdateMetadataValueAsAttributeOnItemDefinition()
         {
             var projectContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1=`v1` />
                         </ItemDefinitionGroup>
@@ -631,7 +631,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             string expected = @"<?xml version=""1.0"" encoding=""utf-16""?>" +
                               ObjectModelHelpers.CleanupFileContents(@"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1=`v2` />
                         </ItemDefinitionGroup>
@@ -647,19 +647,19 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         //      &lt;&amp;&gt;&quot;
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                             <i1 Include=`i` m1=`v1` />
                         </ItemGroup>
                     </Project>",
                 @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemGroup>
                             <i1 Include=`i` m1=`&lt;&amp;&gt;&quot;` />
                         </ItemGroup>
                     </Project>")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include=`i` m1=`v1` />
@@ -667,7 +667,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </Target>
                     </Project>",
                 @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <Target Name=`t`>
                             <ItemGroup>
                                 <i1 Include=`i` m1=`&lt;&amp;&gt;&quot;` />
@@ -713,7 +713,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void UpdateMetadataValueAsAttributeOnItemDefinitionWithSpecialCharacters()
         {
             var projectContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1=`v1` />
                         </ItemDefinitionGroup>
@@ -746,7 +746,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             string expected = @"<?xml version=""1.0"" encoding=""utf-16""?>" +
                               ObjectModelHelpers.CleanupFileContents(@"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1=`&lt;&amp;&gt;&quot;` />
                         </ItemDefinitionGroup>
@@ -758,7 +758,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i'>
                               <m1>v1</m1>
@@ -766,25 +766,25 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </ItemGroup>
                     </Project>",
                 @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemGroup>
                             <i1 Include=`i` m1=`v1` />
                         </ItemGroup>
                     </Project>")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i'><m1>v1</m1></i1>
                         </ItemGroup>
                     </Project>",
                 @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemGroup>
                             <i1 Include=`i` m1=`v1` />
                         </ItemGroup>
                     </Project>")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i'>
@@ -794,7 +794,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </Target>
                     </Project>",
                 @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <Target Name=`t`>
                             <ItemGroup>
                                 <i1 Include=`i` m1=`v1` />
@@ -837,7 +837,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1>
                               <m1>v1</m1>
@@ -845,19 +845,19 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </ItemDefinitionGroup>
                     </Project>",
         @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1=`v1` />
                         </ItemDefinitionGroup>
                     </Project>")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1><m1>v1</m1></i1>
                         </ItemDefinitionGroup>
                     </Project>",
         @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1=`v1` />
                         </ItemDefinitionGroup>
@@ -898,13 +898,13 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i' m1='v1' />
                         </ItemGroup>
                     </Project>",
                     @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemGroup>
                             <i1 Include=`i`>
                               <m1>v1</m1>
@@ -912,7 +912,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </ItemGroup>
                     </Project>")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i' m1='v1' />
@@ -920,7 +920,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </Target>
                     </Project>",
                     @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <Target Name=`t`>
                             <ItemGroup>
                                 <i1 Include=`i`>
@@ -967,7 +967,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ChangeAttributeToMetadataOnItemDefinition()
         {
             var projectContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1='v1'/>
                         </ItemDefinitionGroup>
@@ -999,7 +999,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             string expected = @"<?xml version=""1.0"" encoding=""utf-16""?>" +
                 ObjectModelHelpers.CleanupFileContents(@"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1>
                               <m1>v1</m1>
@@ -1013,19 +1013,19 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i' />
                         </ItemGroup>
                     </Project>",
         @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemGroup>
                             <i1 Include=`i` m1=`v1` />
                         </ItemGroup>
                     </Project>")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i' />
@@ -1033,7 +1033,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </Target>
                     </Project>",
         @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <Target Name=`t`>
                             <ItemGroup>
                                 <i1 Include=`i` m1=`v1` />
@@ -1075,7 +1075,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void AddMetadataAsAttributeToItemDefinition()
         {
             var projectContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1/>
                         </ItemDefinitionGroup>
@@ -1104,7 +1104,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             string expected = @"<?xml version=""1.0"" encoding=""utf-16""?>" +
                               ObjectModelHelpers.CleanupFileContents(@"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1=`v1` />
                         </ItemDefinitionGroup>
@@ -1116,13 +1116,13 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         [Theory]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                             <i1 Include='i' />
                         </ItemGroup>
                     </Project>",
         @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemGroup>
                             <i1 Include=`i` m1=`v1`>
                               <m2>v2</m2>
@@ -1130,7 +1130,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </ItemGroup>
                     </Project>")]
         [InlineData(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup>
                                 <i1 Include='i' />
@@ -1138,7 +1138,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                         </Target>
                     </Project>",
         @"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <Target Name=`t`>
                             <ItemGroup>
                                 <i1 Include=`i` m1=`v1`>
@@ -1189,7 +1189,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void AddMetadataToItemDefinitionAsAttributeAndAsElement()
         {
             var projectContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1/>
                         </ItemDefinitionGroup>
@@ -1225,7 +1225,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             string expected = @"<?xml version=""1.0"" encoding=""utf-16""?>" +
                               ObjectModelHelpers.CleanupFileContents(@"
-                    <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Project>
                         <ItemDefinitionGroup>
                             <i1 m1=`v1`>
                               <m2>v2</m2>
@@ -1243,7 +1243,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectMetadataElement GetMetadataXml()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m Condition='c'>m1</m>

--- a/src/Build.OM.UnitTests/Construction/ProjectOnErrorElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectOnErrorElement_Tests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadTargetTwoOnErrors()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1/>
                             <t2/>
@@ -71,7 +71,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <OnError/>
                         </Target>
@@ -98,7 +98,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <OnError ExecuteTargets=''/>
                         </Target>
@@ -122,7 +122,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <OnError ExecuteTargets='t' XX='YY'/>
                         </Target>
@@ -142,7 +142,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <OnError ExecuteTargets='t'>
                                 <X/>
@@ -164,7 +164,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <OnError ExecuteTargets='t'/>
                             <t/>
@@ -185,7 +185,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <OnError ExecuteTargets='t'/>
                             <PropertyGroup/>
@@ -206,7 +206,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <OnError ExecuteTargets='t'/>
                             <ItemGroup/>
@@ -301,7 +301,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectOnErrorElement GetOnError()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <OnError ExecuteTargets='t' Condition='c'/>
                         </Target>

--- a/src/Build.OM.UnitTests/Construction/ProjectOutputElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectOutputElement_Tests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <Output TaskParameter='p'/>
@@ -80,7 +80,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <Output TaskParameter='p' PropertyName='MSBuildProjectFile'/>
@@ -103,7 +103,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <Output ItemName='i'/>
@@ -126,7 +126,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <Output TaskName='' ItemName='i'/>
@@ -149,7 +149,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <Output ItemName='i' TaskParameter='x'>
@@ -174,7 +174,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <Output TaskParameter='t' PropertyName='p' ItemName=''/>
@@ -197,7 +197,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <Output TaskParameter='t' ItemName='i' PropertyName=''/>
@@ -287,7 +287,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectOutputElement GetOutputItem()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <Output TaskParameter='p' ItemName='i1' />
@@ -309,7 +309,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectOutputElement GetOutputProperty()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <Output TaskParameter='p' PropertyName='p1' />

--- a/src/Build.OM.UnitTests/Construction/ProjectPropertyElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectPropertyElement_Tests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadPropertyWithChildren()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <p>A<B>C<D/></B>E</p>
                         </PropertyGroup>
@@ -50,7 +50,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             ProjectPropertyElement property = Helpers.GetFirst(propertyGroup.Properties);
 
             Assert.Equal("p", property.Name);
-            Assert.Equal(@"A<B xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">C<D /></B>E", property.Value);
+            Assert.Equal(@"A<B>C<D /></B>E", property.Value);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <" + "\u03A3" + @"/>
                         </PropertyGroup>
@@ -82,7 +82,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <PropertyGroup/>
                         </PropertyGroup>
@@ -102,7 +102,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <MSBuildProjectFile/>
                         </PropertyGroup>
@@ -122,7 +122,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <p XX='YY'/>
                         </PropertyGroup>
@@ -142,7 +142,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <p>
                                 <X/>
@@ -275,7 +275,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectPropertyElement GetPropertyXml()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <p Condition='c'>v</p>
                         </PropertyGroup>

--- a/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         [Fact]
         public void ConstructOverSameFileReturnsSameEvenWithOneBeingRelativePath3()
         {
-            string content = "<Project ToolsVersion=\"4.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\r\n</Project>";
+            string content = "<Project ToolsVersion=\"4.0\">\r\n</Project>";
 
             ProjectRootElement projectXml1 = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
 
@@ -233,7 +233,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         [Fact]
         public void ConstructOverSameFileReturnsSameEvenWithOneBeingRelativePath4()
         {
-            string content = "<Project ToolsVersion=\"4.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\r\n</Project>";
+            string content = "<Project ToolsVersion=\"4.0\">\r\n</Project>";
 
             ProjectRootElement projectXml1 = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
 
@@ -292,7 +292,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <XXX xmlns='http://schemas.microsoft.com/developer/msbuild/2003'/>
+                    <XXX />
                 ";
 
                 ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
@@ -308,7 +308,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <XXX/>
                     </Project>
                 ";
@@ -394,7 +394,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                            <XXX YYY='ZZZ'/>
                         </ItemGroup>
@@ -415,7 +415,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <ItemGroup>
                            <XXX YYY='ZZZ'/>
                         </ItemGroup>
@@ -455,10 +455,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         [Trait("Category", "netcore-linux-failing")]
         public void ValidXmlXmlTextReaderNotCache()
         {
-            string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-                    </Project>
-                ";
+            string content = @"<Project />";
 
             string path = null;
 
@@ -493,15 +490,9 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         [Fact]
         public void ValidXmlXmlReaderCache()
         {
-            string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-                    </Project>
-                ";
+            string content = @"<Project />";
 
-            string content2 = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' DefaultTargets='t'>
-                    </Project>
-                ";
+            string content2 = @"<Project DefaultTargets='t' />";
 
             string path = null;
 
@@ -951,7 +942,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// Build a project file that can't be accessed
         /// </summary>
         [Fact]
-        [PlatformSpecific (TestPlatforms.Windows)]
+        [PlatformSpecific(TestPlatforms.Windows)]
         // FileSecurity class is not supported on Unix
         public void ProjectCanNotBeOpened()
         {

--- a/src/Build.OM.UnitTests/Construction/ProjectTargetElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectTargetElement_Tests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadEmptyTarget()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'/>
                     </Project>
                 ";
@@ -166,7 +166,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target/>
                     </Project>
                 ";
@@ -184,7 +184,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target XX='YY'/>
                     </Project>
                 ";
@@ -310,7 +310,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         /// <summary>
         /// Set return value.  Verify that setting to the empty string and null are
-        /// both allowed and have distinct behaviour. 
+        /// both allowed and have distinct behaviour.
         /// </summary>
         [Fact]
         public void SetReturns()
@@ -345,7 +345,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectTargetElement GetTargetXml()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t' Inputs='i' Outputs='o' DependsOnTargets='d' Condition='c'>
                             <t1/>
                             <t2/>

--- a/src/Build.OM.UnitTests/Construction/ProjectTaskElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectTaskElement_Tests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadNoParameters()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1/>
                         </Target>
@@ -47,7 +47,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadContinueOnError()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1 ContinueOnError='coe'/>
                         </Target>
@@ -66,7 +66,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadCondition()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1 Condition='c'/>
                         </Target>
@@ -87,7 +87,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1>
                                 <X/>
@@ -102,14 +102,14 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         }
         /// <summary>
         /// Read task with empty parameter.
-        /// Although MSBuild does not set these on tasks, they 
+        /// Although MSBuild does not set these on tasks, they
         /// are visible in the XML objects for editing purposes.
         /// </summary>
         [Fact]
         public void ReadEmptyParameter()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1 p1='' />
                         </Target>
@@ -130,7 +130,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadParameters()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1 p1='v1' p2='v2' />
                         </Target>
@@ -316,7 +316,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectTaskElement GetBasicTask()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             <t1 p1='v1' />
                         </Target>

--- a/src/Build.OM.UnitTests/Construction/ProjectUsingTaskElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectUsingTaskElement_Tests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask AssemblyFile='af'/>
                     </Project>
                 ";
@@ -57,7 +57,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='' AssemblyFile='af'/>
                     </Project>
                 ";
@@ -75,7 +75,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t' AssemblyFile='af' X='Y'/>
                     </Project>
                 ";
@@ -93,7 +93,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t'/>
                     </Project>
                 ";
@@ -111,7 +111,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t' AssemblyFile=''/>
                     </Project>
                 ";
@@ -129,7 +129,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t' AssemblyFile='' AssemblyName='n'/>
                     </Project>
                 ";
@@ -147,7 +147,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t' AssemblyName='' AssemblyFile='f'/>
                     </Project>
                 ";
@@ -165,7 +165,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t' AssemblyName='an' AssemblyFile='af'/>
                     </Project>
                 ";
@@ -183,7 +183,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t' AssemblyName='' AssemblyFile=''/>
                     </Project>
                 ";
@@ -361,7 +361,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t2' AssemblyName='an' Condition='c' TaskFactory='AssemblyFactory'>
                             <ParameterGroup/>
                             <ParameterGroup/>
@@ -382,7 +382,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t2' AssemblyName='an' Condition='c' TaskFactory='AssemblyFactory'>
                             <Task/>
                             <Task/>
@@ -403,7 +403,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t2' AssemblyName='an' Condition='c' TaskFactory='AssemblyFactory'>
                             <IAMUNKNOWN/>
                         </UsingTask>
@@ -421,7 +421,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void WorksWithChildren()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t2' AssemblyName='an' Condition='c' TaskFactory='AssemblyFactory'>
                             <ParameterGroup>
                                <MyParameter/>
@@ -448,7 +448,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t2' AssemblyName='an' Condition='c'>
                             <ParameterGroup>
                                <MyParameter/>
@@ -472,7 +472,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t2' AssemblyName='an' Condition='c'>
                             <Task/>
                         </UsingTask>
@@ -491,7 +491,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectUsingTaskElement GetUsingTaskFactoryRuntimeAndPlatform()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t2' AssemblyName='an' Condition='c' TaskFactory='AssemblyFactory' />
                     </Project>
                 ";
@@ -507,7 +507,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectUsingTaskElement GetUsingTaskAssemblyFile()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t1' AssemblyFile='af' />
                         <UsingTask TaskName='t2' AssemblyName='an' Condition='c'/>
                     </Project>
@@ -524,7 +524,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectUsingTaskElement GetUsingTaskAssemblyName()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='t2' AssemblyName='an' Condition='c'/>
                     </Project>
                 ";

--- a/src/Build.OM.UnitTests/Construction/UsingTaskBodyElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/UsingTaskBodyElement_Tests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask AssemblyFile='af' TaskFactory='AssemblyFactory'>
                             <Task NotValidAttribute='OHI'/>
                        </UsingTask>
@@ -60,7 +60,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Task>
                             Contents
                         </Task>
@@ -132,7 +132,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         private static ProjectUsingTaskBodyElement GetBodyXml()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='SuperTask' AssemblyFile='af' TaskFactory='AssemblyFactory'>
                             <Task Evaluate='false'>Contents</Task>
                        </UsingTask>

--- a/src/Build.OM.UnitTests/Construction/UsingTaskParameterElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/UsingTaskParameterElement_Tests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// Parameter element with all attributes set
         /// </summary>
         private static string s_contentAllAttributesSet = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='SuperTask' AssemblyFile='af' TaskFactory='AssemblyFactory'>
                            <ParameterGroup>
                               <MyParameter ParameterType='System.String' Output='true' Required='false'/>
@@ -35,7 +35,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// Parameter element with no attributes set
         /// </summary>
         private static string s_contentNoAttributesSet = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='SuperTask' AssemblyFile='af' TaskFactory='AssemblyFactory'>
                            <ParameterGroup>
                               <MyParameter/>
@@ -81,7 +81,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='SuperTask' AssemblyFile='af' TaskFactory='AssemblyFactory'>
                            <ParameterGroup>
                               <MyParameter Invaliid='System.String'/>

--- a/src/Build.OM.UnitTests/Construction/UsingTaskParameterGroup_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/UsingTaskParameterGroup_Tests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// ParameterGroup with no parameters inside
         /// </summary>
         private static string s_contentEmptyParameterGroup = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='SuperTask' AssemblyFile='af' TaskFactory='AssemblyFactory'>
                            <ParameterGroup/>
                        </UsingTask>
@@ -33,7 +33,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// ParameterGroup with duplicate child parameters
         /// </summary>
         private static string s_contentDuplicateParameters = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='SuperTask' AssemblyFile='af' TaskFactory='AssemblyFactory'>
                            <ParameterGroup>
                               <MyParameter/>
@@ -47,7 +47,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// ParameterGroup with multiple parameters
         /// </summary>
         private static string s_contentMultipleParameters = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='SuperTask' AssemblyFile='af' TaskFactory='AssemblyFactory'>
                            <ParameterGroup>
                               <MyParameter1 ParameterType='System.String' Output='true' Required='false'/>
@@ -121,7 +121,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <UsingTask TaskName='SuperTask' AssemblyFile='af' TaskFactory='AssemblyFactory'>
                            <ParameterGroup BadAttribute='Hello'/>
                        </UsingTask>

--- a/src/Build.OM.UnitTests/Definition/EditingElementsReferencedByOrReferences_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/EditingElementsReferencedByOrReferences_Tests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void ChangeItemTypeInReferencedItem()
         {
             Project project = GetProject(
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemGroup>
     <I Include=""X"" />
     <I Include=""@(I);Y"" />
@@ -36,7 +36,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             item.ItemType = "J";
 
             string expected =
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemGroup>
     <J Include=""X"" />
     <I Include=""@(I);Y"" />
@@ -59,7 +59,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void RemoveItemInList()
         {
             Project project = GetProject(
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemGroup>
     <I Include=""X"" />
     <I Include=""@(I);Y;Z"" />
@@ -70,7 +70,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             project.RemoveItem(item);
 
             string expected =
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemGroup>
     <I Include=""X"" />
     <I Include=""X"" />
@@ -88,7 +88,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void RenameItemInList()
         {
             Project project = GetProject(
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemGroup>
     <I Include=""X"" />
     <I Include=""@(I);Y"" />
@@ -99,7 +99,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             item.Rename("Z");
 
             string expected =
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemGroup>
     <I Include=""X"" />
     <I Include=""X"" />
@@ -117,7 +117,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void RemoveMetadata1()
         {
             Project project = GetProject(
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemDefinitionGroup>
     <I>
       <M>A</M>
@@ -143,7 +143,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             item1.RemoveMetadata("M");
 
             string expected =
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemDefinitionGroup>
     <I>
       <M>A</M>
@@ -168,7 +168,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void RemoveMetadata2()
         {
             Project project = GetProject(
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemDefinitionGroup>
     <I>
       <M>A</M>
@@ -189,7 +189,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             item1.RemoveMetadata("M");
 
             string expected =
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemDefinitionGroup>
     <I>
       <M>A</M>
@@ -220,7 +220,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void RemoveMetadata3()
         {
             Project project = GetProject(
-        @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+        @"<Project>
   <ItemDefinitionGroup>
     <I>
       <M>A</M>
@@ -245,7 +245,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             item2.RemoveMetadata("M");
 
             string expected =
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemDefinitionGroup>
     <I>
       <M>A</M>
@@ -274,7 +274,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void RemoveReferencedMetadata()
         {
             Project project = GetProject(
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemGroup>
     <I Include=""i"">
       <M>m</M>
@@ -289,7 +289,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             item.RemoveMetadata("M");
 
             string expected =
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <ItemGroup>
     <I Include=""i"">
       <N>%(I.M)</N>
@@ -313,7 +313,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void RemoveProperty()
         {
             Project project = GetProject(
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <PropertyGroup>
     <P>A</P>
     <P>$(P)B</P>
@@ -324,7 +324,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             project.RemoveProperty(property);
 
             string expected =
-@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+@"<Project>
   <PropertyGroup>
     <P>A</P>
   </PropertyGroup>

--- a/src/Build.OM.UnitTests/Definition/ProjectCollection_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectCollection_Tests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         /// <summary>
-        /// When an unnamed project is saved, it gets a name, and should be entered into 
+        /// When an unnamed project is saved, it gets a name, and should be entered into
         /// the appropriate project collection.
         /// </summary>
         [Fact]
@@ -111,7 +111,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         /// <summary>
-        /// When an unnamed project is saved, it gets a name, and should be entered into 
+        /// When an unnamed project is saved, it gets a name, and should be entered into
         /// the appropriate project collection.
         /// </summary>
         [Fact]
@@ -374,21 +374,21 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         /// <summary>
-        /// Validates that when loading two projects with nominally different global properties, but that match when we take 
-        /// into account the ProjectCollection's global properties, we get the pre-existing project if one exists. 
+        /// Validates that when loading two projects with nominally different global properties, but that match when we take
+        /// into account the ProjectCollection's global properties, we get the pre-existing project if one exists.
         /// </summary>
         [Fact]
         public void TwoProjectsEquivalentWhenOneInheritsFromProjectCollection()
         {
             var project = new Project { FullPath = "c:\\1" };
 
-            // Set a global property on the project collection -- this should be passed on to all 
-            // loaded projects. 
+            // Set a global property on the project collection -- this should be passed on to all
+            // loaded projects.
             ProjectCollection.GlobalProjectCollection.SetGlobalProperty("Configuration", "Debug");
 
             Assert.Equal("Debug", project.GlobalProperties["Configuration"]);
 
-            // now create a global properties dictionary to pass to a new project 
+            // now create a global properties dictionary to pass to a new project
             var globals = new Dictionary<string, string> { { "Configuration", "Debug" } };
 
             ProjectCollection.GlobalProjectCollection.LoadProject("c:\\1", globals, null);
@@ -432,15 +432,15 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
         /// <summary>
         /// Validates that we can correctly load two of the same project file with different global properties, even when
-        /// those global properties are applied to the project by the project collection (and then overridden in one case). 
+        /// those global properties are applied to the project by the project collection (and then overridden in one case).
         /// </summary>
         [Fact]
         public void TwoProjectsDistinguishedByGlobalPropertiesOnly_ProjectOverridesProjectCollection()
         {
             var project = new Project { FullPath = "c:\\1" };
 
-            // Set a global property on the project collection -- this should be passed on to all 
-            // loaded projects. 
+            // Set a global property on the project collection -- this should be passed on to all
+            // loaded projects.
             ProjectCollection.GlobalProjectCollection.SetGlobalProperty("Configuration", "Debug");
 
             Assert.Equal("Debug", project.GlobalProperties["Configuration"]);
@@ -448,7 +448,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             // Differentiate this project from the one below
             project.SetGlobalProperty("MyProperty", "MyValue");
 
-            // now create a global properties dictionary to pass to a new project 
+            // now create a global properties dictionary to pass to a new project
             var project2Globals =
                 new Dictionary<string, string> { { "Configuration", "Release" }, { "Platform", "Win32" } };
 
@@ -456,8 +456,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             Assert.Equal("Release", project2.GlobalProperties["Configuration"]);
 
-            // Setting a global property on the project collection overrides all contained projects, 
-            // whether they were initially loaded with the global project collection's value or not. 
+            // Setting a global property on the project collection overrides all contained projects,
+            // whether they were initially loaded with the global project collection's value or not.
             ProjectCollection.GlobalProjectCollection.SetGlobalProperty("Platform", "X64");
             Assert.Equal("X64", project.GlobalProperties["Platform"]);
             Assert.Equal("X64", project2.GlobalProperties["Platform"]);
@@ -466,14 +466,14 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             project2.SetGlobalProperty("Platform", "Itanium");
             Assert.Equal("Itanium", project2.GlobalProperties["Platform"]);
 
-            // Now set global properties such that the two projects have an identical set.  
+            // Now set global properties such that the two projects have an identical set.
             ProjectCollection.GlobalProjectCollection.SetGlobalProperty("Configuration", "Debug2");
             ProjectCollection.GlobalProjectCollection.SetGlobalProperty("Platform", "X86");
 
             bool exceptionCaught = false;
             try
             {
-                // This will make it identical, so we should get a throw here. 
+                // This will make it identical, so we should get a throw here.
                 ProjectCollection.GlobalProjectCollection.SetGlobalProperty("MyProperty", "MyValue2");
             }
             catch (InvalidOperationException)
@@ -512,14 +512,14 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         /// <summary>
-        /// If the ToolsVersion in the project file is bogus, we'll default to the current ToolsVersion and successfully 
-        /// load it.  Make sure we can RE-load it, too, and successfully pick up the correct copy of the loaded project. 
+        /// If the ToolsVersion in the project file is bogus, we'll default to the current ToolsVersion and successfully
+        /// load it.  Make sure we can RE-load it, too, and successfully pick up the correct copy of the loaded project.
         /// </summary>
         [Fact]
         public void ReloadProjectWithInvalidToolsVersionInFile()
         {
             const string content = @"
-                    <Project ToolsVersion='bogus' xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project ToolsVersion='bogus'>
                         <Target Name='t'/>
                     </Project>
                 ";
@@ -532,14 +532,14 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         /// <summary>
-        /// Make sure we can reload a project that has a ToolsVersion that doesn't match what it ends up getting 
-        /// forced to by default (current). 
+        /// Make sure we can reload a project that has a ToolsVersion that doesn't match what it ends up getting
+        /// forced to by default (current).
         /// </summary>
         [Fact]
         public void ReloadProjectWithProjectToolsVersionDifferentFromEffectiveToolsVersion()
         {
             const string content = @"
-                    <Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project ToolsVersion='4.0'>
                         <Target Name='t'/>
                     </Project>
                 ";
@@ -793,15 +793,15 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         /// <summary>
-        /// Validates that we don't somehow lose the ProjectCollection global properties when renaming the project. 
+        /// Validates that we don't somehow lose the ProjectCollection global properties when renaming the project.
         /// </summary>
         [Fact]
         public void RenameProjectAndVerifyStillContainsProjectCollectionGlobalProperties()
         {
             var project = new Project { FullPath = "c:\\1" };
 
-            // Set a global property on the project collection -- this should be passed on to all 
-            // loaded projects. 
+            // Set a global property on the project collection -- this should be passed on to all
+            // loaded projects.
             ProjectCollection.GlobalProjectCollection.SetGlobalProperty("Configuration", "Debug");
 
             Assert.Equal("Debug", project.GlobalProperties["Configuration"]);
@@ -1115,7 +1115,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         /// <summary>
-        /// Set default tools version; subsequent projects should use it 
+        /// Set default tools version; subsequent projects should use it
         /// </summary>
         [Fact]
         public void SetDefaultToolsVersion()
@@ -1135,10 +1135,10 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var project = new Project(XmlReader.Create(new StringReader(content)), null, null, collection);
 
-            // ... and after all that, we end up defaulting to the current ToolsVersion instead.  There's a way 
-            // to turn this behavior (new in Dev12) off, but it requires setting an environment variable and 
-            // clearing some internal state to make sure that the update environment variable is picked up, so 
-            // there's not a good way of doing it from these deliberately public OM only tests. 
+            // ... and after all that, we end up defaulting to the current ToolsVersion instead.  There's a way
+            // to turn this behavior (new in Dev12) off, but it requires setting an environment variable and
+            // clearing some internal state to make sure that the update environment variable is picked up, so
+            // there's not a good way of doing it from these deliberately public OM only tests.
             Assert.Equal(project.ToolsVersion, ObjectModelHelpers.MSBuildDefaultToolsVersion);
         }
 

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     public class ProjectItem_Tests : IDisposable
     {
         internal const string ItemWithIncludeAndExclude = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='{0}' Exclude='{1}'/>
                         </ItemGroup>
                     </Project>
                 ";
-        internal const string ItemWithIncludeUpdateAndRemove= @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+        internal const string ItemWithIncludeUpdateAndRemove = @"
+                    <Project>
                         <ItemGroup>
                             <i Include='{0}'>
                                <m>contents</m>
@@ -76,7 +76,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void SingleItemWithNoMetadata()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'/>
                         </ItemGroup>
@@ -99,7 +99,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void ReadMetadata()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m1>v1</m1>
@@ -129,7 +129,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void GetMetadataObjectsFromDefinition()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i>
                                 <m0>v0</m0>
@@ -166,7 +166,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void GetMetadataValuesFromDefinition()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i>
                                 <m0>v0</m0>
@@ -464,7 +464,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void ExcludeWithIncludeVector()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='a;b;c'>
                             </i>
@@ -491,7 +491,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void ExcludeVectorWithIncludeVector()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='a;b;c'>
                             </i>
@@ -592,7 +592,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             @"a/b/foo::||bar;a/b/foo::||bar/;a/b/foo::||bar\;a/b\foo::||bar",
             @"a/b/foo::||bar",
             new string[0],
-            new [] { "a/b/foo::||bar/", @"a/b/foo::||bar\", @"a/b\foo::||bar" })]
+            new[] { "a/b/foo::||bar/", @"a/b/foo::||bar\", @"a/b\foo::||bar" })]
         public void IncludeExcludeWithNonPathContents(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude)
         {
             TestIncludeExclude(projectContents, inputFiles, expectedInclude, includeString, excludeString, normalizeSlashes: false);
@@ -909,9 +909,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         [InlineData(
             "../a.cs;b.cs", // include string
             "**/*.cs", // exclude string
-            new[] {"a.cs", "ProjectDir/b.cs"}, // files to create relative to the test root dir
+            new[] { "a.cs", "ProjectDir/b.cs" }, // files to create relative to the test root dir
             "ProjectDir", // relative path from test root to project
-            new[] {"../a.cs"} // expected items
+            new[] { "../a.cs" } // expected items
             )]
         // exclude globbing cone below project level;
         [InlineData(
@@ -919,13 +919,13 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             "a/**/*.cs",
             new[] { "a.cs", "a/b.cs" },
             "",
-            new[] {"a.cs"}
+            new[] { "a.cs" }
             )]
         // exclude globbing above project level;
         [InlineData(
             "a.cs;../b.cs;../../c.cs",
             "../**/*.cs",
-            new[] { "a/ProjectDir/a.cs", "a/b.cs", "c.cs"},
+            new[] { "a/ProjectDir/a.cs", "a/b.cs", "c.cs" },
             "a/ProjectDir",
             new[] { "../../c.cs" }
             )]
@@ -936,7 +936,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             using (var env = TestEnvironment.Create())
             using (var projectCollection = new ProjectCollection())
             {
-                var testFiles = env.CreateTestProjectWithFiles(projectContents, files,relativePathFromRootToProject);
+                var testFiles = env.CreateTestProjectWithFiles(projectContents, files, relativePathFromRootToProject);
                 ObjectModelHelpers.AssertItems(expectedInclude, new Project(testFiles.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, projectCollection).Items.ToList());
             }
         }
@@ -945,9 +945,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         [InlineData(
             "../**/*.cs", // include string
             "a.cs", // exclude string
-            new[] {"ProjectDir/a.cs", "b.cs"}, // files to create relative to the test root dir
+            new[] { "ProjectDir/a.cs", "b.cs" }, // files to create relative to the test root dir
             "ProjectDir", // relative path from test root to project
-            new[] {"../b.cs"} // expected items
+            new[] { "../b.cs" } // expected items
             )]
         public void ExcludingRelativeItemToCurrentDirectoryShouldWorkWithAboveTheConeIncludes(string includeString, string excludeString, string[] files, string relativePathFromRootToProject, string[] expectedInclude)
         {
@@ -968,7 +968,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void CopyFromWithItemListExpressionClonesMetadata()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                           <i Include='i1'>
                             <m>m1</m>
@@ -1005,7 +1005,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void CopyFromWithItemListExpressionDoesNotCloneDefinitionMetadata()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                           <i>
                             <m>m1</m>
@@ -1056,7 +1056,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void CopyFromWithItemListExpressionClonesDefinitionMetadata_Variation()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                           <i>
                             <m>m1</m>
@@ -1106,7 +1106,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void CopyWithItemDefinition()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                           <i>
                             <l>l1</l>
@@ -1203,7 +1203,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void CopyWithItemDefinition2()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                           <i>
                             <l>l1</l>
@@ -1296,7 +1296,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void MetadataReferringToMetadataAbove()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m1>v1</m1>
@@ -1322,7 +1322,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void BuiltInMetadataExpression()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m>%(Identity)</m>
@@ -1343,7 +1343,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void BuiltInQualifiedMetadataExpression()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m>%(i.Identity)</m>
@@ -1364,7 +1364,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void BuiltInMisqualifiedMetadataExpression()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m>%(j.Identity)</m>
@@ -1385,7 +1385,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void BuiltInMetadataInMetadataCondition()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m Condition=""'%(Identity)'=='i1'"">m1</m>
@@ -1410,7 +1410,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' Condition=""'%(Identity)'=='i1'/>
                         </ItemGroup>
@@ -1428,7 +1428,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void BuiltInMetadataTwoItems()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1.cpp;" + (NativeMethodsShared.IsWindows ? @"c:\bar\i2.cpp" : "/bar/i2.cpp") + @"'>
                                 <m>%(Filename).obj</m>
@@ -1450,7 +1450,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void DifferentMetadataItemsFromOtherList()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'>
                                 <m>m1</m>
@@ -1477,7 +1477,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void DifferentBuiltInMetadataItemsFromOtherList()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0.x'/>
                             <h Include='h1.y'/>
@@ -1502,7 +1502,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void BuiltInMetadataTransformInInclude()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <h Include='h1'/>
@@ -1527,7 +1527,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void BuiltInMetadataTransformInMetadataValue()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <h Include='h1'/>
@@ -1552,7 +1552,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void BuiltInMetadataTransformInMetadataValueBareMetadataPresent()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <h Include='h1'/>
@@ -1577,7 +1577,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void MetadataValueReferringToItems()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <i Include='i0'/>
@@ -1600,7 +1600,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void MetadataConditionReferringToItems()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <i Include='i0'/>
@@ -1625,7 +1625,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void MetadataConditionReferringToMetadataOnSameItem()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m0>0</m0>
@@ -1998,7 +1998,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             using (var env = TestEnvironment.Create())
             {
-                var testProject = env.CreateTestProjectWithFiles(projectContents.Cleanup(), new[] {"a.cs"});
+                var testProject = env.CreateTestProjectWithFiles(projectContents.Cleanup(), new[] { "a.cs" });
 
                 var project = new Project(testProject.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, env.CreateProjectCollection().Collection);
 
@@ -2130,7 +2130,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 );
 
             Assert.Equal(2, items.Count);
-            Assert.Equal(@"a.txt;b.cs", string.Join(";", items.Select(i => i.EvaluatedInclude))); 
+            Assert.Equal(@"a.txt;b.cs", string.Join(";", items.Select(i => i.EvaluatedInclude)));
         }
 
         [Fact]
@@ -2143,7 +2143,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 );
 
             Assert.Equal(2, items.Count);
-            Assert.Equal(@"a;c", string.Join(";", items.Select(i => i.EvaluatedInclude))); 
+            Assert.Equal(@"a;c", string.Join(";", items.Select(i => i.EvaluatedInclude)));
         }
 
         [Theory]
@@ -3270,7 +3270,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void UpdateShouldBeAbleToContainProperties()
         {
             var content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                            <P>a</P>
                         </PropertyGroup>
@@ -3454,7 +3454,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     return new Project(p, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, c)
                         .Items
                         .Where(i => i.ItemType.Equals("i"))
-                        .Select(i => (ObjectModelHelpers.TestItem) new ObjectModelHelpers.ProjectItemTestItemAdapter(i))
+                        .Select(i => (ObjectModelHelpers.TestItem)new ObjectModelHelpers.ProjectItemTestItemAdapter(i))
                         .ToList();
                 },
                 project,

--- a/src/Build.OM.UnitTests/Definition/ProjectProperty_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectProperty_Tests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void NoExpansion()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <p>v1</p>
                         </PropertyGroup>
@@ -61,7 +61,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void ExpandProperty()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <PropertyGroup>
                             <o>v1</o>
                             <p>$(o)</p>
@@ -235,7 +235,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         /// <summary>
         /// Verify item expressions are not expanded in new property values.
         /// NOTE: They aren't expanded to "blank". It just seems like that, because
-        /// when you output them, item expansion happens after property expansion, and 
+        /// when you output them, item expansion happens after property expansion, and
         /// they may evaluate to blank then. (Unless items do exist at that point.)
         /// </summary>
         [Fact]

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -3317,7 +3317,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             var project =
                 @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
                   <ItemGroup>
-                    <A Include=`" + longString +  @"`/>
+                    <A Include=`" + longString + @"`/>
                   </ItemGroup>
                 </Project>
                 ";
@@ -3515,7 +3515,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             AssertProvenanceResult(expected, project, "1.foo");
         }
 
-		[Fact]
+        [Fact]
         public void GetItemProvenanceShouldWorkWithRemoveElements()
         {
             var project =
@@ -3569,7 +3569,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 ProvenanceResultTupleList expectedProvenance = null;
 
-                var provenanceKind = includeGlob.IndexOfAny(new[]{'*', '?'}) != -1  ? Provenance.Glob : Provenance.StringLiteral;
+                var provenanceKind = includeGlob.IndexOfAny(new[] { '*', '?' }) != -1 ? Provenance.Glob : Provenance.StringLiteral;
                 expectedProvenance = provenanceShouldFindAMatch
                     ? new ProvenanceResultTupleList
                     {
@@ -3709,13 +3709,13 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 <A Include=`a*;b*;c*` Exclude=`@(E)`/>
 <A Remove=`@(R)`/>
 ",
-        new[] {"aa", "bb", "cc"},
-        new[] {"b", "c"}
+        new[] { "aa", "bb", "cc" },
+        new[] { "b", "c" }
         )]
         [InlineData(
             @"<A Include=`ab*;b|c*;de*`/>",
-            new[] {"ab", "de"},
-            new[] {"bc", "b|c", "b", "c"}
+            new[] { "ab", "de" },
+            new[] { "bc", "b|c", "b", "c" }
             )]
         public void GetAllGlobsShouldProduceGlobThatMatches(string itemContents, string[] stringsThatShouldMatch, string[] stringsThatShouldNotMatch)
         {
@@ -4339,7 +4339,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         private string GetSampleProjectContent()
         {
             string projectFileContent = ObjectModelHelpers.CleanupFileContents(@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='2.0' InitialTargets='it' DefaultTargets='dt'>
+                    <Project ToolsVersion='2.0' InitialTargets='it' DefaultTargets='dt'>
                         <PropertyGroup Condition=""'$(Configuration)'=='Foo'"">
                             <p>v1</p>
                         </PropertyGroup>

--- a/src/Build.OM.UnitTests/Definition/ProtectImports_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProtectImports_Tests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public ProtectImports_Tests()
         {
             string importContents =
-                @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                @"<Project>
                     <PropertyGroup>
                         <$propertyName>OldPropertyValue</$propertyName>
                     </PropertyGroup>
@@ -601,7 +601,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         private Project GetProject()
         {
             string projectContents =
-                @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                @"<Project>
                     <PropertyGroup>
                         <$propertyName>OldPropertyValueInProject</$propertyName>
                     </PropertyGroup>

--- a/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void ItemEvaluationCopiesMetadata()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m>m1</m>
@@ -299,7 +299,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                 string path = Path.Combine(directory, "*.exe");
 
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                           <ItemGroup>
                             <i Include='" + path + @"'/>
@@ -529,8 +529,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
-        /// Validate that the DefiningProject* metadata is set to the correct project based on a variety 
-        /// of means of item creation. 
+        /// Validate that the DefiningProject* metadata is set to the correct project based on a variety
+        /// of means of item creation.
         /// </summary>
         [Fact]
         public void TestDefiningProjectMetadata()
@@ -574,7 +574,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
   </Target>
 
   <Target Name=`Validate` DependsOnTargets=`AddFromMainProject;AddFromImport`>
-    <Warning Text=`A is wrong: EXPECTED: [a] ACTUAL: [%(A.DefiningProjectName)]` Condition=`'%(A.DefiningProjectName)' != 'a'` />    
+    <Warning Text=`A is wrong: EXPECTED: [a] ACTUAL: [%(A.DefiningProjectName)]` Condition=`'%(A.DefiningProjectName)' != 'a'` />
     <Warning Text=`B is wrong: EXPECTED: [a] ACTUAL: [%(B.DefiningProjectName)]` Condition=`'%(B.DefiningProjectName)' != 'a'` />
     <Warning Text=`C is wrong: EXPECTED: [b] ACTUAL: [%(C.DefiningProjectName)]` Condition=`'%(C.DefiningProjectName)' != 'b'` />
     <Warning Text=`D is wrong: EXPECTED: [b] ACTUAL: [%(D.DefiningProjectName)]` Condition=`'%(D.DefiningProjectName)' != 'b'` />
@@ -833,7 +833,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
-        /// Test operation fails on immutable project instance 
+        /// Test operation fails on immutable project instance
         /// </summary>
         [Fact]
         public void ImmutableProjectInstance_SetNewProperty()
@@ -995,7 +995,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         private static ProjectInstance GetSampleProjectInstance(bool isImmutable = false)
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i>
                               <n>n1</n>

--- a/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
@@ -148,8 +148,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
-        /// Set metadata value to null value -- this is allowed, but 
-        /// internally converted to the empty string. 
+        /// Set metadata value to null value -- this is allowed, but
+        /// internally converted to the empty string.
         /// </summary>
         [Fact]
         public void SetNullMetadataValue()
@@ -207,7 +207,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// <summary>
         /// Creates a ProjectItemInstance and casts it to ITaskItem2; makes sure that all escaped information is
         /// maintained correctly.  Also creates a new Microsoft.Build.Utilities.TaskItem from the ProjectItemInstance
-        /// and verifies that none of the information is lost.  
+        /// and verifies that none of the information is lost.
         /// </summary>
         [Fact]
         public void ITaskItem2Operations()
@@ -309,7 +309,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void NoMetadata()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'/>
                         </ItemGroup>
@@ -332,7 +332,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void ReadMetadata()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m1>v1</m1>
@@ -361,21 +361,21 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// <summary>
         /// Create a new Microsoft.Build.Utilities.TaskItem from the ProjectItemInstance where the ProjectItemInstance
         /// has item definition metadata on it.
-        /// 
+        ///
         /// Verify the Utilities task item gets the expanded metadata from the ItemDefinitionGroup.
         /// </summary>
         [Fact]
         public void InstanceItemToUtilItemIDG()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i>
-                                <m0>;x86;</m0>                                
+                                <m0>;x86;</m0>
                                 <m1>%(FileName).extension</m1>
                                 <m2>;%(FileName).extension;</m2>
                                 <m3>v1</m3>
-                                <m4>%3bx86%3b</m4> 
+                                <m4>%3bx86%3b</m4>
                             </i>
                         </ItemDefinitionGroup>
                         <ItemGroup>
@@ -402,7 +402,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void GetMetadataValuesFromDefinition()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemDefinitionGroup>
                             <i>
                                 <m0>v0</m0>
@@ -435,7 +435,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void ExcludeWithIncludeVector()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='a;b;c'>
                             </i>
@@ -462,7 +462,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void ExcludeVectorWithIncludeVector()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='a;b;c'>
                             </i>
@@ -490,7 +490,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void MetadataReferringToMetadataAbove()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m1>v1</m1>
@@ -516,7 +516,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void BuiltInMetadataExpression()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m>%(Identity)</m>
@@ -537,7 +537,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void BuiltInQualifiedMetadataExpression()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m>%(i.Identity)</m>
@@ -558,7 +558,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void BuiltInMisqualifiedMetadataExpression()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m>%(j.Identity)</m>
@@ -573,13 +573,13 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
-        /// Metadata condition should work correctly with built-in metadata 
+        /// Metadata condition should work correctly with built-in metadata
         /// </summary>
         [Fact]
         public void BuiltInMetadataInMetadataCondition()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m Condition=""'%(Identity)'=='i1'"">m1</m>
@@ -604,7 +604,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1' Condition=""'%(Identity)'=='i1'/>
                         </ItemGroup>
@@ -622,7 +622,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void BuiltInMetadataTwoItems()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1.cpp;" + (NativeMethodsShared.IsWindows ? @"c:\bar\i2.cpp" : "/bar/i2.cpp") + @"'>
                                 <m>%(Filename).obj</m>
@@ -644,7 +644,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void DifferentMetadataItemsFromOtherList()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'>
                                 <m>m1</m>
@@ -671,7 +671,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void DifferentBuiltInMetadataItemsFromOtherList()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0.x'/>
                             <h Include='h1.y'/>
@@ -696,7 +696,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void BuiltInMetadataTransformInInclude()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <h Include='h1'/>
@@ -721,7 +721,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void BuiltInMetadataTransformInMetadataValue()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <h Include='h1'/>
@@ -746,7 +746,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void BuiltInMetadataTransformInMetadataValueBareMetadataPresent()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <h Include='h1'/>
@@ -771,7 +771,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void MetadataValueReferringToItems()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <i Include='i0'/>
@@ -794,7 +794,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void MetadataConditionReferringToItems()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <h Include='h0'/>
                             <i Include='i0'/>
@@ -819,7 +819,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void MetadataConditionReferringToMetadataOnSameItem()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             <i Include='i1'>
                                 <m0>0</m0>
@@ -841,7 +841,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void UpdateShouldRespectConditions()
         {
             string content = @"
-                      <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                      <Project>
                           <ItemGroup>
                               <i Include='a;b'>
                                   <m1>m1_contents</m1>

--- a/src/Build.OM.UnitTests/Instance/ProjectOnErrorInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectOnErrorInstance_Tests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         private static ProjectOnErrorInstance GetSampleOnErrorInstance()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                        <Target Name='t'>
                             <OnError ExecuteTargets='et' Condition='c'/>
                         </Target>

--- a/src/Build.OM.UnitTests/Instance/ProjectTargetInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectTargetInstance_Tests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         private static ProjectTargetInstance GetSampleTargetInstance()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t' Inputs='i' Outputs='o' Condition='c' DependsOnTargets='d' BeforeTargets='b' AfterTargets='a' KeepDuplicateOutputs='k' Returns='r'>
                             <t1/>
                         </Target>

--- a/src/Build.OM.UnitTests/Instance/ProjectTaskInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectTaskInstance_Tests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         private static ProjectTaskInstance GetTaskInstance(string taskXmlString)
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'>
                             " + taskXmlString + @"
                         </Target>

--- a/src/Build.OM.UnitTests/Instance/ProjectTaskOutputItemInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectTaskOutputItemInstance_Tests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         private static ProjectTaskOutputItemInstance GetSampleTaskOutputInstance()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                        <Target Name='t'>
                             <t1>
                                 <Output TaskParameter='p' Condition='c' ItemName='i'/>

--- a/src/Build.OM.UnitTests/Instance/ProjectTaskOutputPropertyInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectTaskOutputPropertyInstance_Tests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         private static ProjectTaskOutputPropertyInstance GetSampleTaskOutputInstance()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                        <Target Name='t'>
                             <t1>
                                 <Output TaskParameter='p' Condition='c' PropertyName='p1'/>

--- a/src/Build.OM.UnitTests/LazyFormattedEventArgs_Tests.cs
+++ b/src/Build.OM.UnitTests/LazyFormattedEventArgs_Tests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.UnitTests.Framework
         public void DoNotCrashOnInvalidFormatExpression()
         {
             string content = @"
- <Project DefaultTargets=`t` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+ <Project DefaultTargets=`t` ToolsVersion=`msbuilddefaulttoolsversion`>
    <UsingTask
      TaskName=`Crash`
      TaskFactory=`CodeTaskFactory`

--- a/src/Build.UnitTests/BackEnd/BatchingEngine_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BatchingEngine_Tests.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void Simple()
         {
             string content = @"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
 
                     <ItemGroup>
                         <AToB Include=""a;b""/>
@@ -256,7 +256,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void Regress72803()
         {
             string content = @"
-                <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" DefaultTargets=""ReleaseBuild"">
+                <Project DefaultTargets=""ReleaseBuild"">
                     <ItemGroup>
                         <Environments Include=""dev"" />
                         <Environments Include=""prod"" />
@@ -297,7 +297,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void BucketsWithEmptyListForBatchedItemList()
         {
             string content = @"
- <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+ <Project ToolsVersion=""msbuilddefaulttoolsversion"">
   <ItemGroup>
     <i Include=""b""/>
     <j Include=""a"">
@@ -326,7 +326,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void BucketsWithEmptyListForTargetBatchedItemList()
         {
             string content = @"
-<Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Project ToolsVersion=""msbuilddefaulttoolsversion"">
     <ItemGroup>
         <a Include=""a1""/>
         <b Include=""b1""/>
@@ -351,7 +351,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void BatchOnEmptyOutput()
         {
             string content = @"
-         <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+         <Project ToolsVersion=""msbuilddefaulttoolsversion"">
             <ItemGroup>
               <File Include=""$(foo)"" />
             </ItemGroup>
@@ -377,7 +377,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void EachBatchGetsASeparateTaskObject()
         {
             string content = @"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include=""i1"">
                       <Code>high</Code>
@@ -406,7 +406,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void BatcherPreservesItemOrderWithinASingleItemList()
         {
             string content = @"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
 
                     <ItemGroup>
                         <AToZ Include=""a;b;c;d;e;f;g;h;i;j;k;l;m;n;o;p;q;r;s;t;u;v;w;x;y;z""/>
@@ -441,7 +441,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void UndefinedAndEmptyMetadataValues()
         {
             string content = @"
-                <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemGroup>
                         <i Include='i1'/>
                         <i Include='i2'>

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 EnableNodeReuse = true,
                 DisableInProcNode = true,
                 SaveOperatingEnvironment = false,
-                Loggers = new List<ILogger> {new MockLogger(_output)}
+                Loggers = new List<ILogger> { new MockLogger(_output) }
             };
 
             // Tell the build manager to not disturb process wide state
@@ -508,16 +508,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     {"AnItem", null},
                     {"ItemWithMetadata", new List<string> {"Metadatum1"}},
                 },
-                PropertyFilters = new List<string> {"NewProperty", "RequestedProperty"},
+                PropertyFilters = new List<string> { "NewProperty", "RequestedProperty" },
             };
 
-            var data = new BuildRequestData(project.CreateProjectInstance(), new [] {"test", "other"},
+            var data = new BuildRequestData(project.CreateProjectInstance(), new[] { "test", "other" },
                 _projectCollection.HostServices, BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild, null,
                 requestedProjectState);
             var customparameters = new BuildParameters
             {
                 EnableNodeReuse = false,
-                Loggers = new ILogger[] {_logger},
+                Loggers = new ILogger[] { _logger },
                 DisableInProcNode = true,
             };
 
@@ -1534,7 +1534,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 </Project>
 ");
 
-            BuildParameters parameters = new ()
+            BuildParameters parameters = new()
             {
                 ShutdownInProcNodeOnBuildFinish = true,
                 Loggers = new ILogger[] { _logger, new MockLogger(printEventsToStdout: true) },
@@ -1727,8 +1727,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Project project = CreateProject(contents, MSBuildDefaultToolsVersion, _projectCollection, true);
             ProjectInstance instance = _buildManager.GetProjectInstanceForBuild(project);
             _buildManager.BeginBuild(_parameters);
-            BuildResult result1 = _buildManager.BuildRequest(new BuildRequestData(instance, new[] {"target1"}));
-            BuildResult result2 = _buildManager.BuildRequest(new BuildRequestData(instance, new[] {"target2"}));
+            BuildResult result1 = _buildManager.BuildRequest(new BuildRequestData(instance, new[] { "target1" }));
+            BuildResult result2 = _buildManager.BuildRequest(new BuildRequestData(instance, new[] { "target2" }));
             _buildManager.EndBuild();
 
             Assert.Equal(BuildResultCode.Success, result1.OverallResult);
@@ -1759,9 +1759,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ProjectInstance instance = _buildManager.GetProjectInstanceForBuild(project);
             _buildManager.BeginBuild(_parameters);
 
-            BuildSubmission submission =_buildManager.PendBuildRequest(new BuildRequestData(instance, new[] {"target1"}));
+            BuildSubmission submission = _buildManager.PendBuildRequest(new BuildRequestData(instance, new[] { "target1" }));
             submission.ExecuteAsync(null, null);
-            BuildResult result2 =_buildManager.BuildRequest(new BuildRequestData(project.CreateProjectInstance(), new[] {"target2"}));
+            BuildResult result2 = _buildManager.BuildRequest(new BuildRequestData(project.CreateProjectInstance(), new[] { "target2" }));
 
             submission.WaitHandle.WaitOne();
             var result1 = submission.BuildResult;
@@ -1794,9 +1794,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ProjectInstance instance = _buildManager.GetProjectInstanceForBuild(project);
             _buildManager.BeginBuild(_parameters);
 
-            BuildSubmission submission = _buildManager.PendBuildRequest(new BuildRequestData(instance, new[] {"target1"}));
+            BuildSubmission submission = _buildManager.PendBuildRequest(new BuildRequestData(instance, new[] { "target1" }));
             submission.ExecuteAsync(null, null);
-            BuildResult result2 = _buildManager.BuildRequest(new BuildRequestData(project.CreateProjectInstance(), new[] {"target1"}));
+            BuildResult result2 = _buildManager.BuildRequest(new BuildRequestData(project.CreateProjectInstance(), new[] { "target1" }));
             submission.WaitHandle.WaitOne();
             var result1 = submission.BuildResult;
 
@@ -2569,7 +2569,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             var projD = _env.CreateFile(".proj").Path;
 
             string contentsA = @"<?xml version='1.0' encoding='utf-8'?>
-<Project ToolsVersion='4.0' DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Project ToolsVersion='4.0' DefaultTargets='Build'>
   <ItemGroup>
     <ProjectReference Include='" + projD + @"' />
     <ProjectReference Include='" + projC + @"' />
@@ -2583,7 +2583,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 ";
 
             string contentsB = @"<?xml version='1.0' encoding='utf-8'?>
-<Project ToolsVersion='4.0' DefaultTargets='CallsGenerateImpLib' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Project ToolsVersion='4.0' DefaultTargets='CallsGenerateImpLib'>
   <Target Name='CallsGenerateImpLib'>
     <MSBuild Projects='" + projC + @"' Targets='GenerateImpLib' BuildInParallel='true' />
   </Target>
@@ -2592,7 +2592,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 ";
 
             string contentsC = @"<?xml version='1.0' encoding='utf-8'?>
-<Project ToolsVersion='4.0' DefaultTargets='Default' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Project ToolsVersion='4.0' DefaultTargets='Default'>
   <Target Name='Default' DependsOnTargets='ResolveReferences;BuildCompile'>
     <Message Text='Executed Default' />
   </Target>
@@ -2613,7 +2613,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 ";
 
             string contentsD = @"<?xml version='1.0' encoding='utf-8'?>
-<Project ToolsVersion='4.0' DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Project ToolsVersion='4.0' DefaultTargets='Build'>
   <Target Name='Build'>
     <Message Text='In d.proj' />
   </Target>
@@ -2707,7 +2707,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _parameters.EnableNodeReuse = false;
             _buildManager.BeginBuild(_parameters);
             var data = new BuildRequestData(projA, new Dictionary<string, string>(), null,
-                new[] {"Build"}, new HostServices());
+                new[] { "Build" }, new HostServices());
             BuildResult result = _buildManager.PendBuildRequest(data).Execute();
 
             Assert.Equal(BuildResultCode.Failure, result.OverallResult);
@@ -2808,7 +2808,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _parameters.EnableNodeReuse = false;
             _buildManager.BeginBuild(_parameters);
             var data = new BuildRequestData(projA, new Dictionary<string, string>(), null,
-                new[] {"Build"}, new HostServices());
+                new[] { "Build" }, new HostServices());
             BuildResult result = _buildManager.PendBuildRequest(data).Execute();
 
             Assert.Equal(BuildResultCode.Failure, result.OverallResult);
@@ -2912,7 +2912,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _parameters.EnableNodeReuse = false;
             _buildManager.BeginBuild(_parameters);
             var data = new BuildRequestData(projA, new Dictionary<string, string>(), null,
-                new[] {"Build"}, new HostServices());
+                new[] { "Build" }, new HostServices());
             BuildResult result = _buildManager.PendBuildRequest(data).Execute();
 
             Assert.Equal(BuildResultCode.Failure, result.OverallResult);
@@ -3002,7 +3002,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _parameters.EnableNodeReuse = false;
             _buildManager.BeginBuild(_parameters);
             var data = new BuildRequestData(projA, new Dictionary<string, string>(), null,
-                new[] {"Build"}, new HostServices());
+                new[] { "Build" }, new HostServices());
             BuildResult result = _buildManager.PendBuildRequest(data).Execute();
 
             Assert.Equal(BuildResultCode.Failure, result.OverallResult);
@@ -3071,7 +3071,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             _buildManager.BeginBuild(_parameters);
             var data = new BuildRequestData(projA, new Dictionary<string, string>(), null,
-                new[] {"Build"}, new HostServices());
+                new[] { "Build" }, new HostServices());
             BuildResult result = _buildManager.PendBuildRequest(data).Execute();
 
             Assert.Equal(BuildResultCode.Success, result.OverallResult);
@@ -3530,7 +3530,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             // Gather a sorted list of all the properties.
             return properties?.Cast<DictionaryEntry>()
-                .ToDictionary(prop => (string) prop.Key, prop => (string) prop.Value, StringComparer.OrdinalIgnoreCase);
+                .ToDictionary(prop => (string)prop.Key, prop => (string)prop.Value, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -3609,7 +3609,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // causes the projects to be built to be separate configs, which allows us to build the same project
             // a bunch of times in parallel.
             //
-            // <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'/>
+            // <Project/>
             //   <ItemGroup>
             //     <ProjectReference Include="RootProjectName.proj">
             //       <AdditionalProperties>p={incremented value}</AdditionalProperties>
@@ -3693,7 +3693,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                     Assert.Empty(mainInstance.GlobalProperties);
 
-                    var request = new BuildRequestData(mainInstance, new[] {"BuildOther"});
+                    var request = new BuildRequestData(mainInstance, new[] { "BuildOther" });
 
                     var parameters = new BuildParameters
                     {
@@ -3722,7 +3722,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                         p2pInstance.SetProperty("P", newPropertyValue);
 
-                        request = new BuildRequestData(p2pInstance, new[] {"Foo"});
+                        request = new BuildRequestData(p2pInstance, new[] { "Foo" });
                         submission = manager.PendBuildRequest(request);
                         results = submission.Execute();
 
@@ -3759,13 +3759,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
   </Target>
 
 </Project>";
-            var testFiles = _env.CreateTestProjectWithFiles(string.Empty, new[] {"main", "p2p"}, string.Empty);
+            var testFiles = _env.CreateTestProjectWithFiles(string.Empty, new[] { "main", "p2p" }, string.Empty);
 
             var buildParameters = new BuildParameters(_projectCollection)
             {
                 DisableInProcNode = true,
                 EnableNodeReuse = false,
-                Loggers = new ILogger[] {_logger}
+                Loggers = new ILogger[] { _logger }
             };
 
             _buildManager.BeginBuild(buildParameters);
@@ -3784,7 +3784,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     mainProjectPath,
                     new Dictionary<string, string>(),
                     MSBuildConstants.CurrentToolsVersion,
-                    new[] {"MainTarget"},
+                    new[] { "MainTarget" },
                     null
                 );
 
@@ -3825,7 +3825,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
   </Target>
 </Project>";
 
-            var testFiles = _env.CreateTestProjectWithFiles(string.Empty, new[] {"main", "import"}, string.Empty);
+            var testFiles = _env.CreateTestProjectWithFiles(string.Empty, new[] { "main", "import" }, string.Empty);
 
             var importPath = testFiles.CreatedFiles[1];
             File.WriteAllText(importPath, CleanupFileContents(importProject));
@@ -3843,13 +3843,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             instance.TranslateEntireState = shouldSerializeEntireState;
 
-            var request = new BuildRequestData(instance, new[] {"Foo"});
+            var request = new BuildRequestData(instance, new[] { "Foo" });
 
             var parameters = new BuildParameters(_projectCollection)
             {
                 DisableInProcNode = true,
                 EnableNodeReuse = false,
-                Loggers = new ILogger[] {_logger}
+                Loggers = new ILogger[] { _logger }
             };
 
             _buildManager.BeginBuild(parameters);
@@ -3873,7 +3873,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Building the stale project instance should still succeed when the entire state is translated: MSBuild should use the
             // in-memory state to build and not reload from disk.
             _buildManager.BeginBuild(parameters);
-            request = new BuildRequestData(instance, new[] {"Foo"}, null,
+            request = new BuildRequestData(instance, new[] { "Foo" }, null,
                 BuildRequestDataFlags.ReplaceExistingProjectInstance);
             submission = _buildManager.PendBuildRequest(request);
 
@@ -4028,7 +4028,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     }
                 };
 
-                var buildRequestData = new BuildRequestData(entryFile, new Dictionary<string, string>(), MSBuildDefaultToolsVersion, new[]{ "EntryTarget" }, null);
+                var buildRequestData = new BuildRequestData(entryFile, new Dictionary<string, string>(), MSBuildDefaultToolsVersion, new[] { "EntryTarget" }, null);
 
                 var result = _buildManager.Build(buildParameters, buildRequestData);
 
@@ -4084,8 +4084,8 @@ $@"<Project InitialTargets=`Sleep`>
                      * the request but does not simulate the ProjectStarted / ProjectEnded events. It also leaves logging completion to the
                      * BuildManager.
                      */
-                    var request1 = new BuildRequestData(testFiles.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, new[] {"Build"}, null);
-                    var request2 = new BuildRequestData(testFiles.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, new[] {"Build"}, null);
+                    var request1 = new BuildRequestData(testFiles.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, new[] { "Build" }, null);
+                    var request2 = new BuildRequestData(testFiles.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, new[] { "Build" }, null);
 
                     /* During builds, msbuild changes the current directory.
                      * When this test fails, the build never finishes so the current directory never gets restored.
@@ -4317,7 +4317,7 @@ $@"<Project InitialTargets=`Sleep`>
         [Fact]
         public void GraphBuildShouldBeAbleToConstructGraphButSkipBuild()
         {
-            var graph = Helpers.CreateProjectGraph(env: _env, dependencyEdges: new Dictionary<int, int[]> {{1, new[] {2, 3}}});
+            var graph = Helpers.CreateProjectGraph(env: _env, dependencyEdges: new Dictionary<int, int[]> { { 1, new[] { 2, 3 } } });
 
             MockLogger logger = null;
 
@@ -4325,11 +4325,11 @@ $@"<Project InitialTargets=`Sleep`>
             {
                 var graphResult = buildSession.BuildGraphSubmission(
                     new GraphBuildRequestData(
-                        projectGraphEntryPoints: new[] {new ProjectGraphEntryPoint(graph.GraphRoots.First().ProjectInstance.FullPath)},
+                        projectGraphEntryPoints: new[] { new ProjectGraphEntryPoint(graph.GraphRoots.First().ProjectInstance.FullPath) },
                         targetsToBuild: Array.Empty<string>(),
                         hostServices: null,
                         flags: BuildRequestDataFlags.None,
-                        graphBuildOptions: new GraphBuildOptions {Build = false}));
+                        graphBuildOptions: new GraphBuildOptions { Build = false }));
 
                 graphResult.OverallResult.ShouldBe(BuildResultCode.Success);
                 logger = buildSession.Logger;

--- a/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -459,14 +459,14 @@ namespace Microsoft.Build.UnitTests.Logging
             string targetsFile = Path.Combine(testTempPath, "x.targets");
             string projectfileContent =
                 @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Import Project='x.targets'/>
                     </Project>
                 ";
 
             string targetsfileContent = @"
-                 <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-                   <UsingTask TaskName='RandomTask' AssemblyName='NotARealTaskLocaiton'/>    
+                 <Project DefaultTargets='Build'>
+                   <UsingTask TaskName='RandomTask' AssemblyName='NotARealTaskLocaiton'/>
                    <Target Name='Build'>
                        <RandomTask/>
                    </Target>

--- a/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
@@ -37,13 +37,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         private string _originalWorkingDirectory;
 
-        #pragma warning disable xUnit1013
+#pragma warning disable xUnit1013
 
         public void LoggingException(Exception e)
         {
         }
 
-        #pragma warning restore xUnit1013
+#pragma warning restore xUnit1013
 
         public RequestBuilder_Tests()
         {
@@ -239,7 +239,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private BuildRequestConfiguration CreateTestProject(int configId)
         {
             string projectFileContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <ItemGroup>
                         <Compile Include=`b.cs` />

--- a/src/Build.UnitTests/BackEnd/TargetBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetBuilder_Tests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         private int _nodeRequestId;
 
-        #pragma warning disable xUnit1013
+#pragma warning disable xUnit1013
 
         /// <summary>
         /// Callback used to receive exceptions from loggers.  Unused here.
@@ -58,7 +58,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
         }
 
-        #pragma warning restore xUnit1013
+#pragma warning restore xUnit1013
 
         /// <summary>
         /// Sets up to run tests.  Creates the host object.
@@ -227,7 +227,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 var expected = @"
 Skipping target ""Build"" because all output files are up-to-date with respect to the input files.
-Input files: 
+Input files:
     a.txt
     b.txt
 Output files: c.txt
@@ -252,7 +252,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
             string content = String.Format
                 (
 @"
-<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Project ToolsVersion='msbuilddefaulttoolsversion'>
 
   <Target Name='Build' DependsOnTargets='GFA;GFT;DFTA;GAFT'>
         <Message Text='Build: [@(Outs)]' />
@@ -338,7 +338,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
         public void TestBeforeTargetsMissing()
         {
             string content = @"
-<Project DefaultTargets='t' xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Project DefaultTargets='t'>
 
     <Target Name='t' BeforeTargets='x'>
         <Message Text='[t]' />
@@ -361,7 +361,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
         public void TestBeforeTargetsMissingRunsOthers()
         {
             string content = @"
-<Project DefaultTargets='a;c' xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Project DefaultTargets='a;c'>
 
     <Target Name='t' BeforeTargets='a;b;c'>
         <Message Text='[t]' />
@@ -393,7 +393,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
         public void TestAfterTargetsMissing()
         {
             string content = @"
-<Project DefaultTargets='t' xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Project DefaultTargets='t'>
 
     <Target Name='t' AfterTargets='x'>
         <Message Text='[t]' />
@@ -416,7 +416,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
         public void TestAfterTargetsMissingRunsOthers()
         {
             string content = @"
-<Project DefaultTargets='a;c' xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Project DefaultTargets='a;c'>
 
     <Target Name='t' AfterTargets='a;b'>
         <Message Text='[t]' />
@@ -1273,7 +1273,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
         public void TestCircularDependencyInCallTarget()
         {
             string projectContents = @"
-<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Project>
     <Target Name=""t1"">
         <CallTarget Targets=""t3""/>
     </Target>
@@ -1296,7 +1296,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
         public void TestCircularDependencyTarget()
         {
             string projectContents = @"
-<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Project>
     <Target Name=""TargetA"" AfterTargets=""Build"" DependsOnTargets=""TargetB"">
         <Message Text=""TargetA""></Message>
     </Target>
@@ -1523,7 +1523,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
 
                     <ItemGroup>
                         <Reference Include='System' />
-                    </ItemGroup>                    
+                    </ItemGroup>
 
                     <Target Name='Empty' />
 
@@ -1591,7 +1591,7 @@ Done building target ""Build"" in project ""build.proj"".".Replace("\r\n", "\n")
         /// </summary>
         private ProjectInstance CreateTestProject(string projectBodyContents, string initialTargets, string defaultTargets)
         {
-            string projectFileContents = String.Format("<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003' InitialTargets='{0}' DefaultTargets='{1}'>{2}</Project>", initialTargets, defaultTargets, projectBodyContents);
+            string projectFileContents = String.Format("<Project ToolsVersion='msbuilddefaulttoolsversion' InitialTargets='{0}' DefaultTargets='{1}'>{2}</Project>", initialTargets, defaultTargets, projectBodyContents);
 
             // retries to deal with occasional locking issues where the file can't be written to initially
             for (int retries = 0; retries < 5; retries++)

--- a/src/Build.UnitTests/BackEnd/TargetEntry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetEntry_Tests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         private int _nodeRequestId;
 
-        #pragma warning disable xUnit1013
+#pragma warning disable xUnit1013
 
         /// <summary>
         /// Handles exceptions from the logging system.
@@ -50,7 +50,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
         }
 
-        #pragma warning restore xUnit1013
+#pragma warning restore xUnit1013
 
         /// <summary>
         /// Called prior to each test.
@@ -381,8 +381,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 if (returnsEnabledForThisProject)
                 {
-                    // If returns are enabled, since this is a target with "Outputs", they won't 
-                    // be returned. 
+                    // If returns are enabled, since this is a target with "Outputs", they won't
+                    // be returned.
                     Assert.Empty(results.Items);
                 }
                 else
@@ -474,8 +474,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 if (returnsEnabledForThisProject)
                 {
-                    // If returns are enabled, since this is a target with "Outputs", they won't 
-                    // be returned. 
+                    // If returns are enabled, since this is a target with "Outputs", they won't
+                    // be returned.
                     Assert.Empty(results.Items);
                 }
                 else
@@ -636,7 +636,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             foreach (bool returnsEnabledForThisProject in returnsEnabled)
             {
                 string content = @"
-<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+<Project ToolsVersion=`msbuilddefaulttoolsversion`>
     <ItemGroup>
         <SomeItem1 Include=`item1.cs`/>
         <SomeItem2 Include=`item2.cs`/>
@@ -683,7 +683,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 foreach (bool returnsEnabledForThisProject in returnsEnabled)
                 {
                     string content = @"
-<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+<Project ToolsVersion=`msbuilddefaulttoolsversion`>
     <ItemGroup>
         <SomeItem1 Include=`item1.cs`/>
         <SomeItem2 Include=`item2.cs`/>
@@ -780,7 +780,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 foreach (bool returnsEnabledForThisProject in returnsEnabled)
                 {
                     string content = @"
-<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+<Project ToolsVersion=`msbuilddefaulttoolsversion`>
     <ItemGroup>
         <SomeItem1 Include=`item1.cs`/>
         <SomeItem2 Include=`item2.cs`/>
@@ -835,13 +835,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact(Skip = "https://github.com/dotnet/msbuild/issues/515")]
         public void AfterTargetsShouldReportFailedBuild()
         {
-            // Since we're creating our own BuildManager, we need to make sure that the default 
+            // Since we're creating our own BuildManager, we need to make sure that the default
             // one has properly relinquished the inproc node
             NodeProviderInProc nodeProviderInProc = ((IBuildComponentHost)BuildManager.DefaultBuildManager).GetComponent(BuildComponentType.InProcNodeProvider) as NodeProviderInProc;
             nodeProviderInProc?.Dispose();
 
             string content = @"
-<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build'>
 <Target Name='Build'>
  <Message Text='Hello'/>
 </Target>
@@ -891,7 +891,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             }
             finally
             {
-                // and we should clean up after ourselves, too. 
+                // and we should clean up after ourselves, too.
                 if (manager != null)
                 {
                     NodeProviderInProc inProcNodeProvider = ((IBuildComponentHost)manager).GetComponent(BuildComponentType.InProcNodeProvider) as NodeProviderInProc;
@@ -909,7 +909,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void TestTargetFinishedRaisedOnInvalidTarget()
         {
             string content = @"
-<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+<Project ToolsVersion=`msbuilddefaulttoolsversion`>
     <Target Name=`OnlyInputs` Inputs=`foo`>
         <Message Text=`This is an invalid target -- this text should never show.` />
     </Target>
@@ -1059,7 +1059,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             string returnsAttributeName = returnsAttributeEnabled ? "Returns" : "Outputs";
 
             string projectFileContents = @"
-                <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project ToolsVersion='msbuilddefaulttoolsversion'>
 
                     <ItemGroup>
                         <Compile Include='b.cs' />
@@ -1111,11 +1111,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     <Target Name='SkipCondition' Condition=""'true' == 'false'"" />
 
                     <Target Name='Error' >
-                        <ErrorTask1 ContinueOnError='True'/>                    
-                        <ErrorTask2 ContinueOnError='False'/>  
-                        <ErrorTask3 /> 
-                        <OnError ExecuteTargets='Foo'/>                  
-                        <OnError ExecuteTargets='Bar'/>                  
+                        <ErrorTask1 ContinueOnError='True'/>
+                        <ErrorTask2 ContinueOnError='False'/>
+                        <ErrorTask3 />
+                        <OnError ExecuteTargets='Foo'/>
+                        <OnError ExecuteTargets='Bar'/>
                     </Target>
 
                     <Target Name='Foo' Inputs='foo.cpp' Outputs='foo.o'>

--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /*********************************************************************************
-         * 
+         *
          *                                  OUTPUT PARAMS
-         * 
+         *
          *********************************************************************************/
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
                       <Target Name='t'>
                          <NonExistantTask Condition=""'1'=='1'""/>
-                         <Message Text='Made it'/>                    
+                         <Message Text='Made it'/>
                       </Target>
                       </Project>");
 
@@ -98,7 +98,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
                       <Target Name='t'>
                          <NonExistantTask Condition=""'1'=='2'""/>
-                         <Message Text='Made it'/>                    
+                         <Message Text='Made it'/>
                       </Target>
                       </Project>");
 
@@ -119,7 +119,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 ProjectCollection collection = new ProjectCollection();
 
                 string contents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion ='Current'>
+                    <Project ToolsVersion ='Current'>
                      <Target Name='test'>
                         <Exec Command='" + Helpers.GetSleepCommand(TimeSpan.FromSeconds(10)) + @"'/>
                      </Target>
@@ -192,7 +192,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                                          Condition=""'%(LogicalName)' != '' "">
                              <Output TaskParameter=""Value"" PropertyName=""LinkSwitches""/>
                          </CreateProperty>
-                         <Message Text='final:[$(LinkSwitches)]'/>                    
+                         <Message Text='final:[$(LinkSwitches)]'/>
                       </Target>
                       </Project>");
 
@@ -223,7 +223,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
                       <ItemGroup>
                         <i Include='" + files[0] + "'><output>" + files[1] + @"</output></i>
-                      </ItemGroup> 
+                      </ItemGroup>
                       <ItemGroup>
                          <EmbeddedResource Include='a.resx'>
                         <LogicalName>foo</LogicalName>
@@ -236,7 +236,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                         </EmbeddedResource>
                         </ItemGroup>
                       <Target Name='t2' DependsOnTargets='t'>
-                        <Message Text='final:[$(LinkSwitches)]'/>   
+                        <Message Text='final:[$(LinkSwitches)]'/>
                       </Target>
                       <Target Name='t' Inputs='%(i.Identity)' Outputs='%(i.Output)'>
                         <Message Text='start:[Hello]'/>
@@ -244,7 +244,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                                          Condition=""'%(LogicalName)' != '' "">
                              <Output TaskParameter=""Value"" PropertyName=""LinkSwitches""/>
                         </CreateProperty>
-                        <Message Text='end:[hello]'/>                    
+                        <Message Text='end:[hello]'/>
                     </Target>
                     </Project>");
 
@@ -288,17 +288,17 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     <Target Name='Build'>
                         <CreateProperty Value=""@(TaskParameterItem)"">
                             <Output TaskParameter=""Value"" PropertyName=""Property1""/>
-                        </CreateProperty> 
+                        </CreateProperty>
                         <Message Text='Property1=[$(Property1)]' />
 
                         <CreateProperty Value=""@(TaskParameterItem)"">
                             <Output TaskParameter=""%(TaskParameterItem.ParameterName)"" PropertyName=""Property2""/>
-                        </CreateProperty> 
+                        </CreateProperty>
                         <Message Text='Property2=[$(Property2)]' />
 
                         <CreateProperty Value=""@(TaskParameterItem)"">
                             <Output TaskParameter=""Value"" PropertyName=""%(TaskParameterItem.PropertyName)""/>
-                        </CreateProperty> 
+                        </CreateProperty>
                         <Message Text='MetadataProperty=[$(MetadataProperty)]' />
 
                         <CreateItem Include=""@(TaskParameterItem)"">
@@ -348,9 +348,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
         <Copy SourceFiles='|' DestinationFolder='c:\' ContinueOnError='true' />
         <PropertyGroup>
            <p>$(MSBuildLastTaskResult)</p>
-        </PropertyGroup>                 
-        <Message Text='[1:$(MSBuildLastTaskResult)]'/> <!-- Should be false: propertygroup did not reset it -->   
-        <Message Text='[p:$(p)]'/> <!-- Should be false as stored earlier -->   
+        </PropertyGroup>
+        <Message Text='[1:$(MSBuildLastTaskResult)]'/> <!-- Should be false: propertygroup did not reset it -->
+        <Message Text='[p:$(p)]'/> <!-- Should be false as stored earlier -->
         <Message Text='[2:$(MSBuildLastTaskResult)]'/> <!-- Message succeeded, should now be true -->
     </Target>
     <Target Name='t2' DependsOnTargets='t'>
@@ -850,11 +850,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         #endregion
 
-/*********************************************************************************
- * 
- *                                     Helpers
- * 
- *********************************************************************************/
+        /*********************************************************************************
+         *
+         *                                     Helpers
+         *
+         *********************************************************************************/
 
         /// <summary>
         /// Helper method for validating the setting of defining project metadata on items
@@ -871,7 +871,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     <Import Project=`b.proj` />
 
                     <Target Name=`Run`>
-                      <ItemCreationTask 
+                      <ItemCreationTask
                         InputItemsToPassThrough=`@(PassThrough)`
                         InputItemsToCopy=`@(Copy)`>
                           <Output TaskParameter=`OutputString` ItemName=`A` />
@@ -880,10 +880,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
                           <Output TaskParameter=`CopiedOutputItems` ItemName=`D` />
                       </ItemCreationTask>
 
-                      <Warning Text=`A is wrong: EXPECTED: [a] ACTUAL: [%(A.DefiningProjectName)]` Condition=`'%(A.DefiningProjectName)' != 'a'` />    
-                      <Warning Text=`B is wrong: EXPECTED: [a] ACTUAL: [%(B.DefiningProjectName)]` Condition=`'%(B.DefiningProjectName)' != 'a'` />    
-                      <Warning Text=`C is wrong: EXPECTED: [a] ACTUAL: [%(C.DefiningProjectName)]` Condition=`'%(C.DefiningProjectName)' != 'a'` />    
-                      <Warning Text=`D is wrong: EXPECTED: [a] ACTUAL: [%(D.DefiningProjectName)]` Condition=`'%(D.DefiningProjectName)' != 'a'` />    
+                      <Warning Text=`A is wrong: EXPECTED: [a] ACTUAL: [%(A.DefiningProjectName)]` Condition=`'%(A.DefiningProjectName)' != 'a'` />
+                      <Warning Text=`B is wrong: EXPECTED: [a] ACTUAL: [%(B.DefiningProjectName)]` Condition=`'%(B.DefiningProjectName)' != 'a'` />
+                      <Warning Text=`C is wrong: EXPECTED: [a] ACTUAL: [%(C.DefiningProjectName)]` Condition=`'%(C.DefiningProjectName)' != 'a'` />
+                      <Warning Text=`D is wrong: EXPECTED: [a] ACTUAL: [%(D.DefiningProjectName)]` Condition=`'%(D.DefiningProjectName)' != 'a'` />
                     </Target>
                 </Project>
 ";
@@ -1092,11 +1092,11 @@ namespace ClassLibrary2
                     <Target Name='Skip' Inputs='testProject.proj' Outputs='testProject.proj' />
 
                     <Target Name='Error' >
-                        <ErrorTask1 ContinueOnError='True'/>                    
-                        <ErrorTask2 ContinueOnError='False'/>  
-                        <ErrorTask3 /> 
-                        <OnError ExecuteTargets='Foo'/>                  
-                        <OnError ExecuteTargets='Bar'/>                  
+                        <ErrorTask1 ContinueOnError='True'/>
+                        <ErrorTask2 ContinueOnError='False'/>
+                        <ErrorTask3 />
+                        <OnError ExecuteTargets='Foo'/>
+                        <OnError ExecuteTargets='Bar'/>
                     </Target>
 
                     <Target Name='Foo' Inputs='foo.cpp' Outputs='foo.o'>
@@ -1147,7 +1147,7 @@ namespace ClassLibrary2
         /// </summary>
         private class MockHost : MockLoggingService, IBuildComponentHost, IBuildComponent
         {
-#region IBuildComponentHost Members
+            #region IBuildComponentHost Members
 
             /// <summary>
             /// The config cache
@@ -1285,9 +1285,9 @@ namespace ClassLibrary2
             {
             }
 
-#endregion
+            #endregion
 
-#region IBuildComponent Members
+            #region IBuildComponent Members
 
             /// <summary>
             /// Sets the component host
@@ -1306,7 +1306,7 @@ namespace ClassLibrary2
                 throw new NotImplementedException();
             }
 
-#endregion
+            #endregion
         }
     }
 }

--- a/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
@@ -498,7 +498,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void LogCustomAfterTaskIsDone()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName='test' TaskFactory='CodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll' >
                             <Task>
                               <Using Namespace='System' />
@@ -534,7 +534,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void LogCommentAfterTaskIsDone()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName='test' TaskFactory='CodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll' >
                             <Task>
                               <Using Namespace='System' />
@@ -570,7 +570,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void LogWarningAfterTaskIsDone()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName='test' TaskFactory='CodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll' >
                             <Task>
                               <Using Namespace='System' />
@@ -606,7 +606,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void LogErrorAfterTaskIsDone()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName='test' TaskFactory='CodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll' >
                             <Task>
                               <Using Namespace='System' />

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.UnitTests
     public class BinaryLoggerTests : IDisposable
     {
         private const string s_testProject = @"
-         <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+         <Project>
             <PropertyGroup>
                <TestProperty>Test</TestProperty>
             </PropertyGroup>

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.UnitTests
         private Dictionary<string, string> _environment;
 
         private static string s_dummyProjectContents = @"
-         <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+         <Project>
             <Target Name='XXX'>
                <Message Text='[hee haw]'/>
             </Target>
@@ -103,7 +103,7 @@ namespace Microsoft.Build.UnitTests
                 _simulatedConsole.Append("<reset color>");
             }
 
-            public static implicit operator string (SimulatedConsole sc)
+            public static implicit operator string(SimulatedConsole sc)
             {
                 return sc.ToString();
             }
@@ -289,7 +289,7 @@ namespace Microsoft.Build.UnitTests
             <ItemGroup>
                 <P Include='$(MSBuildThisFileFullPath)' AdditionalProperties='Number=1' />
                 <P Include='$(MSBuildThisFileFullPath)' AdditionalProperties='Number=2' />
-    
+
                 <ProjectConfigurationDescription Include='Number=$(Number)' />
                 <ProjectConfigurationDescription Include='TargetFramework=$(TargetFramework)' />
             </ItemGroup>

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -249,8 +249,8 @@ EndProject
         }
 
         /// <summary>
-        /// Test to make sure that if the solution file version doesn't map to a sub-toolset version, we won't try 
-        /// to force it to be used.  
+        /// Test to make sure that if the solution file version doesn't map to a sub-toolset version, we won't try
+        /// to force it to be used.
         /// </summary>
         [Fact(Skip = "Needs investigation")]
         public void DefaultSubToolsetIfSolutionVersionSubToolsetDoesntExist()
@@ -291,8 +291,8 @@ EndProject
         }
 
         /// <summary>
-        /// Test to make sure that if the solution version corresponds to an existing sub-toolset version, 
-        /// barring other factors that might override, the sub-toolset will be based on the solution version. 
+        /// Test to make sure that if the solution version corresponds to an existing sub-toolset version,
+        /// barring other factors that might override, the sub-toolset will be based on the solution version.
         /// </summary>
         [Fact]
         public void SubToolsetSetBySolutionVersion()
@@ -327,7 +327,7 @@ EndProject
         }
 
         /// <summary>
-        /// Test to make sure that even if the solution version corresponds to an existing sub-toolset version, 
+        /// Test to make sure that even if the solution version corresponds to an existing sub-toolset version,
         /// </summary>
         [Fact]
         [Trait("Category", "mono-osx-failing")]
@@ -503,7 +503,7 @@ EndProject
 
         /// <summary>
         /// Test to make sure that, when we're not TV 4.0 -- which even for Dev11 solutions we are not by default -- that we
-        /// do not pass VisualStudioVersion down to the child projects.  
+        /// do not pass VisualStudioVersion down to the child projects.
         /// </summary>
         [Fact(Skip = "Needs investigation")]
         public void SolutionDoesntPassSubToolsetToChildProjects()
@@ -512,7 +512,7 @@ EndProject
             {
                 string classLibraryContents =
                     @"
-                        <Project ToolsVersion=""4.0"" DefaultTargets=""Build"" xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                        <Project ToolsVersion=""4.0"" DefaultTargets=""Build"">
                             <Target Name='Build'>
                                 <Message Text='.[$(VisualStudioVersion)].' />
                                 <Message Text='.[[$(MSBuildToolsVersion)]].' />
@@ -568,7 +568,7 @@ EndProject
         }
 
         /// <summary>
-        /// Verify that we throw the appropriate error if the solution declares a dependency 
+        /// Verify that we throw the appropriate error if the solution declares a dependency
         /// on a project that doesn't exist.
         /// </summary>
         [Fact]
@@ -1192,7 +1192,7 @@ EndGlobal
 
 #if FEATURE_MULTIPLE_TOOLSETS
         /// <summary>
-        /// Make sure that whatever the solution ToolsVersion is, it gets mapped to all its metaprojs, too. 
+        /// Make sure that whatever the solution ToolsVersion is, it gets mapped to all its metaprojs, too.
         /// </summary>
         [Fact]
         public void SolutionWithDependenciesHasCorrectToolsVersionInMetaprojs()
@@ -1239,22 +1239,22 @@ EndGlobal
 
                 Assert.Equal(2, instances.Length);
 
-                // Solution metaproj 
+                // Solution metaproj
                 Assert.Equal(solutionToolsVersion, instances[0].ToolsVersion);
 
                 ICollection<ProjectItemInstance> projectReferences = instances[0].GetItems("ProjectReference");
 
                 foreach (ProjectItemInstance projectReference in projectReferences)
                 {
-                    // If this is the reference to the metaproj, its ToolsVersion metadata needs to match 
-                    // the solution ToolsVersion -- that's how the build knows which ToolsVersion to use. 
+                    // If this is the reference to the metaproj, its ToolsVersion metadata needs to match
+                    // the solution ToolsVersion -- that's how the build knows which ToolsVersion to use.
                     if (projectReference.EvaluatedInclude.EndsWith(".metaproj", StringComparison.OrdinalIgnoreCase))
                     {
                         Assert.Equal(solutionToolsVersion, projectReference.GetMetadataValue("ToolsVersion"));
                     }
                 }
 
-                // Project metaproj for project with dependencies 
+                // Project metaproj for project with dependencies
                 Assert.Equal(solutionToolsVersion, instances[1].ToolsVersion);
             }
         }
@@ -1293,7 +1293,7 @@ EndGlobal
 
             try
             {
-                // SolutionProjectGenerator.Generate() is used at build-time, and creates evaluation- and 
+                // SolutionProjectGenerator.Generate() is used at build-time, and creates evaluation- and
                 // execution-model projects; as such it will throw if fed an explicitly invalid toolsversion
                 ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, "invalid", _buildEventContext, CreateMockLoggingService());
             }
@@ -1525,7 +1525,7 @@ EndGlobal
             msbuildProject = CreateVenusSolutionProject("2.0");
             Assert.Equal("v2.0", msbuildProject.GetPropertyValue("TargetFrameworkVersion"));
 
-            // may be user defined 
+            // may be user defined
             IDictionary<string, string> globalProperties = new Dictionary<string, string>();
             globalProperties.Add("TargetFrameworkVersion", "userdefined");
             msbuildProject = CreateVenusSolutionProject(globalProperties);
@@ -1915,7 +1915,7 @@ EndGlobal
 
             try
             {
-                // Since we're creating our own BuildManager, we need to make sure that the default 
+                // Since we're creating our own BuildManager, we need to make sure that the default
                 // one has properly relinquished the inproc node
                 NodeProviderInProc nodeProviderInProc = ((IBuildComponentHost)BuildManager.DefaultBuildManager).GetComponent(BuildComponentType.InProcNodeProvider) as NodeProviderInProc;
                 nodeProviderInProc?.Dispose();
@@ -2003,7 +2003,7 @@ EndGlobal
 
             try
             {
-                // Since we're creating our own BuildManager, we need to make sure that the default 
+                // Since we're creating our own BuildManager, we need to make sure that the default
                 // one has properly relinquished the inproc node
                 NodeProviderInProc nodeProviderInProc = ((IBuildComponentHost)BuildManager.DefaultBuildManager).GetComponent(BuildComponentType.InProcNodeProvider) as NodeProviderInProc;
                 nodeProviderInProc?.Dispose();
@@ -2448,7 +2448,7 @@ EndGlobal
                 var solutionFile = SolutionFile.Parse(solutionFilePath);
 
                 ProjectInstance projectInstance = SolutionProjectGenerator.Generate(solutionFile, globalProperties, null, BuildEventContext.Invalid, CreateMockLoggingService(), new[] { "Build" }).FirstOrDefault();
-                
+
                 Assert.NotNull(projectInstance);
 
                 Assert.Equal(enable ? expectedPropertyValue : string.Empty, projectInstance.GetPropertyValue("PropertyA"));
@@ -2570,7 +2570,7 @@ EndProject";
 
         /// <summary>
         /// Checks the provided project for a matching itemtype and include value.  If it
-        /// does not exist, asserts. 
+        /// does not exist, asserts.
         /// </summary>
         private void AssertProjectContainsItem(ProjectInstance msbuildProject, string itemType, string include)
         {
@@ -2589,7 +2589,7 @@ EndProject";
         }
 
         /// <summary>
-        /// Counts the number of items with a particular itemtype in the provided project, and 
+        /// Counts the number of items with a particular itemtype in the provided project, and
         /// asserts if it doesn't match the provided count.
         /// </summary>
         private void AssertProjectItemNameCount(ProjectInstance msbuildProject, string itemType, int count)

--- a/src/Build.UnitTests/Construction/XmlReaderWithoutLocation_Tests.cs
+++ b/src/Build.UnitTests/Construction/XmlReaderWithoutLocation_Tests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Build.UnitTests.Construction
         {
             XmlReader reader = XmlReader.Create(new StringReader
                 (
-                @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                @"<Project>
                       <Target Name='foo'/>
                   </Project>"
                 ));

--- a/src/Build.UnitTests/Definition/ItemDefinitionGroup_Tests.cs
+++ b/src/Build.UnitTests/Definition/ItemDefinitionGroup_Tests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionGroupExistsInProject()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile>
                             <First>1st</First>
@@ -53,7 +53,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void MultipleItemDefinitionGroupExistsInProject()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile>
                             <First>1st</First>
@@ -82,7 +82,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void EmptyItemsInheritValues()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile>
                             <First>1st</First>
@@ -115,7 +115,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemMetadataOverridesInheritedValues()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile>
                             <First>1st</First>
@@ -160,7 +160,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 Project p = new Project(XmlReader.Create(new StringReader(
-                @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemGroup>
                         <Compile Include='a.cs'>
                             <Foo>Bar</Foo>
@@ -190,7 +190,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 Project p = new Project(XmlReader.Create(new StringReader(
-                @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemGroup>
                         <Compile Include='a.cs'>
                             <Foo>Bar</Foo>
@@ -219,7 +219,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 Project p = new Project(XmlReader.Create(new StringReader(
-                @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemGroup>
                         <Compile Include='a.cs'>
                             <Foo>Bar</Foo>
@@ -247,7 +247,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemMetadataReferringToDifferentItemGivesEmptyValue()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile>
                             <First>1st</First>
@@ -285,7 +285,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void EmptyItemDefinitionGroup()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                     </ItemDefinitionGroup>
                     <ItemGroup>
@@ -302,7 +302,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void EmptyItemDefinitions()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile />
                     </ItemDefinitionGroup>
@@ -323,7 +323,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-   <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+   <Project ToolsVersion='msbuilddefaulttoolsversion'>
 
     <ItemDefinitionGroup>
       <CppCompile>
@@ -352,7 +352,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-   <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+   <Project ToolsVersion='msbuilddefaulttoolsversion'>
 
     <ItemDefinitionGroup>
       <CppCompile>
@@ -380,7 +380,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-   <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+   <Project ToolsVersion='msbuilddefaulttoolsversion'>
 
     <ItemDefinitionGroup>
       <CppCompile>
@@ -413,7 +413,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionGroupWithFalseCondition()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup Condition=""'$(Foo)'!=''"">
                         <Compile>
                             <First>1st</First>
@@ -439,7 +439,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionGroupWithTrueCondition()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup Condition=""'$(Foo)'==''"">
                         <Compile>
                             <First>1st</First>
@@ -465,7 +465,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionWithFalseCondition()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile  Condition=""'$(Foo)'!=''"">
                             <First>1st</First>
@@ -491,7 +491,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionWithTrueCondition()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile Condition=""'$(Foo)'==''"">
                             <First>1st</First>
@@ -517,7 +517,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionMetadataWithFalseCondition()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile>
                             <First Condition=""'$(Foo)'!=''"">1st</First>
@@ -543,7 +543,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionMetadataWithTrueCondition()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                     <ItemDefinitionGroup>
                         <Compile>
                             <First Condition=""'$(Foo)'==''"">1st</First>
@@ -569,7 +569,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionMetadataCopiedToTaskItem()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                 <ItemDefinitionGroup>
                     <ItemA>
                         <MetaA>M-A(b)</MetaA>
@@ -604,7 +604,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionMetadataCopiedToTaskItem2()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                 <ItemDefinitionGroup>
                     <ItemA>
                         <MetaA>M-A(b)</MetaA>
@@ -642,7 +642,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionMetadataCopiedToTaskItem3()
         {
             Project p = new Project(XmlReader.Create(new StringReader(
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion'>
                 <ItemDefinitionGroup>
                     <ItemA>
                         <MetaA>M-A(b)</MetaA>
@@ -685,7 +685,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <CppCompile Include='a.cpp'/>
                   </ItemGroup>
@@ -693,7 +693,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <CppCompile>
                       <Defines>DEBUG</Defines>
                     </CppCompile>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemGroup>
                     <CppCompile Include='b.cpp'/>
                   </ItemGroup>
@@ -712,7 +712,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -720,7 +720,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <i Condition=""'%24'=='$'"">
                       <m Condition=""'%24'=='$'"">%24(xyz)</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)]""/>
                   </Target>
@@ -737,7 +737,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -745,7 +745,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <j>
                       <m>m1</m>
                     </j>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)]""/>
                   </Target>
@@ -761,7 +761,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -770,13 +770,13 @@ namespace Microsoft.Build.UnitTests.Definition
                       <m>m1</m>
                       <n>n1</n>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemDefinitionGroup>
                     <i>
                       <m>m2</m>
                       <o>o1</o>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)-%(i.n)-%(i.o)]""/>
                   </Target>
@@ -795,12 +795,12 @@ namespace Microsoft.Build.UnitTests.Definition
                 // We don't allow item expressions on an ItemDefinitionGroup because there are no items when IDG is evaluated.
                 MockLogger logger = new MockLogger();
                 Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>@(x)</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                 </Project>
             ")));
                 p.Build("t", new ILogger[] { logger });
@@ -815,7 +815,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 // We don't allow unqualified metadata on an ItemDefinitionGroup because we don't know what item type it refers to.
                 MockLogger logger = new MockLogger();
                 Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup Condition=""'%(m)'=='m1'""/>
                 </Project>
             ")));
@@ -832,7 +832,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 // We don't allow qualified metadata because it's not worth distinguishing from unqualified, when you can just move the condition to the child.
                 MockLogger logger = new MockLogger();
                 Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup Condition=""'%(x.m)'=='m1'""/>
                 </Project>
             ")));
@@ -845,7 +845,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                     <j Include='j1'/>
@@ -857,16 +857,16 @@ namespace Microsoft.Build.UnitTests.Definition
                     <j>
                       <n>n1</n>
                     </j>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemDefinitionGroup>
                     <i Condition=""'%(m)'=='m1'"">
                       <m>m2</m>
                     </i>
                     <!-- verify j metadata is distinct -->
                     <j Condition=""'%(j.n)'=='n1' and '%(n)'=='n1'"">
-                      <n>n2</n>   
+                      <n>n2</n>
                     </j>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)]""/>
                     <Message Text=""[%(j.n)]""/>
@@ -883,7 +883,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -891,12 +891,12 @@ namespace Microsoft.Build.UnitTests.Definition
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemDefinitionGroup>
                     <i Condition=""'%(i.m)'=='m1' and '%(m)'=='m1'"">
                       <m>m2</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)]""/>
                   </Target>
@@ -912,7 +912,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -920,12 +920,12 @@ namespace Microsoft.Build.UnitTests.Definition
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemDefinitionGroup>
                     <i Condition=""'%(m)'=='m2' or '%(i.m)'!='m1'"">
                       <m>m3</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)]""/>
                   </Target>
@@ -941,7 +941,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -950,12 +950,12 @@ namespace Microsoft.Build.UnitTests.Definition
                       <m>m1</m>
                       <n>n1</n>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemDefinitionGroup>
                     <i>
                       <m Condition=""'%(m)'=='m1' and '%(n)'=='n1' and '%(i.m)'=='m1'"">m2</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)]""/>
                   </Target>
@@ -971,7 +971,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -980,7 +980,7 @@ namespace Microsoft.Build.UnitTests.Definition
                       <m>m1</m>
                       <n>n1</n>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemDefinitionGroup>
                     <i>
                       <m Condition=""'%(m)'=='m2' or !('%(n)'=='n1') or '%(i.m)' != 'm1'"">m3</m>
@@ -1001,7 +1001,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -1009,12 +1009,12 @@ namespace Microsoft.Build.UnitTests.Definition
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemDefinitionGroup>
                     <i Condition=""'%(j.m)'=='' and '%(j.m)'!='x'"">
                       <m Condition=""'%(j.m)'=='' and '%(j.m)'!='x'"">m2</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)]""/>
                   </Target>
@@ -1027,8 +1027,8 @@ namespace Microsoft.Build.UnitTests.Definition
 
         /// <summary>
         /// Make ItemDefinitionGroup inside a target produce a nice error.
-        /// It will normally produce an error due to the invalid child tag, but 
-        /// we want to error even if there's no child tag. This will make it 
+        /// It will normally produce an error due to the invalid child tag, but
+        /// we want to error even if there's no child tag. This will make it
         /// easier to support it inside targets in a future version.
         /// </summary>
         [Fact]
@@ -1038,7 +1038,7 @@ namespace Microsoft.Build.UnitTests.Definition
             {
                 MockLogger logger = new MockLogger();
                 Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <Target Name=""t"">
                     <ItemDefinitionGroup/>
                   </Target>
@@ -1056,7 +1056,7 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ItemDefinitionGroupTask()
         {
             MockLogger ml = Helpers.BuildProjectWithNewOMExpectSuccess(String.Format(@"
-                    <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                    <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                         <UsingTask TaskName=""ItemDefinitionGroup"" AssemblyFile=""{0}""/>
                         <Target Name=""Build"">
                             <Microsoft.Build.UnitTests.Definition.ItemDefinitionGroup/>
@@ -1073,7 +1073,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <CppCompile Include='a.cpp'>
                       <Defines>RETAIL</Defines>
@@ -1084,7 +1084,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <CppCompile>
                       <Defines>DEBUG</Defines>
                     </CppCompile>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(CppCompile.Identity)==%(CppCompile.Defines)]""/>
                   </Target>
@@ -1100,7 +1100,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <CppCompile Include='a.cpp'>
                       <WarningLevel>4</WarningLevel>
@@ -1110,7 +1110,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <CppCompile>
                       <Defines>DEBUG</Defines>
                     </CppCompile>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(CppCompile.Identity)==%(CppCompile.Defines)]""/>
                     <Message Text=""[%(CppCompile.Identity)==%(CppCompile.WarningLevel)]""/>
@@ -1127,7 +1127,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -1135,7 +1135,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <ItemGroup>
                       <i>
@@ -1156,7 +1156,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -1164,7 +1164,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <ItemGroup>
                       <i Condition=""'%(i.m)'=='m1'"">
@@ -1190,18 +1190,18 @@ namespace Microsoft.Build.UnitTests.Definition
             {
                 importedFile = FileUtilities.GetTemporaryFile();
                 File.WriteAllText(importedFile, @"
-                <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project ToolsVersion='msbuilddefaulttoolsversion'>
                   <ItemDefinitionGroup>
                     <CppCompile>
                       <Defines>DEBUG</Defines>
                     </CppCompile>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                 </Project>
             ");
                 Project p = new Project(XmlReader.Create(new StringReader(@"
-                    <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                    <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                       <ItemGroup>
-                        <CppCompile Include='a.cpp'/>                      
+                        <CppCompile Include='a.cpp'/>
                       </ItemGroup>
                       <Import Project='" + importedFile + @"'/>
                       <Target Name=""t"">
@@ -1227,12 +1227,12 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ProjectAddNewItemPicksUpProjectItemDefinitions()
         {
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                 </Project>
                 ")));
 
@@ -1250,12 +1250,12 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ProjectAddNewItemExistingGroupPicksUpProjectItemDefinitions()
         {
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemGroup>
                     <i Include='i2'>
                       <m>m2</m>
@@ -1276,13 +1276,13 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>m1</m>
                       <n>n1</n>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <CreateItem Include=""i1"" AdditionalMetadata=""n=n2"">
                       <Output ItemName=""i"" TaskParameter=""Include""/>
@@ -1302,13 +1302,13 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>m1</m>
                       <n>n1</n>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <ItemGroup>
                       <i Include=""i1"">
@@ -1334,12 +1334,12 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemGroup>
                     <i Include=""i1""/>
                   </ItemGroup>
@@ -1365,12 +1365,12 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemGroup>
                     <i Include=""i1""/>
                   </ItemGroup>
@@ -1403,7 +1403,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>m1</m>
@@ -1411,7 +1411,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <j>
                       <m>m2</m>
                     </j>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemGroup>
                     <i Include=""n1""/>
                     <j Include=""@(i)""/>
@@ -1443,7 +1443,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>im1</m>
@@ -1461,7 +1461,7 @@ namespace Microsoft.Build.UnitTests.Definition
                       <q>kq4</q>
                       <r>kr4</r>
                     </k>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemGroup>
                     <i Include=""1"">
                       <o>io2</o>
@@ -1535,7 +1535,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>im1</m>
@@ -1552,7 +1552,7 @@ namespace Microsoft.Build.UnitTests.Definition
                       <m>km4</m>
                       <q>kq4</q>
                     </k>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <ItemGroup>
                     <i Include=""1"">
                       <o>io2</o>
@@ -1591,16 +1591,16 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>m1</m>
                       <n>~%(m)~</n>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                     <ItemGroup>
                       <i Include=""i1""/>
-                    </ItemGroup>   
+                    </ItemGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)][%(i.n)]""/>
                   </Target>
@@ -1617,16 +1617,16 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>~%(n)~</m>
                       <n>n1</n>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                     <ItemGroup>
                       <i Include=""i1""/>
-                    </ItemGroup>   
+                    </ItemGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)][%(i.n)]""/>
                   </Target>
@@ -1643,17 +1643,17 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemDefinitionGroup>
                     <i>
                       <m>m1</m>
                       <n>%(i.m)</n>
                       <o>%(j.m)</o>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                     <ItemGroup>
                       <i Include=""i1""/>
-                    </ItemGroup>   
+                    </ItemGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(i.m)][%(i.n)][%(i.o)]""/>
                   </Target>
@@ -1670,7 +1670,7 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             MockLogger logger = new MockLogger();
             Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <PropertyGroup>
                     <Defines>CODEANALYSIS</Defines>
                   </PropertyGroup>
@@ -1682,7 +1682,7 @@ namespace Microsoft.Build.UnitTests.Definition
                       <Defines Condition=""'$(BuildFlavor)'=='ret'"">$(Defines);RETAIL</Defines>
                       <Defines Condition=""'$(BuildFlavor)'=='chk'"">$(Defines);DEBUG</Defines>
                     </CppCompile>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[%(CppCompile.Identity)==%(CppCompile.Defines)]""/>
                   </Target>
@@ -1711,7 +1711,7 @@ namespace Microsoft.Build.UnitTests.Definition
             try
             {
                 otherProject = FileUtilities.GetTemporaryFile();
-                string otherProjectContent = @"<Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                string otherProjectContent = @"<Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -1719,7 +1719,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <i>
                       <m>m2</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[CHILD:%(i.m)]""/>
                   </Target>
@@ -1732,7 +1732,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
                 MockLogger logger = new MockLogger();
                 Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
                   </ItemGroup>
@@ -1740,7 +1740,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <i>
                       <m>m1</m>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"">
                     <Message Text=""[PARENT-before:%(i.m)]""/>
                     <MSBuild Projects=""" + otherProject + @"""/>
@@ -1767,7 +1767,7 @@ namespace Microsoft.Build.UnitTests.Definition
             try
             {
                 otherProject = FileUtilities.GetTemporaryFile();
-                string otherProjectContent = @"<Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                string otherProjectContent = @"<Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'>
                        <m>m1</m>
@@ -1777,7 +1777,7 @@ namespace Microsoft.Build.UnitTests.Definition
                     <i>
                       <n>n1</n>
                     </i>
-                  </ItemDefinitionGroup> 
+                  </ItemDefinitionGroup>
                   <Target Name=""t"" Outputs=""@(i)"">
                     <Message Text=""[CHILD:%(i.Identity):m=%(i.m),n=%(i.n)]""/>
                   </Target>
@@ -1790,7 +1790,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
                 MockLogger logger = new MockLogger();
                 Project p = new Project(XmlReader.Create(new StringReader(@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <Target Name=""t"">
                     <MSBuild Projects=""" + otherProject + @""">
                        <Output TaskParameter='TargetOutputs' ItemName='i'/>

--- a/src/Build.UnitTests/Definition/ProjectHelpers.cs
+++ b/src/Build.UnitTests/Definition/ProjectHelpers.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             XmlReader reader = XmlReader.Create(new StringReader
                 (
-                @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='4.0'>
+                @"<Project>
                       <Target Name='foo'/>
                   </Project>"
                 ));

--- a/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
+++ b/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
@@ -16,12 +16,12 @@ using Xunit;
 namespace Microsoft.Build.UnitTests.Definition
 {
     /// <summary>
-    /// Tests some manipulations of Project and ProjectCollection that require dealing with internal data. 
+    /// Tests some manipulations of Project and ProjectCollection that require dealing with internal data.
     /// </summary>
     public class Project_Internal_Tests
     {
         /// <summary>
-        /// Set default tools version; subsequent projects should use it 
+        /// Set default tools version; subsequent projects should use it
         /// </summary>
         [Fact]
         public void SetDefaultToolsVersion()
@@ -31,8 +31,8 @@ namespace Microsoft.Build.UnitTests.Definition
             try
             {
                 // In the new world of figuring out the ToolsVersion to use, we completely ignore the default
-                // ToolsVersion in the ProjectCollection.  However, this test explicitly depends on modifying 
-                // that, so we need to turn the new defaulting behavior off in order to verify that this still works.  
+                // ToolsVersion in the ProjectCollection.  However, this test explicitly depends on modifying
+                // that, so we need to turn the new defaulting behavior off in order to verify that this still works.
                 Environment.SetEnvironmentVariable("MSBUILDLEGACYDEFAULTTOOLSVERSION", "1");
                 InternalUtilities.RefreshInternalEnvironmentValues();
 
@@ -44,7 +44,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 Assert.Equal("x", collection.DefaultToolsVersion);
 
                 string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <Target Name='t'/>
                     </Project>
                 ";
@@ -61,10 +61,10 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 
         /// <summary>
-        /// If the ToolsVersion in the project file is bogus, we'll default to the current ToolsVersion and successfully 
-        /// load it.  Make sure we can RE-load it, too, and successfully pick up the correct copy of the loaded project. 
-        /// 
-        /// ... Make sure we can do this even if we're not using the "always default everything to current anyway" codepath. 
+        /// If the ToolsVersion in the project file is bogus, we'll default to the current ToolsVersion and successfully
+        /// load it.  Make sure we can RE-load it, too, and successfully pick up the correct copy of the loaded project.
+        ///
+        /// ... Make sure we can do this even if we're not using the "always default everything to current anyway" codepath.
         /// </summary>
         [Fact]
         public void ReloadProjectWithInvalidToolsVersionInFile()
@@ -74,13 +74,13 @@ namespace Microsoft.Build.UnitTests.Definition
             try
             {
                 // In the new world of figuring out the ToolsVersion to use, we completely ignore the default
-                // ToolsVersion in the ProjectCollection.  However, this test explicitly depends on modifying 
-                // that, so we need to turn the new defaulting behavior off in order to verify that this still works.  
+                // ToolsVersion in the ProjectCollection.  However, this test explicitly depends on modifying
+                // that, so we need to turn the new defaulting behavior off in order to verify that this still works.
                 Environment.SetEnvironmentVariable("MSBUILDLEGACYDEFAULTTOOLSVERSION", "1");
                 InternalUtilities.RefreshInternalEnvironmentValues();
 
                 string content = @"
-                    <Project ToolsVersion='bogus' xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project ToolsVersion='bogus'>
                         <Target Name='t'/>
                     </Project>
                 ";
@@ -118,10 +118,10 @@ namespace Microsoft.Build.UnitTests.Definition
 
             try
             {
-                // In the new world of figuring out the ToolsVersion to use, we completely ignore what 
+                // In the new world of figuring out the ToolsVersion to use, we completely ignore what
                 // is written in the project file.  However, this test explicitly depends on effectively
-                // modifying the "project file" (through the construction model OM), so we need to turn 
-                // that behavior off in order to verify that it still works.  
+                // modifying the "project file" (through the construction model OM), so we need to turn
+                // that behavior off in order to verify that it still works.
                 Environment.SetEnvironmentVariable("MSBUILDLEGACYDEFAULTTOOLSVERSION", "1");
                 InternalUtilities.RefreshInternalEnvironmentValues();
 
@@ -169,10 +169,10 @@ namespace Microsoft.Build.UnitTests.Definition
 
             try
             {
-                // In the new world of figuring out the ToolsVersion to use, we completely ignore what 
+                // In the new world of figuring out the ToolsVersion to use, we completely ignore what
                 // is written in the project file.  However, this test explicitly depends on effectively
-                // modifying the "project file" (through the construction model OM), so we need to turn 
-                // that behavior off in order to verify that it still works.  
+                // modifying the "project file" (through the construction model OM), so we need to turn
+                // that behavior off in order to verify that it still works.
                 Environment.SetEnvironmentVariable("MSBUILDLEGACYDEFAULTTOOLSVERSION", "1");
                 InternalUtilities.RefreshInternalEnvironmentValues();
 
@@ -202,13 +202,13 @@ namespace Microsoft.Build.UnitTests.Definition
         public void ProjectEvaluationShouldRespectConditionsIfProjectLoadSettingsSaysSo()
         {
             var projectContents = @"
-<Project>   
+<Project>
    <ItemDefinitionGroup Condition=`1 == 2`>
      <I>
        <m>v</m>
      </I>
    </ItemDefinitionGroup>
-   
+
    <PropertyGroup Condition=`1 == 2`>
      <P1>v</P1>
    </PropertyGroup>

--- a/src/Build.UnitTests/Definition/ToolsVersion_Tests.cs
+++ b/src/Build.UnitTests/Definition/ToolsVersion_Tests.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='98.6' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='98.6'>
                         <Target Name='Foo'>
                         </Target>
                        </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -326,7 +326,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='0.1' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='0.1'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -359,7 +359,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='invalidToolsVersion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='invalidToolsVersion'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -387,7 +387,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='invalidToolsVersion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='invalidToolsVersion'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, "goober", p);
@@ -418,7 +418,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -446,7 +446,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Environment.SetEnvironmentVariable("MSBUILDTREATALLTOOLSVERSIONSASCURRENT", String.Empty);
             try
             {
-                string content = @"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                string content = @"<Project ToolsVersion=""14.0"">
     <Target Name=""a"">
         <Message Text=""[$(MSBUILDTOOLSVERSION)]"" />
     </Target>
@@ -487,7 +487,7 @@ namespace Microsoft.Build.UnitTests.Definition
             MockLogger mockLogger = new MockLogger();
             LoggingService service = (LoggingService)LoggingService.CreateLoggingService(LoggerMode.Synchronous, 1);
             service.RegisterLogger(mockLogger);
-            Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -522,7 +522,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -559,7 +559,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -599,7 +599,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -632,7 +632,7 @@ namespace Microsoft.Build.UnitTests.Definition
             MockLogger mockLogger = new MockLogger();
             LoggingService service = (LoggingService)LoggingService.CreateLoggingService(LoggerMode.Synchronous, 1);
             service.RegisterLogger(mockLogger);
-            Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -668,7 +668,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -708,7 +708,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -751,7 +751,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -784,7 +784,7 @@ namespace Microsoft.Build.UnitTests.Definition
             MockLogger mockLogger = new MockLogger();
             LoggingService service = (LoggingService)LoggingService.CreateLoggingService(LoggerMode.Synchronous, 1);
             service.RegisterLogger(mockLogger);
-            Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+            Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -819,7 +819,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -859,7 +859,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 service.RegisterLogger(mockLogger);
 
                 bool success = false;
-                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                Project project = new Project(XmlReader.Create(new StringReader(@"<Project ToolsVersion='4.0'>
                     <Target Name='Foo'>
                     </Target>
                    </Project>")), null /* no global properties */, null /* don't explicitly set the toolsversion */, p);
@@ -956,7 +956,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\directory1\\directory2\\a.tasks"
                                          : "/directory1/directory2/a.tasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='a1' AssemblyName='a' />
                             <UsingTask TaskName='a2' AssemblyName='a' />
                             <UsingTask TaskName='a3' AssemblyName='a' />
@@ -965,37 +965,37 @@ namespace Microsoft.Build.UnitTests.Definition
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\directory1\\directory2\\b.tasks"
                                          : "/directory1/directory2/b.tasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='b1' AssemblyName='b' />
                        </Project>"),
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\directory1\\directory2\\c.tasksfile"
                                          : "/directory1/directory2/c.taskfile",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='c1' AssemblyName='c' />
                        </Project>"),
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\directory1\\directory2\\directory3\\d.tasks"
                                          : "/directory1/directory2/directory3/d.tasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='d1' AssemblyName='d' />
                        </Project>"),
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\directory1\\directory2\\e.tasks"
                                          : "/directory1/directory2/e.tasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='e1' AssemblyName='e' />
                        </Project>"),
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "d:\\directory1\\directory2\\f.tasks"
                                          : "/d/directory1/directory2/f.tasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='f1' AssemblyName='f' />
                        </Project>"),
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\directory1\\directory2\\g.custom.tasks"
                                          : "/directory1/directory2/g.custom.tasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='g1' AssemblyName='g' />
                             <UsingTask TaskName='g2' AssemblyName='g' />
                             <UsingTask TaskName='g3' AssemblyName='g' />
@@ -1003,7 +1003,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\somepath\\1.tasks"
                                          : "/somepath/1.tasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='11' AssemblyName='1' />
                             <UsingTask TaskName='12' AssemblyName='1' />
                             <UsingTask TaskName='13' AssemblyName='1' />
@@ -1011,13 +1011,13 @@ namespace Microsoft.Build.UnitTests.Definition
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\somepath\\2.tasks"
                                          : "/somepath/2.tasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='21' AssemblyName='2' />
                        </Project>"),
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\inline\\inlinetasks.tasks"
                                          : "/inline/inlinetasks.tasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='t2' AssemblyName='an' Condition='true' TaskFactory='AssemblyFactory' Runtime='CLR2' Architecture='x86' RequiredRuntime='2.0' RequiredPlatform='x86'>
                                 <ParameterGroup>
                                    <MyParameter ParameterType='System.String' Output='true' Required='false'/>
@@ -1030,7 +1030,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\msbuildoverridetasks\\1.overridetasks"
                                          : "/msbuildoverridetasks/1.overridetasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='a1' AssemblyName='o' />
                             <UsingTask TaskName='oa1' AssemblyName='o' />
                             <UsingTask TaskName='oa2' AssemblyName='o' />
@@ -1039,7 +1039,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 new DefaultTasksFile(NativeMethodsShared.IsWindows
                                          ? "c:\\msbuildoverridetasks\\2.overridetasks"
                                          : "/msbuildoverridetasks/2.overridetasks",
-                      @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                      @"<Project>
                             <UsingTask TaskName='ooo' AssemblyName='o' />
                         </Project>")
 };

--- a/src/Build.UnitTests/Definition/ToolsetReader_Tests.cs
+++ b/src/Build.UnitTests/Definition/ToolsetReader_Tests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.UnitTests.Definition
         private const string testRegistryPath = @"msbuildUnitTests";
 
         /// <summary>
-        /// Store the value of the "VisualStudioVersion" environment variable here so that 
+        /// Store the value of the "VisualStudioVersion" environment variable here so that
         /// we can unset it for the duration of the test.
         /// </summary>
         private string _oldVisualStudioVersion;
@@ -124,7 +124,7 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 #endif
 
-    #region "Reading from application configuration file tests"
+        #region "Reading from application configuration file tests"
 
 #if FEATURE_SYSTEM_CONFIGURATION
 
@@ -669,7 +669,7 @@ namespace Microsoft.Build.UnitTests.Definition
            );
         }
         /// <summary>
-        /// Tests the case when a blank property name is specified in the registry in a 
+        /// Tests the case when a blank property name is specified in the registry in a
         /// sub-toolset.
         /// </summary>
         [Fact]
@@ -957,7 +957,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
         /// <summary>
         /// Tests that any escaped xml in config file, is treated well
-        /// Note that this comes for free with the current implementation using the 
+        /// Note that this comes for free with the current implementation using the
         /// framework api to access section in the config file
         /// </summary>
         [Fact]
@@ -988,9 +988,9 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(@"some>value", values["2>.0"].Properties["foo"].EvaluatedValue);
         }
 #endif
-    #endregion
+        #endregion
 
-    #region "GetToolsetData tests"
+        #region "GetToolsetData tests"
 
         /// <summary>
         /// Tests the case where registry and config file contains different toolsVersion
@@ -1407,7 +1407,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
                 Dictionary<string, Toolset> values = new Dictionary<string, Toolset>(StringComparer.OrdinalIgnoreCase);
 
-                // should throw... 
+                // should throw...
                 ToolsetReader.ReadAllToolsets
                                                            (
                                                                values,
@@ -2006,9 +2006,9 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 
         /// <summary>
-        /// Tests the case where application configuration file overrides a value already specified in the registry, 
-        /// where that registry value is bogus and would otherwise throw.  However, since the config file also 
-        /// contains an entry for that toolset, the registry toolset never gets read, and thus never throws.  
+        /// Tests the case where application configuration file overrides a value already specified in the registry,
+        /// where that registry value is bogus and would otherwise throw.  However, since the config file also
+        /// contains an entry for that toolset, the registry toolset never gets read, and thus never throws.
         /// </summary>
         [Fact]
         public void GetToolsetData_ConflictingPropertyValuesRegistryThrows()
@@ -2115,8 +2115,8 @@ namespace Microsoft.Build.UnitTests.Definition
             try
             {
                 // In the new world of figuring out the ToolsVersion to use, we completely ignore the default
-                // ToolsVersion in the ProjectCollection.  However, this test explicitly depends on modifying 
-                // that, so we need to turn the new defaulting behavior off in order to verify that this still works.  
+                // ToolsVersion in the ProjectCollection.  However, this test explicitly depends on modifying
+                // that, so we need to turn the new defaulting behavior off in order to verify that this still works.
                 Environment.SetEnvironmentVariable("MSBUILDLEGACYDEFAULTTOOLSVERSION", "1");
                 InternalUtilities.RefreshInternalEnvironmentValues();
 
@@ -2126,7 +2126,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 projectCollection.AddToolset(new Toolset("2.0", "20toolsPath", projectCollection, msbuildOverrideTasksPath));
                 projectCollection.AddToolset(new Toolset(ObjectModelHelpers.MSBuildDefaultToolsVersion, "120toolsPath", projectCollection, msbuildOverrideTasksPath));
 
-                string projectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("x.proj", @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />");
+                string projectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("x.proj", @"<Project />");
 
                 Project project = projectCollection.LoadProject(projectPath);
 
@@ -2188,8 +2188,8 @@ namespace Microsoft.Build.UnitTests.Definition
 
         /// <summary>
         /// Test the case where nothing is specified in the config file
-        /// Note that config file not present is same as config file 
-        /// with no MSBuildToolsets Section 
+        /// Note that config file not present is same as config file
+        /// with no MSBuildToolsets Section
         /// </summary>
         [Fact]
         public void GetToolsetData_ConfigFileNotPresent()
@@ -2324,9 +2324,9 @@ namespace Microsoft.Build.UnitTests.Definition
             });
         }
 
-    #endregion
+        #endregion
 
-    #region "SetDefaultToolsetVersion tests"
+        #region "SetDefaultToolsetVersion tests"
 
         /// <summary>
         /// Tests that the default ToolsVersion is correctly resolved when specified
@@ -2837,7 +2837,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal("gv1", values["4.0"].Properties["p2"].EvaluatedValue);
         }
 
-    #endregion
+        #endregion
 
         private ToolsetRegistryReader GetStandardRegistryReader()
         {

--- a/src/Build.UnitTests/EscapingInProjects_Tests.cs
+++ b/src/Build.UnitTests/EscapingInProjects_Tests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         public void SemicolonInPropertyPassedIntoStringParam()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <MyPropertyWithSemicolons>abc %3b def %3b ghi</MyPropertyWithSemicolons>
                     </PropertyGroup>
@@ -107,7 +107,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         public void SemicolonInPropertyPassedIntoStringParam_UsingTaskHost()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <UsingTask TaskName=`Message` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` TaskFactory=`TaskHostFactory` />
                     <PropertyGroup>
                         <MyPropertyWithSemicolons>abc %3b def %3b ghi</MyPropertyWithSemicolons>
@@ -131,7 +131,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@$"
 
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <UsingTask TaskName=`Microsoft.Build.UnitTests.EscapingInProjects_Tests.MyTestTask` AssemblyFile=`{new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath}` />
 
@@ -161,7 +161,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(String.Format(@"
 
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <UsingTask TaskName=`Microsoft.Build.UnitTests.EscapingInProjects_Tests.MyTestTask` AssemblyFile=`{0}` TaskFactory=`TaskHostFactory` />
 
@@ -194,7 +194,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               BEFORE
             // ************************************
             string projectOriginalContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <ItemGroup>
                         <MyWildCard Include=`*.weirdo`/>
                     </ItemGroup>
@@ -206,7 +206,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               AFTER
             // ************************************
             string projectNewExpectedContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <ItemGroup>
                         <MyWildCard Include=`*.weirdo`/>
                         <MyWildCard Include=`foo;bar.weirdo`/>
@@ -232,7 +232,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               BEFORE
             // ************************************
             string projectOriginalContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <FilenameWithSemicolon>foo;bar</FilenameWithSemicolon>
                     </PropertyGroup>
@@ -247,7 +247,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               AFTER
             // ************************************
             string projectNewExpectedContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <FilenameWithSemicolon>foo;bar</FilenameWithSemicolon>
                     </PropertyGroup>
@@ -277,7 +277,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               BEFORE
             // ************************************
             string projectOriginalContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <ItemGroup>
                         <MyWildcard Include=`*.weirdo` />
@@ -291,7 +291,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               AFTER
             // ************************************
             string projectNewExpectedContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <ItemGroup>
                         <MyWildcard Include=`a.weirdo` />
@@ -330,7 +330,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               BEFORE
             // ************************************
             string projectOriginalContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <ItemGroup>
                         <MyWildcard Include=`*.weirdo` />
@@ -344,7 +344,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               AFTER
             // ************************************
             string projectNewExpectedContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <ItemGroup>
                         <MyWildcard Include=`*.weirdo` />
@@ -387,7 +387,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               BEFORE
             // ************************************
             string projectOriginalContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <PropertyGroup>
                         <FilenameWithSemicolon>foo;bar</FilenameWithSemicolon>
@@ -405,7 +405,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               AFTER
             // ************************************
             string projectNewExpectedContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <PropertyGroup>
                         <FilenameWithSemicolon>foo;bar</FilenameWithSemicolon>
@@ -448,7 +448,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               BEFORE
             // ************************************
             string projectOriginalContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <ItemGroup>
                         <MyWildCard Include=`*.weirdo`/>
                     </ItemGroup>
@@ -460,7 +460,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               AFTER
             // ************************************
             string projectNewExpectedContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <ItemGroup>
                         <MyWildCard Include=`*.weirdo`/>
                     </ItemGroup>
@@ -490,7 +490,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               BEFORE
             // ************************************
             string projectOriginalContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <ItemGroup>
                         <MyWildCard Include=`*.AAA%253bBBB`/>
                     </ItemGroup>
@@ -502,7 +502,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             //               AFTER
             // ************************************
             string projectNewExpectedContents = @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <ItemGroup>
                         <MyWildCard Include=`*.AAA%253bBBB`/>
                     </ItemGroup>
@@ -539,7 +539,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
 
                 MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(String.Format(@"
 
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <Target Name=`GenerateResources` Inputs=`{0}` Outputs=`{1}`>
                         <NonExistentTask OutputResources=`aaa%253bbbb.resx; ccc%253bddd.resx`>
@@ -574,7 +574,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
 
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <ItemGroup>
                         <TextFile Include=`X.txt`/>
                         <TextFile Include=`Y.txt`/>
@@ -600,7 +600,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
 
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <UsingTask TaskName=`Message` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` TaskFactory=`TaskHostFactory` />
 
                     <ItemGroup>
@@ -661,7 +661,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         {
             MockLogger logger = new MockLogger();
             Project project = ObjectModelHelpers.CreateInMemoryProject(@"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <Target Name=`Build`>
                         <Message Text=`MyGlobalProperty = '$(MyGlobalProperty)'` />
                     </Target>
@@ -690,7 +690,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // Populate the project directory with three physical files on disk -- a.weirdo, b.weirdo, c.weirdo.
                 EscapingInProjectsHelper.CreateThreeWeirdoFiles();
                 Project project = ObjectModelHelpers.CreateInMemoryProject(@"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <Target Name=`t`>
                         <ItemGroup>
                             <type Include=`%2A` Exclude=``/>
@@ -759,7 +759,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             try
             {
                 ObjectModelHelpers.CreateInMemoryProject(@"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                     <Target Name=`%24` />
                 </Project>
                 ");
@@ -783,7 +783,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         public void TargetNamesAlwaysUnescaped_Override()
         {
             Project project = ObjectModelHelpers.CreateInMemoryProject(@"
-            <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+            <Project ToolsVersion=`msbuilddefaulttoolsversion`>
                 <Target Name=`%3B`>
                     <Message Text=`[WRONG]` />
                 </Target>
@@ -806,7 +806,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         public void SpecialCharactersInMetadataValueConstruction()
         {
             string projectString = @"
-                <Project DefaultTargets=""Build"" ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project DefaultTargets=""Build"" ToolsVersion=""msbuilddefaulttoolsversion"">
                     <ItemGroup>
                         <None Include='MetadataTests'>
                             <EscapedSemicolon>%3B</EscapedSemicolon>
@@ -849,7 +849,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         public void CanGetCorrectListOfItemsWithSemicolonsInThem()
         {
             string projectString = @"
-                <Project DefaultTargets=""Build"" ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project DefaultTargets=""Build"" ToolsVersion=""msbuilddefaulttoolsversion"">
                     <PropertyGroup>
                         <MyUserMacro>foo%3bbar</MyUserMacro>
                     </PropertyGroup>
@@ -881,7 +881,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         public void CanGetCorrectListOfItemsWithSemicolonsInThem2()
         {
             string projectString = @"
-                <Project DefaultTargets=""Build"" ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project DefaultTargets=""Build"" ToolsVersion=""msbuilddefaulttoolsversion"">
                     <PropertyGroup>
                         <MyUserMacro>foo;bar</MyUserMacro>
                     </PropertyGroup>
@@ -952,7 +952,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // Foo.csproj
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", $@"
-                <Project DefaultTargets=`Build` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
@@ -1017,7 +1017,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // Foo.csproj
                 // ---------------------
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", $@"
-                <Project DefaultTargets=`Build` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
@@ -1082,7 +1082,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // Foo.csproj
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", $@"
-                <Project DefaultTargets=`Build` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
@@ -1142,7 +1142,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // Foo.csproj
                 // ---------------------
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", $@"
-                <Project DefaultTargets=`Build` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
@@ -1202,7 +1202,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // Foo.csproj
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", $@"
-                <Project DefaultTargets=`Build` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
@@ -1262,7 +1262,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // Foo.csproj
                 // ---------------------
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", $@"
-                <Project DefaultTargets=`Build` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
@@ -1322,7 +1322,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // Foo.csproj
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", $@"
-                <Project DefaultTargets=`Build` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
@@ -1382,7 +1382,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // Foo.csproj
                 // ---------------------
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", $@"
-                <Project DefaultTargets=`Build` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
@@ -1454,7 +1454,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 @"SLN;!@(foo)'^1\Console;!@(foo)'^(Application1\Cons.ole;!@(foo)'^(Application1.csproj",
 
                 @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1531,7 +1531,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 @"SLN;!@(foo)'^1\Class;!@(foo)'^(Library1\Class;!@(foo)'^(Library1.csproj",
 
                 @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1625,7 +1625,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                     @"SLN;!@(foo)'^1\Console;!@(foo)'^(Application1\Cons.ole;!@(foo)'^(Application1.csproj",
 
                     @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1702,7 +1702,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                     @"SLN;!@(foo)'^1\Class;!@(foo)'^(Library1\Class;!@(foo)'^(Library1.csproj",
 
                     @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsChainedProject1()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
-<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
     <ItemGroup>
         <Compile Include=`a.cpp`>
@@ -393,7 +393,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         </Compile>
     </ItemGroup>
 
-    <Target Name=`Build`>      
+    <Target Name=`Build`>
         <Message Text=`DirChain0: @(Compile->'%(SomeMeta)'->'%(Directory)'->Distinct())`/>
         <Message Text=`DirChain1: @(Compile->'%(SomeMeta)'->'%(Directory)'->Distinct(), '%(A)')`/>
         <Message Text=`DirChain2: @(Compile->'%(SomeMeta)'->'%(Directory)'->Distinct(), '%(A)%(B)')`/>
@@ -416,8 +416,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsCount1()
         {
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`foo;bar`/>
@@ -438,8 +438,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsCount2()
         {
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`foo;bar`/>
@@ -461,8 +461,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsCountOperatingOnEmptyResult1()
         {
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`foo;bar`/>
@@ -483,8 +483,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsCountOperatingOnEmptyResult2()
         {
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`foo;bar`/>
@@ -506,8 +506,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsBuiltIn1()
         {
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`foo;bar`/>
@@ -528,8 +528,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsBuiltIn2()
         {
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`foo;bar`/>
@@ -550,8 +550,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsBuiltIn3()
         {
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`foo;bar;foo;bar;foo`/>
@@ -572,8 +572,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsBuiltIn4()
         {
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`foo;bar;foo;bar;foo`/>
@@ -595,8 +595,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandItemVectorFunctionsBuiltIn_PathTooLongError()
         {
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo`/>
@@ -621,8 +621,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
 
             string content = @"
- <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
- 
+ <Project DefaultTargets=`t`>
+
         <Target Name=`t`>
             <ItemGroup>
                 <I Include=`aaa|||bbb\ccc.txt`/>
@@ -816,7 +816,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ZeroItemsInProjectExpandsToEmpty()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <Target Name=`Build` Condition=`'@(foo)'!=''` >
                         <Message Text=`This target should NOT run.`/>
@@ -828,7 +828,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             logger.AssertLogDoesntContain("This target should NOT run.");
 
             logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=`msbuilddefaulttoolsversion`>
 
                     <ItemGroup>
                         <foo Include=`abc` Condition=` '@(foo)' == '' ` />
@@ -848,7 +848,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ItemIncludeContainsMultipleItemReferences()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
-                <Project DefaultTarget=`ShowProps` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" >
+                <Project DefaultTarget=`ShowProps` ToolsVersion=`msbuilddefaulttoolsversion` >
                     <PropertyGroup>
                         <OutputType>Library</OutputType>
                     </PropertyGroup>
@@ -880,7 +880,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidPathAndMetadataItemFunctionPathTooLong()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='" + new string('x', 250) + @"'/>
                     </ItemGroup>
@@ -902,7 +902,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidPathAndMetadataItemFunctionInvalidWindowsPathChars()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='" + ":|?*" + @"'/>
                     </ItemGroup>
@@ -921,7 +921,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidMetadataName()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='x'/>
                     </ItemGroup>
@@ -942,7 +942,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidPathAndMetadataItemFunctionPathTooLong2()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='" + new string('x', 250) + @"'/>
                     </ItemGroup>
@@ -964,7 +964,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidPathAndMetadataItemFunctionInvalidWindowsPathChars2()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='" + ":|?*" + @"'/>
                     </ItemGroup>
@@ -983,7 +983,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidMetadataName2()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='x'/>
                     </ItemGroup>
@@ -1004,7 +1004,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidPathAndMetadataItemFunctionPathTooLong3()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='" + new string('x', 250) + @"'/>
                     </ItemGroup>
@@ -1026,7 +1026,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidPathAndMetadataItemInvalidWindowsPathChars3()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='" + ":|?*" + @"'/>
                     </ItemGroup>
@@ -1044,7 +1044,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidPathInDirectMetadata()
         {
             var logger = Helpers.BuildProjectContentUsingBuildManagerExpectResult(
-                @"<Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                @"<Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include=':|?*'>
                             <m>%(FullPath)</m>
@@ -1062,7 +1062,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void PathTooLongInDirectMetadata()
         {
             var logger = Helpers.BuildProjectContentUsingBuildManagerExpectResult(
-                @"<Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                @"<Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='" + new string('x', 250) + @"'>
                             <m>%(FullPath)</m>
@@ -1081,7 +1081,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void InvalidMetadataName3()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <ItemGroup>
                         <x Include='x'/>
                     </ItemGroup>
@@ -1100,7 +1100,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void HasMetadata()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
-<Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Project ToolsVersion=""msbuilddefaulttoolsversion"">
 
   <ItemGroup>
     <_Item Include=""One"">
@@ -1149,7 +1149,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                   <Target Name=`Build`>
                     <Message Importance=`high` Text=`QualifiedNotMatchCase %(Foo.FileName)=%(Foo.sensitive)`/>
                     <Message Importance=`high` Text=`QualifiedMatchCase %(Foo.FileName)=%(Foo.SENSITIVE)`/>
-                    
+
                     <Message Importance=`high` Text=`UnqualifiedNotMatchCase %(Foo.FileName)=%(sensitive)`/>
                     <Message Importance=`high` Text=`UnqualifiedMatchCase %(Foo.FileName)=%(SENSITIVE)`/>
                   </Target>
@@ -1178,7 +1178,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                   <Target Name=`Build`>
                     <Message Importance=`high` Text=`QualifiedNotMatchCase %(Foo.FileName)=%(Foo.sensitive)`/>
                     <Message Importance=`high` Text=`QualifiedMatchCase %(Foo.FileName)=%(Foo.SENSITIVE)`/>
-                    
+
                     <Message Importance=`high` Text=`UnqualifiedNotMatchCase %(Foo.FileName)=%(sensitive)`/>
                     <Message Importance=`high` Text=`UnqualifiedMatchCase %(Foo.FileName)=%(SENSITIVE)`/>
                   </Target>
@@ -1202,7 +1202,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                   <Target Name=`Build`>
                     <Message Importance=`high` Text=`QualifiedNotMatchCase %(Foo.Identity)=%(Foo.FILENAME)`/>
                     <Message Importance=`high` Text=`QualifiedMatchCase %(Foo.Identity)=%(Foo.FileName)`/>
-                    
+
                     <Message Importance=`high` Text=`UnqualifiedNotMatchCase %(Foo.Identity)=%(FILENAME)`/>
                     <Message Importance=`high` Text=`UnqualifiedMatchCase %(Foo.Identity)=%(FileName)`/>
                   </Target>
@@ -1224,7 +1224,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             try
             {
                 Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <PropertyGroup>
                         <Function>$([System.IO.Path]::Combine(null,''))</Function>
                     </PropertyGroup>
@@ -1251,7 +1251,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             try
             {
                 Helpers.BuildProjectWithNewOMExpectFailure(@"
-                <Project DefaultTargets='Build' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <Project DefaultTargets='Build'>
                     <PropertyGroup>
                         <Function>$(System.IO.Path::Combine('a','b'))</Function>
                     </PropertyGroup>
@@ -1515,7 +1515,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
             var lookup = new Lookup(projectItemGroups, pg);
             lookup.EnterScope("x");
-            lookup.PopulateWithItems("ManySpacesItem", new []
+            lookup.PopulateWithItems("ManySpacesItem", new[]
             {
                 new ProjectItemInstance (project, "ManySpacesItem", "Foo", project.FullPath),
                 new ProjectItemInstance (project, "ManySpacesItem", manySpaces, project.FullPath),
@@ -1850,7 +1850,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void TestItemSpecModiferEscaping()
         {
             string content = @"
- <Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+ <Project DefaultTargets=""Build"">
 
         <Target Name=""Build"">
             <WriteLinesToFile Overwrite=""true"" File=""unittest.%28msbuild%29.file"" Lines=""Nothing much here""/>
@@ -1884,7 +1884,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
 
             string content = $@"
-                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"">
 
                     <PropertyGroup>
                         <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
@@ -2638,7 +2638,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.IO.Path]::Combine(`" +
-                Path.Combine(s_rootPathPrefix, "foo goo")  + "`, `$(File)`))",
+                Path.Combine(s_rootPathPrefix, "foo goo") + "`, `$(File)`))",
                 ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
             Assert.Equal(Path.Combine(s_rootPathPrefix, "foo goo", "foo goo", "file.txt"), result);
@@ -2854,7 +2854,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void StringIndexOfTests(string propertyName, string properyValue, string propertyFunction, string expectedExpansion)
         {
             var pg = new PropertyDictionary<ProjectPropertyInstance>
-                {[propertyName] = ProjectPropertyInstance.Create(propertyName, properyValue)};
+            { [propertyName] = ProjectPropertyInstance.Create(propertyName, properyValue) };
 
             var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
@@ -2916,9 +2916,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
             var pg = new PropertyDictionary<ProjectPropertyInstance>();
             var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
-            AssertSuccess(expander, expectedSign >  0, $"$([MSBuild]::VersionGreaterThan('{a}', '{b}'))");
+            AssertSuccess(expander, expectedSign > 0, $"$([MSBuild]::VersionGreaterThan('{a}', '{b}'))");
             AssertSuccess(expander, expectedSign >= 0, $"$([MSBuild]::VersionGreaterThanOrEquals('{a}', '{b}'))");
-            AssertSuccess(expander, expectedSign <  0, $"$([MSBuild]::VersionLessThan('{a}', '{b}'))");
+            AssertSuccess(expander, expectedSign < 0, $"$([MSBuild]::VersionLessThan('{a}', '{b}'))");
             AssertSuccess(expander, expectedSign <= 0, $"$([MSBuild]::VersionLessThanOrEquals('{a}', '{b}'))");
             AssertSuccess(expander, expectedSign == 0, $"$([MSBuild]::VersionEquals('{a}', '{b}'))");
             AssertSuccess(expander, expectedSign != 0, $"$([MSBuild]::VersionNotEquals('{a}', '{b}'))");
@@ -3740,25 +3740,25 @@ namespace Microsoft.Build.UnitTests.Evaluation
             "$(listofthings.Split(';')[-1])",
             "$([]::())",
                                                       @"
- 
+
 $(
- 
+
 $(
- 
+
 [System.IO]::Path.GetDirectory('c:\foo\bar\baz.txt')
- 
+
 ).Substring(
- 
+
 '$([System.IO]::Path.GetPathRoot(
- 
+
 '$([System.IO]::Path.GetDirectory('c:\foo\bar\baz.txt'))'
- 
+
 ).Length)'
- 
- 
- 
+
+
+
 )
- 
+
 ",
                 "$([Microsoft.VisualBasic.FileIO.FileSystem]::CurrentDirectory)", // not allowed
                 "$(e.Length..ToString())",
@@ -3876,7 +3876,7 @@ $(
             {
                 // If no registry or not running on windows, this gets expanded to the empty string
                 // example: xplat build running on OSX
-                validTests.Add(new string[]{"$(Registry:X)", ""});
+                validTests.Add(new string[] { "$(Registry:X)", "" });
             }
 
             string result;

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ConditionalImportFromExtensionsPathNotFound()
         {
             string extnTargetsFileContentWithCondition = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <PropertyGroup>
                         <PropertyFromExtn1>FooBar</PropertyFromExtn1>
                     </PropertyGroup>
@@ -94,7 +94,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] { extnDir1, Path.Combine("tmp", "nonexistent") },
                                                             null,
-                                                            (p, l) => {
+                                                            (p, l) =>
+                                                            {
                                                                 Assert.True(p.Build());
 
                                                                 l.AssertLogContains("Running FromExtn");
@@ -106,7 +107,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ImportFromExtensionsPathCircularImportError()
         {
             string extnTargetsFileContent1 = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='FromExtn'>
                         <Message Text='Running FromExtn'/>
                     </Target>
@@ -115,7 +116,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ";
 
             string extnTargetsFileContent2 = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='FromExtn2'>
                         <Message Text='Running FromExtn'/>
                     </Target>
@@ -138,7 +139,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExtensionPathFallbackIsCaseInsensitive()
         {
             string mainTargetsFileContent = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='Main'>
                         <Message Text='Running Main'/>
                     </Target>
@@ -147,7 +148,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 </Project>";
 
             string extnTargetsFileContent = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='FromExtn'>
                         <Message Text='Running {0}'/>
                     </Target>
@@ -175,7 +176,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ImportFromExtensionsPathWithWildCard()
         {
             string mainTargetsFileContent = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='Main'>
                         <Message Text='Running Main'/>
                     </Target>
@@ -184,7 +185,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 </Project>";
 
             string extnTargetsFileContent = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='{0}'>
                         <Message Text='Running {0}'/>
                     </Target>
@@ -218,7 +219,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ImportFromExtensionsPathWithWildCardAndSelfImport()
         {
             string mainTargetsFileContent = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='Main'>
                         <Message Text='Running Main'/>
                     </Target>
@@ -227,14 +228,14 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 </Project>";
 
             string extnTargetsFileContent = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='{0}'>
                         <Message Text='Running {0}'/>
                     </Target>
                 </Project>";
 
             string extnTargetsFileContent2 = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Import Project='$(MSBuildExtensionsPath)\circularwildcardtest\*.proj'/>
                     <Target Name='{0}'>
                         <Message Text='Running {0}'/>
@@ -271,7 +272,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ImportFromExtensionsPathWithWildCardNothingFound()
         {
             string extnTargetsFileContent = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='FromExtn'>
                         <Message Text='Running FromExtn'/>
                     </Target>
@@ -289,7 +290,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ImportFromExtensionsPathInvalidFile()
         {
-            string extnTargetsFileContent = @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >";
+            string extnTargetsFileContent = @"<Project>";
 
             string extnDir1 = null;
             string mainProjectPath = null;
@@ -325,7 +326,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ImportFromExtensionsPathSearchOrder()
         {
             string extnTargetsFileContent1 = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <PropertyGroup>
                         <PropertyFromExtn1>FromFirstFile</PropertyFromExtn1>
                     </PropertyGroup>
@@ -337,7 +338,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ";
 
             string extnTargetsFileContent2 = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <PropertyGroup>
                         <PropertyFromExtn1>FromSecondFile</PropertyFromExtn1>
                     </PropertyGroup>
@@ -357,7 +358,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] { extnDir2, Path.Combine("tmp", "nonexistent"), extnDir1 },
                                                             null,
-                                                            (p, l) => {
+                                                            (p, l) =>
+                                                            {
                                                                 Assert.True(p.Build());
 
                                                                 l.AssertLogContains("Running FromExtn");
@@ -369,7 +371,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ImportFromExtensionsPathSearchOrder2()
         {
             string extnTargetsFileContent1 = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <PropertyGroup>
                         <PropertyFromExtn1>FromFirstFile</PropertyFromExtn1>
                     </PropertyGroup>
@@ -381,7 +383,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ";
 
             string extnTargetsFileContent2 = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <PropertyGroup>
                         <PropertyFromExtn1>FromSecondFile</PropertyFromExtn1>
                     </PropertyGroup>
@@ -448,7 +450,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ImportFromExtensionsPathAnd32And64()
         {
             string extnTargetsFileContentTemplate = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='FromExtn{0}' DependsOnTargets='{1}'>
                         <Message Text='Running FromExtn{0}'/>
                     </Target>
@@ -531,7 +533,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandExtensionsPathFallback()
         {
             string extnTargetsFileContentTemplate = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='FromExtn'>
                         <Message Text='Running FromExtn'/>
                     </Target>
@@ -592,7 +594,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandExtensionsPathFallbackInErrorMessage()
         {
             string extnTargetsFileContentTemplate = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='FromExtn'>
                         <Message Text='Running FromExtn'/>
                     </Target>
@@ -654,7 +656,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void FallbackImportWithIndirectReference()
         {
             string mainTargetsFileContent = @"
-               <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+               <Project>
                    <PropertyGroup>
                        <VSToolsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v99</VSToolsPath>
                    </PropertyGroup>
@@ -663,7 +665,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                </Project>";
 
             string extnTargetsFileContentTemplate = @"
-               <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+               <Project>
                    <Target Name='FromExtn'>
                        <Message Text='Running FromExtn'/>
                    </Target>
@@ -723,13 +725,13 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void FallbackImportWithUndefinedProperty()
         {
             string mainTargetsFileContent = @"
-               <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+               <Project>
                    <Import Project='$(UndefinedProperty)\file.props' Condition=""Exists('$(UndefinedProperty)\file.props')"" />
                    <Target Name='Main' DependsOnTargets='FromExtn' />
                </Project>";
 
             string extnTargetsFileContentTemplate = @"
-               <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+               <Project>
                    <Target Name='FromExtn'>
                        <Message Text='Running FromExtn'/>
                    </Target>
@@ -788,7 +790,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             // Import something from $(UndefinedProperty)
             string mainTargetsFileContent = @"
-               <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+               <Project>
                    <Import Project='$(UndefinedProperty)\filenotfound.props' />
                    <Target Name='Main' DependsOnTargets='FromExtn' />
                </Project>";
@@ -967,7 +969,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         string GetMainTargetFileContent(string extensionsPathPropertyName = "MSBuildExtensionsPath")
         {
             string mainTargetsFileContent = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='Main' DependsOnTargets='FromExtn'>
                         <Message Text='PropertyFromExtn1: $(PropertyFromExtn1)'/>
                     </Target>
@@ -981,7 +983,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         string GetExtensionTargetsFileContent1(string extensionsPathPropertyName = "MSBuildExtensionsPath")
         {
             string extnTargetsFileContent1 = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <PropertyGroup>
                         <PropertyFromExtn1>FooBar</PropertyFromExtn1>
                     </PropertyGroup>
@@ -999,7 +1001,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         string GetExtensionTargetsFileContent2(string extensionsPathPropertyName = "MSBuildExtensionsPath")
         {
             string extnTargetsFileContent2 = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <PropertyGroup>
                         <PropertyFromExtn2>Abc</PropertyFromExtn2>
                     </PropertyGroup>

--- a/src/Build.UnitTests/FixPathOnUnix_Tests.cs
+++ b/src/Build.UnitTests/FixPathOnUnix_Tests.cs
@@ -9,20 +9,20 @@ using Xunit;
 namespace Microsoft.Build.UnitTests
 {
     [PlatformSpecific(TestPlatforms.AnyUnix)]
-    public  class FixPathOnUnixTests
+    public class FixPathOnUnixTests
     {
         [Fact]
         public void TestPathFixupInMetadata()
         {
             string buildProjectContents = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <Target Name='Build'>
                         <MSBuild Projects='projectDirectory/main.proj' />
                     </Target>
                </Project>";
 
             string mainProjectContents = @"
-                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                <Project>
                     <UsingTask TaskName='LogTaskPropertiesTask' AssemblyName='Microsoft.Build.Engine.UnitTests' />
                     <ItemGroup>
                         <Item0 Include='xyz'>
@@ -61,10 +61,10 @@ namespace Microsoft.Build.UnitTests
             {
                 foreach (var item in Items)
                 {
-                    Log.LogMessage ($"Item: {item.ItemSpec}");
+                    Log.LogMessage($"Item: {item.ItemSpec}");
                     foreach (string name in item.MetadataNames)
                     {
-                        Log.LogMessage ($"ItemMetadata: {name} = {item.GetMetadata(name)}");
+                        Log.LogMessage($"ItemMetadata: {name} = {item.GetMetadata(name)}");
                     }
                 }
             }

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             try
             {
                 string projectFileContent = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <UsingTask TaskName='t0' AssemblyFile='af0'/>
                         <UsingTask TaskName='t1' AssemblyFile='af1a'/>
                         <ItemGroup>
@@ -54,7 +54,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                     </Project>";
 
                 string importContent = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <UsingTask TaskName='t1' AssemblyName='an1' Condition=""'$(p)'=='v'""/>
                         <UsingTask TaskName='t2' AssemblyName='an2' Condition=""'@(i)'=='i0'""/>
                         <UsingTask TaskName='t3' AssemblyFile='af' Condition='false'/>
@@ -91,19 +91,19 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             try
             {
                 string projectFileContent = @"
-                    <Project DefaultTargets='d0a;d0b' InitialTargets='i0a;i0b' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project DefaultTargets='d0a;d0b' InitialTargets='i0a;i0b'>
                         <Import Project='{0}'/>
                         <Import Project='{1}'/>
                     </Project>";
 
                 string import1Content = @"
-                    <Project DefaultTargets='d1a;d1b' InitialTargets='i1a;i1b' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project DefaultTargets='d1a;d1b' InitialTargets='i1a;i1b'>
                         <Import Project='{0}'/>
                     </Project>";
 
-                string import2Content = @"<Project DefaultTargets='d2a;2db' InitialTargets='i2a;i2b' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'/>";
+                string import2Content = @"<Project DefaultTargets='d2a;2db' InitialTargets='i2a;i2b'/>";
 
-                string import3Content = @"<Project DefaultTargets='d3a;d3b' InitialTargets='i3a;i3b' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'/>";
+                string import3Content = @"<Project DefaultTargets='d3a;d3b' InitialTargets='i3a;i3b'/>";
 
                 string import2Path = ObjectModelHelpers.CreateFileInTempProjectDirectory("import2.targets", import2Content);
                 string import3Path = ObjectModelHelpers.CreateFileInTempProjectDirectory("import3.targets", import3Content);
@@ -135,7 +135,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             try
             {
                 string projectFileContent = @"
-                    <Project DefaultTargets='d0a%3bd0b' InitialTargets='i0a%3bi0b' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project DefaultTargets='d0a%3bd0b' InitialTargets='i0a%3bi0b'>
                     </Project>";
 
                 ProjectInstance project = new Project(ProjectRootElement.Create(XmlReader.Create(new StringReader(projectFileContent)))).CreateProjectInstance();
@@ -156,7 +156,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void GetPropertyGroupUnderTarget()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <Target Name='t'>
                             <PropertyGroup Condition='c1'>
                                 <p1 Condition='c2'>v1</p1>
@@ -188,12 +188,12 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         public void GetItemGroupUnderTarget()
         {
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <Target Name='t'>
                             <ItemGroup Condition='c1'>
                                 <i Include='i1' Exclude='e1' Condition='c2'>
-                                    <m Condition='c3'>m1</m>    
-                                    <n>n1</n>                        
+                                    <m Condition='c3'>m1</m>
+                                    <n>n1</n>
                                 </i>
                                 <j Remove='r1'/>
                                 <k>
@@ -337,8 +337,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
-        /// Test ProjectInstance's surfacing of the sub-toolset version when it is overridden by a value in the 
-        /// environment 
+        /// Test ProjectInstance's surfacing of the sub-toolset version when it is overridden by a value in the
+        /// environment
         /// </summary>
         [Fact]
         [Trait("Category", "mono-osx-failing")]
@@ -390,8 +390,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
-        /// Verify that if a sub-toolset version is passed to the constructor, it all other heuristic methods for 
-        /// getting the sub-toolset version. 
+        /// Verify that if a sub-toolset version is passed to the constructor, it all other heuristic methods for
+        /// getting the sub-toolset version.
         /// </summary>
         [Fact]
         public void GetSubToolsetVersion_FromConstructor()
@@ -402,7 +402,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             {
                 Environment.SetEnvironmentVariable("VisualStudioVersion", "ABC");
 
-                string projectContent = @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                string projectContent = @"<Project>
                         <Target Name='t'>
                             <Message Text='Hello'/>
                         </Target>
@@ -532,7 +532,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
             Assert.Equal(first.Toolset, second.Toolset);
         }
-        
+
         /// <summary>
         /// Cloning project copies toolsversion
         /// </summary>
@@ -559,7 +559,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             Directory.SetCurrentDirectory(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
 
             string projectFileContent = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                    <Project>
                         <UsingTask TaskName='Microsoft.Build.Tasks.Message' AssemblyFile='Microsoft.Build.Tasks.Core.dll'/>
                         <ItemGroup>
                             <i Include='i0'/>
@@ -683,7 +683,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
             original.TranslateEntireState = true;
 
-            ((ITranslatable) original).Translate(TranslationHelpers.GetWriteTranslator());
+            ((ITranslatable)original).Translate(TranslationHelpers.GetWriteTranslator());
             var copy = ProjectInstance.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
 
             Assert.Equal(original, copy, new ProjectInstanceComparer());
@@ -892,7 +892,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
             if (globalProperties == null)
             {
-                // choose some interesting defaults if we weren't explicitly asked to use a set. 
+                // choose some interesting defaults if we weren't explicitly asked to use a set.
                 globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 globalProperties.Add("g1", "v1");
                 globalProperties.Add("g2", "v2");
@@ -928,7 +928,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         {
             string toolsVersionSubstring = toolsVersion != null ? "ToolsVersion=\"" + toolsVersion + "\" " : String.Empty;
             string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' InitialTargets='it' DefaultTargets='dt' " + toolsVersionSubstring + @">
+                    <Project InitialTargets='it' DefaultTargets='dt' " + toolsVersionSubstring + @">
                         <PropertyGroup>
                             <p1>v1</p1>
                             <p2>v2</p2>

--- a/src/Build.UnitTests/ProjectEvaluationFinishedEventArgs_Tests.cs
+++ b/src/Build.UnitTests/ProjectEvaluationFinishedEventArgs_Tests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.UnitTests
 {
     // Although this tests the ProfilerResult API from Microsoft.Build.Framework, it uses the
     //  construction APIs in Microsoft.Build in the test, so this test is in the Microsoft.Build tests
-    public class ProjectEvaluationFinishedEventArgs_Tests 
+    public class ProjectEvaluationFinishedEventArgs_Tests
     {
         /// <summary>
         /// Roundtrip serialization tests for <see cref="ProfilerResult"/>
@@ -52,7 +52,7 @@ namespace Microsoft.Build.UnitTests
 
             var element = new ProjectRootElement(
                 XmlReader.Create(new MemoryStream(Encoding.UTF8.GetBytes(
-                    "<Project xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"/>"))),
+                    "<Project />"))),
                 new ProjectRootElementCache(false), false, false);
 
             yield return new object[] { new ProfilerResult(new Dictionary<EvaluationLocation, ProfiledLocation>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project DefaultTargets="Build">
   <!-- Import the repo root props -->
   <Import Project="..\Directory.Build.props"/>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project DefaultTargets="Build">
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -451,7 +451,7 @@ namespace Microsoft.Build.UnitTests
             MSBuildApp.ExtractSwitchParameters(commandLineArg, unquotedCommandLineArg, doubleQuotesRemovedFromArg, "p", unquotedCommandLineArg.IndexOf(':'), 1).ShouldBe(":\"foo foo\"=\"bar bar\";\"baz=onga\"");
             doubleQuotesRemovedFromArg.ShouldBe(6);
         }
-        
+
         [Fact]
         public void ExtractSwitchParametersTestDoubleDash()
         {
@@ -489,7 +489,7 @@ namespace Microsoft.Build.UnitTests
             unquotedCommandLineArg = QuotingUtilities.Unquote(commandLineArg, out doubleQuotesRemovedFromArg);
             MSBuildApp.ExtractSwitchParameters(commandLineArg, unquotedCommandLineArg, doubleQuotesRemovedFromArg, "p", unquotedCommandLineArg.IndexOf(':'), 2).ShouldBe(":\"foo foo\"=\"bar bar\";\"baz=onga\"");
             doubleQuotesRemovedFromArg.ShouldBe(6);
-        }        
+        }
 
         [Fact]
         public void GetLengthOfSwitchIndicatorTest()
@@ -695,7 +695,7 @@ namespace Microsoft.Build.UnitTests
                 var pathToProjectFile = Path.Combine(startDirectory, "foo.proj");
                 string projectString =
                    "<?xml version='1.0' encoding='utf-8'?>" +
-                    "<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='X'>" +
+                    "<Project ToolsVersion='X'>" +
                     "<Target Name='t'></Target>" +
                     "</Project>";
                 File.WriteAllText(pathToProjectFile, projectString);
@@ -806,7 +806,7 @@ namespace Microsoft.Build.UnitTests
         {
             string projectString =
                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
-                    "<Project ToolsVersion=\"4.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">" +
+                    "<Project ToolsVersion=\"4.0\">" +
                     "<Target Name=\"t\"><Message Text=\"[Hello]\"/></Target>" +
                     "</Project>";
             string tempdir = Path.GetTempPath();
@@ -1278,10 +1278,10 @@ namespace Microsoft.Build.UnitTests
 
         private void RunPriorityBuildTest(ProcessPriorityClass expectedPrority, params string[] arguments)
         {
-            string[] aggregateArguments = arguments.Union(new[] { " /nr:false /v:diag "}).ToArray();
+            string[] aggregateArguments = arguments.Union(new[] { " /nr:false /v:diag " }).ToArray();
 
             string contents = ObjectModelHelpers.CleanupFileContents(@"
-<Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Project DefaultTargets=""Build"">
  <Target Name=""Build"">
     <Message Text=""Task priority is '$([System.Diagnostics.Process]::GetCurrentProcess().PriorityClass)'""/>
  </Target>
@@ -1706,9 +1706,9 @@ namespace Microsoft.Build.UnitTests
                 RobustDelete(projectDirectory);
             }
         }
-#endregion
+        #endregion
 
-#region ProcessFileLoggerSwitches
+        #region ProcessFileLoggerSwitches
         /// <summary>
         /// Test the case where no file logger switches are given, should be no file loggers attached
         /// </summary>
@@ -1951,9 +1951,9 @@ namespace Microsoft.Build.UnitTests
             distributedLoggerRecords.Count.ShouldBe(0); // "Expected no distributed loggers to be attached"
             loggers.Count.ShouldBe(0); // "Expected no central loggers to be attached"
         }
-#endregion
+        #endregion
 
-#region ProcessConsoleLoggerSwitches
+        #region ProcessConsoleLoggerSwitches
         [Fact]
         public void ProcessConsoleLoggerSwitches()
         {
@@ -2001,14 +2001,14 @@ namespace Microsoft.Build.UnitTests
             distributedLogger.CentralLogger.Parameters.ShouldBe("SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;parameter;Parameter", StringCompareShould.IgnoreCase); // "Expected parameter in logger to match parameters passed in"
             distributedLogger.ForwardingLoggerDescription.LoggerSwitchParameters.ShouldBe("SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;Parameter;Parameter", StringCompareShould.IgnoreCase); // "Expected parameter in logger to match parameter passed in"
         }
-#endregion
+        #endregion
 
         [Fact]
         public void RestoreFirstReevaluatesImportGraph()
         {
             string guid = Guid.NewGuid().ToString("N");
 
-            string projectContents = ObjectModelHelpers.CleanupFileContents($@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+            string projectContents = ObjectModelHelpers.CleanupFileContents($@"<Project>
 
   <PropertyGroup>
     <RestoreFirstProps>{Guid.NewGuid():N}.props</RestoreFirstProps>
@@ -2023,7 +2023,7 @@ namespace Microsoft.Build.UnitTests
 
   <Target Name=""Restore"">
     <ItemGroup>
-      <Lines Include=""&lt;Project ToolsVersion=&quot;Current&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;&lt;PropertyGroup&gt;&lt;PropertyA&gt;{guid}&lt;/PropertyA&gt;&lt;/PropertyGroup&gt;&lt;/Project&gt;"" />
+      <Lines Include=""&lt;Project ToolsVersion=&quot;Current&quot;&gt;&lt;PropertyGroup&gt;&lt;PropertyA&gt;{guid}&lt;/PropertyA&gt;&lt;/PropertyGroup&gt;&lt;/Project&gt;"" />
     </ItemGroup>
 
     <WriteLinesToFile File=""$(RestoreFirstProps)"" Lines=""@(Lines)"" Overwrite=""true"" />
@@ -2043,7 +2043,7 @@ namespace Microsoft.Build.UnitTests
             string guid2 = Guid.NewGuid().ToString("N");
             string restoreFirstProps = $"{Guid.NewGuid():N}.props";
 
-            string projectContents = ObjectModelHelpers.CleanupFileContents($@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+            string projectContents = ObjectModelHelpers.CleanupFileContents($@"<Project>
 
   <PropertyGroup>
     <RestoreFirstProps>{restoreFirstProps}</RestoreFirstProps>
@@ -2059,7 +2059,7 @@ namespace Microsoft.Build.UnitTests
   <Target Name=""Restore"">
     <Message Text=""PropertyA's value is &quot;$(PropertyA)&quot;"" />
     <ItemGroup>
-      <Lines Include=""&lt;Project ToolsVersion=&quot;Current&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;&lt;PropertyGroup&gt;&lt;PropertyA&gt;{guid2}&lt;/PropertyA&gt;&lt;/PropertyGroup&gt;&lt;/Project&gt;"" />
+      <Lines Include=""&lt;Project ToolsVersion=&quot;Current&quot;&gt;&lt;PropertyGroup&gt;&lt;PropertyA&gt;{guid2}&lt;/PropertyA&gt;&lt;/PropertyGroup&gt;&lt;/Project&gt;"" />
     </ItemGroup>
 
     <WriteLinesToFile File=""$(RestoreFirstProps)"" Lines=""@(Lines)"" Overwrite=""true"" />
@@ -2069,7 +2069,7 @@ namespace Microsoft.Build.UnitTests
 
             IDictionary<string, string> preExistingProps = new Dictionary<string, string>
             {
-                { restoreFirstProps, $@"<Project ToolsVersion=""Current"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                { restoreFirstProps, $@"<Project ToolsVersion=""Current"">
   <PropertyGroup>
     <PropertyA>{guid1}</PropertyA>
   </PropertyGroup>
@@ -2090,7 +2090,7 @@ namespace Microsoft.Build.UnitTests
             string guid2 = Guid.NewGuid().ToString("N");
             string restoreFirstProps = $"{Guid.NewGuid():N}.props";
 
-            string projectContents = ObjectModelHelpers.CleanupFileContents($@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+            string projectContents = ObjectModelHelpers.CleanupFileContents($@"<Project>
 
   <PropertyGroup>
     <RestoreFirstProps>{restoreFirstProps}</RestoreFirstProps>
@@ -2106,7 +2106,7 @@ namespace Microsoft.Build.UnitTests
   <Target Name=""Restore"">
     <Message Text=""PropertyA's value is &quot;$(PropertyA)&quot;"" />
     <ItemGroup>
-      <Lines Include=""&lt;Project ToolsVersion=&quot;Current&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;&lt;PropertyGroup&gt;&lt;PropertyA&gt;{guid2}&lt;/PropertyA&gt;&lt;/PropertyGroup&gt;&lt;/Project&gt;"" />
+      <Lines Include=""&lt;Project ToolsVersion=&quot;Current&quot;&gt;&lt;PropertyGroup&gt;&lt;PropertyA&gt;{guid2}&lt;/PropertyA&gt;&lt;/PropertyGroup&gt;&lt;/Project&gt;"" />
     </ItemGroup>
 
     <WriteLinesToFile File=""$(RestoreFirstProps)"" Lines=""@(Lines)"" Overwrite=""true"" />
@@ -2116,7 +2116,7 @@ namespace Microsoft.Build.UnitTests
 
             IDictionary<string, string> preExistingProps = new Dictionary<string, string>
             {
-                { restoreFirstProps, $@"<Project ToolsVersion=""Current"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                { restoreFirstProps, $@"<Project ToolsVersion=""Current"">
   <PropertyGroup>
     <PropertyA>{guid1}</PropertyA>
   </PropertyGroup>
@@ -2180,7 +2180,7 @@ $@"<Project>
         [Fact]
         public void MultipleTargetsDoesNotCrash()
         {
-            string projectContents = ObjectModelHelpers.CleanupFileContents($@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+            string projectContents = ObjectModelHelpers.CleanupFileContents($@"<Project>
   <Target Name=""Target1"">
     <Message Text=""7514CB1641A948D0A3930C5EC2DC1940"" />
   </Target>
@@ -2225,7 +2225,7 @@ $@"<Project>
         [InlineData("/interactive /p:NuGetInteractive=true")]
         public void InteractiveSetsBuiltInProperty(string arguments)
         {
-            string projectContents = ObjectModelHelpers.CleanupFileContents(@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+            string projectContents = ObjectModelHelpers.CleanupFileContents(@"<Project>
 
   <Target Name=""Build"">
     <Message Text=""MSBuildInteractive = [$(MSBuildInteractive)]"" />
@@ -2245,7 +2245,7 @@ $@"<Project>
         public void BinaryLogContainsImportedFiles()
         {
             var testProject = _env.CreateFile("Importer.proj", ObjectModelHelpers.CleanupFileContents(@"
-            <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+            <Project>
                 <Import Project=""TestProject.proj"" />
 
                 <Target Name=""Build"">
@@ -2254,7 +2254,7 @@ $@"<Project>
             </Project>"));
 
             _env.CreateFile("TestProject.proj", @"
-            <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+            <Project>
               <Target Name=""Build"">
                 <Message Text=""Hello from TestProject!"" />
               </Target>
@@ -2317,7 +2317,7 @@ EndGlobal
 
             string testMessage = "Hello from TestProject!";
             _env.CreateFile("TestProject.proj", @$"
-            <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+            <Project>
               <Target Name=""Build"">
                 <Message Text=""{testMessage}"" />
               </Target>
@@ -2466,7 +2466,7 @@ EndGlobal
             }
         }
 
-        private string ExecuteMSBuildExeExpectSuccess(string projectContents, IDictionary<string, string> filesToCreate = null,  IDictionary<string, string> envsToCreate = null, params string[] arguments)
+        private string ExecuteMSBuildExeExpectSuccess(string projectContents, IDictionary<string, string> filesToCreate = null, IDictionary<string, string> envsToCreate = null, params string[] arguments)
         {
             (bool result, string output) = ExecuteMSBuildExe(projectContents, filesToCreate, envsToCreate, arguments);
 

--- a/src/Samples/MultiprocessBuild/1.csproj
+++ b/src/Samples/MultiprocessBuild/1.csproj
@@ -1,4 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
+<Project>
   <PropertyGroup>
     <AssemblyPath Condition="'$(AssemblyPath)' == ''">PortableTask.dll</AssemblyPath>
   </PropertyGroup>

--- a/src/Samples/MultiprocessBuild/2.csproj
+++ b/src/Samples/MultiprocessBuild/2.csproj
@@ -1,4 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
+<Project>
   <PropertyGroup>
     <AssemblyPath Condition="'$(AssemblyPath)' == ''">PortableTask.dll</AssemblyPath>
   </PropertyGroup>
@@ -8,4 +8,4 @@
     <Sleep Seconds="3" />
      <Message Importance="high" Text="## finishing 2 ##"/>
   </Target>
-</Project> 
+</Project>

--- a/src/Samples/MultiprocessBuild/root.proj
+++ b/src/Samples/MultiprocessBuild/root.proj
@@ -1,4 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
+<Project>
   <Target Name="t">
     <Message Importance="high" Text="## in root building children ##"/>
     <MSBuild Projects="1.csproj;2.csproj" BuildInParallel="true"/>

--- a/src/Samples/PortableTask/portableTaskTest.proj
+++ b/src/Samples/PortableTask/portableTaskTest.proj
@@ -1,9 +1,9 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
+<Project ToolsVersion="12.0" DefaultTargets="Build">
+
   <PropertyGroup>
     <AssemblyPath Condition="'$(AssemblyPath)' == ''">PortableTask.dll</AssemblyPath>
   </PropertyGroup>
-  
+
   <UsingTask TaskName="ShowItems" AssemblyFile="$(AssemblyPath)"/>
   <ItemGroup>
     <TestItems Include="$(MSBuildBinPath)\**\Microsoft.Build.*.dll"/>

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Build.UnitTests
                 {
                     return new Project(p, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, c)
                         .Items
-                        .Select(i => (TestItem) new ProjectItemTestItemAdapter(i))
+                        .Select(i => (TestItem)new ProjectItemTestItemAdapter(i))
                         .ToList();
                 },
             projectContents,
@@ -244,7 +244,7 @@ namespace Microsoft.Build.UnitTests
 
         internal static void AssertItems(string[] expectedItems, ICollection<ProjectItem> items, Dictionary<string, string> expectedDirectMetadata = null, bool normalizeSlashes = false)
         {
-            var converteditems = items.Select(i => (TestItem) new ProjectItemTestItemAdapter(i)).ToList();
+            var converteditems = items.Select(i => (TestItem)new ProjectItemTestItemAdapter(i)).ToList();
             AssertItems(expectedItems, converteditems, expectedDirectMetadata, normalizeSlashes);
         }
 
@@ -271,7 +271,7 @@ namespace Microsoft.Build.UnitTests
 
         public static void AssertItems(string[] expectedItems, IList<ProjectItem> items, Dictionary<string, string>[] expectedDirectMetadataPerItem, bool normalizeSlashes = false)
         {
-            var convertedItems = items.Select(i => (TestItem) new ProjectItemTestItemAdapter(i)).ToList();
+            var convertedItems = items.Select(i => (TestItem)new ProjectItemTestItemAdapter(i)).ToList();
             AssertItems(expectedItems, convertedItems, expectedDirectMetadataPerItem, normalizeSlashes);
         }
 
@@ -716,7 +716,7 @@ namespace Microsoft.Build.UnitTests
             string toolsVersion /* may be null */
             )
         {
-            XmlReaderSettings readerSettings = new XmlReaderSettings {DtdProcessing = DtdProcessing.Ignore};
+            XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
 
             Project project = new Project
                 (
@@ -1102,7 +1102,7 @@ namespace Microsoft.Build.UnitTests
         {
             return
                 $@"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Project>
                         <ItemGroup>
                             {fragment}
                         </ItemGroup>
@@ -1384,8 +1384,8 @@ namespace Microsoft.Build.UnitTests
                 if (logger != null)
                 {
                     parameters.Loggers = parameters.Loggers == null
-                        ? new[] {logger}
-                        : parameters.Loggers.Concat(new[] {logger});
+                        ? new[] { logger }
+                        : parameters.Loggers.Concat(new[] { logger });
                 }
 
                 var request = new BuildRequestData(
@@ -1585,7 +1585,7 @@ namespace Microsoft.Build.UnitTests
 
             sb.Append("</ItemGroup>");
 
-            
+
             foreach (var defaultTarget in (defaultTargets ?? string.Empty).Split(MSBuildConstants.SemicolonChar, StringSplitOptions.RemoveEmptyEntries))
             {
                 sb.Append("<Target Name='").Append(defaultTarget).Append("'/>");
@@ -1783,7 +1783,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         internal static void VerifyAssertLineByLine(string expected, string actual, bool ignoreFirstLineOfActual, ITestOutputHelper testOutput = null)
         {
-            Action<string> LogLine = testOutput == null ? (Action<string>) Console.WriteLine : testOutput.WriteLine;
+            Action<string> LogLine = testOutput == null ? (Action<string>)Console.WriteLine : testOutput.WriteLine;
 
             string[] actualLines = SplitIntoLines(actual);
 
@@ -1934,7 +1934,7 @@ namespace Microsoft.Build.UnitTests
                 _env = env;
 
                 Logger = new MockLogger(_env.Output);
-                var loggers = new[] {Logger};
+                var loggers = new[] { Logger };
 
                 var actualBuildParameters = buildParameters ?? new BuildParameters();
 

--- a/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
+++ b/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Build.UnitTests
         public void BuildTaskSimpleCodeFactory()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactory` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -48,17 +48,17 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// Test the simple case where we have a string parameter and we want to log that.
-        /// Specifically testing that even when the ToolsVersion is post-4.0, and thus 
-        /// Microsoft.Build.Tasks.v4.0.dll is expected to NOT be in MSBuildToolsPath, that 
+        /// Specifically testing that even when the ToolsVersion is post-4.0, and thus
+        /// Microsoft.Build.Tasks.v4.0.dll is expected to NOT be in MSBuildToolsPath, that
         /// we will redirect under the covers to use the current tasks instead.
         /// </summary>
         [Fact]
         public void BuildTaskSimpleCodeFactory_RedirectFrom4()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactory` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -79,17 +79,17 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// Test the simple case where we have a string parameter and we want to log that.
-        /// Specifically testing that even when the ToolsVersion is post-12.0, and thus 
-        /// Microsoft.Build.Tasks.v12.0.dll is expected to NOT be in MSBuildToolsPath, that 
+        /// Specifically testing that even when the ToolsVersion is post-12.0, and thus
+        /// Microsoft.Build.Tasks.v12.0.dll is expected to NOT be in MSBuildToolsPath, that
         /// we will redirect under the covers to use the current tasks instead.
         /// </summary>
         [Fact]
         public void BuildTaskSimpleCodeFactory_RedirectFrom12()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactory` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -111,17 +111,17 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Test the simple case where we have a string parameter and we want to log that.
         /// Specifically testing that even when the ToolsVersion is post-4.0, and we have redirection
-        /// logic in place for the AssemblyFile case to deal with Microsoft.Build.Tasks.v4.0.dll not 
-        /// being in MSBuildToolsPath anymore, that this does NOT affect full fusion AssemblyNames -- 
-        /// it's picked up from the GAC, where it is anyway, so there's no need to redirect. 
+        /// logic in place for the AssemblyFile case to deal with Microsoft.Build.Tasks.v4.0.dll not
+        /// being in MSBuildToolsPath anymore, that this does NOT affect full fusion AssemblyNames --
+        /// it's picked up from the GAC, where it is anyway, so there's no need to redirect.
         /// </summary>
         [Fact]
         public void BuildTaskSimpleCodeFactory_NoAssemblyNameRedirect()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactory` TaskFactory=`CodeTaskFactory` AssemblyName=`Microsoft.Build.Tasks.Core, Version=15.1.0.0` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -147,9 +147,9 @@ namespace Microsoft.Build.UnitTests
         public void VerifyRequiredAttribute()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_VerifyRequiredAttribute` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text Required='true'/>
                           </ParameterGroup>
                             <Task>
@@ -174,9 +174,9 @@ namespace Microsoft.Build.UnitTests
         public void RuntimeException()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_RuntimeException` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -203,9 +203,9 @@ namespace Microsoft.Build.UnitTests
         public void EmptyLanguage()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_EmptyLanguage` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -232,9 +232,9 @@ namespace Microsoft.Build.UnitTests
         public void EmptyType()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_EmptyType` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -261,9 +261,9 @@ namespace Microsoft.Build.UnitTests
         public void EmptySource()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_EmptySource` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -290,9 +290,9 @@ namespace Microsoft.Build.UnitTests
         public void EmptyReferenceInclude()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_EmptyReferenceInclude` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -320,9 +320,9 @@ namespace Microsoft.Build.UnitTests
         public void EmptyUsingNamespace()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_EmptyUsingNamespace` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -349,9 +349,9 @@ namespace Microsoft.Build.UnitTests
         public void ReferenceNotPath()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_ReferenceNotPath` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -378,9 +378,9 @@ namespace Microsoft.Build.UnitTests
         public void ReferenceInvalidChars()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_ReferenceInvalidChars` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -408,9 +408,9 @@ namespace Microsoft.Build.UnitTests
         public void UsingInvalidChars()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_UsingInvalidChars` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -438,9 +438,9 @@ namespace Microsoft.Build.UnitTests
             string tempFileName = "Moose_" + Guid.NewGuid().ToString() + ".cs";
 
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_SourcesInvalidFile` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -466,9 +466,9 @@ namespace Microsoft.Build.UnitTests
         public void MissingCodeElement()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_MissingCodeElement` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -490,9 +490,9 @@ namespace Microsoft.Build.UnitTests
         public void BuildTaskSimpleCodeFactoryTestExtraUsing()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactoryTestExtraUsing` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -520,7 +520,7 @@ namespace Microsoft.Build.UnitTests
         public void BuildTaskDateCodeFactory()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`DateTaskFromCodeFactory_BuildTaskDateCodeFactory` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                             <ParameterGroup>
                                <CurrentDate ParameterType=`System.String` Output=`true` />
@@ -551,7 +551,7 @@ namespace Microsoft.Build.UnitTests
         public void MethodImplmentationVB()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CodeMethod_MethodImplmentationVB` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                         <ParameterGroup>
                             <Text ParameterType='System.String' />
@@ -583,9 +583,9 @@ namespace Microsoft.Build.UnitTests
         public void BuildTaskSimpleCodeFactoryTestSystemVB()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactoryTestSystemVB` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -612,9 +612,9 @@ namespace Microsoft.Build.UnitTests
         public void BuildTaskSimpleCodeFactoryTestSystemCS()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactoryTestSystemCS` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -634,7 +634,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Make sure we can pass in extra references than the automatic ones. For example the c# compiler does not pass in 
+        /// Make sure we can pass in extra references than the automatic ones. For example the c# compiler does not pass in
         /// system.dll. So lets test that case
         /// </summary>
         [Fact]
@@ -656,9 +656,9 @@ namespace Microsoft.Build.UnitTests
             }
 
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactoryTestExtraReferenceCS` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -693,7 +693,7 @@ namespace Microsoft.Build.UnitTests
             }
 
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CodeMethod_MethodImplementationJScriptNet` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                         <ParameterGroup>
                             <Text ParameterType='System.String' />
@@ -726,7 +726,7 @@ namespace Microsoft.Build.UnitTests
         public void MethodImplementation()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CodeMethod_MethodImplementation` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                         <ParameterGroup>
                             <Text ParameterType='System.String' />
@@ -759,7 +759,7 @@ namespace Microsoft.Build.UnitTests
         public void ClassImplementationTest()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`LogNameValue_ClassImplementationTest` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                         <ParameterGroup>
                             <Name ParameterType='System.String' />
@@ -825,7 +825,7 @@ namespace Microsoft.Build.UnitTests
         public void ClassImplementationTestDoesNotInheritFromITask()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`ClassImplementationTestDoesNotInheritFromITask` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                         <ParameterGroup>
                             <Name ParameterType='System.String' />
@@ -883,9 +883,9 @@ namespace Microsoft.Build.UnitTests
         public void MultipleCodeElements()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_EmptyType` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -915,9 +915,9 @@ namespace Microsoft.Build.UnitTests
         public void ReferenceNestedInCode()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_EmptyType` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -949,9 +949,9 @@ namespace Microsoft.Build.UnitTests
         public void UnknownElementInTask()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_EmptyType` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -1025,7 +1025,7 @@ namespace Microsoft.Build.UnitTests
             try
             {
                 string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`LogNameValue_ClassSourcesTest` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                         <ParameterGroup>
                             <Name ParameterType='System.String' />
@@ -1061,9 +1061,9 @@ namespace Microsoft.Build.UnitTests
         public void BuildTaskSimpleCodeFactoryTempDirectoryDoesntExist()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactory` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -1111,9 +1111,9 @@ namespace Microsoft.Build.UnitTests
         public void RedundantMSBuildReferences()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_RedundantMSBuildReferences` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
@@ -1141,9 +1141,9 @@ namespace Microsoft.Build.UnitTests
         public void CodeTaskFactoryNotSupported()
         {
             string projectFileContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactory` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>

--- a/src/Tasks.UnitTests/DirectoryBuildProjectImportTestBase.cs
+++ b/src/Tasks.UnitTests/DirectoryBuildProjectImportTestBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.UnitTests
     abstract public class DirectoryBuildProjectImportTestBase : IDisposable
     {
         private const string BasicDirectoryBuildProjectContents = @"
-                <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project>
                     <PropertyGroup>
                         <WasDirectoryBuildProjectImported>true</WasDirectoryBuildProjectImported>
                     </PropertyGroup>
@@ -75,7 +75,7 @@ namespace Microsoft.Build.UnitTests
             // ---------------------
 
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
 
                     <Import Project=`$(MSBuildBinPath)\Microsoft.CSharp.targets` />
@@ -104,7 +104,7 @@ namespace Microsoft.Build.UnitTests
             // ---------------------
 
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, $@"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <{ImportDirectoryBuildProjectPropertyName}>false</{ImportDirectoryBuildProjectPropertyName}>
                     </PropertyGroup>
@@ -135,7 +135,7 @@ namespace Microsoft.Build.UnitTests
             // ---------------------
 
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, $@"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <{DirectoryBuildProjectPathPropertyName}>{customFilePath}</{DirectoryBuildProjectPathPropertyName}>
                     </PropertyGroup>
@@ -163,7 +163,7 @@ namespace Microsoft.Build.UnitTests
             // ---------------------
 
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
 
                     <Import Project=`$(MSBuildBinPath)\Microsoft.CSharp.targets` />

--- a/src/Tasks.UnitTests/NuGetPropsImportTests.cs
+++ b/src/Tasks.UnitTests/NuGetPropsImportTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.UnitTests
     public sealed class NuGetPropsImportTests : IDisposable
     {
         private const string NuGetPropsContent = @"
-                <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project>
                     <PropertyGroup>
                         <NuGetPropsIsImported>true</NuGetPropsIsImported>
                     </PropertyGroup>
@@ -43,7 +43,7 @@ namespace Microsoft.Build.UnitTests
             // src\Foo\Foo.csproj
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory(projectRelativePath, $@"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <{NuGetPropsPropertyName}>{nugetPropsRelativePath}</{NuGetPropsPropertyName}>
                     </PropertyGroup>
@@ -69,7 +69,7 @@ namespace Microsoft.Build.UnitTests
             // src\Foo\Foo.csproj
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory(projectRelativePath, $@"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <{NuGetPropsPropertyName}>{nugetPropsRelativePath}</{NuGetPropsPropertyName}>
                     </PropertyGroup>

--- a/src/Tasks.UnitTests/ProjectExtensionsImportTestBase.cs
+++ b/src/Tasks.UnitTests/ProjectExtensionsImportTestBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         protected virtual string BasicProjectImportContents => $@"
-            <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+            <Project>
                 <PropertyGroup>
                 <{PropertyNameToSignalImportSucceeded}>true</{PropertyNameToSignalImportSucceeded}>
                 </PropertyGroup>
@@ -52,7 +52,7 @@ namespace Microsoft.Build.UnitTests
             // ---------------------
 
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
 
                     <Import Project=`$(MSBuildBinPath)\Microsoft.CSharp.targets` />
@@ -83,7 +83,7 @@ namespace Microsoft.Build.UnitTests
             // ---------------------
 
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, $@"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <{PropertyNameToEnableImport}>false</{PropertyNameToEnableImport}>
                     </PropertyGroup>
@@ -115,7 +115,7 @@ namespace Microsoft.Build.UnitTests
             // ---------------------
 
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, $@"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <PropertyGroup>
                         <MSBuildProjectExtensionsPath>{Path.GetDirectoryName(CustomImportProjectPath)}</MSBuildProjectExtensionsPath>
                     </PropertyGroup>
@@ -142,7 +142,7 @@ namespace Microsoft.Build.UnitTests
             // ---------------------
 
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
 
                     <Import Project=`$(MSBuildBinPath)\Microsoft.CSharp.targets` />
@@ -160,7 +160,7 @@ namespace Microsoft.Build.UnitTests
         public void ErrorIfChangedInBodyOfProject()
         {
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
 
                     <PropertyGroup>
@@ -173,20 +173,20 @@ namespace Microsoft.Build.UnitTests
 
             MockLogger logger = new MockLogger();
 
-            project.Build("_CheckForInvalidConfigurationAndPlatform", new[] {logger}).ShouldBeFalse();
+            project.Build("_CheckForInvalidConfigurationAndPlatform", new[] { logger }).ShouldBeFalse();
 
             logger.Errors.Select(i => i.Code).FirstOrDefault().ShouldBe("MSB3540");
         }
 
         /// <summary>
-        /// Ensures that an error is logged if BaseIntermediateOutputPath is modified after it was set by Microsoft.Common.props and 
+        /// Ensures that an error is logged if BaseIntermediateOutputPath is modified after it was set by Microsoft.Common.props and
         /// EnableBaseIntermediateOutputPathMismatchWarning is 'true'.
         /// </summary>
         [Fact]
         public void WarningIfBaseIntermediateOutputPathIsChangedInBodyOfProject()
         {
             Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, @"
-                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion`>
                     <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
 
                     <PropertyGroup>

--- a/src/Tasks.UnitTests/XamlDataDrivenToolTask_Tests.cs
+++ b/src/Tasks.UnitTests/XamlDataDrivenToolTask_Tests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         }
 
         /// <summary>
-        /// Tests the basic string array type 
+        /// Tests the basic string array type
         /// </summary>
         [Fact]
         [Trait("Category", "mono-osx-failing")]
@@ -104,7 +104,7 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         }
 
         /// <summary>
-        /// Tests the basic string array type, with an array that contains multiple values. 
+        /// Tests the basic string array type, with an array that contains multiple values.
         /// </summary>
         [Fact]
         [Trait("Category", "mono-osx-failing")]
@@ -226,9 +226,9 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         }
 
         /// <summary>
-        /// XamlTaskFactory does not, in and of itself, support the idea of "always" switches or default values.  At least 
-        /// for Dev10, the workaround is to create a property as usual, and then specify the required values in the .props 
-        /// file.  Since these unit tests are just testing the task itself, this method serves as our ".props file".  
+        /// XamlTaskFactory does not, in and of itself, support the idea of "always" switches or default values.  At least
+        /// for Dev10, the workaround is to create a property as usual, and then specify the required values in the .props
+        /// file.  Since these unit tests are just testing the task itself, this method serves as our ".props file".
         /// </summary>
         public object CreateFakeTask()
         {
@@ -242,19 +242,19 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
     }
 
     /// <summary>
-    /// Tests for XamlDataDrivenToolTask / XamlTaskFactory in the context of a project file.  
+    /// Tests for XamlDataDrivenToolTask / XamlTaskFactory in the context of a project file.
     /// </summary>
     public class ProjectFileTests
     {
         /// <summary>
-        /// Tests that when a call to a XamlDataDrivenTask fails, the commandline is reported in the error message. 
+        /// Tests that when a call to a XamlDataDrivenTask fails, the commandline is reported in the error message.
         /// </summary>
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         public void CommandLineErrorsReportFullCommandlineAmpersandTemp()
         {
             string projectFile = @"
-                      <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                      <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory`>
                         <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyName=`Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`>
                           <Task>
                             <![CDATA[
@@ -301,14 +301,14 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
 
 
         /// <summary>
-        /// Tests that when a call to a XamlDataDrivenTask fails, the commandline is reported in the error message. 
+        /// Tests that when a call to a XamlDataDrivenTask fails, the commandline is reported in the error message.
         /// </summary>
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         public void CommandLineErrorsReportFullCommandline()
         {
             string projectFile = @"
-                      <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                      <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory`>
                         <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyName=`Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`>
                           <Task>
                             <![CDATA[
@@ -338,14 +338,14 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         }
 
         /// <summary>
-        /// Tests that when a call to a XamlDataDrivenTask fails, the commandline is reported in the error message. 
+        /// Tests that when a call to a XamlDataDrivenTask fails, the commandline is reported in the error message.
         /// </summary>
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         public void SquareBracketEscaping()
         {
             string projectFile = @"
-                      <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                      <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory`>
                         <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyName=`Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`>
                           <Task>
                             <![CDATA[

--- a/src/Tasks.UnitTests/XmlPeek_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPeek_Tests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.UnitTests
 ";
 
         private string _xmlFileNoNsNoDtd = @"<?xml version='1.0' encoding='utf-8'?>
-        
+
 <class AccessModifier='public' Name='test'>
   <variable Type='String' Name='a'></variable>
   <variable Type='String' Name='b'></variable>
@@ -303,7 +303,7 @@ namespace Microsoft.Build.UnitTests
         public void PeekWithoutUsingTask()
         {
             string projectContents = @"
-<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Project ToolsVersion='msbuilddefaulttoolsversion'>
   <Target Name='x'>
     <XmlPeek Query='abc' ContinueOnError='true' />
   </Target>

--- a/src/Tasks.UnitTests/XmlPoke_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPoke_Tests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.UnitTests
         private const string XmlNamespaceUsedByTests = "http://nsurl";
 
         private const string _xmlFileWithNs = @"<?xml version='1.0' encoding='utf-8'?>
-        
+
 <class AccessModifier='public' Name='test' xmlns:s='" + XmlNamespaceUsedByTests + @"'>
   <s:variable Type='String' Name='a'></s:variable>
   <s:variable Type='String' Name='b'></s:variable>
@@ -29,7 +29,7 @@ namespace Microsoft.Build.UnitTests
 </class>";
 
         private const string _xmlFileNoNs = @"<?xml version='1.0' encoding='utf-8'?>
-        
+
 <class AccessModifier='public' Name='test'>
   <variable Type='String' Name='a'></variable>
   <variable Type='String' Name='b'></variable>
@@ -273,16 +273,16 @@ namespace Microsoft.Build.UnitTests
         public void PokeWithoutUsingTask()
         {
             string projectContents = @"
-<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Project ToolsVersion='msbuilddefaulttoolsversion'>
   <Target Name='x'>
     <XmlPoke Value='abc' Query='def' XmlInputPath='ghi.jkl' ContinueOnError='true' />
   </Target>
 </Project>";
 
-            // The task will error, but ContinueOnError means that it will just be a warning.  
+            // The task will error, but ContinueOnError means that it will just be a warning.
             MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(projectContents);
 
-            // Verify that the task was indeed found. 
+            // Verify that the task was indeed found.
             logger.AssertLogDoesntContain("MSB4036");
         }
 

--- a/src/Tasks/Microsoft.CSharp.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.CSharp.CrossTargeting.targets
@@ -10,7 +10,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
   <!-- Import design time targets before the common crosstargeting targets, which import targets from Nuget. -->

--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -15,7 +15,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
     <PropertyGroup>
        <ImportByWildcardBeforeMicrosoftCSharpTargets Condition="'$(ImportByWildcardBeforeMicrosoftCSharpTargets)' == ''">true</ImportByWildcardBeforeMicrosoftCSharpTargets>

--- a/src/Tasks/Microsoft.CSharp.targets
+++ b/src/Tasks/Microsoft.CSharp.targets
@@ -15,7 +15,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
    <Choose>
       <When Condition="'$(IsCrossTargetingBuild)' == 'true'">

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -10,7 +10,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build">
 
   <PropertyGroup>
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -14,7 +14,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project DefaultTargets="Build" TreatAsLocalProperty="OutDir" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" TreatAsLocalProperty="OutDir">
 
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(MicrosoftCommonPropsHasBeenImported)' != 'true' and Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
 
@@ -1610,8 +1610,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ====================================================================================
                                         _GetProjectReferencePlatformProperties
 
-    If a project is opted in via $(EnableDynamicPlatformResolution), this target calls the 
-    GetCompatiblePlatform task on all ProjectReference items to determine the most compatible 
+    If a project is opted in via $(EnableDynamicPlatformResolution), this target calls the
+    GetCompatiblePlatform task on all ProjectReference items to determine the most compatible
     platform for each project. It then sets SetPlatform metadata on each ProjectReference.
     This prevents overbuilding a project when 'AnyCPU' is available.
 
@@ -1637,7 +1637,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup>
-      <_ProjectReferencePlatformPossibilities Include="@(_MSBuildProjectReferenceExistent)" 
+      <_ProjectReferencePlatformPossibilities Include="@(_MSBuildProjectReferenceExistent)"
                                               Condition="'%(_MSBuildProjectReferenceExistent.SkipGetPlatformProperties)' != 'true'"/>
     </ItemGroup>
 
@@ -1737,7 +1737,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    -->
    <ItemGroup>
       <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' == '' and ('%(Extension)' == '.vcxproj' or '%(Extension)' == '.nativeproj')">
-        <!-- 
+        <!--
           Platform negotiation requires the MSBuild task call to GetTargetFrameworks.
           Don't skip when opted into the feature.
         -->
@@ -1759,7 +1759,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
     <ItemGroup>
       <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SetTargetFramework)' != ''">
-        <!-- 
+        <!--
           Platform negotiation requires the MSBuild task call to GetTargetFrameworks.
           Don't skip when opted into the feature.
         -->
@@ -1828,7 +1828,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             https://github.com/dotnet/sdk/issues/416
 
         Furthermore, if we're referencing a .vcxproj or .nativeproj, those items won't be populated into `AnnotatedProjects`
-        by `GetReferenceNearestTargetFrameworkTask`, so let them flow when `EnableDynamicPlatformResolution` is set. 
+        by `GetReferenceNearestTargetFrameworkTask`, so let them flow when `EnableDynamicPlatformResolution` is set.
       -->
       <AnnotatedProjects Include="@(_ProjectReferenceTargetFrameworkPossibilities)"
                          Condition="'$(ReferringTargetFrameworkForProjectReferences)' == '' or

--- a/src/Tasks/Microsoft.Common.overridetasks
+++ b/src/Tasks/Microsoft.Common.overridetasks
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
     <!-- This file lists UsingTask elements that we wish to override
          any other UsingTask elements -->

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -10,7 +10,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <PropertyGroup>
     <ImportByWildcardBeforeMicrosoftCommonProps Condition="'$(ImportByWildcardBeforeMicrosoftCommonProps)' == ''">true</ImportByWildcardBeforeMicrosoftCommonProps>

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -14,7 +14,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build">
 
   <PropertyGroup>
     <CommonTargetsPath>$(MSBuildToolsPath)\Microsoft.Common.CurrentVersion.targets</CommonTargetsPath>

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
     <!-- This file lists all the tasks that ship by default with MSBuild -->
 

--- a/src/Tasks/Microsoft.Data.Entity.targets
+++ b/src/Tasks/Microsoft.Data.Entity.targets
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory

--- a/src/Tasks/Microsoft.NET.props
+++ b/src/Tasks/Microsoft.NET.props
@@ -13,7 +13,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <!--
     ============================================================

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
@@ -13,7 +13,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <PropertyGroup>
      <ImportByWildcardBeforeMicrosoftNetFrameworkProps Condition="'$(ImportByWildcardBeforeMicrosoftNetFrameworkProps)' == ''">true</ImportByWildcardBeforeMicrosoftNetFrameworkProps>

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
@@ -13,7 +13,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <PropertyGroup>
      <ImportByWildcardBeforeMicrosoftNetFrameworkTargets Condition="'$(ImportByWildcardBeforeMicrosoftNetFrameworkTargets)' == ''">true</ImportByWildcardBeforeMicrosoftNetFrameworkTargets>

--- a/src/Tasks/Microsoft.NETFramework.props
+++ b/src/Tasks/Microsoft.NETFramework.props
@@ -13,7 +13,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build">
 
   <PropertyGroup>
     <NetFrameworkPropsPath>$(MSBuildToolsPath)\Microsoft.NETFramework.CurrentVersion.props</NetFrameworkPropsPath>

--- a/src/Tasks/Microsoft.NETFramework.targets
+++ b/src/Tasks/Microsoft.NETFramework.targets
@@ -13,7 +13,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build">
 
     <PropertyGroup>
       <NetFrameworkTargetsPath>$(MSBuildToolsPath)\Microsoft.NETFramework.CurrentVersion.targets</NetFrameworkTargetsPath>

--- a/src/Tasks/Microsoft.ServiceModel.targets
+++ b/src/Tasks/Microsoft.ServiceModel.targets
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory

--- a/src/Tasks/Microsoft.VisualBasic.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CrossTargeting.targets
@@ -10,7 +10,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
   <!-- Import design time targets before the common crosstargeting targets, which import targets from Nuget. -->

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -15,7 +15,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
     <PropertyGroup>
        <ImportByWildcardBeforeMicrosoftVisualBasicTargets Condition="'$(ImportByWildcardBeforeMicrosoftVisualBasicTargets)' == ''">true</ImportByWildcardBeforeMicrosoftVisualBasicTargets>

--- a/src/Tasks/Microsoft.VisualBasic.targets
+++ b/src/Tasks/Microsoft.VisualBasic.targets
@@ -16,7 +16,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <Choose>
     <When Condition="'$(IsCrossTargetingBuild)' == 'true'">

--- a/src/Tasks/Microsoft.WinFx.targets
+++ b/src/Tasks/Microsoft.WinFx.targets
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory

--- a/src/Tasks/Microsoft.WorkflowBuildExtensions.targets
+++ b/src/Tasks/Microsoft.WorkflowBuildExtensions.targets
@@ -10,7 +10,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory

--- a/src/Tasks/Microsoft.Xaml.targets
+++ b/src/Tasks/Microsoft.Xaml.targets
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory

--- a/src/Tasks/Workflow.VisualBasic.targets
+++ b/src/Tasks/Workflow.VisualBasic.targets
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory

--- a/src/Tasks/Workflow.targets
+++ b/src/Tasks/Workflow.targets
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
    <!--
         With MSBuild 12, we've changed MSBuildToolsPath to for the first time point to a directory

--- a/src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj
+++ b/src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build">
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{E1ADB824-2B34-4920-953F-746DFD6DB3C1}</ProjectGuid>

--- a/src/Utilities.UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities.UnitTests/ToolLocationHelper_Tests.cs
@@ -761,13 +761,13 @@ namespace Microsoft.Build.UnitTests
             // Test out of range .net version.
             foreach (var vsVersion in EnumVisualStudioVersions())
             {
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey((TargetDotNetFrameworkVersion)99, vsVersion) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey((TargetDotNetFrameworkVersion)99, vsVersion));
             }
 
             // Test out of range visual studio version.
             foreach (var dotNetVersion in EnumDotNetFrameworkVersions())
             {
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(dotNetVersion, (VisualStudioVersion)99) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(dotNetVersion, (VisualStudioVersion)99));
             }
 
             foreach (var vsVersion in EnumVisualStudioVersions())
@@ -779,7 +779,7 @@ namespace Microsoft.Build.UnitTests
                 ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version20, vsVersion).ShouldBe(FrameworkLocationHelper.fullDotNetFrameworkRegistryKey);
 
                 // v3.0
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version30, vsVersion) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version30, vsVersion));
 
                 // v3.5
                 ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version35, vsVersion).ShouldBe(
@@ -810,39 +810,39 @@ namespace Microsoft.Build.UnitTests
             ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version45, VisualStudioVersion.Version140).ShouldBe(fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK46);
 
             // v4.5.1
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version110) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version110));
             ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version120).ShouldBe(fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK81A);
             ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version140).ShouldBe(fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK46);
 
             // v4.5.2
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version452, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version452, VisualStudioVersion.Version110) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version452, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version452, VisualStudioVersion.Version110));
             ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version452, VisualStudioVersion.Version120).ShouldBe(fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK81A);
             ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version452, VisualStudioVersion.Version140).ShouldBe(fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK46);
 
             // v4.6
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version110) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version120) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version110));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version120));
             ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version140).ShouldBe(fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK46);
 
             // v4.6.1
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version461, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version461, VisualStudioVersion.Version110) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version461, VisualStudioVersion.Version120) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version461, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version461, VisualStudioVersion.Version110));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version461, VisualStudioVersion.Version120));
             ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version461, VisualStudioVersion.Version140).ShouldBe(fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK461);
 
             // v4.6.2
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version110) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version120) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version110));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version120));
             ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version150).ShouldBe(fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK462);
 
             // v4.7
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version110) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version120) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version110));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version120));
             ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version150).ShouldBe(fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK47);
 
             // v4.7.1
@@ -874,13 +874,13 @@ namespace Microsoft.Build.UnitTests
             // Test out of range .net version.
             foreach (var vsVersion in EnumVisualStudioVersions())
             {
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue((TargetDotNetFrameworkVersion)99, vsVersion) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue((TargetDotNetFrameworkVersion)99, vsVersion));
             }
 
             // Test out of range visual studio version.
             foreach (var dotNetVersion in EnumDotNetFrameworkVersions())
             {
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(dotNetVersion, (VisualStudioVersion)99) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(dotNetVersion, (VisualStudioVersion)99));
             }
 
             string InstallationFolder = "InstallationFolder";
@@ -894,7 +894,7 @@ namespace Microsoft.Build.UnitTests
                 ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version20, vsVersion).ShouldBe(FrameworkLocationHelper.dotNetFrameworkSdkInstallKeyValueV20);
 
                 // v3.0
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version30, vsVersion) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version30, vsVersion));
 
                 // v3.5
                 ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version35, vsVersion).ShouldBe(InstallationFolder);
@@ -907,15 +907,15 @@ namespace Microsoft.Build.UnitTests
             }
 
             // v4.5.1
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version110) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version110));
             ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version120).ShouldBe(InstallationFolder);
             ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version140).ShouldBe(InstallationFolder);
 
             // v4.6
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version110) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version120) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version110));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version120));
             ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version140).ShouldBe(InstallationFolder);
         }
 
@@ -930,13 +930,13 @@ namespace Microsoft.Build.UnitTests
             // Test out of range .net version.
             foreach (var vsVersion in EnumVisualStudioVersions())
             {
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToDotNetFrameworkSdk((TargetDotNetFrameworkVersion)99, vsVersion) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToDotNetFrameworkSdk((TargetDotNetFrameworkVersion)99, vsVersion));
             }
 
             // Test out of range visual studio version.
             foreach (var dotNetVersion in EnumDotNetFrameworkVersions())
             {
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToDotNetFrameworkSdk(dotNetVersion, (VisualStudioVersion)99) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToDotNetFrameworkSdk(dotNetVersion, (VisualStudioVersion)99));
             }
 
             string pathToSdk35InstallRoot = Path.Combine(FrameworkLocationHelper.programFiles32, @"Microsoft SDKs\Windows\v7.0A\");
@@ -970,7 +970,7 @@ namespace Microsoft.Build.UnitTests
                 ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version20, vsVersion).ShouldBe(FrameworkLocationHelper.PathToDotNetFrameworkSdkV20);
 
                 // v3.0
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version30, vsVersion) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version30, vsVersion));
 
                 // v3.5
                 ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version35, vsVersion).ShouldBe(pathToSdk35InstallRoot);
@@ -989,15 +989,15 @@ namespace Microsoft.Build.UnitTests
             ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version45, VisualStudioVersion.Version140).ShouldBe(pathToSdkV4InstallRootOnVS14);
 
             // v4.5.1
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version110) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version110));
             ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version120).ShouldBe(pathToSdkV4InstallRootOnVS12);
             ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version451, VisualStudioVersion.Version140).ShouldBe(pathToSdkV4InstallRootOnVS14);
 
             // v4.6
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version100) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version110) );
-            Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version120) );
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version100));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version110));
+            Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version120));
             ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version46, VisualStudioVersion.Version140).ShouldBe(pathToSdkV4InstallRootOnVS14);
         }
 
@@ -1010,7 +1010,7 @@ namespace Microsoft.Build.UnitTests
             // Test out of range .net version.
             foreach (var vsVersion in EnumVisualStudioVersions())
             {
-                Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToWindowsSdk((TargetDotNetFrameworkVersion)99, vsVersion) );
+                Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToWindowsSdk((TargetDotNetFrameworkVersion)99, vsVersion));
             }
 
             string pathToWindowsSdkV80 = GetRegistryValueHelper(RegistryHive.LocalMachine, RegistryView.Registry32, @"SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0", "InstallationFolder");
@@ -1021,7 +1021,7 @@ namespace Microsoft.Build.UnitTests
                 // v1.1, v2.0, v3.0, v3.5, v4.0
                 foreach (var dotNetVersion in EnumDotNetFrameworkVersions().Where(v => v <= TargetDotNetFrameworkVersion.Version40))
                 {
-                    Should.Throw<ArgumentException>( () => ToolLocationHelper.GetPathToWindowsSdk(dotNetVersion, vsVersion) );
+                    Should.Throw<ArgumentException>(() => ToolLocationHelper.GetPathToWindowsSdk(dotNetVersion, vsVersion));
                 }
 
                 // v4.5
@@ -1098,7 +1098,7 @@ namespace Microsoft.Build.UnitTests
             string projectContents = ObjectModelHelpers.CleanupFileContents(@"
                     <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
                         <UsingTask TaskName='VerifySdkPaths' TaskFactory='CodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll' >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Sdk35ToolsPath />
                              <Sdk40ToolsPath />
                              <WindowsSDK80Path />
@@ -1151,9 +1151,9 @@ namespace Microsoft.Build.UnitTests
         public void VerifyToolsetAndToolLocationHelperAgreeWhenVisualStudioVersionIsEmpty()
         {
             string projectContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='4.0'>
+                    <Project ToolsVersion='4.0'>
                         <UsingTask TaskName='VerifySdkPaths' TaskFactory='CodeTaskFactory' AssemblyName='Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Sdk35ToolsPath />
                              <Sdk40ToolsPath />
                              <WindowsSDK80Path />
@@ -1193,9 +1193,9 @@ namespace Microsoft.Build.UnitTests
         public void VerifyToolsetAndToolLocationHelperAgreeWhenVisualStudioVersionIs10()
         {
             string projectContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='4.0'>
+                    <Project ToolsVersion='4.0'>
                         <UsingTask TaskName='VerifySdkPaths' TaskFactory='CodeTaskFactory' AssemblyName='Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Sdk35ToolsPath />
                              <Sdk40ToolsPath />
                              <WindowsSDK80Path />
@@ -1237,9 +1237,9 @@ namespace Microsoft.Build.UnitTests
         public void VerifyToolsetAndToolLocationHelperAgreeWhenVisualStudioVersionIs11()
         {
             string projectContents = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='4.0'>
+                    <Project ToolsVersion='4.0'>
                         <UsingTask TaskName='VerifySdkPaths' TaskFactory='CodeTaskFactory' AssemblyName='Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' >
-                         <ParameterGroup>     
+                         <ParameterGroup>
                              <Sdk35ToolsPath />
                              <Sdk40ToolsPath />
                              <WindowsSDK80Path />
@@ -2732,7 +2732,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         private void CheckGetPathToReferenceAssemblies(TestEnvironment env, string customFrameworkDir, string fallbackSearchPaths, Func<string, string, string, string, string, IList<string>> getPathToReferenceAssemblies)
-         {
+        {
             string frameworkName = "Foo Framework";
             string frameworkVersion = "0.1";
             string frameworkVersionWithV = "v" + frameworkVersion;
@@ -2751,8 +2751,8 @@ namespace Microsoft.Build.UnitTests
             {
                 stdLibPaths.Count.ShouldBe(1);
                 stdLibPaths[0].ShouldBe(Path.Combine(customFrameworkDir, frameworkName, frameworkVersionWithV) + Path.DirectorySeparatorChar, stdLibPaths[0]);
-             }
-         }
+            }
+        }
 
         [Fact]
         public void GetPathToReferenceAssembliesWithNullTargetFrameworkRootPath()
@@ -2935,21 +2935,21 @@ namespace Microsoft.Build.UnitTests
                 switch (version)
                 {
                     case TargetDotNetFrameworkVersion.Version40:
-                    {
-                        return DotNetReferenceAssemblies40Installed ? DotNet40ReferenceAssemblyPath : null;
-                    }
+                        {
+                            return DotNetReferenceAssemblies40Installed ? DotNet40ReferenceAssemblyPath : null;
+                        }
                     case TargetDotNetFrameworkVersion.Version35:
-                    {
-                        return DotNetReferenceAssemblies35Installed ? DotNet35ReferenceAssemblyPath : null;
-                    }
+                        {
+                            return DotNetReferenceAssemblies35Installed ? DotNet35ReferenceAssemblyPath : null;
+                        }
                     case TargetDotNetFrameworkVersion.Version30:
-                    {
-                        return DotNetReferenceAssemblies30Installed ? DotNet30ReferenceAssemblyPath : null;
-                    }
+                        {
+                            return DotNetReferenceAssemblies30Installed ? DotNet30ReferenceAssemblyPath : null;
+                        }
                     default:
-                    {
-                        return null;
-                    }
+                        {
+                            return null;
+                        }
                 }
             }
 
@@ -2962,25 +2962,25 @@ namespace Microsoft.Build.UnitTests
                 switch (version)
                 {
                     case TargetDotNetFrameworkVersion.Version20:
-                    {
-                        return DotNet20Installed ? DotNet20FrameworkPath : null;
-                    }
+                        {
+                            return DotNet20Installed ? DotNet20FrameworkPath : null;
+                        }
                     case TargetDotNetFrameworkVersion.Version30:
-                    {
-                        return DotNet30Installed ? DotNet30FrameworkPath : null;
-                    }
+                        {
+                            return DotNet30Installed ? DotNet30FrameworkPath : null;
+                        }
                     case TargetDotNetFrameworkVersion.Version35:
-                    {
-                        return DotNet35Installed ? DotNet35FrameworkPath : null;
-                    }
+                        {
+                            return DotNet35Installed ? DotNet35FrameworkPath : null;
+                        }
                     case TargetDotNetFrameworkVersion.Version40:
-                    {
-                        return DotNet40Installed ? DotNet40FrameworkPath : null;
-                    }
+                        {
+                            return DotNet40Installed ? DotNet40FrameworkPath : null;
+                        }
                     default:
-                    {
-                        return null;
-                    }
+                        {
+                            return null;
+                        }
                 }
             }
         }
@@ -3176,7 +3176,7 @@ namespace Microsoft.Build.UnitTests
 
             // Try a path with invalid chars which does not exist
             string directoryWithInvalidChars = "c:\\<>?";
-            var paths = new List<string> {directoryWithInvalidChars};
+            var paths = new List<string> { directoryWithInvalidChars };
             Should.Throw<ArgumentException>(() => { ToolLocationHelper.GatherSDKListFromDirectory(paths, targetPlatform); });
         }
 
@@ -3709,7 +3709,7 @@ namespace Microsoft.Build.UnitTests
                     <TargetPlatformVersion>8.0</TargetPlatformVersion>" +
                    @"<SDKDirectoryRoot>" + testDirectoryRoot + "</SDKDirectoryRoot>" +
                     @"<SDKLocation1>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformExtensionSDKLocation('SDkWithManifest, Version=2.0','MyPlatform','8.0', '$(SDKDirectoryRoot)',''))</SDKLocation1>
-                      <SDKLocation2>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformExtensionSDKLocation('SDkWithManifest, Version=V2.0','MyPlatform','8.0', '$(SDKDirectoryRoot)',''))</SDKLocation2>                 
+                      <SDKLocation2>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformExtensionSDKLocation('SDkWithManifest, Version=V2.0','MyPlatform','8.0', '$(SDKDirectoryRoot)',''))</SDKLocation2>
                       <SDKLocation3>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKLocation('MyPlatform','8.0', '$(SDKDirectoryRoot)',''))</SDKLocation3>
                       <SDKName>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKDisplayName('MyPlatform','8.0', '$(SDKDirectoryRoot)', ''))</SDKName>
                  </PropertyGroup>
@@ -4120,7 +4120,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void GetPlatformsForSDKWithMatchingPlatformNotMatchingVersion()
         {
-            ToolLocationHelper.GetPlatformsForSDK("MyPlatform", new Version("0.0.0.0"), new[] {_fakeStructureRoot}, null).Any().ShouldBeFalse();
+            ToolLocationHelper.GetPlatformsForSDK("MyPlatform", new Version("0.0.0.0"), new[] { _fakeStructureRoot }, null).Any().ShouldBeFalse();
         }
 
         /// <summary>
@@ -4130,7 +4130,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void GetPlatformsForSDKForLegacyPlatformSDK()
         {
-            ToolLocationHelper.GetPlatformsForSDK("Windows", new Version("8.0"), new[] {_fakeStructureRoot}, null).Any().ShouldBeFalse();
+            ToolLocationHelper.GetPlatformsForSDK("Windows", new Version("8.0"), new[] { _fakeStructureRoot }, null).Any().ShouldBeFalse();
         }
 
         /// <summary>
@@ -4203,13 +4203,13 @@ namespace Microsoft.Build.UnitTests
 
             string testDirectoryRoot = Path.Combine(Path.GetTempPath(), "VerifyFindRootFolderWhereAllFilesExist");
             string[] rootDirectories = new string[] { Path.Combine(testDirectoryRoot, "Root1"), Path.Combine(testDirectoryRoot, "Root2") };
-            
-            for(int i = 0; i < rootDirectories.Length; i++)
+
+            for (int i = 0; i < rootDirectories.Length; i++)
             {
                 // create directory
                 string subdir = Path.Combine(rootDirectories[i], "Subdir");
                 Directory.CreateDirectory(subdir);
-                var fileInSubDir = string.Format("file{0}.txt", i+1);
+                var fileInSubDir = string.Format("file{0}.txt", i + 1);
                 File.Create(Path.Combine(rootDirectories[i], "file1.txt")).Close();
                 File.Create(Path.Combine(subdir, fileInSubDir)).Close();
             }
@@ -4846,17 +4846,17 @@ namespace Microsoft.Build.UnitTests
             switch (hive)
             {
                 case RegistryHive.CurrentUser:
-                {
-                    return Registry.CurrentUser;
-                }
+                    {
+                        return Registry.CurrentUser;
+                    }
                 case RegistryHive.LocalMachine:
-                {
-                    return Registry.LocalMachine;
-                }
+                    {
+                        return Registry.LocalMachine;
+                    }
                 default:
-                {
-                    return null;
-                }
+                    {
+                        return null;
+                    }
             }
         }
 #endif


### PR DESCRIPTION
xmlns hasn't been requires in project files for a while now (v15?), so this change removes it from all props/targets as well as all UTs (minus the ones explicitly testing the xmlns stuff).