### PR TITLE
SA1006 A C# preprocessor-type keyword is preceded by space.

### DIFF
--- a/src/Deprecated/Engine/ItemsAndProperties/ExpressionShredder.cs
+++ b/src/Deprecated/Engine/ItemsAndProperties/ExpressionShredder.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Build.BuildEngine
         }
     }
 
-    # region Related Types
+    #region Related Types
 
     /// <summary>
     /// What the shredder should be looking for.


### PR DESCRIPTION
Relates to #7174
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md