### PR TITLE
Force `IncludeEvaluationPropertiesAndItems` if escape hatch is set

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -525,9 +525,17 @@ namespace Microsoft.Build.BackEnd.Logging
             {
                 if (_includeEvaluationPropertiesAndItems == null)
                 {
-                    var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>();
-                    // .All() on an empty list defaults to true, we want to default to false
-                    _includeEvaluationPropertiesAndItems = sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
+                    var escapeHatch = Traits.Instance.EscapeHatches.LogPropertiesAndItemsAfterEvaluation;
+                    if (escapeHatch.HasValue)
+                    {
+                        _includeEvaluationPropertiesAndItems = escapeHatch.Value;
+                    }
+                    else
+                    {
+                        var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>();
+                        // .All() on an empty list defaults to true, we want to default to false
+                        _includeEvaluationPropertiesAndItems = sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
+                    }
                 }
 
                 return _includeEvaluationPropertiesAndItems ?? false;


### PR DESCRIPTION
If there's an environment variable `MSBUILDLOGPROPERTIESANDITEMSAFTEREVALUATION`, it should take precedence over the logic that sets it to false if any logger hasn't opted in.