### PR TITLE
Embed EmbedInBinlog items added within targets

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -516,6 +516,10 @@ Build
             Write((int)e.Kind);
             WriteDeduplicatedString(e.ItemType);
             WriteTaskItemList(e.Items, e.LogItemMetadata);
+            if (e.Kind == TaskParameterMessageKind.AddItem)
+            {
+                CheckForFilesToEmbed(e.ItemType, e.Items);
+            }
         }
 
         private void WriteBuildEventArgsFields(BuildEventArgs e, bool writeMessage = true, bool writeLineAndColumn = false)


### PR DESCRIPTION
So far we've only respected EmbedInBinlog items during ProjectEvaluationFinished (or ProjectStarted, wherever the eval items are logged).

This simple change also respects EmbedInBinlog items added from ItemGroups inside Targets during target execution.

We can now insert "printf" targets in any place in the build to embed arbitrary files in the binlog at the time that target runs.

This could also allow embedding the same file more than once, if we first copy into a temp file with a timestamp or target name attached. This can allow capturing the state of files at various stages of the build.

I have tested it and it works.