### PR TITLE
Add link to VS2022 ProjectSystemTools extension

### DIFF
--- a/documentation/wiki/Binary-Log.md
+++ b/documentation/wiki/Binary-Log.md
@@ -66,7 +66,10 @@ http://msbuildlog.com
 
 # Collecting binary logs from Visual Studio builds
 
-If you need to capture a binary log in Visual Studio, instead of the command line, you'll need a Visual Studio plugin: https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.ProjectSystemTools
+If you need to capture a binary log in Visual Studio, instead of the command line, you'll need a Visual Studio plugin:
+
+- https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.ProjectSystemTools for VS 2017 & 2019
+- https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.ProjectSystemTools2022 for VS 2022
 
 After installing that, enable logging and run your build ([more details](https://github.com/dotnet/project-system-tools)).
 


### PR DESCRIPTION
### Context

For 64-bit VS, we had to fork the extension.

### Changes Made

Link to both versions of the extension.

### Testing

N/A

### Notes

N/A