### PR TITLE
Fix NU1701 warning Fixes #7212

### DIFF
--- a/src/Xunit.NetCore.Extensions/Xunit.NetCore.Extensions.csproj
+++ b/src/Xunit.NetCore.Extensions/Xunit.NetCore.Extensions.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <CLSCompliant>false</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsShipping>false</IsShipping>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit.core" />

--- a/src/Xunit.NetCore.Extensions/Xunit.NetCore.Extensions.csproj
+++ b/src/Xunit.NetCore.Extensions/Xunit.NetCore.Extensions.csproj
@@ -4,7 +4,7 @@
     <CLSCompliant>false</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsShipping>false</IsShipping>
-    <IsTestProject>false</IsTestProject>
+    <IsTestProject>false</IsTestProject><!-- while this project references xunit it isn't itself a test -->
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit.core" />


### PR DESCRIPTION
That project references Xunit.Core (because it needs xunit types), which defines IsTestProject=true. Then Arcade's tests.targets checks that and imports XUnit.targets

https://github.com/dotnet/arcade/blob/98018d5a808e5167a4ce5e81dc6513382676d4c9/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets#L83

which adds a reference to xunit.runner.visualstudio

https://github.com/dotnet/arcade/blob/98018d5a808e5167a4ce5e81dc6513382676d4c9/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets#L10

even though that's not really needed.

Fixes #7212

All credit to @rainersigwald (see the bug). I just tested it.