### PR TITLE
Emit the BuildStop ETW event at the right time

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -516,8 +516,6 @@ namespace Microsoft.Build.Execution
                     throw;
                 }
 
-                MSBuildEventSource.Log.BuildStop();
-
                 return loggingService;
             }
 
@@ -928,6 +926,8 @@ namespace Microsoft.Build.Execution
 
                     Reset();
                     _buildManagerState = BuildManagerState.Idle;
+
+                    MSBuildEventSource.Log.BuildStop();
 
                     _threadException?.Throw();
 


### PR DESCRIPTION
### Context

The BuildStop event as emitted now does not really correspond to stopping the build.

### Changes Made

Moved the statement to `EndBuild`.

### Testing

Verified the event is present with PerfView.

### Notes

The semantics of BuildStart / BuildStop is not super clear but if it should delimit the BuildManager session, `EndBuild` appears to be the right place.