### PR TITLE
Share read for text resource files

### DIFF
--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -3874,7 +3874,7 @@ namespace Microsoft.Build.Tasks
             private int _col;
 
             internal LineNumberStreamReader(String fileName, Encoding encoding, bool detectEncoding)
-                : base(File.Open(fileName, FileMode.Open, FileAccess.Read), encoding, detectEncoding)
+                : base(File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read), encoding, detectEncoding)
             {
                 _lineNumber = 1;
                 _col = 0;


### PR DESCRIPTION
Fixes #7229 by ensuring that MSBuild's processing of a `.txt` resource holds only the minimal lock: open for read and allowing other processes to read while it's open.