### PR TITLE
SA1006 A C# preprocessor-type keyword is preceded by space.

### DIFF
--- a/eng/Common.globalconfig
+++ b/eng/Common.globalconfig
@@ -717,7 +717,7 @@ dotnet_diagnostic.SA1004.severity = suggestion
 dotnet_diagnostic.SA1005.severity = suggestion
 
 # Region should not be preceded by a space
-dotnet_diagnostic.SA1006.severity = suggestion
+dotnet_diagnostic.SA1006.severity = warning
 
 # Opening parenthesis should not be preceded by a space
 dotnet_diagnostic.SA1008.severity = suggestion


### PR DESCRIPTION
Relates to #7174
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md