### PR TITLE
CA5350 Do Not Use Weak Cryptographic Algorithms

### DIFF
--- a/eng/Common.globalconfig
+++ b/eng/Common.globalconfig
@@ -549,7 +549,7 @@ dotnet_diagnostic.CA3077.severity = suggestion
 dotnet_diagnostic.CA3147.severity = warning
 
 # Do Not Use Weak Cryptographic Algorithms
-dotnet_diagnostic.CA5350.severity = suggestion
+dotnet_diagnostic.CA5350.severity = warning
 
 # Do Not Use Broken Cryptographic Algorithms
 dotnet_diagnostic.CA5351.severity = warning

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -42,9 +42,11 @@ namespace Microsoft.Build.Tasks
         [Output]
         public string HashResult { get; set; }
 
+
         /// <summary>
         /// Execute the task.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "This is not intended as a cryptographic security measure, only for uniqueness between build executions.")]
         public override bool Execute()
         {
             if (ItemsToHash?.Length > 0)

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Build.Tasks
         [Output]
         public string HashResult { get; set; }
 
-
         /// <summary>
         /// Execute the task.
         /// </summary>

--- a/src/Tasks/ManifestUtil/Util.cs
+++ b/src/Tasks/ManifestUtil/Util.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             GetFileInfoImpl(path, targetFrameworkVersion, out hash, out length);
         }
 
-        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354: SHA1CannotBeUsed.", Justification = ".NET 4.0 and earlier versions cannot parse SHA-2.")]
+        [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = ".NET 4.0 and earlier versions cannot parse SHA-2.")]
         private static void GetFileInfoImpl(string path, string targetFrameWorkVersion, out string hash, out long length)
         {
             FileInfo fi = new FileInfo(path);

--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -559,7 +559,7 @@ namespace System.Deployment.Internal.CodeSigning
             return ComputeHashFromManifest(manifestDom, false, useSha256);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Cryptographic.Standard", "CA5354:SHA1CannotBeUsed", Justification = "SHA1 is retained for compatibility reasons as an option in VisualStudio signing page and consequently in the trust manager, default is SHA2.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "SHA1 is retained for compatibility reasons as an option in VisualStudio signing page and consequently in the trust manager, default is SHA2.")]
         private static byte[] ComputeHashFromManifest(XmlDocument manifestDom, bool oldFormat, bool useSha256)
         {
             if (oldFormat)


### PR DESCRIPTION
Relates to #7174 
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/CA5350

I just updated the suppression attributes.