### PR TITLE
CA5384 Asymmetric encryption algorithm DSA is weak. Switch to an RSA …

### DIFF
--- a/src/Tasks/ManifestUtil/CngLightup.cs
+++ b/src/Tasks/ManifestUtil/CngLightup.cs
@@ -29,7 +29,6 @@ namespace System.Security.Cryptography
 {
     internal static partial class CngLightup
     {
-        private const string DsaOid = "1.2.840.10040.4.1";
         private const string RsaOid = "1.2.840.113549.1.1.1";
 
         private const string HashAlgorithmNameTypeName = "System.Security.Cryptography.HashAlgorithmName";
@@ -59,9 +58,6 @@ namespace System.Security.Cryptography
             s_rsaEncryptionPaddingType?.GetProperty("OaepSHA1", BindingFlags.Static | BindingFlags.Public).GetValue(null);
 
         private static readonly Lazy<bool> s_preferRsaCng = new Lazy<bool>(DetectRsaCngSupport);
-
-        private static volatile Func<X509Certificate2, DSA> s_getDsaPublicKey;
-        private static volatile Func<X509Certificate2, DSA> s_getDsaPrivateKey;
 
         private static volatile Func<X509Certificate2, RSA> s_getRsaPublicKey;
         private static volatile Func<X509Certificate2, RSA> s_getRsaPrivateKey;
@@ -113,30 +109,6 @@ namespace System.Security.Cryptography
             }
 
             return s_getRsaPrivateKey(cert);
-        }
-
-        internal static DSA GetDSAPublicKey(X509Certificate2 cert)
-        {
-            if (s_getDsaPublicKey == null)
-            {
-                s_getDsaPublicKey =
-                    BindCoreDelegate<DSA>("DSA", isPublic: true) ??
-                    BindGetCapiPublicKey<DSA, DSACryptoServiceProvider>(DsaOid);
-            }
-
-            return s_getDsaPublicKey(cert);
-        }
-
-        internal static DSA GetDSAPrivateKey(X509Certificate2 cert)
-        {
-            if (s_getDsaPrivateKey == null)
-            {
-                s_getDsaPrivateKey =
-                    BindCoreDelegate<DSA>("DSA", isPublic: false) ??
-                    BindGetCapiPrivateKey<DSA>(DsaOid, csp => new DSACryptoServiceProvider(csp));
-            }
-
-            return s_getDsaPrivateKey(cert);
         }
 
 #if !CNG_LIGHTUP_NO_SYSTEM_CORE


### PR DESCRIPTION
Relates to #7174
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/CA5384