### PR TITLE
SA1020 Increment symbol '++' should not be preceded by a space

### DIFF
--- a/eng/Common.globalconfig
+++ b/eng/Common.globalconfig
@@ -746,7 +746,7 @@ dotnet_diagnostic.SA1015.severity = suggestion
 dotnet_diagnostic.SA1019.severity = none
 
 # Increment symbol '++' should not be preceded by a space
-dotnet_diagnostic.SA1020.severity = suggestion
+dotnet_diagnostic.SA1020.severity = warning
 
 # Negative sign should be preceded by a space
 dotnet_diagnostic.SA1021.severity = suggestion

--- a/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -598,7 +598,7 @@ namespace Microsoft.Build.UnitTests.Definition
             var paths = pathsTable[kind];
             Assert.Equal(paths.SearchPaths.Count, expectedPaths.Length);
 
-            for (int i = 0; i < paths.SearchPaths.Count; i ++)
+            for (int i = 0; i < paths.SearchPaths.Count; i++)
             {
                 Assert.Equal(paths.SearchPaths[i], expectedPaths[i]);
             }


### PR DESCRIPTION
Relates to #7174
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md