### PR TITLE
SA1023 Dereference symbol '*' should not be preceded by a space.

### DIFF
--- a/eng/Common.globalconfig
+++ b/eng/Common.globalconfig
@@ -751,8 +751,8 @@ dotnet_diagnostic.SA1020.severity = suggestion
 # Negative sign should be preceded by a space
 dotnet_diagnostic.SA1021.severity = suggestion
 
-# Dereference symbol '*' should not be preceded by a space."
-dotnet_diagnostic.SA1023.severity = suggestion
+# Dereference symbol '*' should not be preceded by a space.
+dotnet_diagnostic.SA1023.severity = warning
 
 # Colon should be followed by a space
 dotnet_diagnostic.SA1024.severity = suggestion


### PR DESCRIPTION
Relates to #7174
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md