### PR TITLE
SA1122 Use string.Empty for empty strings

### DIFF
--- a/eng/Common.globalconfig
+++ b/eng/Common.globalconfig
@@ -812,7 +812,7 @@ dotnet_diagnostic.SA1120.severity = suggestion
 dotnet_diagnostic.SA1121.severity = none
 
 # Use string.Empty for empty strings
-dotnet_diagnostic.SA1122.severity = suggestion
+dotnet_diagnostic.SA1122.severity = none
 
 # Region should not be located within a code element
 dotnet_diagnostic.SA1123.severity = suggestion


### PR DESCRIPTION
Relates to #7174
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md