### PR TITLE
Simplify MainNodeSdkResolverService

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -8,8 +8,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 #nullable disable
 
@@ -34,6 +32,8 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// </summary>
         public static IBuildComponent CreateComponent(BuildComponentType type)
         {
+            ErrorUtilities.VerifyThrowArgumentOutOfRange(type == BuildComponentType.SdkResolverService, nameof(type));
+
             return new MainNodeSdkResolverService();
         }
 
@@ -65,38 +65,33 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             // Associate the node with the request
             request.NodeId = node;
 
-            Task.Run(() =>
+            SdkResult response = null;
+
+            try
             {
-                Thread.CurrentThread.Name = $"Process SDK request {request.Name} for node {request.NodeId}";
+                // Create an SdkReference from the request
+                SdkReference sdkReference = new SdkReference(request.Name, request.Version, request.MinimumVersion);
 
-                SdkResult response = null;
+                ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
 
-                try
-                {
-                    // Create an SdkReference from the request
-                    SdkReference sdkReference = new SdkReference(request.Name, request.Version, request.MinimumVersion);
+                // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
+                response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive, request.IsRunningInVisualStudio);
+            }
+            catch (Exception e)
+            {
+                ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
 
-                    ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
+                EvaluationLoggingContext loggingContext = new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath);
 
-                    // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
-                    response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive, request.IsRunningInVisualStudio);
-                }
-                catch (Exception e)
-                {
-                    ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
+                loggingService.LogFatalBuildError(loggingContext.BuildEventContext, e, new BuildEventFileInfo(request.ElementLocation));
+            }
+            finally
+            {
+                // Get the node manager and send the response back to the node that requested the SDK
+                INodeManager nodeManager = Host.GetComponent(BuildComponentType.NodeManager) as INodeManager;
 
-                    EvaluationLoggingContext loggingContext = new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath);
-
-                    loggingService.LogFatalBuildError(loggingContext.BuildEventContext, e, new BuildEventFileInfo(request.ElementLocation));
-                }
-                finally
-                {
-                    // Get the node manager and send the response back to the node that requested the SDK
-                    INodeManager nodeManager = Host.GetComponent(BuildComponentType.NodeManager) as INodeManager;
-
-                    nodeManager.SendData(request.NodeId, response);
-                }
-            }).ConfigureAwait(continueOnCapturedContext: false);
+                nodeManager.SendData(request.NodeId, response);
+            }
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <inheritdoc cref="INodePacketHandler.PacketReceived"/>
         public override void PacketReceived(int node, INodePacket packet)
         {
-            if (packet.Type != NodePacketType.ResolveSdkRequest || packet is not SdkResolverRequest request)
+            if (packet is not SdkResolverRequest request)
             {
                 return;
             }

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -7,7 +7,6 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +17,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 {
     /// <summary>
     /// An implementation of <see cref="ISdkResolverService"/> that is hosted in the main node for multi-proc builds.  This instance of the service
-    /// listens for requests from out-of-proc nodes so that SDK resolution is handled in a central location.  This instance is registered in <see cref="BuildComponentFactoryCollection.RegisterDefaultFactories"/>
+    /// handles requests from out-of-proc nodes so that SDK resolution is handled in a central location.  This instance is registered in <see cref="BuildComponentFactoryCollection.RegisterDefaultFactories"/>
     /// and can be overridden for different contexts.  This service calls the <see cref="SdkResolverService"/> to do any actual SDK resolution
     /// because the <see cref="SdkResolverService"/> is used for stand-alone evaluations where there is no build context available so caching
     /// is not an option.
@@ -28,26 +27,6 @@ namespace Microsoft.Build.BackEnd.SdkResolution
     /// </summary>
     internal sealed class MainNodeSdkResolverService : HostedSdkResolverServiceBase
     {
-        /// <summary>
-        /// An object used for locking in this class instance.
-        /// </summary>
-        private readonly object _lockObject = new object();
-
-        /// <summary>
-        /// A <see cref="Task"/> running in the background which handles requests from remote nodes.
-        /// </summary>
-        private Task _requestHandler;
-
-        /// <summary>
-        /// An event which is signaled when a request is received from a remote host.
-        /// </summary>
-        private ManualResetEvent _requestReceivedEvent;
-
-        /// <summary>
-        /// A list of requests from remote hosts which need to be processed.
-        /// </summary>
-        private ConcurrentQueue<SdkResolverRequest> _requests;
-
         private readonly ISdkResolverService _cachedSdkResolver = new CachingSdkResolverService();
 
         /// <summary>
@@ -78,12 +57,46 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <inheritdoc cref="INodePacketHandler.PacketReceived"/>
         public override void PacketReceived(int node, INodePacket packet)
         {
-            switch (packet.Type)
+            if (packet.Type != NodePacketType.ResolveSdkRequest || packet is not SdkResolverRequest request)
             {
-                case NodePacketType.ResolveSdkRequest:
-                    HandleRequest(node, packet as SdkResolverRequest);
-                    break;
+                return;
             }
+
+            // Associate the node with the request
+            request.NodeId = node;
+
+            Task.Run(() =>
+            {
+                Thread.CurrentThread.Name = $"Process SDK request {request.Name} for node {request.NodeId}";
+
+                SdkResult response = null;
+
+                try
+                {
+                    // Create an SdkReference from the request
+                    SdkReference sdkReference = new SdkReference(request.Name, request.Version, request.MinimumVersion);
+
+                    ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
+
+                    // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
+                    response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive, request.IsRunningInVisualStudio);
+                }
+                catch (Exception e)
+                {
+                    ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
+
+                    EvaluationLoggingContext loggingContext = new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath);
+
+                    loggingService.LogFatalBuildError(loggingContext.BuildEventContext, e, new BuildEventFileInfo(request.ElementLocation));
+                }
+                finally
+                {
+                    // Get the node manager and send the response back to the node that requested the SDK
+                    INodeManager nodeManager = Host.GetComponent(BuildComponentType.NodeManager) as INodeManager;
+
+                    nodeManager.SendData(request.NodeId, response);
+                }
+            }).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
@@ -95,131 +108,6 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             ErrorUtilities.VerifyThrowInternalLength(projectPath, nameof(projectPath));
 
             return _cachedSdkResolver.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
-        }
-
-        /// <summary>
-        /// Handles a request from a remote node.
-        /// </summary>
-        /// <param name="node">The ID of the remote node.</param>
-        /// <param name="request">The <see cref="SdkResolverRequest"/> containing information about the SDK to resolve.</param>
-        /// <remarks>This method must not directly handle requests because it would block requests from other nodes.  Instead, it simply
-        /// adds requests to a queue which are processed by a background thread.</remarks>
-        private void HandleRequest(int node, SdkResolverRequest request)
-        {
-            if (_requestHandler == null)
-            {
-                // Start the background thread which will process queued requests if it has not already been started.
-                lock (_lockObject)
-                {
-                    if (_requestHandler == null)
-                    {
-                        // Create the event used to signal that a request was received
-                        _requestReceivedEvent = new ManualResetEvent(initialState: false);
-
-                        // Create the queue used to store requests that need to be processed
-                        _requests = new ConcurrentQueue<SdkResolverRequest>();
-
-                        // Create the thread which processes requests
-                        _requestHandler = Task.Factory.StartNew(RequestHandlerPumpProc, TaskCreationOptions.LongRunning);
-                    }
-                }
-            }
-
-            // Associate the node with the request
-            request.NodeId = node;
-
-            _requests.Enqueue(request);
-
-            // Signal that one or more requests have been received
-            _requestReceivedEvent.Set();
-        }
-
-        /// <summary>
-        /// Processes all requests that are currently in the queue.
-        /// </summary>
-        private void ProcessRequests()
-        {
-            // Store a list of threads which are resolving SDKs
-            List<Task> tasks = new List<Task>(_requests.Count);
-
-            SdkResolverRequest item;
-
-            while (_requests.TryDequeue(out item))
-            {
-                SdkResolverRequest request = item;
-
-                // Start a thread to resolve an SDK and add it to the list of threads
-                tasks.Add(Task.Run(() =>
-                {
-                    SdkResult response = null;
-                    try
-                    {
-                        // Create an SdkReference from the request
-                        SdkReference sdkReference = new SdkReference(request.Name, request.Version, request.MinimumVersion);
-
-                        ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
-
-                        // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
-                        response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive, request.IsRunningInVisualStudio);
-                    }
-                    catch (Exception e)
-                    {
-                        ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
-
-                        EvaluationLoggingContext loggingContext = new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath);
-
-                        loggingService.LogFatalBuildError(loggingContext.BuildEventContext, e, new BuildEventFileInfo(request.ElementLocation));
-                    }
-                    finally
-                    {
-                        // Get the node manager and send the response back to the node that requested the SDK
-                        INodeManager nodeManager = Host.GetComponent(BuildComponentType.NodeManager) as INodeManager;
-
-                        nodeManager.SendData(request.NodeId, response);
-                    }
-                }));
-            }
-
-            // Wait for all tasks to complete
-            Task.WaitAll(tasks.ToArray());
-        }
-
-        /// <summary>
-        /// A background thread that waits for requests to be received.
-        /// </summary>
-        private void RequestHandlerPumpProc()
-        {
-            try
-            {
-                Thread.CurrentThread.Name = "MSBuild SDK Resolver";
-
-                while (true)
-                {
-                    WaitHandle[] handles = new WaitHandle[] { ShutdownEvent, _requestReceivedEvent };
-
-                    int waitId = WaitHandle.WaitAny(handles);
-                    switch (waitId)
-                    {
-                        case 0:
-                            return;
-
-                        case 1:
-                            _requestReceivedEvent.Reset();
-
-                            ProcessRequests();
-                            break;
-
-                        default:
-                            ErrorUtilities.ThrowInternalError("waitId {0} out of range.", waitId);
-                            break;
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                ExceptionHandling.DumpExceptionToFile(e);
-                throw;
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/7137

### Context
The MainNodeSdkResolverService process incoming requests from out-of-proc nodes to handle SDK resolution.  The main node has a queue of all incoming packets that are processed by appropriate handlers.  The MainNodeSdkResolverService currently takes SdkResolverRequests and places them in a queue for processing.  This seems unnecessary to have two queues and two threads draining the queues.

### Changes Made
Remove queue and thread that process it in favor of launching a fire-and-forget task that resolves the SDK and sends the response.

### Testing
Existing tests cover this area

### Notes
