### PR TITLE
Remove redundant copy of BuildRequestData.TargetNames

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -220,7 +220,6 @@ namespace Microsoft.Build.Execution
             ErrorUtilities.VerifyThrowArgumentNull(globalProperties, nameof(globalProperties));
 
             ProjectFullPath = FileUtilities.NormalizePath(projectFullPath);
-            TargetNames = (ICollection<string>)targetsToBuild.Clone();
             GlobalPropertiesDictionary = new PropertyDictionary<ProjectPropertyInstance>(globalProperties.Count);
             foreach (KeyValuePair<string, string> propertyPair in globalProperties)
             {
@@ -238,7 +237,11 @@ namespace Microsoft.Build.Execution
             ErrorUtilities.VerifyThrowArgumentNull(targetsToBuild, nameof(targetsToBuild));
 
             HostServices = hostServices;
-            TargetNames = new List<string>(targetsToBuild);
+
+            var targetsToBuildCopy = new string[targetsToBuild.Length];
+            targetsToBuild.CopyTo(targetsToBuildCopy, 0);
+            TargetNames = targetsToBuildCopy;
+
             Flags = flags;
         }
 

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -237,11 +237,7 @@ namespace Microsoft.Build.Execution
             ErrorUtilities.VerifyThrowArgumentNull(targetsToBuild, nameof(targetsToBuild));
 
             HostServices = hostServices;
-
-            var targetsToBuildCopy = new string[targetsToBuild.Length];
-            targetsToBuild.CopyTo(targetsToBuildCopy, 0);
-            TargetNames = targetsToBuildCopy;
-
+            TargetNames = new List<string>(targetsToBuild);
             Flags = flags;
         }
 


### PR DESCRIPTION
Minor change to remove an extra defensive copy of an array. A `BuildRequestData` ctor overload copies it despite the `this` ctor it calls also copying it.

~Also a very minor perf change to use an array and copy via `CopyTo` instead of cloning with a `List<>`.~