### PR TITLE
Use Stack<T> instead of Stack

### DIFF
--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -822,7 +822,7 @@ namespace Microsoft.Build.BackEnd.Logging
         internal struct Frame
         {
             /// <summary>
-            /// Creates a new instance of frame with all fields specified.
+            /// Initializes a new instance of the <see cref="Frame"/> struct with all fields specified.
             /// </summary>
             /// <param name="t">the type of the this frame</param>
             /// <param name="d">display state. true indicates this frame has been displayed to the user</param>
@@ -907,14 +907,14 @@ namespace Microsoft.Build.BackEnd.Logging
             /// The frames member is contained by FrameStack and does
             /// all the heavy lifting for FrameStack.
             /// </summary>
-            private System.Collections.Stack _frames;
+            private readonly Stack<Frame> _frames;
 
             /// <summary>
-            /// Create a new, empty, FrameStack.
+            /// Initializes a new instance of the <see cref="FrameStack"/> class.
             /// </summary>
             internal FrameStack()
             {
-                _frames = new System.Collections.Stack();
+                _frames = new Stack<Frame>();
             }
 
             /// <summary>
@@ -923,7 +923,7 @@ namespace Microsoft.Build.BackEnd.Logging
             /// <exception cref="InvalidOperationException">Thrown when stack is empty.</exception>
             internal Frame Pop()
             {
-                return (Frame)(_frames.Pop());
+                return _frames.Pop();
             }
 
             /// <summary>
@@ -931,7 +931,7 @@ namespace Microsoft.Build.BackEnd.Logging
             /// </summary>
             internal Frame Peek()
             {
-                return (Frame)(_frames.Peek());
+                return _frames.Peek();
             }
 
             /// <summary>

--- a/src/Tasks/ParserState.cs
+++ b/src/Tasks/ParserState.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Text;
-using System.Collections;
+using System.Collections.Generic;
 
 #nullable disable
 
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Tasks
         private int _openConditionalDirectives;
 
         // A stack of namespaces so that nested namespaces can be supported.
-        private readonly Stack _namespaceStack = new Stack();
+        private readonly Stack<string> _namespaceStack = new Stack<string>();
 
         internal ParseState()
         {
@@ -90,7 +90,7 @@ namespace Microsoft.Build.Tasks
                 return null;
             }
 
-            return (string)_namespaceStack.Pop();
+            return _namespaceStack.Pop();
         }
 
         /// <summary>


### PR DESCRIPTION
### Context
Whilst going through the code I noticed the use of [`Stack`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.stack?view=net-6.0). In the documentation it suggests using [`Stack<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.stack-1?view=net-6.0).

### Changes Made
Change `Stack` to `Stack<T>`
