### PR TITLE
Remove CultureName and CultureInfo from LazyFormattedBuildEventArgs

### DIFF
--- a/src/Framework/LazyFormattedBuildEventArgs.cs
+++ b/src/Framework/LazyFormattedBuildEventArgs.cs
@@ -37,17 +37,6 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
-        /// Stores the original culture for String.Format.
-        /// </summary>
-        private string originalCultureName;
-
-        /// <summary>
-        /// Non-serializable CultureInfo object
-        /// </summary>
-        [NonSerialized]
-        private volatile CultureInfo originalCultureInfo;
-
-        /// <summary>
         /// This constructor allows all event data to be initialized.
         /// </summary>
         /// <param name="message">text message.</param>
@@ -82,8 +71,6 @@ namespace Microsoft.Build.Framework
             : base(message, helpKeyword, senderName, eventTimestamp)
         {
             argumentsOrFormattedMessage = messageArgs;
-            originalCultureName = CultureInfo.CurrentCulture.Name;
-            originalCultureInfo = CultureInfo.CurrentCulture;
         }
 
         /// <summary>
@@ -109,12 +96,7 @@ namespace Microsoft.Build.Framework
 
                 if (argsOrMessage is object[] arguments && arguments.Length > 0)
                 {
-                    if (originalCultureInfo == null)
-                    {
-                        originalCultureInfo = new CultureInfo(originalCultureName);
-                    }
-
-                    formattedMessage = FormatString(originalCultureInfo, base.Message, arguments);
+                    formattedMessage = FormatString(base.Message, arguments);
                     argumentsOrFormattedMessage = formattedMessage;
                     return formattedMessage;
                 }
@@ -147,8 +129,6 @@ namespace Microsoft.Build.Framework
                 base.WriteToStreamWithExplicitMessage(writer, (argsOrMessage is string formattedMessage) ? formattedMessage : base.Message);
                 writer.Write(-1);
             }
-
-            writer.Write(originalCultureName);
         }
 
         /// <summary>
@@ -176,8 +156,6 @@ namespace Microsoft.Build.Framework
                 }
 
                 argumentsOrFormattedMessage = messageArgs;
-
-                originalCultureName = reader.ReadString();
             }
         }
 
@@ -188,11 +166,10 @@ namespace Microsoft.Build.Framework
         /// the array of arguments -- do not call this method repeatedly in performance-critical scenarios
         /// </summary>
         /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="culture">The culture info for formatting the message.</param>
         /// <param name="unformatted">The string to format.</param>
         /// <param name="args">Optional arguments for formatting the given string.</param>
         /// <returns>The formatted string.</returns>
-        private static string FormatString(CultureInfo culture, string unformatted, params object[] args)
+        private static string FormatString(string unformatted, params object[] args)
         {
             // Based on the one in Shared/ResourceUtilities.
             string formatted = unformatted;
@@ -210,7 +187,7 @@ namespace Microsoft.Build.Framework
                     // another one, add it here.
                     if (param != null && param.ToString() == param.GetType().FullName)
                     {
-                        throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, "Invalid type for message formatting argument, was {0}", param.GetType().FullName));
+                        throw new InvalidOperationException(string.Format("Invalid type for message formatting argument, was {0}", param.GetType().FullName));
                     }
                 }
 #endif
@@ -218,7 +195,7 @@ namespace Microsoft.Build.Framework
                 // NOTE: all String methods are thread-safe
                 try
                 {
-                    formatted = String.Format(culture, unformatted, args);
+                    formatted = string.Format(unformatted, args);
                 }
                 catch (FormatException ex)
                 {
@@ -230,12 +207,12 @@ namespace Microsoft.Build.Framework
                     //       Task "Crash"
                     //          (16,14):  error : "This message logged from a task {1} has too few formatting parameters."
                     //             at System.Text.StringBuilder.AppendFormat(IFormatProvider provider, String format, Object[] args)
-                    //             at System.String.Format(IFormatProvider provider, String format, Object[] args)
-                    //             at Microsoft.Build.Framework.LazyFormattedBuildEventArgs.FormatString(CultureInfo culture, String unformatted, Object[] args) in d:\W8T_Refactor\src\vsproject\xmake\Framework\LazyFormattedBuildEventArgs.cs:line 263
+                    //             at System.String.Format(String format, Object[] args)
+                    //             at Microsoft.Build.Framework.LazyFormattedBuildEventArgs.FormatString(String unformatted, Object[] args) in d:\W8T_Refactor\src\vsproject\xmake\Framework\LazyFormattedBuildEventArgs.cs:line 263
                     //          Done executing task "Crash".
                     //
                     // T
-                    formatted = String.Format(CultureInfo.CurrentCulture, "\"{0}\"\n{1}", unformatted, ex.ToString());
+                    formatted = string.Format("\"{0}\"\n{1}", unformatted, ex.ToString());
                 }
             }
 


### PR DESCRIPTION
Fixes #7015

### Context

The intent was to stash the current culture when the event args are created and then use it for formatting (which may happen later). It turns out that despite the code in `WriteToStream` and `CreateFromStream`, the culture doesn't propagate when our args are serialized and deserialized; see how new instances are created during deserialization:

https://github.com/dotnet/msbuild/blob/14efa06d736aabb3af01ff827fff9426518f5fac/src/Shared/LogMessagePacketBase.cs#L517-L535

This, together with @KirillOsenkov's comment in the linked issue, and the general doubt about the incidence of scenarios where this would be useful (a custom task emitting custom build events, explicitly changing the current culture, and relying in the culture-specific formatting) makes me want to take the risk and just remove all of this.

### Changes Made

Removed the fields and the related logic. Also removed a couple of redundant `CultureInfo.CurrentCulture` arguments.

### Testing

Built large solutions, verified that the code being removed was not hit/used.

### Notes

This PR is changing private members of a serializable (but not `ISerializable`) type so technically a breaking change. We've done this before when we tweaked fields in the same class in #7010 and serialization is intended for IPC here anyway, but still, if we want to be 100% backward compatible, this PR would have to be rejected.

The perf win in terms of memory allocations is in the order of 0.1's of % in a typical build.