### PR TITLE
Taskhosts die within build

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
@@ -27,23 +27,32 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             <Output PropertyName=""PID"" TaskParameter=""Pid"" />
         </ProcessIdTask>
     </Target>
+    <Target Name='AccessPID2' AfterTargets='AccessPID'>
+        <ProcessIdTask>
+            <Output PropertyName=""PID2"" TaskParameter=""Pid"" />
+        </ProcessIdTask>
+    </Target>
 </Project>";
                 TransientTestFile project = env.CreateFile("testProject.csproj", pidTaskProject);
-                ProjectInstance projectInstance = new ProjectInstance(project.Path);
+                ProjectInstance projectInstance = new(project.Path);
                 projectInstance.Build().ShouldBeTrue();
                 string processId = projectInstance.GetPropertyValue("PID");
                 string.IsNullOrEmpty(processId).ShouldBeFalse();
                 Int32.TryParse(processId, out int pid).ShouldBeTrue();
+                string processId2 = projectInstance.GetPropertyValue("PID2");
+                string.IsNullOrEmpty(processId2).ShouldBeFalse();
+                Int32.TryParse(processId2, out int pid2).ShouldBeTrue();
+                pid2.ShouldNotBe(pid);
                 Process.GetCurrentProcess().Id.ShouldNotBe<int>(pid);
                 try
                 {
-                    Process taskHostNode = Process.GetProcessById(pid);
+                    Process taskHostNode = Process.GetProcessById(pid2);
                     taskHostNode.WaitForExit(2000).ShouldBeTrue();
                 }
                 // We expect the TaskHostNode to exit quickly. If it exits before Process.GetProcessById, it will throw an ArgumentException.
                 catch (ArgumentException e)
                 {
-                    e.Message.ShouldBe($"Process with an Id of {pid} is not running.");
+                    e.Message.ShouldBe($"Process with an Id of {pid2} is not running.");
                 }
             }
         }

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Build.BackEnd
 
 #if FEATURE_NODE_REUSE
             // Try to connect to idle nodes if node reuse is enabled.
-            if (_componentHost.BuildParameters.EnableNodeReuse)
+            if (_componentHost.BuildParameters.EnableNodeReuse && ((hostHandshake.RetrieveHandshakeComponents()[0] & 0x01) == 0 || Traits.Instance.EscapeHatches.ReuseTaskHostNodes))
             {
                 (string expectedProcessName, List<Process> processes) runningNodesTuple = GetPossibleRunningNodes(msbuildLocation);
 


### PR DESCRIPTION
Fixes #3141

### Context
#5144 ensured TaskHost processes died after a build was complete. That didn't affect whether they could be reused within a single build. We do not want them to be reused within a build, so this prevents intra-build node reuse with TaskHosts unless the user requests it via escape hatch.

### Changes Made
Prevent TaskHosts from even looking for old TaskHosts unless the user says it's ok.

### Testing
Adjusted a test. It failed. Now it passes.

### Notes
