### PR TITLE
SA1134 Each attribute should be placed on its own line of code

### DIFF
--- a/eng/Common.globalconfig
+++ b/eng/Common.globalconfig
@@ -843,7 +843,7 @@ dotnet_diagnostic.SA1132.severity = warning
 dotnet_diagnostic.SA1133.severity = suggestion
 
 # Each attribute should be placed on its own line of code
-dotnet_diagnostic.SA1134.severity = suggestion
+dotnet_diagnostic.SA1134.severity = warning
 
 # Using directive should be qualified
 dotnet_diagnostic.SA1135.severity = suggestion

--- a/src/MSBuildTaskHost/Concurrent/ConcurrentQueue.cs
+++ b/src/MSBuildTaskHost/Concurrent/ConcurrentQueue.cs
@@ -554,7 +554,9 @@ namespace Microsoft.Build.Shared.Concurrent
     [StructLayout(LayoutKind.Explicit, Size = 192)] // padding before/between/after fields based on typical cache line size of 64
     internal struct PaddedHeadAndTail
     {
-        [FieldOffset(64)] public int Head;
-        [FieldOffset(128)] public int Tail;
+        [FieldOffset(64)]
+        public int Head;
+        [FieldOffset(128)]
+        public int Tail;
     }
 }

--- a/src/MSBuildTaskHost/Concurrent/ConcurrentQueue.cs
+++ b/src/MSBuildTaskHost/Concurrent/ConcurrentQueue.cs
@@ -549,6 +549,7 @@ namespace Microsoft.Build.Shared.Concurrent
             }
         }
     }
+
     /// <summary>Padded head and tail indices, to avoid false sharing between producers and consumers.</summary>
     [DebuggerDisplay("Head = {Head}, Tail = {Tail}")]
     [StructLayout(LayoutKind.Explicit, Size = 192)] // padding before/between/after fields based on typical cache line size of 64
@@ -556,6 +557,7 @@ namespace Microsoft.Build.Shared.Concurrent
     {
         [FieldOffset(64)]
         public int Head;
+
         [FieldOffset(128)]
         public int Tail;
     }


### PR DESCRIPTION
Relates to #7174
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md