### PR TITLE
SA1506 Element documentation headers should not be followed by blank …

### DIFF
--- a/eng/Common.globalconfig
+++ b/eng/Common.globalconfig
@@ -987,7 +987,7 @@ dotnet_diagnostic.SA1504.severity = suggestion
 dotnet_diagnostic.SA1505.severity = suggestion
 
 # Element documentation headers should not be followed by blank line
-dotnet_diagnostic.SA1506.severity = suggestion
+dotnet_diagnostic.SA1506.severity = warning
 
 # Code should not contain multiple blank lines in a row
 dotnet_diagnostic.SA1507.severity = suggestion

--- a/src/Framework/ILogger.cs
+++ b/src/Framework/ILogger.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Build.Framework
     // WARNING: VS Automation code for the Tools/Options MSBuild build verbosity setting will be broken
     // by changes to this enum (not to mention existing MSBuild clients and vsproject code). 
     // Please make sure to talk to automation devs before changing it.
-
     [ComVisible(true)]
     public enum LoggerVerbosity
     {

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -441,7 +441,6 @@ namespace Microsoft.Build.Framework
         /// <remarks>
         /// Clone from ErrorUtilities which isn't (yet?) available in Framework.
         /// </remarks>
-
         private static readonly bool s_throwExceptions = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDONOTTHROWINTERNAL"));
 
         /// <summary>

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -370,7 +370,6 @@ namespace Microsoft.Build.Utilities
         /// path that matches. 
         /// </summary>
         /// <returns>The full path to Tracker.exe, or <see langword="null" /> if a matching path is not found.</returns>
-        
         public static string FindTrackerOnPath()
         {
             string[] paths = Environment.GetEnvironmentVariable(pathEnvironmentVariableName).Split(pathSeparatorArray, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
Relates to #7174
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md