### PR TITLE
Revert "Add more SdkResolverService events and allow SdkResolvers to log events (#7139)"

### DIFF
--- a/documentation/specs/event-source.md
+++ b/documentation/specs/event-source.md
@@ -5,30 +5,23 @@
 ## EventSource in MSBuild
 EventSource is primarily used to profile code. For MSBuild specifically, a major goal is to reduce the time it takes to run, as measured (among other metrics) by the Regression Prevention System (RPS), i.e., running specific scenarios. To find which code segments were likely candidates for improvement, EventSources were added around a mix of code segments. Larger segments that encompass several steps within a build occur nearly every time MSBuild is run and take a long time. They generally run relatively few times. Smaller methods with well-defined purposes may occur numerous times. Profiling both types of events provides both broad strokes to identify large code segments that underperform and, more specifically, which parts of them. Profiled functions include:
 
-| Event | Description |
-| ------| ------------|
-| MSBuildExe | Executes MSBuild from the command line. |
-| Build | Sets up a BuildManager to receive build requests. |
-| BuildProject | Builds a project file. |
-| RequestThreadProc | A function to requesting a new builder thread. |
-| LoadDocument | Loads an XMLDocumentWithLocation from a path.
-| RarRemoveReferencesMarkedForExclusion | Removes blacklisted references from the reference table, putting primary and dependency references in invalid file lists. |
-| RarComputeClosure | Resolves references from, for example, properties to explicit values. Used in resolving assembly references (RAR). |
-| EvaluateCondition | Checks whether a condition is true and removes false conditionals. |
-| Parse | Parses an XML document into a ProjectRootElement. |
-| Evaluate | Evaluates a project, running several other parts of MSBuild in the process. |
-| GenerateResourceOverall | Uses resource APIs to transform resource files into strongly-typed resource classes. |
-| ExpandGlob | Identifies a list of files that correspond to an item, potentially with a wildcard. |
-| ApplyLazyItemOperations | Collects a set of items, mutates them in a specified way, and saves the results in a lazy way. |
-| RarOverall | Initiates the process of resolving assembly references (RAR). |
-| Save | Saves a project to the file system if dirty, creating directories as necessary. |
-| Target | Executes a target. |
-| RarLogResults | Logs the results from having resolved assembly references (RAR). |
-| SdkResolverServiceInitialize | Initializes SDK resolvers. |
-| SdkResolverResolveSdk | A single SDK resolver is called. |
-| CachedSdkResolverServiceResolveSdk | The caching SDK resolver service is resolving an SDK. |
-| SdkResolverEvent | An SDK resolver logs an event. |
-| OutOfProcSdkResolverServiceRequestSdkPathFromMainNode | An out-of-proc node requests an SDK be resolved from the main node. |
+* MSBuildExe: Executes MSBuild from the command line.
+* Build: Sets up a BuildManager to receive build requests.
+* BuildProject: Builds a project file.
+* RequestThreadProc: A function to requesting a new builder thread.
+* LoadDocument: Loads an XMLDocumentWithLocation from a path.
+* RarRemoveReferencesMarkedForExclusion: Removes blacklisted references from the reference table, putting primary and dependency references in invalid file lists.
+* RarComputeClosure: Resolves references from, for example, properties to explicit values. Used in resolving assembly references (RAR).
+* EvaluateCondition: Checks whether a condition is true and removes false conditionals.
+* Parse: Parses an XML document into a ProjectRootElement.
+* Evaluate: Evaluates a project, running several other parts of MSBuild in the process.
+* GenerateResourceOverall: Uses resource APIs to transform resource files into strongly-typed resource classes.
+* ExpandGlob: Identifies a list of files that correspond to an item, potentially with a wildcard.
+* ApplyLazyItemOperations: Collects a set of items, mutates them in a specified way, and saves the results in a lazy way.
+* RarOverall: Initiates the process of resolving assembly references (RAR).
+* Save: Saves a project to the file system if dirty, creating directories as necessary.
+* Target: Executes a target.
+* RarLogResults: Logs the results from having resolved assembly references (RAR).
 
 One can run MSBuild with eventing using the following command:
 

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -4,7 +4,6 @@
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
-using Microsoft.Build.Eventing;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using System;
@@ -27,7 +26,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <summary>
         /// The cache of responses which is cleared between builds.
         /// </summary>
-        private readonly ConcurrentDictionary<string, Lazy<SdkResult>> _responseCache = new ConcurrentDictionary<string, Lazy<SdkResult>>(MSBuildNameIgnoreCaseComparer.Default);
+        private readonly ConcurrentDictionary<string, SdkResult> _responseCache = new ConcurrentDictionary<string, SdkResult>(MSBuildNameIgnoreCaseComparer.Default);
 
         /// <summary>
         /// An event to signal when a response has been received.
@@ -64,29 +63,20 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
         public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
-            bool wasResultCached = true;
-
-            MSBuildEventSource.Log.OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStart(submissionId, sdk.Name, solutionPath, projectPath);
-
             // Get a cached response if possible, otherwise send the request
-            Lazy<SdkResult> sdkResultLazy = _responseCache.GetOrAdd(
+            var sdkResult = _responseCache.GetOrAdd(
                 sdk.Name,
-                key => new Lazy<SdkResult>(() =>
+                key =>
                 {
-                    wasResultCached = false;
-
-                    return RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
-                }));
-
-            SdkResult sdkResult = sdkResultLazy.Value;
+                    var result = RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
+                    return result;
+                });
 
             if (sdkResult.Version != null && !SdkResolverService.IsReferenceSameVersion(sdk, sdkResult.Version))
             {
                 // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.
                 loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "ReferencingMultipleVersionsOfTheSameSdk", sdk.Name, sdkResult.Version, sdkResult.ElementLocation, sdk.Version);
             }
-
-            MSBuildEventSource.Log.OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStop(submissionId, sdk.Name, solutionPath, projectPath, _lastResponse.Success, wasResultCached);
 
             return sdkResult;
         }

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -485,9 +485,9 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(67, Keywords = Keywords.All)]
-        public void CachedSdkResolverServiceResolveSdkStop(string sdkName, string solutionPath, string projectPath, bool success, bool wasResultCached)
+        public void CachedSdkResolverServiceResolveSdkStop(string sdkName, string solutionPath, string projectPath, bool success)
         {
-            WriteEvent(67, sdkName, solutionPath, projectPath, success, wasResultCached);
+            WriteEvent(67, sdkName, solutionPath, projectPath, success);
         }
 
         /// <remarks>
@@ -519,36 +519,6 @@ namespace Microsoft.Build.Eventing
             WriteEvent(70, oldHash, newHash);
         }
 
-        [Event(71, Keywords = Keywords.All)]
-        public void SdkResolverEvent(params object[] args)
-        {
-            WriteEvent(71, args);
-        }
-
-        [Event(72, Keywords = Keywords.All)]
-        public void SdkResolverEventStart(params object[] args)
-        {
-            WriteEvent(72, args);
-        }
-
-        [Event(73, Keywords = Keywords.All)]
-        public void SdkResolverEventStop(params object[] args)
-        {
-            WriteEvent(73, args);
-        }
-
-        [Event(74, Keywords = Keywords.All)]
-        public void OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStart(int submissionId, string sdkName, string solutionPath, string projectPath)
-        {
-            WriteEvent(74, submissionId, sdkName, solutionPath, projectPath);
-        }
-
-        [Event(75, Keywords = Keywords.All)]
-        public void OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStop(int submissionId, string sdkName, string solutionPath, string projectPath, bool success, bool wasResultCached)
-        {
-            WriteEvent(75, submissionId, sdkName, solutionPath, projectPath, success, wasResultCached);
-        }
-
-        #endregion
+#endregion
     }
 }

--- a/src/Framework/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Framework/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,3 +1,0 @@
-virtual Microsoft.Build.Framework.SdkLogger.LogEvent(params object[] args) -> void
-virtual Microsoft.Build.Framework.SdkLogger.LogEventStart(params object[] args) -> void
-virtual Microsoft.Build.Framework.SdkLogger.LogEventStop(params object[] args) -> void

--- a/src/Framework/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Framework/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,0 @@
-virtual Microsoft.Build.Framework.SdkLogger.LogEvent(params object[] args) -> void
-virtual Microsoft.Build.Framework.SdkLogger.LogEventStart(params object[] args) -> void
-virtual Microsoft.Build.Framework.SdkLogger.LogEventStop(params object[] args) -> void

--- a/src/Framework/Sdk/SdkLogger.cs
+++ b/src/Framework/Sdk/SdkLogger.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Build.Eventing;
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -17,32 +15,5 @@ namespace Microsoft.Build.Framework
         /// <param name="message">Message string.</param>
         /// <param name="messageImportance">Optional message importances. Default to low.</param>
         public abstract void LogMessage(string message, MessageImportance messageImportance = MessageImportance.Low);
-
-        /// <summary>
-        /// Logs that an event.
-        /// </summary>
-        /// <param name="args">An array of arguments to log with the event.</param>
-        public virtual void LogEvent(params object[] args)
-        {
-            MSBuildEventSource.Log.SdkResolverEvent(args);
-        }
-
-        /// <summary>
-        /// Logs that an event when an operation has started.
-        /// </summary>
-        /// <param name="args">An array of arguments to log with the event.</param>
-        public virtual void LogEventStart(params object[] args)
-        {
-            MSBuildEventSource.Log.SdkResolverEventStart(args);
-        }
-
-        /// <summary>
-        /// Logs that an event when an operation has completed.
-        /// </summary>
-        /// <param name="args">An array of arguments to log with the event.</param>
-        public virtual void LogEventStop(params object[] args)
-        {
-            MSBuildEventSource.Log.SdkResolverEventStop(args);
-        }
     }
 }


### PR DESCRIPTION
This reverts commit 73ee6c0b41ebfa80f5dd54560a90566a8efb20cb.

### Description

As of #7139 Microsoft-Build events can no longer be reported (i.e. they don't show in PerfView) because the ETW manifest builder is failing due to Object[] being an unsupported type. This change is a straight revert of the PR that introduced the regression.

### Customer Impact

The bug makes it harder to diagnose MSBuild issues internally and externally. Note that Microsoft-Build ETW events are recorded by the VS Feedback tool, for example.

### Regression?

Yes, introduced in #7139 on Dec 22nd 2021.

### Risk

Very low.

### Is there a packaging impact?

No.

### Does the change affect files included in any ref pack (Microsoft.NETCore.App.Ref, Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref)?

No.