### PR TITLE
Start windowless process for the KillTree test

### DIFF
--- a/src/Utilities.UnitTests/ProcessExtensions_Tests.cs
+++ b/src/Utilities.UnitTests/ProcessExtensions_Tests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.UnitTests
         {
             var psi =
                 NativeMethodsShared.IsWindows ?
-                    new ProcessStartInfo("powershell", "-NoLogo -NoProfile -command \"Start-Sleep -Seconds 600\"") :
+                    new ProcessStartInfo("rundll32", "kernel32.dll, Sleep") :
                     new ProcessStartInfo("sleep", "600");
 
             Process p = Process.Start(psi); // sleep 10m.


### PR DESCRIPTION
Fixes #7255

### Context
KillTree test starts a powershell process during execution. When the default terminal is set to Windows Terminal, the WT window is still opened after test execution.

### Changes Made
Test now starts windowless process.

### Testing
The KillTree test is still passing.