### PR TITLE
Add NuGet package READMEs

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,13 +1,15 @@
 <Project>
 
   <PropertyGroup>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <ThirdPartyNotice Condition=" '$(ThirdPartyNotice)' == '' ">$(RepoRoot)THIRDPARTYNOTICES.txt</ThirdPartyNotice>
     <AssemblyTitle>$(TargetFileName)</AssemblyTitle>
     <Description Condition="'$(Description)' == ''">$(TargetFileName)</Description>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="$(ThirdPartyNotice)" Pack="true" PackagePath="notices" Visible="false" Condition=" '$(IsPackable)' == 'true' " />
+  <ItemGroup Condition=" '$(IsPackable)' == 'true' ">
+    <None Include="$(ThirdPartyNotice)" Pack="true" PackagePath="notices" Visible="false" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <!-- Global Analyzer Config -->
@@ -15,13 +17,13 @@
     <!-- Include Common.globalconfig for non-deprecated projects-->
     <EditorConfigFiles Include="$(MSBuildThisFileDirectory)eng/Common.globalconfig" />
   </ItemGroup>
-  
+
   <!-- Test Project Global Analyzer Config -->
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <!-- Include Common.Test.globalconfig for Test projects-->
     <EditorConfigFiles Include="$(MSBuildThisFileDirectory)eng/Common.Test.globalconfig" />
   </ItemGroup>
-  
+
   <PropertyGroup>
     <CentralPackagesFile>$(MSBuildThisFileDirectory)eng/Packages.props</CentralPackagesFile>
   </PropertyGroup>
@@ -31,7 +33,7 @@
   <Target Name="DeleteDevPackage" AfterTargets="GenerateNuspec">
     <!-- If package just built was already in global packages folder, delete it.  This helps support a local dev cycle where you are consuming
          a package from another repo without having to update the package version each time. -->
-    
+
     <PropertyGroup>
       <_PackageFolderInGlobalPackages>$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())\$(PackageVersion)</_PackageFolderInGlobalPackages>
     </PropertyGroup>

--- a/documentation/consuming-nuget-package.md
+++ b/documentation/consuming-nuget-package.md
@@ -1,8 +1,8 @@
 # Consuming MSBuild NuGet packages
 
-The MSBuild team currently publishes five NuGet packages.  Our packages are published to NuGet.org 
+The MSBuild team currently publishes five NuGet packages.  Our packages are published to NuGet.org
 
-| Package ID    | URL      | Status   |
+| Package ID    | URL      | Latest Version   |
 | ------------- |-------------| -----|
 | Microsoft.Build.Framework      | https://www.nuget.org/Packages/Microsoft.Build.Framework | [![Microsoft.Build.Framework package](https://img.shields.io/nuget/vpre/Microsoft.Build.Framework.svg)](https://www.nuget.org/Packages/Microsoft.Build.Framework) |
 | Microsoft.Build.Utilities.Core      | https://www.nuget.org/Packages/Microsoft.Build.Utilities.Core | [![Microsoft.Build.Utilities.Core package](https://img.shields.io/nuget/vpre/Microsoft.Build.Utilities.Core.svg)](https://www.nuget.org/Packages/Microsoft.Build.Utilities.Core) |
@@ -11,42 +11,42 @@ The MSBuild team currently publishes five NuGet packages.  Our packages are publ
 | Microsoft.Build.Runtime      | https://www.nuget.org/Packages/Microsoft.Build.Runtime | [![Microsoft.Build.Runtime package](https://img.shields.io/nuget/vpre/Microsoft.Build.Runtime.svg)](https://www.nuget.org/Packages/Microsoft.Build.Runtime) |
 
 ## Microsoft.Build.Framework
-This package contains the `Microsoft.Build.Framework.dll` assembly which makes available items in the [Microsoft.Build.Framework](https://msdn.microsoft.com/en-us/library/microsoft.build.framework.aspx) namespace.
-The items in this namespace are primarily base-level classes and interfaces shared across MSBuild's object model.  MSBuild task developers can reference this package to implement interfaces such as
-[ITask](https://msdn.microsoft.com/en-us/library/microsoft.build.framework.itask.aspx), [ILogger](https://msdn.microsoft.com/en-us/library/microsoft.build.framework.ilogger.aspx), and
-[IForwardingLogger](https://msdn.microsoft.com/en-us/library/microsoft.build.framework.iforwardinglogger.aspx).
+
+This package contains `Microsoft.Build.Framework.dll`, which defines [fundamental types](https://docs.microsoft.com/dotnet/api/microsoft.build.framework) used in MSBuild's API and extensibility model.
 
 ## Microsoft.Build.Utilities.Core
-This package contains the `Microsoft.Build.Utilities.Core.dll` assembly which makes available items in the [Microsoft.Build.Utilities](https://msdn.microsoft.com/en-us/library/microsoft.build.utilities.aspx) namespace.
-The items in this namespace are used by MSBuild to implement utility classes which do things such as create command lines, implement ILogger, locate tools, and track dependencies.
 
-MSBuild task developers often reference this package to develop tasks that inherit from the base class [Task](https://msdn.microsoft.com/en-us/library/microsoft.build.utilities.task.aspx).  This class is implements [ITask] 
-but also provides a logging helper which can reduce code required to develop an MSBuild task.  It also contains the [ToolTask](https://msdn.microsoft.com/en-us/library/microsoft.build.utilities.tooltask.aspx) class which
-should be used by tasks which wrap the execution of another tool.  It provides functionality to capture standard output and standard error as well as the exit code of the process.
+This package contains the `Microsoft.Build.Utilities.Core.dll` assembly which makes available items in the [Microsoft.Build.Utilities](https://docs.microsoft.com/dotnet/api/microsoft.build.utilities) namespace.
 
 ## Microsoft.Build.Tasks.Core
-This package contains the `Microsoft.Build.Tasks.Core.dll` assembly which makes available items in the [Microsoft.Build.Tasks](https://msdn.microsoft.com/en-us/library/microsoft.build.tasks.aspx) namespace.
-The items in this namespace are MSBuild tasks that have been developed by the MSBuild team.  This includes [Copy](https://msdn.microsoft.com/en-us/library/microsoft.build.tasks.copy.aspx),
-[Csc](https://msdn.microsoft.com/en-us/library/microsoft.build.tasks.csc.aspx), and [Exec](https://msdn.microsoft.com/en-us/library/microsoft.build.tasks.exec.aspx).
 
-Most developers do not need to reference this package unless they want to extend a stock MSBuild task with custom functionality.  Alternatively, we recommend that MSBuild task developers reference the 
-`Microsoft.Build.Utilities.Core` package and implement the abstract class [Task](https://msdn.microsoft.com/en-us/library/microsoft.build.utilities.task.aspx) or
-[ToolTask](https://msdn.microsoft.com/en-us/library/microsoft.build.utilities.tooltask.aspx).
+This package contains implementations of [commonly-used MSBuild
+tasks](https://docs.microsoft.com/visualstudio/msbuild/msbuild-task-reference)
+that ship with MSBuild itself.
+
+Most developers do not need to reference this package. We recommend that MSBuild
+task developers reference the `Microsoft.Build.Utilities.Core` package and
+implement the abstract class
+[`Task`](https://docs.microsoft.com/dotnet/api/microsoft.build.utilities.task)
+or
+[`ToolTask`](https://docs.microsoft.com/dotnet/api/microsoft.build.utilities.tooltask).
 
 ## Microsoft.Build
-This package contains the `Microsoft.Build.dll` assembly which makes available items in the [Microsoft.Build.Construction](https://msdn.microsoft.com/en-us/library/microsoft.build.construction.aspx),
-[Microsoft.Build.Evaluation](https://msdn.microsoft.com/en-us/library/microsoft.build.evaluation.aspx), and [Microsoft.Build.Execution](https://msdn.microsoft.com/en-us/library/microsoft.build.execution.aspx) namespaces.
+
+This package contains the `Microsoft.Build.dll` assembly which makes available items in the [Microsoft.Build.Construction](https://msdn.microsoft.com/library/microsoft.build.construction.aspx),
+[Microsoft.Build.Evaluation](https://msdn.microsoft.com/library/microsoft.build.evaluation.aspx), and [Microsoft.Build.Execution](https://msdn.microsoft.com/library/microsoft.build.execution.aspx) namespaces.
+
 Developers should reference this package to create, edit, evaluate, or build MSBuild projects.
 
-To create or edit an MSBuild project, use the [Microsoft.Build.Construction.ProjectRootElement](https://msdn.microsoft.com/en-us/library/microsoft.build.construction.projectrootelement.aspx) class and call the 
-[Create](https://msdn.microsoft.com/en-us/library/microsoft.build.construction.projectrootelement.create.aspx) or
-[Open](https://msdn.microsoft.com/en-us/library/microsoft.build.construction.projectrootelement.open.aspx) method.
-
-To evaluate or build an MSBuild project, use the [Microsoft.Build.Evaluation.Project](https://msdn.microsoft.com/en-us/library/microsoft.build.evaluation.project.aspx) class by creating an instance of it with the
-appropriate parameters for your project.  To retrieve evaluated items, call methods such as  properties such as [GetItem](https://msdn.microsoft.com/en-us/library/microsoft.build.evaluation.project.getitems.aspx)
-or [GetPropertyValue](https://msdn.microsoft.com/en-us/library/microsoft.build.evaluation.project.getpropertyvalue.aspx).
-
 ## Microsoft.Build.Runtime
-This package contains the standard set of MSBuild projects which are imported by other projects such as CSharp and Visual Basic as well as the MSBuild executable.  Developers should reference this package if they want to
-redistribute the MSBuild runtime to evaluate or build MSBuild projects within their application.  This can be necessary because prior to MSBuild version 15, MSBuild was installed globally on a machine and universally
-available to all applications.  However, in MSBuild version 15 and forward, MSBuild is redistributed by each application that uses it and applications are unable to share other instances.  
+
+This package delivers a complete executable copy of MSBuild. Reference this
+package only if your application needs to load projects or execute in-process
+builds without requiring installation of MSBuild. Successfully evaluating
+projects using this package requires aggregating additional components (like the
+compilers) into an application directory.
+
+🗒️ NOTE: if you are building an application that wants to use MSBuild to
+evaluate or build projects, you will generally not need this package. Instead,
+use [MSBuildLocator](https://aka.ms/msbuild/locator) to use a complete toolset
+provided by the .NET SDK or Visual Studio.

--- a/src/Build/README.md
+++ b/src/Build/README.md
@@ -5,3 +5,13 @@ This package contains `Microsoft.Build.dll`, which defines MSBuild's API, includ
 * [`Microsoft.Build.Evaluation`](https://docs.microsoft.com/dotnet/api/microsoft.build.evaluation) for evaluating MSBuild projects,
 * [`Microsoft.Build.Construction`](https://docs.microsoft.com/dotnet/api/microsoft.build.construction) for creating new MSBuild projects, and
 * [`Microsoft.Build.Execution`](https://docs.microsoft.com/dotnet/api/microsoft.build.execution) for building MSBuild projects.
+
+Developers should reference this package to write applications that create, edit, evaluate, or build MSBuild projects.
+
+To create or edit an MSBuild project, use the [Microsoft.Build.Construction.ProjectRootElement](https://docs.microsoft.com/dotnet/api/microsoft.build.construction.projectrootelement) class and call the
+[Create](https://docs.microsoft.com/dotnet/api/microsoft.build.construction.projectrootelement.create) or
+[Open](https://docs.microsoft.com/dotnet/api/microsoft.build.construction.projectrootelement.open) method.
+
+To evaluate or build an MSBuild project, use the [Microsoft.Build.Evaluation.Project](https://docs.microsoft.com/dotnet/api/microsoft.build.evaluation.project) class by creating an instance of it with the
+appropriate parameters for your project.  To retrieve evaluated items, call methods such as  properties such as [GetItems](https://docs.microsoft.com/dotnet/api/microsoft.build.evaluation.project.getitems)
+or [GetPropertyValue](https://docs.microsoft.com/dotnet/api/microsoft.build.evaluation.project.getpropertyvalue).

--- a/src/Build/README.md
+++ b/src/Build/README.md
@@ -1,0 +1,7 @@
+# Microsoft.Build
+
+This package contains `Microsoft.Build.dll`, which defines MSBuild's API, including
+
+* [`Microsoft.Build.Evaluation`](https://docs.microsoft.com/dotnet/api/microsoft.build.evaluation) for evaluating MSBuild projects,
+* [`Microsoft.Build.Construction`](https://docs.microsoft.com/dotnet/api/microsoft.build.construction) for creating new MSBuild projects, and
+* [`Microsoft.Build.Execution`](https://docs.microsoft.com/dotnet/api/microsoft.build.execution) for building MSBuild projects.

--- a/src/Deprecated/Conversion/README.md
+++ b/src/Deprecated/Conversion/README.md
@@ -1,0 +1,5 @@
+# Microsoft.Build.Conversion.Core
+
+⚠️ This package is **deprecated** and should not be referenced. It will be removed in a future version of MSBuild.
+
+Contains `Microsoft.Build.Conversion.Core.dll`, which is provided with MSBuild for compatibility purposes.

--- a/src/Deprecated/Engine/README.md
+++ b/src/Deprecated/Engine/README.md
@@ -1,0 +1,5 @@
+# Microsoft.Build.Engine
+
+⚠️ This package is **deprecated** and should not be referenced. It will be removed in a future version of MSBuild.
+
+Contains `Microsoft.Build.Engine.dll`, which is provided with MSBuild for compatibility purposes.

--- a/src/Framework/README.md
+++ b/src/Framework/README.md
@@ -1,3 +1,6 @@
 # Microsoft.Build.Framework
 
 This package contains `Microsoft.Build.Framework.dll`, which defines [fundamental types](https://docs.microsoft.com/dotnet/api/microsoft.build.framework) used in MSBuild's API and extensibility model.
+
+The items in this namespace are primarily base-level classes and interfaces shared across MSBuild's object model.  MSBuild task or extension developers can reference this package to implement interfaces such as
+[`ITask`](https://docs.microsoft.com/dotnet/api/microsoft.build.framework.itask), and [`ILogger`](https://docs.microsoft.com/dotnet/api/microsoft.build.framework.ilogger).

--- a/src/Framework/README.md
+++ b/src/Framework/README.md
@@ -1,0 +1,3 @@
+# Microsoft.Build.Framework
+
+This package contains `Microsoft.Build.Framework.dll`, which defines [fundamental types](https://docs.microsoft.com/dotnet/api/microsoft.build.framework) used in MSBuild's API and extensibility model.

--- a/src/MSBuild/README.md
+++ b/src/MSBuild/README.md
@@ -1,0 +1,12 @@
+﻿# Microsoft.Build.Runtime
+
+This package delivers a complete executable copy of MSBuild. Reference this
+package only if your application needs to load projects or execute in-process
+builds without requiring installation of MSBuild. Successfully evaluating
+projects using this package requires aggregating additional components (like the
+compilers) into an application directory.
+
+🗒️ NOTE: if you are building an application that wants to use MSBuild to
+evaluate or build projects, you will generally not need this package. Instead,
+use [MSBuildLocator](https://aka.ms/msbuild/locator) to use a complete toolset
+provided by the .NET SDK or Visual Studio.

--- a/src/StringTools/README.md
+++ b/src/StringTools/README.md
@@ -1,0 +1,5 @@
+# Microsoft.NET.StringTools
+
+This package contains the Microsoft.NET.StringTools assembly which implements common string-related functionality such as weak interning.
+
+At this time, this is primarily an internal implementation detail of MSBuild and Visual Studio and we do not expect other consumers of the package. If you think you might like to use it, please start a discussion at https://github.com/dotnet/msbuild/discussions to let us know your use cases.

--- a/src/Tasks/README.md
+++ b/src/Tasks/README.md
@@ -1,0 +1,8 @@
+# Microsoft.Build.Tasks
+
+This package contains implementations of [commonly-used MSBuild
+tasks](https://docs.microsoft.com/visualstudio/msbuild/msbuild-task-reference)
+that ship with MSBuild itself.
+
+You do not need to reference this package to use these tasks in a build--they
+are available in any MSBuild environment.

--- a/src/Tasks/README.md
+++ b/src/Tasks/README.md
@@ -6,3 +6,8 @@ that ship with MSBuild itself.
 
 You do not need to reference this package to use these tasks in a build--they
 are available in any MSBuild environment.
+
+If you are writing a new task, you may wish to reference
+[Microsoft.Build.Utilities.Core](https://www.nuget.org/Packages/Microsoft.Build.Utilities.Core)
+and derive from `Microsoft.Build.Utilities.Task` or
+`Microsoft.Build.Utilities.ToolTask`.

--- a/src/Utilities/README.md
+++ b/src/Utilities/README.md
@@ -1,0 +1,7 @@
+# Microsoft.Build.Utilities.Core
+
+This package contains `Microsoft.Build.Utilities.Core.dll`, which defines helper functionality for MSBuild extenders, including
+
+* [`Task`](https://docs.microsoft.com/dotnet/api/microsoft.build.utilities.task), a base class for custom tasks,
+* [`ToolTask`](https://docs.microsoft.com/dotnet/api/microsoft.build.utilities.tooltask), a base class for tasks that run a command-line tool, and
+* [`Logger`](https://docs.microsoft.com/dotnet/api/microsoft.build.utilities.logger), a base class for custom logging functionality.


### PR DESCRIPTION
This should improve understandablity of our packages.

Fixes #6991.

Details on the format:

* https://docs.microsoft.com/nuget/nuget-org/package-readme-on-nuget-org
* https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/
