### PR TITLE
Account for ARM64 in ProcessorArchitecture Tests

### DIFF
--- a/src/Utilities.UnitTests/ProcessorArchitecture_Tests.cs
+++ b/src/Utilities.UnitTests/ProcessorArchitecture_Tests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Build.UnitTests
                 NativeMethodsShared.ProcessorArchitectures.X64 => ProcessorArchitecture.AMD64,
                 NativeMethodsShared.ProcessorArchitectures.IA64 => ProcessorArchitecture.IA64,
                 NativeMethodsShared.ProcessorArchitectures.ARM => ProcessorArchitecture.ARM,
+                NativeMethodsShared.ProcessorArchitectures.ARM64 => ProcessorArchitecture.ARM64,
                 // unknown architecture? return null
                 _ => null,
             };
@@ -35,6 +36,7 @@ namespace Microsoft.Build.UnitTests
             ProcessorArchitecture.AMD64.ShouldBe("AMD64"); // "AMD64 ProcessorArchitecture isn't correct"
             ProcessorArchitecture.MSIL.ShouldBe("MSIL"); // "MSIL ProcessorArchitecture isn't correct"
             ProcessorArchitecture.ARM.ShouldBe("ARM"); // "ARM ProcessorArchitecture isn't correct"
+            ProcessorArchitecture.ARM64.ShouldBe("ARM64"); // "ARM ProcessorArchitecture isn't correct"
         }
 
         [Fact]
@@ -55,7 +57,15 @@ namespace Microsoft.Build.UnitTests
                     procArchitecture.ShouldBe(ProcessorArchitecture.ARM);
 
                     procArchitecture = ToolLocationHelper.ConvertDotNetFrameworkArchitectureToProcessorArchitecture(Utilities.DotNetFrameworkArchitecture.Bitness64);
-                    procArchitecture.ShouldBeNull(); // "We should not have any Bitness64 Processor architecture returned in arm"
+                    procArchitecture.ShouldBeNull();
+                    break;
+
+                case ProcessorArchitecture.ARM64:
+                    procArchitecture = ToolLocationHelper.ConvertDotNetFrameworkArchitectureToProcessorArchitecture(Utilities.DotNetFrameworkArchitecture.Bitness64);
+                    procArchitecture.ShouldBe(ProcessorArchitecture.ARM64);
+
+                    procArchitecture = ToolLocationHelper.ConvertDotNetFrameworkArchitectureToProcessorArchitecture(Utilities.DotNetFrameworkArchitecture.Bitness32);
+                    procArchitecture.ShouldBe(ProcessorArchitecture.ARM);
                     break;
 
                 case ProcessorArchitecture.X86:

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -3410,6 +3410,7 @@ namespace Microsoft.Build.Utilities
                     {
                         NativeMethodsShared.ProcessorArchitectures.X64 => ProcessorArchitecture.AMD64,
                         NativeMethodsShared.ProcessorArchitectures.IA64 => ProcessorArchitecture.IA64,
+                        NativeMethodsShared.ProcessorArchitectures.ARM64 => ProcessorArchitecture.ARM64,
                         // Error, OK, we're trying to get the 64-bit path on a 32-bit machine.
                         // That ... doesn't make sense. 
                         NativeMethodsShared.ProcessorArchitectures.X86 => null,

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -3399,7 +3399,8 @@ namespace Microsoft.Build.Utilities
             switch (architecture)
             {
                 case DotNetFrameworkArchitecture.Bitness32:
-                    if (ProcessorArchitecture.CurrentProcessArchitecture == ProcessorArchitecture.ARM)
+                    if (ProcessorArchitecture.CurrentProcessArchitecture == ProcessorArchitecture.ARM ||
+                        ProcessorArchitecture.CurrentProcessArchitecture == ProcessorArchitecture.ARM64)
                     {
                         return ProcessorArchitecture.ARM;
                     }


### PR DESCRIPTION
Fixes #7292

### Context
ProcessorArchitecture unit tests needed to be updated to account for arm64 machines.

### Changes Made
Accounts for arm64 as a valid processor architecture

### Testing
Tested locally on an m1 mac.

### Notes
