### PR TITLE
Reuse StringBuilders in EventArgsFormatting

### DIFF
--- a/src/Framework/ReuseableStringBuilder.cs
+++ b/src/Framework/ReuseableStringBuilder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using System.Threading;
 using Microsoft.Build.Eventing;
@@ -110,6 +111,28 @@ namespace Microsoft.Build.Framework
         {
             LazyPrepare();
             _borrowedBuilder.Append(value, startIndex, count);
+            return this;
+        }
+
+        /// <inheritdoc cref="StringBuilder.AppendFormat(IFormatProvider, string, object[])"/>
+        internal ReuseableStringBuilder AppendFormat(
+            CultureInfo currentCulture,
+            string format,
+            params object[] args)
+        {
+            LazyPrepare();
+            _borrowedBuilder.AppendFormat(
+                currentCulture,
+                format,
+                args);
+            return this;
+        }
+
+        /// <inheritdoc cref="StringBuilder.AppendLine()"/>
+        internal ReuseableStringBuilder AppendLine()
+        {
+            LazyPrepare();
+            _borrowedBuilder.AppendLine();
             return this;
         }
 

--- a/src/Shared/EventArgsFormatting.cs
+++ b/src/Shared/EventArgsFormatting.cs
@@ -219,7 +219,9 @@ namespace Microsoft.Build.Shared
             string logOutputProperties
         )
         {
-            StringBuilder format = new StringBuilder();
+            // capacity is the longest possible path through the below
+            // to avoid reallocating while constructing the string
+            using ReuseableStringBuilder format = new(51);
 
             // Uncomment these lines to show show the processor, if present.
             /*
@@ -328,9 +330,11 @@ namespace Microsoft.Build.Shared
 
             string finalFormat = format.ToString();
 
+            // Reuse the string builder to create the final message
+            ReuseableStringBuilder formattedMessage = format.Clear();
+
             // If there are multiple lines, show each line as a separate message.
             string[] lines = SplitStringOnNewLines(message);
-            StringBuilder formattedMessage = new StringBuilder();
 
             for (int i = 0; i < lines.Length; i++)
             {


### PR DESCRIPTION
While I was editing in this area I noticed that the calling pattern around StringBuilders in FormatEventMessage looked allocatey.

Instead of creating two throwaway StringBuilders to format a single message,

1. Make a guess at the initial size based on the maximum format string,
2. Use a StringBuilder from StringBuilderCache, and
3. Reuse the builder between "construct format string" and "get final message"

