### PR TITLE
Support ProjectConfigurationDescription when SDK loggers are attached

### DIFF
--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -222,8 +222,8 @@ namespace Microsoft.Build.UnitTests
                 new BuildRequestData(p.CreateProjectInstance(), new[] { "Spawn" }));
 
             p.Build().ShouldBeTrue();
-            sc.ToString().ShouldContain("source_of_warning : warning : Hello from project 1 [" + project.ProjectFile + ":: Number=1]");
-            sc.ToString().ShouldContain("source_of_warning : warning : Hello from project 2 [" + project.ProjectFile + ":: Number=2]");
+            sc.ToString().ShouldContain("source_of_warning : warning : Hello from project 1 [" + project.ProjectFile + "::Number=1]");
+            sc.ToString().ShouldContain("source_of_warning : warning : Hello from project 2 [" + project.ProjectFile + "::Number=2]");
         }
 
         [Fact]
@@ -263,8 +263,8 @@ namespace Microsoft.Build.UnitTests
                 new BuildRequestData(p.CreateProjectInstance(), new[] { "Spawn" }));
 
             p.Build().ShouldBeFalse();
-            sc.ToString().ShouldContain("source_of_error : error : Hello from project 1 [" + project.ProjectFile + ":: Number=1]");
-            sc.ToString().ShouldContain("source_of_error : error : Hello from project 2 [" + project.ProjectFile + ":: Number=2]");
+            sc.ToString().ShouldContain("source_of_error : error : Hello from project 1 [" + project.ProjectFile + "::Number=1]");
+            sc.ToString().ShouldContain("source_of_error : error : Hello from project 2 [" + project.ProjectFile + "::Number=2]");
         }
 
         [Theory]
@@ -316,8 +316,8 @@ namespace Microsoft.Build.UnitTests
 
             p.Build().ShouldBeFalse();
             string output = sc.ToString();
-            output.ShouldContain("source_of_error : error : Hello from project 1 [" + project.ProjectFile + ":: Number=1 TargetFramework=netcoreapp2.1]");
-            output.ShouldContain("source_of_error : error : Hello from project 2 [" + project.ProjectFile + ":: Number=2 TargetFramework=netcoreapp2.1]");
+            output.ShouldContain("source_of_error : error : Hello from project 1 [" + project.ProjectFile + "::Number=1 TargetFramework=netcoreapp2.1]");
+            output.ShouldContain("source_of_error : error : Hello from project 2 [" + project.ProjectFile + "::Number=2 TargetFramework=netcoreapp2.1]");
         }
 
         [Fact(Skip = "https://github.com/dotnet/msbuild/issues/6518")]

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2979,7 +2979,7 @@ namespace Microsoft.Build.Execution
                         loggerClassName: typeof(ConfigurableForwardingLogger).FullName,
                         loggerAssemblyName: typeof(ConfigurableForwardingLogger).GetTypeInfo().Assembly.GetName().FullName,
                         loggerAssemblyFile: null,
-                        loggerSwitchParameters: "PROJECTSTARTEDEVENT;PROJECTFINISHEDEVENT",
+                        loggerSwitchParameters: "PROJECTSTARTEDEVENT;PROJECTFINISHEDEVENT;FORWARDPROJECTCONTEXTEVENTS",
                         verbosity: LoggerVerbosity.Quiet);
 
                     ForwardingLoggerRecord[] forwardingLogger = { new ForwardingLoggerRecord(new NullLogger(), forwardingLoggerDescription) };

--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -114,11 +114,20 @@ namespace Microsoft.Build.Logging
                     }
                 }
                 // Setting events to forward on the commandline will override the verbosity and other switches such as
-                // showPerfSummand and ShowSummary
+                // showPerfSummary and ShowSummary
                 if (_forwardingSetFromParameters)
                 {
                     _showPerfSummary = false;
                     _showSummary = true;
+                }
+
+                if (_forwardProjectContext)
+                {
+                    // We can't know whether the project items needed to find ForwardProjectContextDescription
+                    // will be set on ProjectStarted or ProjectEvaluationFinished because we don't know
+                    // all of the other loggers that will be attached. So turn both on.
+                    _forwardingTable[ProjectStartedEventDescription] = 1;
+                    _forwardingTable[ProjectEvaluationFinishedEventDescription] = 1;
                 }
             }
         }
@@ -150,6 +159,10 @@ namespace Microsoft.Build.Logging
             else if (String.Equals(parameterName, ShowCommandLineDescription, StringComparison.OrdinalIgnoreCase))
             {
                 _showCommandLine = true;
+            }
+            else if (string.Equals(parameterName, ForwardProjectContextDescription, StringComparison.OrdinalIgnoreCase))
+            {
+                _forwardProjectContext = true;
             }
         }
 
@@ -545,6 +558,7 @@ namespace Microsoft.Build.Logging
         private const string PerformanceSummaryDescription = "PERFORMANCESUMMARY";
         private const string NoSummaryDescription = "NOSUMMARY";
         private const string ShowCommandLineDescription = "SHOWCOMMANDLINE";
+        private const string ForwardProjectContextDescription = "FORWARDPROJECTCONTEXTEVENTS";
 
         #region Per-build Members
 
@@ -565,6 +579,12 @@ namespace Microsoft.Build.Logging
         /// if this is false the events to forward are based on verbosity else verbosity settings will be ignored
         /// </summary>
         private bool _forwardingSetFromParameters;
+
+        /// <summary>
+        /// Indicates if the events to forward should include project context events, if not
+        /// overridden by individual-event forwarding in <see cref="_forwardingSetFromParameters"/>.
+        /// </summary>
+        private bool _forwardProjectContext = false;
 
         /// <summary>
         /// Console logger should show error and warning summary at the end of build?

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -573,6 +573,7 @@ namespace Microsoft.Build.BackEnd.Logging
             }
 
             ReuseableStringBuilder projectConfigurationDescription = null;
+            bool descriptionEmpty = true;
 
             Internal.Utilities.EnumerateItems(items, item =>
             {
@@ -592,7 +593,14 @@ namespace Microsoft.Build.BackEnd.Logging
                     };
 
                     // Add the item value to the string to be printed in error/warning messages.
-                    projectConfigurationDescription.Append(" ").Append(itemSpec);
+                    if (!descriptionEmpty)
+                    {
+                        projectConfigurationDescription.Append(" "); 
+                    }
+
+                    projectConfigurationDescription.Append(itemSpec);
+
+                    descriptionEmpty = false;
                 }
             });
 
@@ -653,7 +661,7 @@ namespace Microsoft.Build.BackEnd.Logging
                         // should be shown
                         string targets = startedEvent.TargetNames;
                         string projectName = startedEvent.ProjectFile ?? string.Empty;
-                        
+
                         // Show which targets were built as part of this project
                         if (string.IsNullOrEmpty(targets))
                         {

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2006,8 +2006,8 @@ namespace Microsoft.Build.UnitTests
                 "Expected parameter in logger to match parameters passed in",
                 StringCompareShould.IgnoreCase);
             distributedLogger.ForwardingLoggerDescription.LoggerSwitchParameters.ShouldBe(
-                "SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;Parameter;Parameter",
-                "Expected parameter in logger to match parameter passed in",
+                "SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;Parameter;Parameter;FORWARDPROJECTCONTEXTEVENTS",
+                "Expected parameter in logger to match parameter passed in + FORWARDPROJECTCONTEXTEVENTS",
                 StringCompareShould.IgnoreCase);
         }
         #endregion

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -19,6 +19,7 @@ using Shouldly;
 using System.IO.Compression;
 using System.Reflection;
 using Microsoft.Build.Utilities;
+using Microsoft.Build.Logging;
 
 #nullable disable
 
@@ -1968,8 +1969,8 @@ namespace Microsoft.Build.UnitTests
                            1,
                            loggers
                        );
-            loggers.Count.ShouldBe(0); // "Expected no central loggers to be attached"
-            distributedLoggerRecords.Count.ShouldBe(0); // "Expected no distributed loggers to be attached"
+            loggers.ShouldBeEmpty("Expected no central loggers to be attached");
+            distributedLoggerRecords.ShouldBeEmpty("Expected no distributed loggers to be attached");
 
             MSBuildApp.ProcessConsoleLoggerSwitch
                        (
@@ -1980,8 +1981,12 @@ namespace Microsoft.Build.UnitTests
                            1,
                            loggers
                        );
-            loggers.Count.ShouldBe(1); // "Expected a central loggers to be attached"
-            loggers[0].Parameters.ShouldBe("EnableMPLogging;SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;parameter;Parameter", StringCompareShould.IgnoreCase); // "Expected parameter in logger to match parameters passed in"
+            loggers.ShouldHaveSingleItem("Expected a central logger to be attached");
+            loggers[0].ShouldBeOfType<ConsoleLogger>();
+            loggers[0].Parameters.ShouldBe(
+                "EnableMPLogging;SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;parameter;Parameter",
+                "Expected parameter in logger to match parameters passed in",
+                StringCompareShould.IgnoreCase);
 
             MSBuildApp.ProcessConsoleLoggerSwitch
                        (
@@ -1992,11 +1997,18 @@ namespace Microsoft.Build.UnitTests
                           2,
                           loggers
                       );
-            loggers.Count.ShouldBe(1); // "Expected a central loggers to be attached"
-            distributedLoggerRecords.Count.ShouldBe(1); // "Expected a distributed logger to be attached"
+            loggers.ShouldHaveSingleItem("Expected a central logger to be attached");
+            distributedLoggerRecords.ShouldHaveSingleItem("Expected a distributed logger to be attached");
             DistributedLoggerRecord distributedLogger = distributedLoggerRecords[0];
-            distributedLogger.CentralLogger.Parameters.ShouldBe("SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;parameter;Parameter", StringCompareShould.IgnoreCase); // "Expected parameter in logger to match parameters passed in"
-            distributedLogger.ForwardingLoggerDescription.LoggerSwitchParameters.ShouldBe("SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;Parameter;Parameter", StringCompareShould.IgnoreCase); // "Expected parameter in logger to match parameter passed in"
+            distributedLogger.CentralLogger.ShouldBeOfType<ConsoleLogger>();
+            distributedLogger.CentralLogger.Parameters.ShouldBe(
+                "SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;parameter;Parameter",
+                "Expected parameter in logger to match parameters passed in",
+                StringCompareShould.IgnoreCase);
+            distributedLogger.ForwardingLoggerDescription.LoggerSwitchParameters.ShouldBe(
+                "SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;Parameter;Parameter",
+                "Expected parameter in logger to match parameter passed in",
+                StringCompareShould.IgnoreCase);
         }
         #endregion
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Build.CommandLine
         /// Also, the strings are not localized.
         /// Before execution, this is called with initialize only, causing counters to get called with NextValue() to
         /// initialize them.
-        /// </comments>         
+        /// </comments>
         private static void DumpCounters(bool initializeOnly)
         {
             Process currentProcess = Process.GetCurrentProcess();
@@ -305,7 +305,7 @@ namespace Microsoft.Build.CommandLine
             // Generally, the instance names, such as "msbuild" and "msbuild#2" are non deterministic; we want this process.
             // Don't use the "ID Process" counter out of the "Process" category, as it doesn't use the same naming scheme
             // as the .NET counters. However, the "Process ID" counter out of the ".NET CLR Memory" category apparently uses
-            // the same scheme as the other .NET categories.            
+            // the same scheme as the other .NET categories.
             string currentInstance = null;
             PerformanceCounterCategory processCategory = new PerformanceCounterCategory("Process");
             foreach (string instance in processCategory.GetInstanceNames())
@@ -334,7 +334,7 @@ namespace Microsoft.Build.CommandLine
 #if FEATURE_PERFORMANCE_COUNTERS
         /// <summary>
         /// Dumps all counters in the category
-        /// </summary>        
+        /// </summary>
         private static void DumpAllInCategory(string currentInstance, PerformanceCounterCategory category, bool initializeOnly)
         {
             if (category.CategoryName.IndexOf("remoting", StringComparison.OrdinalIgnoreCase) != -1) // not interesting
@@ -371,7 +371,7 @@ namespace Microsoft.Build.CommandLine
 
         /// <summary>
         /// Dumps one counter
-        /// </summary>          
+        /// </summary>
         private static void DumpCounter(PerformanceCounter counter, bool initializeOnly)
         {
             try
@@ -386,7 +386,7 @@ namespace Microsoft.Build.CommandLine
                 if (!initializeOnly)
                 {
                     string friendlyCounterType = GetFriendlyCounterType(counter.CounterType, counter.CounterName);
-                    
+
                     // At least some (such as % in GC; maybe all) "%" counters are already multiplied by 100. So we don't do that here.
 
                     // Show decimal places if meaningful
@@ -404,7 +404,7 @@ namespace Microsoft.Build.CommandLine
 
         /// <summary>
         /// Gets a friendly representation of the counter units
-        /// </summary>        
+        /// </summary>
         private static string GetFriendlyCounterType(PerformanceCounterType type, string name)
         {
             if (name.IndexOf("bytes", StringComparison.OrdinalIgnoreCase) != -1)
@@ -611,7 +611,7 @@ namespace Microsoft.Build.CommandLine
                     }
                     if (preprocessWriter != null && !BuildEnvironmentHelper.Instance.RunningTests)
                     {
-                        // Indicate to the engine that it can NOT toss extraneous file content: we want to 
+                        // Indicate to the engine that it can NOT toss extraneous file content: we want to
                         // see that in preprocessing/debugging
                         Environment.SetEnvironmentVariable("MSBUILDLOADALLFILESASWRITEABLE", "1");
                     }
@@ -864,7 +864,7 @@ namespace Microsoft.Build.CommandLine
             // The OS takes a lock in
             // kernel32.dll!_SetConsoleCtrlHandler, so if a task
             // waits for that lock somehow before quitting, it would hang
-            // because we're in it here. One way a task can end up here is 
+            // because we're in it here. One way a task can end up here is
             // by calling Microsoft.Win32.SystemEvents.Initialize.
             // So do our work asynchronously so we can return immediately.
             // We're already on a threadpool thread anyway.
@@ -1070,7 +1070,7 @@ namespace Microsoft.Build.CommandLine
                 }
 
 #if FEATURE_XML_SCHEMA_VALIDATION
-                // If the user has requested that the schema be validated, do that here. 
+                // If the user has requested that the schema be validated, do that here.
                 if (needToValidateProject && !FileUtilities.IsSolutionFilename(projectFile))
                 {
                     Microsoft.Build.Evaluation.Project project = projectCollection.LoadProject(projectFile, globalProperties, toolsVersion);
@@ -1084,7 +1084,7 @@ namespace Microsoft.Build.CommandLine
                     ProjectSchemaValidationHandler.VerifyProjectSchema(projectFile, schemaFile, toolset.ToolsPath);
 
                     // If there are schema validation errors, an InitializationException is thrown, so if we get here,
-                    // we can safely assume that the project successfully validated. 
+                    // we can safely assume that the project successfully validated.
                     projectCollection.UnloadProject(project);
                 }
 #endif
@@ -1152,7 +1152,7 @@ namespace Microsoft.Build.CommandLine
                     {
                         parameters.MemoryUseLimit = Convert.ToInt32(memoryUseLimit, CultureInfo.InvariantCulture);
 
-                        // The following ensures that when we divide the use by node count to get the per-limit amount, we always end up with a 
+                        // The following ensures that when we divide the use by node count to get the per-limit amount, we always end up with a
                         // positive value - otherwise setting it too low will result in a zero, which will enable only the default cache behavior
                         // which is not what is intended by using this environment variable.
                         if (parameters.MemoryUseLimit < parameters.MaxNodeCount)
@@ -1168,7 +1168,7 @@ namespace Microsoft.Build.CommandLine
                     IEnumerable<BuildManager.DeferredBuildMessage> messagesToLogInBuildLoggers = null;
                     if (!Traits.Instance.EscapeHatches.DoNotSendDeferredMessagesToBuildManager)
                     {
-                        var commandLineString = 
+                        var commandLineString =
 #if FEATURE_GET_COMMANDLINE
                             commandLine;
 #else
@@ -1266,7 +1266,7 @@ namespace Microsoft.Build.CommandLine
                             }
                             else
                             {
-                                // After throwing again below the stack will be reset. Make certain we log everything we 
+                                // After throwing again below the stack will be reset. Make certain we log everything we
                                 // can now
                                 Console.WriteLine(AssemblyResources.GetString("FatalError"));
 #if DEBUG
@@ -1591,7 +1591,7 @@ namespace Microsoft.Build.CommandLine
 
                         // Special case: for the switches "/m" (or "/maxCpuCount") and "/bl" (or "/binarylogger") we wish to pretend we saw a default argument
                         // This allows a subsequent /m:n on the command line to override it.
-                        // We could create a new kind of switch with optional parameters, but it's a great deal of churn for this single case. 
+                        // We could create a new kind of switch with optional parameters, but it's a great deal of churn for this single case.
                         // Note that if no "/m" or "/maxCpuCount" switch -- either with or without parameters -- is present, then we still default to 1 cpu
                         // for backwards compatibility.
                         if (string.IsNullOrEmpty(switchParameters))
@@ -2825,7 +2825,7 @@ namespace Microsoft.Build.CommandLine
         private static readonly char[] s_propertyValueSeparator = MSBuildConstants.EqualsChar;
 
         /// <summary>
-        /// This is a set of wildcard chars which can cause a file extension to be invalid 
+        /// This is a set of wildcard chars which can cause a file extension to be invalid
         /// </summary>
         private static readonly char[] s_wildcards = MSBuildConstants.WildcardChars;
 
@@ -2839,7 +2839,7 @@ namespace Microsoft.Build.CommandLine
         {
             if (parameters.Length > 0)
             {
-                // We don't do any validation on the value of the ToolsVersion here, since we don't 
+                // We don't do any validation on the value of the ToolsVersion here, since we don't
                 // know what a valid value looks like.  The engine will take care of this later.
                 return parameters[parameters.Length - 1];
             }
@@ -2931,7 +2931,7 @@ namespace Microsoft.Build.CommandLine
         /// Parameters for a particular logger may be passed in fragments that we have to aggregate: for example,
         ///   /flp:foo=bar;baz=biz /flp:boz=bez becomes "foo=bar;baz=biz;boz=bez"
         /// We are going to aggregate the LoggerParameters into one LoggerParameters string
-        /// to do this we must first trim off the ; from the start and the end of the strings as 
+        /// to do this we must first trim off the ; from the start and the end of the strings as
         /// this would interfere with the use of string.Join by possibly having ;; at the beginning or end of a
         /// logger parameter
         /// </summary>
@@ -2963,7 +2963,7 @@ namespace Microsoft.Build.CommandLine
 
                 string fileParameters = "SHOWPROJECTFILE=TRUE;";
                 // Use a default log file name of "msbuild.log", "msbuild1.log", "msbuild2.log", etc; put this first on the parameter
-                // list so that any supplied log file parameter will override it 
+                // list so that any supplied log file parameter will override it
                 if (i == 0)
                 {
                     fileParameters += "logfile=msbuild.log;";
@@ -3041,7 +3041,7 @@ namespace Microsoft.Build.CommandLine
             // the console logger is always active, unless specifically disabled
             if (!noConsoleLogger)
             {
-                // A central logger will be created for single proc and multiproc 
+                // A central logger will be created for single proc and multiproc
                 ConsoleLogger logger = new ConsoleLogger(verbosity);
                 string consoleParameters = "SHOWPROJECTFILE=TRUE;";
 
@@ -3073,7 +3073,7 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
-        /// Returns a DistributedLoggerRecord containing this logger and a ConfigurableForwardingLogger. 
+        /// Returns a DistributedLoggerRecord containing this logger and a ConfigurableForwardingLogger.
         /// Looks at the logger's parameters for any verbosity parameter in order to make sure it is setting up the ConfigurableForwardingLogger
         /// with the verbosity level that the logger will actually use.
         /// </summary>
@@ -3088,6 +3088,11 @@ namespace Microsoft.Build.CommandLine
             {
                 effectiveVerbosity = ProcessVerbositySwitch(verbosityValue);
             }
+
+            // Ensure that the forwarding logger is passed evaluation-finished
+            // and project-started events unless the user has specified individual
+            // events of interest.
+            loggerParameters += ";FORWARDPROJECTCONTEXTEVENTS";
 
             // Gets the currently loaded assembly in which the specified class is defined
             Assembly engineAssembly = typeof(ProjectCollection).GetTypeInfo().Assembly;
@@ -3213,7 +3218,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         /// <remarks>
         /// Internal for unit testing only
-        /// </remarks> 
+        /// </remarks>
         /// <param name="value"></param>
         /// <returns>The logger verbosity level.</returns>
         internal static LoggerVerbosity ProcessVerbositySwitch(string value)
@@ -3556,7 +3561,7 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
-        /// Given an invalid ToolsVersion string and the collection of valid toolsets, 
+        /// Given an invalid ToolsVersion string and the collection of valid toolsets,
         /// throws an InitializationException with the appropriate message.
         /// </summary>
         private static void ThrowInvalidToolsVersionInitializationException(IEnumerable<Toolset> toolsets, string toolsVersion)

--- a/src/Shared/EventArgsFormatting.cs
+++ b/src/Shared/EventArgsFormatting.cs
@@ -310,15 +310,30 @@ namespace Microsoft.Build.Shared
 
             // If the project file was specified, tack that onto the very end.
             // Check for additional properties that should be output with project file
-            if (projectFile != null && !String.Equals(projectFile, file))
+            if (projectFile != null)
             {
-                if (logOutputProperties?.Length > 0)
+                // If the project file was specified, tack that onto the very end.
+                if (!string.Equals(projectFile, file))
                 {
-                    format.Append(" [{10}::{11}]");
+                    // Check for additional properties that should be output with project file
+                    if (logOutputProperties?.Length > 0)
+                    {
+                        format.Append(" [{10}::{11}]");
+                    }
+                    else
+                    {
+                        format.Append(" [{10}]");
+                    }
                 }
                 else
                 {
-                    format.Append(" [{10}]");
+                    // If the file location of the error _was_ the project file, append only the
+                    // additional output properties
+
+                    if (logOutputProperties?.Length > 0)
+                    {
+                        format.Append(" [{11}]");
+                    }
                 }
             }
 


### PR DESCRIPTION
Unblocks https://github.com/dotnet/sdk/pull/12030 by fixing problems that arose when combining `dotnet build` with `ProjectConfigurationDescription`.

Part of #1222.

I recommend reviewing commit-by-commit.