### PR TITLE
Refactoring: use C# pattern matching for type checking & type casting.

### DIFF
--- a/src/Build.UnitTests/BackEnd/CustomLogAndReturnTask.cs
+++ b/src/Build.UnitTests/BackEnd/CustomLogAndReturnTask.cs
@@ -26,12 +26,12 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         public override bool Execute()
         {
-            if(!string.IsNullOrEmpty(WarningCode))
+            if (!string.IsNullOrEmpty(WarningCode))
             {
                 Log.LogWarning(null, WarningCode, null, null, 0, 0, 0, 0, "Warning Logged!", null);
             }
 
-            if(!string.IsNullOrEmpty(ErrorCode))
+            if (!string.IsNullOrEmpty(ErrorCode))
             {
                 Log.LogError(null, ErrorCode, null, null, 0, 0, 0, 0, "Error Logged!", null);
             }

--- a/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -1900,13 +1900,13 @@ namespace Microsoft.Build.UnitTests.Logging
             /// <param name="buildEvent">Build event which was asked to be processed</param>
             internal override void ProcessLoggingEvent(object buildEvent, bool allowThrottling = false)
             {
-                if (buildEvent is BuildEventArgs)
+                if (buildEvent is BuildEventArgs buildEventArgs)
                 {
-                    _processedBuildEvent = buildEvent as BuildEventArgs;
+                    _processedBuildEvent = buildEventArgs;
                 }
-                else if (buildEvent is KeyValuePair<int, BuildEventArgs>)
+                else if (buildEvent is KeyValuePair<int, BuildEventArgs> kvp)
                 {
-                    _processedBuildEvent = ((KeyValuePair<int, BuildEventArgs>)buildEvent).Value;
+                    _processedBuildEvent = kvp.Value;
                 }
                 else
                 {

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -1433,10 +1433,10 @@ namespace Microsoft.Build.UnitTests
             string prop1;
             string prop2;
             string prop3;
-            if (cl is SerialConsoleLogger)
+            if (cl is SerialConsoleLogger scl)
             {
-                var propertyList = ((SerialConsoleLogger)cl).ExtractPropertyList(properties);
-                ((SerialConsoleLogger)cl).WriteProperties(propertyList);
+                var propertyList = scl.ExtractPropertyList(properties);
+                scl.WriteProperties(propertyList);
                 prop1 = String.Format(CultureInfo.CurrentCulture, "{0,-30} = {1}", "prop1", "val1");
                 prop2 = String.Format(CultureInfo.CurrentCulture, "{0,-30} = {1}", "prop2", "val2");
                 prop3 = String.Format(CultureInfo.CurrentCulture, "{0,-30} = {1}", "pro(p3)", "va;%3b;l3");
@@ -1688,10 +1688,10 @@ namespace Microsoft.Build.UnitTests
             string item3spec;
             string item3metadatum = string.Empty;
 
-            if (cl is SerialConsoleLogger)
+            if (cl is SerialConsoleLogger scl)
             {
-                SortedList itemList = ((SerialConsoleLogger)cl).ExtractItemList(items);
-                ((SerialConsoleLogger)cl).WriteItems(itemList);
+                SortedList itemList = scl.ExtractItemList(items);
+                scl.WriteItems(itemList);
                 item1spec = "spec" + Environment.NewLine;
                 item2spec = "spec2" + Environment.NewLine;
                 item3spec = "(spec;3" + Environment.NewLine;
@@ -1770,10 +1770,10 @@ namespace Microsoft.Build.UnitTests
                     cl = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
                 }
 
-                if (cl is SerialConsoleLogger)
+                if (cl is SerialConsoleLogger scl)
                 {
-                    SortedList itemList = ((SerialConsoleLogger)cl).ExtractItemList(items);
-                    ((SerialConsoleLogger)cl).WriteItems(itemList);
+                    SortedList itemList = scl.ExtractItemList(items);
+                    scl.WriteItems(itemList);
                 }
                 else
                 {

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1407,13 +1407,13 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             BuildEventArgs buildEventArgs = null;
 
-            if (loggingEvent is BuildEventArgs)
+            if (loggingEvent is BuildEventArgs bea)
             {
-                buildEventArgs = (BuildEventArgs)loggingEvent;
+                buildEventArgs = bea;
             }
-            else if (loggingEvent is KeyValuePair<int, BuildEventArgs>)
+            else if (loggingEvent is KeyValuePair<int, BuildEventArgs> kvp)
             {
-                buildEventArgs = ((KeyValuePair<int, BuildEventArgs>)loggingEvent).Value;
+                buildEventArgs = kvp.Value;
             }
             else
             {
@@ -1475,13 +1475,13 @@ namespace Microsoft.Build.BackEnd.Logging
                 _warningsAsMessagesByProject?.Remove(GetWarningsAsErrorOrMessageKey(projectFinishedEvent));
             }
 
-            if (loggingEvent is BuildEventArgs)
+            if (loggingEvent is BuildEventArgs loggingEventBuildArgs)
             {
-                RouteBuildEvent((BuildEventArgs)loggingEvent);
+                RouteBuildEvent(loggingEventBuildArgs);
             }
-            else if (loggingEvent is KeyValuePair<int, BuildEventArgs>)
+            else if (loggingEvent is KeyValuePair<int, BuildEventArgs> loggingEventKeyValuePair)
             {
-                RouteBuildEvent((KeyValuePair<int, BuildEventArgs>)loggingEvent);
+                RouteBuildEvent(loggingEventKeyValuePair);
             }
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -705,7 +705,7 @@ namespace Microsoft.Build.BackEnd
             get
             {
                 // Test compatibility
-                if(_taskLoggingContext == null)
+                if (_taskLoggingContext == null)
                 {
                     return null;
                 }

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3384,9 +3384,9 @@ namespace Microsoft.Build.Evaluation
                         // The object that we're about to call methods on may have escaped characters
                         // in it, we want to operate on the unescaped string in the function, just as we
                         // want to pass arguments that are unescaped (see below)
-                        if (objectInstance is string)
+                        if (objectInstance is string objectInstanceString)
                         {
-                            objectInstance = EscapingUtilities.UnescapeAll((string)objectInstance);
+                            objectInstance = EscapingUtilities.UnescapeAll(objectInstanceString);
                         }
                     }
 
@@ -3510,9 +3510,9 @@ namespace Microsoft.Build.Evaluation
                     // If the result of the function call is a string, then we need to escape the result
                     // so that we maintain the "engine contains escaped data" state.
                     // The exception is that the user is explicitly calling MSBuild::Unescape or MSBuild::Escape
-                    if (functionResult is string && !String.Equals("Unescape", _methodMethodName, StringComparison.OrdinalIgnoreCase) && !String.Equals("Escape", _methodMethodName, StringComparison.OrdinalIgnoreCase))
+                    if (functionResult is string functionResultString && !String.Equals("Unescape", _methodMethodName, StringComparison.OrdinalIgnoreCase) && !String.Equals("Escape", _methodMethodName, StringComparison.OrdinalIgnoreCase))
                     {
-                        functionResult = EscapingUtilities.Escape((string)functionResult);
+                        functionResult = EscapingUtilities.Escape(functionResultString);
                     }
 
                     // We have nothing left to parse, so we'll return what we have
@@ -3762,9 +3762,8 @@ namespace Microsoft.Build.Evaluation
                         }
                     }
                 }
-                else if (objectInstance is string[])
+                else if (objectInstance is string[] stringArray)
                 {
-                    string[] stringArray = (string[])objectInstance;
                     if (string.Equals(_methodMethodName, "GetValue", StringComparison.OrdinalIgnoreCase))
                     {
                         if (TryGetArg(args, out int index))

--- a/src/Build/Instance/ProjectTargetInstance.cs
+++ b/src/Build/Instance/ProjectTargetInstance.cs
@@ -493,14 +493,12 @@ namespace Microsoft.Build.Execution
 
                 foreach (ProjectTaskInstanceChild outputInstance in taskInstance.Outputs)
                 {
-                    if (outputInstance is ProjectTaskOutputItemInstance)
+                    if (outputInstance is ProjectTaskOutputItemInstance outputItemInstance)
                     {
-                        ProjectTaskOutputItemInstance outputItemInstance = outputInstance as ProjectTaskOutputItemInstance;
                         taskElement.AddOutputItem(outputItemInstance.TaskParameter, outputItemInstance.ItemType, outputItemInstance.Condition);
                     }
-                    else if (outputInstance is ProjectTaskOutputPropertyInstance)
+                    else if (outputInstance is ProjectTaskOutputPropertyInstance outputPropertyInstance)
                     {
-                        ProjectTaskOutputPropertyInstance outputPropertyInstance = outputInstance as ProjectTaskOutputPropertyInstance;
                         taskElement.AddOutputItem(outputPropertyInstance.TaskParameter, outputPropertyInstance.PropertyName, outputPropertyInstance.Condition);
                     }
                 }

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -203,9 +203,9 @@ namespace Microsoft.Build.BackEnd
             {
                 // If we returned an exception, then we want to throw it when we 
                 // do the get.  
-                if (value is Exception)
+                if (value is Exception ex)
                 {
-                    throw (Exception)value;
+                    throw ex;
                 }
 
                 return value;
@@ -520,21 +520,21 @@ namespace Microsoft.Build.BackEnd
 
                     // "Custom events" in terms of the communications infrastructure can also be, e.g. custom error events, 
                     // in which case they need to be dealt with in the same way as their base type of event. 
-                    if (buildEvent is BuildErrorEventArgs)
+                    if (buildEvent is BuildErrorEventArgs buildErrorEventArgs)
                     {
-                        this.BuildEngine.LogErrorEvent((BuildErrorEventArgs)buildEvent);
+                        this.BuildEngine.LogErrorEvent(buildErrorEventArgs);
                     }
-                    else if (buildEvent is BuildWarningEventArgs)
+                    else if (buildEvent is BuildWarningEventArgs buildWarningEventArgs)
                     {
-                        this.BuildEngine.LogWarningEvent((BuildWarningEventArgs)buildEvent);
+                        this.BuildEngine.LogWarningEvent(buildWarningEventArgs);
                     }
-                    else if (buildEvent is BuildMessageEventArgs)
+                    else if (buildEvent is BuildMessageEventArgs buildMessageEventArgs)
                     {
-                        this.BuildEngine.LogMessageEvent((BuildMessageEventArgs)buildEvent);
+                        this.BuildEngine.LogMessageEvent(buildMessageEventArgs);
                     }
-                    else if (buildEvent is CustomBuildEventArgs)
+                    else if (buildEvent is CustomBuildEventArgs customBuildEventArgs)
                     {
-                        this.BuildEngine.LogCustomEvent((CustomBuildEventArgs)buildEvent);
+                        this.BuildEngine.LogCustomEvent(customBuildEventArgs);
                     }
                     else
                     {

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
@@ -87,57 +87,57 @@ namespace Microsoft.Build.Logging
         /// </summary>
         public void Dispatch(BuildEventArgs buildEvent)
         {
-            if (buildEvent is BuildMessageEventArgs)
+            if (buildEvent is BuildMessageEventArgs buildMessageEventArgs)
             {
-                MessageRaised?.Invoke(null, (BuildMessageEventArgs)buildEvent);
+                MessageRaised?.Invoke(null, buildMessageEventArgs);
             }
-            else if (buildEvent is TaskStartedEventArgs)
+            else if (buildEvent is TaskStartedEventArgs taskStartedEventArgs)
             {
-                TaskStarted?.Invoke(null, (TaskStartedEventArgs)buildEvent);
+                TaskStarted?.Invoke(null, taskStartedEventArgs);
             }
-            else if (buildEvent is TaskFinishedEventArgs)
+            else if (buildEvent is TaskFinishedEventArgs taskFinishedEventArgs)
             {
-                TaskFinished?.Invoke(null, (TaskFinishedEventArgs)buildEvent);
+                TaskFinished?.Invoke(null, taskFinishedEventArgs);
             }
-            else if (buildEvent is TargetStartedEventArgs)
+            else if (buildEvent is TargetStartedEventArgs targetStartedEventArgs)
             {
-                TargetStarted?.Invoke(null, (TargetStartedEventArgs)buildEvent);
+                TargetStarted?.Invoke(null, targetStartedEventArgs);
             }
-            else if (buildEvent is TargetFinishedEventArgs)
+            else if (buildEvent is TargetFinishedEventArgs targetFinishedEventArgs)
             {
-                TargetFinished?.Invoke(null, (TargetFinishedEventArgs)buildEvent);
+                TargetFinished?.Invoke(null, targetFinishedEventArgs);
             }
-            else if (buildEvent is ProjectStartedEventArgs)
+            else if (buildEvent is ProjectStartedEventArgs projectStartedEventArgs)
             {
-                ProjectStarted?.Invoke(null, (ProjectStartedEventArgs)buildEvent);
+                ProjectStarted?.Invoke(null, projectStartedEventArgs);
             }
-            else if (buildEvent is ProjectFinishedEventArgs)
+            else if (buildEvent is ProjectFinishedEventArgs projectFinishedEventArgs)
             {
-                ProjectFinished?.Invoke(null, (ProjectFinishedEventArgs)buildEvent);
+                ProjectFinished?.Invoke(null, projectFinishedEventArgs);
             }
-            else if (buildEvent is BuildStartedEventArgs)
+            else if (buildEvent is BuildStartedEventArgs buildStartedEventArgs)
             {
-                BuildStarted?.Invoke(null, (BuildStartedEventArgs)buildEvent);
+                BuildStarted?.Invoke(null, buildStartedEventArgs);
             }
-            else if (buildEvent is BuildFinishedEventArgs)
+            else if (buildEvent is BuildFinishedEventArgs buildFinishedEventArgs)
             {
-                BuildFinished?.Invoke(null, (BuildFinishedEventArgs)buildEvent);
+                BuildFinished?.Invoke(null, buildFinishedEventArgs);
             }
-            else if (buildEvent is CustomBuildEventArgs)
+            else if (buildEvent is CustomBuildEventArgs customBuildEventArgs)
             {
-                CustomEventRaised?.Invoke(null, (CustomBuildEventArgs)buildEvent);
+                CustomEventRaised?.Invoke(null, customBuildEventArgs);
             }
-            else if (buildEvent is BuildStatusEventArgs)
+            else if (buildEvent is BuildStatusEventArgs buildStatusEventArgs)
             {
-                StatusEventRaised?.Invoke(null, (BuildStatusEventArgs)buildEvent);
+                StatusEventRaised?.Invoke(null, buildStatusEventArgs);
             }
-            else if (buildEvent is BuildWarningEventArgs)
+            else if (buildEvent is BuildWarningEventArgs buildWarningEventArgs)
             {
-                WarningRaised?.Invoke(null, (BuildWarningEventArgs)buildEvent);
+                WarningRaised?.Invoke(null, buildWarningEventArgs);
             }
-            else if (buildEvent is BuildErrorEventArgs)
+            else if (buildEvent is BuildErrorEventArgs buildErrorEventArgs)
             {
-                ErrorRaised?.Invoke(null, (BuildErrorEventArgs)buildEvent);
+                ErrorRaised?.Invoke(null, buildErrorEventArgs);
             }
 
             AnyEventRaised?.Invoke(null, buildEvent);

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -474,13 +474,13 @@ namespace Microsoft.Build.BackEnd.Logging
                 // Print out all of the errors under the ProjectEntryPoint / target
                 foreach (BuildEventArgs errorWarningEvent in valuePair.Value)
                 {
-                    if (errorWarningEvent is BuildErrorEventArgs)
+                    if (errorWarningEvent is BuildErrorEventArgs buildErrorEventArgs)
                     {
-                        WriteMessageAligned("  " + EventArgsFormatting.FormatEventMessage(errorWarningEvent as BuildErrorEventArgs, showProjectFile, FindLogOutputProperties(errorWarningEvent)), false);
+                        WriteMessageAligned("  " + EventArgsFormatting.FormatEventMessage(buildErrorEventArgs, showProjectFile, FindLogOutputProperties(errorWarningEvent)), false);
                     }
-                    else if (errorWarningEvent is BuildWarningEventArgs)
+                    else if (errorWarningEvent is BuildWarningEventArgs buildWarningEventArgs)
                     {
-                        WriteMessageAligned("  " + EventArgsFormatting.FormatEventMessage(errorWarningEvent as BuildWarningEventArgs, showProjectFile, FindLogOutputProperties(errorWarningEvent)), false);
+                        WriteMessageAligned("  " + EventArgsFormatting.FormatEventMessage(buildWarningEventArgs, showProjectFile, FindLogOutputProperties(errorWarningEvent)), false);
                     }
                 }
                 WriteNewLine();

--- a/src/Deprecated/Engine.UnitTests/FileLogger_Tests.cs
+++ b/src/Deprecated/Engine.UnitTests/FileLogger_Tests.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Build.UnitTests
                 }
                 finally
                 {
-                    if(Directory.Exists(Path.Combine(Environment.CurrentDirectory, "tempura")))
+                    if (Directory.Exists(Path.Combine(Environment.CurrentDirectory, "tempura")))
                     {
                         File.Delete(Path.Combine(Environment.CurrentDirectory, "tempura\\mylogfile1.log"));
                         Directory.Delete(Path.Combine(Environment.CurrentDirectory, "tempura"));

--- a/src/Deprecated/Engine.UnitTests/Project_Tests.cs
+++ b/src/Deprecated/Engine.UnitTests/Project_Tests.cs
@@ -4641,7 +4641,7 @@ namespace Microsoft.Build.UnitTests.Project_Tests
             Project myProject = new Project(myEngine);
 
             string expectedValue = null;
-            if(Environment.Is64BitOperatingSystem)
+            if (Environment.Is64BitOperatingSystem)
             {
                 expectedValue = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
             }

--- a/src/Deprecated/Engine/Collections/CopyOnWriteHashtable.cs
+++ b/src/Deprecated/Engine/Collections/CopyOnWriteHashtable.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Build.BuildEngine
             {
                 lock (sharedLock)
                 {
-                    if(writeableData != null)
+                    if (writeableData != null)
                     {
                         writeableData[key] = value;
                     }

--- a/src/Deprecated/Engine/Engine/Engine.cs
+++ b/src/Deprecated/Engine/Engine/Engine.cs
@@ -2503,7 +2503,7 @@ namespace Microsoft.Build.BuildEngine
                 ArrayList actuallyBuiltTargets;
 
                 // If the tools version is empty take a quick peek at the project file to determine if it has a tools version defined
-                if(String.IsNullOrEmpty(buildRequest.ToolsetVersion))
+                if (String.IsNullOrEmpty(buildRequest.ToolsetVersion))
                 {
                     buildRequest.ToolsetVersion = XmlUtilities.GetAttributeValueForElementFromFile(buildRequest.ProjectFileName, XMakeAttributes.project, XMakeAttributes.toolsVersion);
                     buildRequest.ToolsVersionPeekedFromProjectFile = true;

--- a/src/Deprecated/Engine/Engine/EngineProxy.cs
+++ b/src/Deprecated/Engine/Engine/EngineProxy.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Build.BuildEngine
             }
             else
             {
-                if(e.GetType().Equals(BuildErrorEventArgsType))
+                if (e.GetType().Equals(BuildErrorEventArgsType))
                 {
                     // We'd like to add the project file to the subcategory, but since this property
                     // is read-only on the BuildErrorEventArgs type, this requires creating a new
@@ -264,7 +264,7 @@ namespace Microsoft.Build.BuildEngine
             }
 
             // Don't bother adding the project file path if it's already in the file part
-            if(String.Equals(file, parentProjectFullFileName, StringComparison.OrdinalIgnoreCase))
+            if (String.Equals(file, parentProjectFullFileName, StringComparison.OrdinalIgnoreCase))
             {
                 return message;
             }

--- a/src/Deprecated/Engine/Engine/ToolsetReader.cs
+++ b/src/Deprecated/Engine/Engine/ToolsetReader.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Build.BuildEngine
                         );
                     }
                 }
-                else if(ReservedPropertyNames.IsReservedProperty(property.Name))
+                else if (ReservedPropertyNames.IsReservedProperty(property.Name))
                 {
                     // We don't allow toolsets to define reserved properties
                     string baseMessage = ResourceUtilities.FormatResourceString("CannotModifyReservedProperty", property.Name);

--- a/src/Deprecated/Engine/Logging/ConsoleLogger.cs
+++ b/src/Deprecated/Engine/Logging/ConsoleLogger.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Build.BuildEngine
                     consoleLogger = new ParallelConsoleLogger(verbosity, write, colorSet, colorReset);
                 }
 
-                if(!string.IsNullOrEmpty(parameters))
+                if (!string.IsNullOrEmpty(parameters))
                 {
                     consoleLogger.Parameters = parameters;
                     parameters = null;

--- a/src/Deprecated/Engine/Logging/DistributedLoggers/DistributedFileLogger.cs
+++ b/src/Deprecated/Engine/Logging/DistributedLoggers/DistributedFileLogger.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.BuildEngine
         {
             if (String.Equals("LOGFILE", parameterName, StringComparison.OrdinalIgnoreCase))
             {
-                if(string.IsNullOrEmpty(parameterValue))
+                if (string.IsNullOrEmpty(parameterValue))
                 {
                     string message = ResourceUtilities.FormatResourceString("InvalidFileLoggerFile", string.Empty, ResourceUtilities.FormatResourceString("logfilePathNullOrEmpty"));
                     throw new LoggerException(message);

--- a/src/Deprecated/Engine/Shared/FileUtilities.cs
+++ b/src/Deprecated/Engine/Shared/FileUtilities.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Build.BuildEngine.Shared
                 {
                     if (String.Equals(modifier, ItemSpecModifiers.FullPath, StringComparison.OrdinalIgnoreCase))
                     {
-                        if(currentDirectory == null)
+                        if (currentDirectory == null)
                         {
                             currentDirectory = String.Empty;
                         }

--- a/src/Deprecated/Engine/Shared/FrameworkLocationHelper.cs
+++ b/src/Deprecated/Engine/Shared/FrameworkLocationHelper.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Build.BuildEngine.Shared
             string programFilesReferenceAssemblyDirectory = Path.Combine(programFilesReferenceAssemblyLocation, versionPrefix);
             string referenceAssemblyDirectory = null;
 
-            if(Directory.Exists(programFilesReferenceAssemblyDirectory))
+            if (Directory.Exists(programFilesReferenceAssemblyDirectory))
             {
                 referenceAssemblyDirectory = programFilesReferenceAssemblyDirectory;
             }

--- a/src/Deprecated/Engine/Shared/UnitTests/MockEngine.cs
+++ b/src/Deprecated/Engine/Shared/UnitTests/MockEngine.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Build.UnitTests
             // If we do not contain this string than pass it to
             // MockLogger. Since MockLogger is also registered as
             // a logger it may have this string.
-            if(!upperLog.Contains
+            if (!upperLog.Contains
                 (
                     contains.ToUpperInvariant()
                 )

--- a/src/Framework/Profiler/EvaluationLocation.cs
+++ b/src/Framework/Profiler/EvaluationLocation.cs
@@ -229,9 +229,8 @@ namespace Microsoft.Build.Framework.Profiler
         /// <nodoc/>
         public override bool Equals(object obj)
         {
-            if (obj is EvaluationLocation)
+            if (obj is EvaluationLocation other)
             {
-                var other = (EvaluationLocation) obj;
                 return
                     Id == other.Id &&
                     ParentId == other.ParentId &&

--- a/src/Framework/Profiler/ProfilerResult.cs
+++ b/src/Framework/Profiler/ProfilerResult.cs
@@ -73,14 +73,10 @@ namespace Microsoft.Build.Framework.Profiler
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            if (obj is ProfiledLocation location)
-            {
-                return InclusiveTime.Equals(location.InclusiveTime) &&
-                       ExclusiveTime.Equals(location.ExclusiveTime) &&
-                       NumberOfHits == location.NumberOfHits;
-            }
-
-            return false;
+            return obj is ProfiledLocation location &&
+                   InclusiveTime.Equals(location.InclusiveTime) &&
+                   ExclusiveTime.Equals(location.ExclusiveTime) &&
+                   NumberOfHits == location.NumberOfHits;
         }
 
         /// <inheritdoc />

--- a/src/Framework/Profiler/ProfilerResult.cs
+++ b/src/Framework/Profiler/ProfilerResult.cs
@@ -28,12 +28,10 @@ namespace Microsoft.Build.Framework.Profiler
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            if (!(obj is ProfilerResult))
+            if (!(obj is ProfilerResult result))
             {
                 return false;
             }
-
-            var result = (ProfilerResult)obj;
 
             return (ProfiledLocations == result.ProfiledLocations) ||
                    (ProfiledLocations.Count == result.ProfiledLocations.Count &&

--- a/src/Framework/Profiler/ProfilerResult.cs
+++ b/src/Framework/Profiler/ProfilerResult.cs
@@ -73,15 +73,14 @@ namespace Microsoft.Build.Framework.Profiler
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            if (!(obj is ProfiledLocation))
+            if (obj is ProfiledLocation location)
             {
-                return false;
+                return InclusiveTime.Equals(location.InclusiveTime) &&
+                       ExclusiveTime.Equals(location.ExclusiveTime) &&
+                       NumberOfHits == location.NumberOfHits;
             }
 
-            var location = (ProfiledLocation)obj;
-            return InclusiveTime.Equals(location.InclusiveTime) &&
-                   ExclusiveTime.Equals(location.ExclusiveTime) &&
-                   NumberOfHits == location.NumberOfHits;
+            return false;
         }
 
         /// <inheritdoc />

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2444,7 +2444,7 @@ namespace Microsoft.Build.CommandLine
             }
 
 #if !FEATURE_NODE_REUSE
-            if(enableNodeReuse) // Only allowed to pass False on the command line for this switch if the feature is disabled for this installation
+            if (enableNodeReuse) // Only allowed to pass False on the command line for this switch if the feature is disabled for this installation
                 CommandLineSwitchException.Throw("InvalidNodeReuseTrueValue", parameters[parameters.Length - 1]);
 #endif
 

--- a/src/Shared/FileUtilitiesRegex.cs
+++ b/src/Shared/FileUtilitiesRegex.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Shared
                         //We get here in the case of an extra slash.
                         return -1;
                     }
-                    else if(hasShare)
+                    else if (hasShare)
                     {
                         return i;
                     }
@@ -138,7 +138,7 @@ namespace Microsoft.Build.Shared
                 }
             }
 
-            if(!hasShare)
+            if (!hasShare)
             {
                 //no subfolder means no unc pattern. string is something like "\\abc" in this case
                 return -1;

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -284,11 +284,8 @@ namespace Microsoft.Build.BackEnd
                 escapedDefiningProject = copyFromAsITaskItem2.GetMetadataValueEscaped(FileUtilities.ItemSpecModifiers.DefiningProjectFullPath);
                 IDictionary nonGenericEscapedMetadata = copyFromAsITaskItem2.CloneCustomMetadataEscaped();
 
-                if (nonGenericEscapedMetadata is Dictionary<string, string>)
-                {
-                    escapedMetadata = (Dictionary<string, string>)nonGenericEscapedMetadata;
-                }
-                else
+                escapedMetadata = nonGenericEscapedMetadata as Dictionary<string, string>;
+                if (escapedMetadata is null)
                 {
                     escapedMetadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                     foreach (object key in nonGenericEscapedMetadata.Keys)

--- a/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
+++ b/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
@@ -105,12 +105,12 @@ namespace Microsoft.Build.Tasks
 
             var writeOutput = true;
 
-            if(FileSystems.Default.FileExists(OutputAppConfigFile.ItemSpec))
+            if (FileSystems.Default.FileExists(OutputAppConfigFile.ItemSpec))
             {
                 try
                 {
                     var outputDoc = LoadAppConfig(OutputAppConfigFile);
-                    if(outputDoc.ToString() == doc.ToString())
+                    if (outputDoc.ToString() == doc.ToString())
                     {
                         writeOutput = false;
                     }
@@ -130,7 +130,7 @@ namespace Microsoft.Build.Tasks
                 OutputAppConfigFile.SetMetadata(ItemMetadataNames.targetPath, TargetName);
             }
 
-            if(writeOutput)
+            if (writeOutput)
             {
                 using (var stream = FileUtilities.OpenWrite(OutputAppConfigFile.ItemSpec, false))
                 {

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1237,9 +1237,8 @@ namespace Microsoft.Build.Tasks
                     // Log general resolution exceptions.
                     foreach (Exception error in generalResolutionExceptions)
                     {
-                        if (error is InvalidReferenceAssemblyNameException)
+                        if (error is InvalidReferenceAssemblyNameException e)
                         {
-                            InvalidReferenceAssemblyNameException e = (InvalidReferenceAssemblyNameException)error;
                             Log.LogWarningWithCodeFromResources("General.MalformedAssemblyName", e.SourceItemSpec);
                         }
                         else
@@ -1257,9 +1256,9 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (Resolver r in dependencyTable.Resolvers)
                 {
-                    if (r is AssemblyFoldersExResolver)
+                    if (r is AssemblyFoldersExResolver assemblyFoldersExResolver)
                     {
-                        AssemblyFoldersEx assemblyFoldersEx = ((AssemblyFoldersExResolver)r).AssemblyFoldersExLocations;
+                        AssemblyFoldersEx assemblyFoldersEx = (assemblyFoldersExResolver).AssemblyFoldersExLocations;
 
                         if (assemblyFoldersEx != null && _showAssemblyFoldersExLocations.TryGetValue(r.SearchPath, out messageImportance))
                         {

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1258,7 +1258,7 @@ namespace Microsoft.Build.Tasks
                 {
                     if (r is AssemblyFoldersExResolver assemblyFoldersExResolver)
                     {
-                        AssemblyFoldersEx assemblyFoldersEx = (assemblyFoldersExResolver).AssemblyFoldersExLocations;
+                        AssemblyFoldersEx assemblyFoldersEx = assemblyFoldersExResolver.AssemblyFoldersExLocations;
 
                         if (assemblyFoldersEx != null && _showAssemblyFoldersExLocations.TryGetValue(r.SearchPath, out messageImportance))
                         {

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -600,7 +600,7 @@ namespace Microsoft.Build.Tasks
                 if (NativeMethodsShared.IsWindows)
                 {
                     commandLine.AppendSwitch("/Q"); // echo off
-                    if(!Traits.Instance.EscapeHatches.UseAutoRunWhenLaunchingProcessUnderCmd)
+                    if (!Traits.Instance.EscapeHatches.UseAutoRunWhenLaunchingProcessUnderCmd)
                     {
                         commandLine.AppendSwitch("/D"); // do not load AutoRun configuration from the registry (perf)
                     }

--- a/src/Tasks/GenerateManifestBase.cs
+++ b/src/Tasks/GenerateManifestBase.cs
@@ -237,9 +237,8 @@ namespace Microsoft.Build.Tasks
             }
 
             // Fixup for non-ClickOnce case...
-            if (_manifest is ApplicationManifest)
+            if (_manifest is ApplicationManifest applicationManifest)
             {
-                var applicationManifest = _manifest as ApplicationManifest;
                 if (!applicationManifest.IsClickOnceManifest)
                 {
                     // Don't need publicKeyToken attribute for non-ClickOnce case

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -552,9 +552,9 @@ namespace Microsoft.Build.Tasks
             try
             {
                 object allowUntrustedFiles = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\SDK", "AllowProcessOfUntrustedResourceFiles", null);
-                if (allowUntrustedFiles is String allowUntrustedFilesString)
+                if (allowUntrustedFiles is string allowUntrustedFilesString)
                 {
-                    allowMOTW = (allowUntrustedFilesString).Equals("true", StringComparison.OrdinalIgnoreCase);
+                    allowMOTW = allowUntrustedFilesString.Equals("true", StringComparison.OrdinalIgnoreCase);
                 }
             }
             catch { }

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -552,9 +552,9 @@ namespace Microsoft.Build.Tasks
             try
             {
                 object allowUntrustedFiles = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\SDK", "AllowProcessOfUntrustedResourceFiles", null);
-                if (allowUntrustedFiles is String)
+                if (allowUntrustedFiles is String allowUntrustedFilesString)
                 {
-                    allowMOTW = ((string)allowUntrustedFiles).Equals("true", StringComparison.OrdinalIgnoreCase);
+                    allowMOTW = (allowUntrustedFilesString).Equals("true", StringComparison.OrdinalIgnoreCase);
                 }
             }
             catch { }
@@ -894,10 +894,10 @@ namespace Microsoft.Build.Tasks
                                 {
                                     foreach (ITaskItem item in _remotedTaskItems)
                                     {
-                                        if (item is MarshalByRefObject)
+                                        if (item is MarshalByRefObject marshalByRefObject)
                                         {
                                             // Tell remoting to forget connections to the taskitem
-                                            RemotingServices.Disconnect((MarshalByRefObject)item);
+                                            RemotingServices.Disconnect(marshalByRefObject);
                                         }
                                     }
                                 }
@@ -2610,9 +2610,8 @@ namespace Microsoft.Build.Tasks
             }
             catch (ArgumentException ae)
             {
-                if (ae.InnerException is XmlException)
+                if (ae.InnerException is XmlException xe)
                 {
-                    XmlException xe = (XmlException) ae.InnerException;
                     _logger.LogErrorWithCodeFromResources(null, FileUtilities.GetFullPathNoThrow(inFile), xe.LineNumber,
                         xe.LinePosition, 0, 0, "General.InvalidResxFile", xe.Message);
                 }

--- a/src/Tasks/ManifestUtil/Manifest.cs
+++ b/src/Tasks/ManifestUtil/Manifest.cs
@@ -759,22 +759,20 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     Debug.Fail("Comparing null objects");
                     return 0;
                 }
-                if (!(x is BaseReference) || !(y is BaseReference))
+
+                if (x is BaseReference xRef && y is BaseReference yRef)
                 {
-                    Debug.Fail("Comparing objects that are not BaseReferences");
-                    return 0;
+                    if (xRef.SortName == null || yRef.SortName == null)
+                    {
+                        Debug.Fail("Objects do not have a SortName");
+                        return 0;
+                    }
+
+                    return xRef.SortName.CompareTo(yRef.SortName);
                 }
 
-                BaseReference xRef = x as BaseReference;
-                BaseReference yRef = y as BaseReference;
-
-                if (xRef.SortName == null || yRef.SortName == null)
-                {
-                    Debug.Fail("Objects do not have a SortName");
-                    return 0;
-                }
-
-                return xRef.SortName.CompareTo(yRef.SortName);
+                Debug.Fail("Comparing objects that are not BaseReferences");
+                return 0;
             }
         }
 

--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -644,9 +644,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                         }
                         var manifest = new SignedCmiManifest2(doc, useSha256);
                         CmiManifestSigner2 signer;
-                        if (useSha256 && rsa is RSACryptoServiceProvider)
+                        if (useSha256 && rsa is RSACryptoServiceProvider rsacsp)
                         {
-                            RSACryptoServiceProvider csp = SignedCmiManifest2.GetFixedRSACryptoServiceProvider(rsa as RSACryptoServiceProvider, useSha256);
+                            RSACryptoServiceProvider csp = SignedCmiManifest2.GetFixedRSACryptoServiceProvider(rsacsp, useSha256);
                             signer = new CmiManifestSigner2(csp, cert, useSha256);
                         }
                         else

--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -514,8 +514,8 @@ namespace System.Deployment.Internal.CodeSigning
 
             byte[] cspPublicKeyBlob;
 
-            if(snKey is RSACryptoServiceProvider){
-                cspPublicKeyBlob = (GetFixedRSACryptoServiceProvider((RSACryptoServiceProvider)snKey, useSha256)).ExportCspBlob(false);
+            if(snKey is RSACryptoServiceProvider rsacsp){
+                cspPublicKeyBlob = (GetFixedRSACryptoServiceProvider(rsacsp, useSha256)).ExportCspBlob(false);
                 if (cspPublicKeyBlob == null || cspPublicKeyBlob.Length == 0)
                 {
                     throw new CryptographicException(Win32.NTE_BAD_KEY);
@@ -931,9 +931,9 @@ namespace System.Deployment.Internal.CodeSigning
 
             // Setup up XMLDSIG engine.
             ManifestSignedXml2 signedXml = new ManifestSignedXml2(signatureParent);
-            if (signer.StrongNameKey is RSACryptoServiceProvider)
+            if (signer.StrongNameKey is RSACryptoServiceProvider rsacsp)
             {
-                signedXml.SigningKey = GetFixedRSACryptoServiceProvider(signer.StrongNameKey as RSACryptoServiceProvider, useSha256);
+                signedXml.SigningKey = GetFixedRSACryptoServiceProvider(rsacsp, useSha256);
             }
             else
             {

--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -514,7 +514,8 @@ namespace System.Deployment.Internal.CodeSigning
 
             byte[] cspPublicKeyBlob;
 
-            if(snKey is RSACryptoServiceProvider rsacsp){
+            if (snKey is RSACryptoServiceProvider rsacsp)
+            {
                 cspPublicKeyBlob = (GetFixedRSACryptoServiceProvider(rsacsp, useSha256)).ExportCspBlob(false);
                 if (cspPublicKeyBlob == null || cspPublicKeyBlob.Length == 0)
                 {

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -738,7 +738,7 @@ namespace Microsoft.Build.Tasks
 
         private static string[] GetMonoLibDirs()
         {
-            if(NativeMethodsShared.IsMono)
+            if (NativeMethodsShared.IsMono)
             {
                 string monoLibDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
                 string monoLibFacadesDir = Path.Combine(monoLibDir, "Facades");

--- a/src/Utilities/CommandLineBuilder.cs
+++ b/src/Utilities/CommandLineBuilder.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Build.Utilities
                 {
                     CommandLine.Append(Environment.NewLine);
                 }
-                else if(CommandLine[CommandLine.Length - 1] != ' ')
+                else if (CommandLine[CommandLine.Length - 1] != ' ')
                 {
                     CommandLine.Append(' ');
                 }

--- a/src/Utilities/PlatformManifest.cs
+++ b/src/Utilities/PlatformManifest.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Build.Utilities
                             {
                                 ApiContract.ReadContractsElement(childElement, ApiContracts);
                             }
-                            else if(ApiContract.IsVersionedContentElement(childElement.Name))
+                            else if (ApiContract.IsVersionedContentElement(childElement.Name))
                             {
                                 bool.TryParse(childElement.InnerText, out bool versionedContent);
                                 VersionedContent = versionedContent;

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1513,7 +1513,7 @@ namespace Microsoft.Build.Utilities
                         }
                     }
 
-                    if(allFilesFound)
+                    if (allFilesFound)
                     {
                         return root;
                     }


### PR DESCRIPTION
### Context
There are places in code ([example](https://github.com/dotnet/msbuild/blob/764b54b73225a14353e2a1a10e72ae8febb779e0/src/Build/BackEnd/Components/Logging/LoggingService.cs#L1478-L1481)) where an obsolete and suboptimal way of type checking + type casting is used.

### Changes Made
Clean up obsolete type checking + type casting, using C# pattern matching instead.

### Testing
Unit tests.