### PR TITLE
Add targetpath metadata to file getting added to ContentWithTargetPath group

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4187,7 +4187,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       use the built DLL as the entry point
     -->
     <ItemGroup Condition="'$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true' and exists('$(AppHostIntermediatePath)')">
-      <EntryPointForLauncher Include="$(AppHostIntermediatePath)"/>
+      <EntryPointForLauncher Include="$(AppHostIntermediatePath)" TargetPath="$(AssemblyName).exe"/>
       <ContentWithTargetPath Include="@(EntryPointForLauncher)"/>
     </ItemGroup>
     <ItemGroup Condition="'$(EntryPointForLauncher)'==''">


### PR DESCRIPTION
Fixes [AB#1461672](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1461672) / https://developercommunity.visualstudio.com/t/Unable-to-publish-via-ClickOnce-for-Unpa/1631852

### Context
Apps referencing Windows App SDK packages fail ClickOnce publish due to a copy error for apphost.exe.

Apps with this package reference invoke targets that try to copy files in the ContentWithTargetPath to the output folder. ClickOnce targets add apphost.exe to ContentWithTargetPath w/o the TargetPath metadata. This results in the copy error.

### Changes Made
Add TargetPath metadata to the item before it gets added to ContentWithTargetPath group.

### Testing
CTI team has run test cases for clickonce publish across all supported configuration

### Notes
