### PR TITLE
Require VS 2022 to build this repo

### DIFF
--- a/MSBuild.sln
+++ b/MSBuild.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30413.136
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 17.0.31903.59
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4900B3B8-4310-4D5B-B1F7-2FDF9199765F}"
 	ProjectSection(SolutionItems) = preProject
 		NuGet.Config = NuGet.Config

--- a/README.md
+++ b/README.md
@@ -32,20 +32,20 @@ MSBuild 15.9 builds from the branch [`vs15.9`](https://github.com/dotnet/msbuild
 
 ## Building
 
-### Building MSBuild with Visual Studio 2019 on Windows
+### Building MSBuild with Visual Studio 2022 on Windows
 
-For the full supported experience, you will need to have Visual Studio 2019 or higher.
+For the full supported experience, you will need to have Visual Studio 2022 or higher.
 
-To get started on **Visual Studio 2019**:
+To get started on **Visual Studio 2022**:
 
-1. [Install Visual Studio 2019](https://www.visualstudio.com/vs/).  Select the following Workloads:
+1. [Install Visual Studio 2022](https://www.visualstudio.com/vs/).  Select the following Workloads:
   - .NET desktop development
   - .NET Core cross-platform development
-2. Open a `Developer Command Prompt for VS 2019` prompt.
+2. Open a `Developer Command Prompt for VS 2022` prompt.
 3. Clone the source code: `git clone https://github.com/dotnet/msbuild`
   - You may have to [download Git](https://git-scm.com/downloads) first.
 4. Run `.\build.cmd` from the root of the repo to build the code. This also restores packages needed to open the projects in Visual Studio.
-5. Open `MSBuild.sln` or `MSBuild.Dev.slnf` in Visual Studio 2019.
+5. Open `MSBuild.sln` or `MSBuild.Dev.slnf` in Visual Studio 2022.
 
 Note: To create a usable MSBuild with your changes, run `.\build.cmd /p:CreateBootstrap=true`.
 To build release, add `-c Release`: `.\build.cmd -c Release /p:CreateBootstrap=true`.

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -4,7 +4,7 @@ These instructions refer to working with the `master` branch.
 
 ## Required Software
 
-**Latest Microsoft Visual Studio 2019**: You can download the Visual Studio Community edition from [https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx).
+**Latest Microsoft Visual Studio 2022**: You can download the Visual Studio Community edition from [https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx).
 
 All command lines should be executed from a Visual Studio developer command prompt.
 

--- a/global.json
+++ b/global.json
@@ -5,8 +5,10 @@
   "tools": {
     "dotnet": "6.0.100",
     "vs": {
-      "version": "16.0"
-    }
+      "version": "17.0"
+    },
+    "$comment1": "Disable the packaged version of MSBuild; require a VS installation",
+    "xcopy-msbuild": "none"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
This will be required to target .NET 6.0+ using newer SDKs and it's easier to just move.

Also disabled the Arcade default behavior to download a copy of .NET Framework MSBuild if it's not installed; instead we'll require an installed Visual Studio 17.0+.
