### PR TITLE
Improved error message when created node crashes

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -289,6 +289,15 @@ namespace Microsoft.Build.BackEnd
                     CommunicationsUtilities.Trace("Successfully connected to created node {0} which is PID {1}", nodeId, msbuildProcess.Id);
                     return new NodeContext(nodeId, msbuildProcess, nodeStream, factory, terminateNode);
                 }
+
+                if (msbuildProcess.HasExited)
+                {
+                    CommunicationsUtilities.Trace($"Could not connect to node with PID {msbuildProcess.Id}; it has exited. This can indicate a crash at startup");
+                }
+                else
+                {
+                    CommunicationsUtilities.Trace($"Could not connect to node with PID {msbuildProcess.Id}; it is still running. This can occur when two multiprocess builds run in parallel and the other one 'stole' this node");
+                }
             }
 
             // We were unable to launch a node.

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -292,11 +292,23 @@ namespace Microsoft.Build.BackEnd
 
                 if (msbuildProcess.HasExited)
                 {
-                    CommunicationsUtilities.Trace($"Could not connect to node with PID {msbuildProcess.Id}; it has exited. This can indicate a crash at startup");
+                    if (Traits.Instance.DebugNodeCommunication)
+                    {
+                        try
+                        {
+                            CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with exit code {1}. This can indicate a crash at startup", msbuildProcess.Id, msbuildProcess.ExitCode);
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // This case is common on Windows where we called CreateProcess and the Process object
+                            // can't get the exit code.
+                            CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with unknown exit code. This can indicate a crash at startup", msbuildProcess.Id);
+                        }
+                    }
                 }
                 else
                 {
-                    CommunicationsUtilities.Trace($"Could not connect to node with PID {msbuildProcess.Id}; it is still running. This can occur when two multiprocess builds run in parallel and the other one 'stole' this node");
+                    CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it is still running. This can occur when two multiprocess builds run in parallel and the other one 'stole' this node", msbuildProcess.Id);
                 }
             }
 


### PR DESCRIPTION
Occasionally, someone will have a misconfiguration that causes MSBuild
worker nodes to crash immediately or shortly after launch (before
establishing communication with the node that created them).

This can be really hard to diagnose, because it's not obvious that it's
happening--failure to connect to a process is nonfatal and can happen
if a user is building with two disconnected `-m` invocations. But
repeated failure is bad and if the node _never_ connects, that's a
problem.

Add comm-trace information about process lifetime. I wanted to include
the exit code too but couldn't because on Windows we call CreateProcess
instead of Process.Start.
