### PR TITLE
Explain perf keywords

### DIFF
--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -12,7 +12,22 @@ namespace Microsoft.Build.Eventing
     {
         public static class Keywords
         {
+            /// <summary>
+            /// Keyword applied to all MSBuild events.
+            /// </summary>
+            /// <remarks>
+            /// Literally every event should define this.
+            /// </remarks>
             public const EventKeywords All = (EventKeywords)0x1;
+
+            /// <summary>
+            /// Keyword for events that should go in the text performance log when turned on.
+            /// </summary>
+            /// <remarks>
+            /// This keyword should be applied only to events that are low-volume
+            /// and likely to be useful to diagnose perf issues using the
+            /// <see href="https://github.com/dotnet/msbuild/pull/5861">text perf log</see>.
+            /// </remarks>
             public const EventKeywords PerformanceLog = (EventKeywords)0x2;
         }
 


### PR DESCRIPTION
These have specific meanings but they weren't written down in an easy form so it was easy to misuse them especially via copy/paste. Now they'll show up in hover.
