### PR TITLE
Provide option to fail ClickOnce publish if RFC3161 timestamping fails.

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -3386,6 +3386,9 @@ elementFormDefault="qualified">
                     <xs:attribute name="CertificateThumbprint" use="required" />
                     <xs:attribute name="SigningTarget" use="required" />
                     <xs:attribute name="TimestampUrl" />
+                    <xs:attribute name="TargetFrameworkIdentifier" />
+                    <xs:attribute name="TargetFrameworkVersion" />
+                    <xs:attribute name="DisallowMansignTimestampFallback" />
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>

--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -319,7 +319,7 @@ namespace System.Deployment.Internal.CodeSigning
             Sign(signer, null);
         }
 
-        internal void Sign(CmiManifestSigner2 signer, string timeStampUrl)
+        internal void Sign(CmiManifestSigner2 signer, string timeStampUrl, bool disallowMansignTimestampFallback = false)
         {
             // Reset signer infos.
             _strongNameSignerInfo = null;
@@ -350,7 +350,7 @@ namespace System.Deployment.Internal.CodeSigning
 
                 // Now create the license DOM, and then sign it.
                 licenseDom = CreateLicenseDom(signer, ExtractPrincipalFromManifest(), ComputeHashFromManifest(_manifestDom, _useSha256));
-                AuthenticodeSignLicenseDom(licenseDom, signer, timeStampUrl, _useSha256);
+                AuthenticodeSignLicenseDom(licenseDom, signer, timeStampUrl, _useSha256, disallowMansignTimestampFallback);
             }
             StrongNameSignManifestDom(_manifestDom, licenseDom, signer, _useSha256);
         }
@@ -676,7 +676,7 @@ namespace System.Deployment.Internal.CodeSigning
             return licenseDom;
         }
 
-        private static void AuthenticodeSignLicenseDom(XmlDocument licenseDom, CmiManifestSigner2 signer, string timeStampUrl, bool useSha256)
+        private static void AuthenticodeSignLicenseDom(XmlDocument licenseDom, CmiManifestSigner2 signer, string timeStampUrl, bool useSha256, bool disallowMansignTimestampFallback)
         {
             // Make sure it is RSA, as this is the only one Fusion will support.
 #if RUNTIME_TYPE_NETCORE
@@ -747,7 +747,7 @@ namespace System.Deployment.Internal.CodeSigning
             // Time stamp it if requested.
             if (!string.IsNullOrEmpty(timeStampUrl))
             {
-                TimestampSignedLicenseDom(licenseDom, timeStampUrl, useSha256);
+                TimestampSignedLicenseDom(licenseDom, timeStampUrl, useSha256, disallowMansignTimestampFallback);
             }
 
             // Wrap it inside a RelData element.
@@ -831,7 +831,7 @@ namespace System.Deployment.Internal.CodeSigning
             return timestamp;
         }
 
-        private static void TimestampSignedLicenseDom(XmlDocument licenseDom, string timeStampUrl, bool useSha256)
+        private static void TimestampSignedLicenseDom(XmlDocument licenseDom, string timeStampUrl, bool useSha256, bool disallowMansignTimestampFallback)
         {
             XmlNamespaceManager nsm = new XmlNamespaceManager(licenseDom.NameTable);
             nsm.AddNamespace("r", LicenseNamespaceUri);
@@ -850,31 +850,38 @@ namespace System.Deployment.Internal.CodeSigning
             // Catch CryptographicException to ensure fallback to old code (non-RFC3161)
             catch (CryptographicException)
             {
-                Win32.CRYPT_DATA_BLOB timestampBlob = new Win32.CRYPT_DATA_BLOB();
-
-                byte[] licenseXml = Encoding.UTF8.GetBytes(licenseDom.OuterXml);
-
-                unsafe
+                if (disallowMansignTimestampFallback)
                 {
-                    fixed (byte* pbLicense = licenseXml)
-                    {
-                        Win32.CRYPT_DATA_BLOB licenseBlob = new Win32.CRYPT_DATA_BLOB();
-                        IntPtr pvLicense = new IntPtr(pbLicense);
-                        licenseBlob.cbData = (uint)licenseXml.Length;
-                        licenseBlob.pbData = pvLicense;
+                    throw;
+                }
+                else
+                {
+                    Win32.CRYPT_DATA_BLOB timestampBlob = new Win32.CRYPT_DATA_BLOB();
 
-                        int hr = Win32.CertTimestampAuthenticodeLicense(ref licenseBlob, timeStampUrl, ref timestampBlob);
-                        if (hr != Win32.S_OK)
+                    byte[] licenseXml = Encoding.UTF8.GetBytes(licenseDom.OuterXml);
+
+                    unsafe
+                    {
+                        fixed (byte* pbLicense = licenseXml)
                         {
-                            throw new CryptographicException(hr);
+                            Win32.CRYPT_DATA_BLOB licenseBlob = new Win32.CRYPT_DATA_BLOB();
+                            IntPtr pvLicense = new IntPtr(pbLicense);
+                            licenseBlob.cbData = (uint)licenseXml.Length;
+                            licenseBlob.pbData = pvLicense;
+
+                            int hr = Win32.CertTimestampAuthenticodeLicense(ref licenseBlob, timeStampUrl, ref timestampBlob);
+                            if (hr != Win32.S_OK)
+                            {
+                                throw new CryptographicException(hr);
+                            }
                         }
                     }
-                }
 
-                byte[] timestampSignature = new byte[timestampBlob.cbData];
-                Marshal.Copy(timestampBlob.pbData, timestampSignature, 0, timestampSignature.Length);
-                Win32.HeapFree(Win32.GetProcessHeap(), 0, timestampBlob.pbData);
-                timestamp = Encoding.UTF8.GetString(timestampSignature);
+                    byte[] timestampSignature = new byte[timestampBlob.cbData];
+                    Marshal.Copy(timestampBlob.pbData, timestampSignature, 0, timestampSignature.Length);
+                    Win32.HeapFree(Win32.GetProcessHeap(), 0, timestampBlob.pbData);
+                    timestamp = Encoding.UTF8.GetString(timestampSignature);
+                }
             }
 
             XmlElement asTimestamp = licenseDom.CreateElement("as", "Timestamp", AuthenticodeNamespaceUri);

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5984,6 +5984,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SigningTarget="$(_DeploymentApplicationDir)$(_DeploymentTargetApplicationManifestFileName)"
         TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        DisallowMansignTimestampFallback="$(DisallowMansignTimestampFallback)"
         Condition="'$(_DeploymentSignClickOnceManifests)'=='true'" />
 
     <!-- Update entry point path in deploy manifest -->
@@ -6004,6 +6005,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SigningTarget="$(PublishDir)$(TargetDeployManifestFileName)"
         TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        DisallowMansignTimestampFallback="$(DisallowMansignTimestampFallback)"
         Condition="'$(_DeploymentSignClickOnceManifests)'=='true'" />
 
     <SignFile

--- a/src/Tasks/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Tasks/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Build.Tasks.SignFile.DisallowMansignTimestampFallback.get -> bool
+Microsoft.Build.Tasks.SignFile.DisallowMansignTimestampFallback.set -> void
+static Microsoft.Build.Tasks.Deployment.ManifestUtilities.SecurityUtilities.SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion, string targetFrameworkIdentifier, bool disallowMansignTimestampFallback) -> void

--- a/src/Tasks/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Tasks/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Build.Tasks.SignFile.DisallowMansignTimestampFallback.get -> bool
+Microsoft.Build.Tasks.SignFile.DisallowMansignTimestampFallback.set -> void
+static Microsoft.Build.Tasks.Deployment.ManifestUtilities.SecurityUtilities.SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion, string targetFrameworkIdentifier, bool disallowMansignTimestampFallback) -> void

--- a/src/Tasks/SignFile.cs
+++ b/src/Tasks/SignFile.cs
@@ -38,13 +38,19 @@ namespace Microsoft.Build.Tasks
 
         public string TimestampUrl { get; set; }
 
+        public bool DisallowMansignTimestampFallback { get; set; } = false;
+
         public override bool Execute()
         {
             try
             {
-                SecurityUtilities.SignFile(CertificateThumbprint,
-                TimestampUrl == null ? null : new Uri(TimestampUrl),
-                SigningTarget.ItemSpec, TargetFrameworkVersion, TargetFrameworkIdentifier);
+                SecurityUtilities.SignFile(
+                    CertificateThumbprint,
+                    TimestampUrl == null ? null : new Uri(TimestampUrl),
+                    SigningTarget.ItemSpec, 
+                    TargetFrameworkVersion, 
+                    TargetFrameworkIdentifier,
+                    DisallowMansignTimestampFallback);
                 return true;
             }
             catch (ArgumentException ex) when (ex.ParamName.Equals("certThumbprint"))


### PR DESCRIPTION
… timestamping fails during ClickOnce manifest signing

Fixes # 7164

### Context
ClickOnce manifest signing will obtain a RFC3161 timestamp if a timestamp server URL has been specified. If the RFC3161 timestamping fails, the code falls back to calling a legacy non-RFC3161 timestamp API. Customers do not have any option to disable this behavior if they want to enforce RFC3161 timestamping.

### Changes Made
Add a new property DisallowMansignTimestampFallback that will not allow the fallback behavior. The default is false which means fallback will be allowed. If the property is set to true either through the csproj or msbuild CLI, the fallback API will not be called and instead the build will throw an error when RFC3161 timestamping fails.

### Testing
Ongoing.

### Notes
