### PR TITLE
MSBuild command line arguments aren't logged in dotnet build

### DIFF
--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1005,7 +1005,8 @@ namespace Microsoft.Build.UnitTests
                                         graphBuildOptions: null,
                                         lowPriority: false,
                                         inputResultsCaches: null,
-                                        outputResultsCache: null
+                                        outputResultsCache: null,
+                                        commandLine: null
                         );
                 }
                 finally


### PR DESCRIPTION
Fixes #7216 

### Context
See #7216 

### Changes Made
- Logging commandLine arguments passed into Execute method as oppose to Environment.CommandLine

### Testing
- ren before and after and compared its binary log in viewer.

### Notes
- I reviewed other places which uses  Environment.CommandLine and it seems to be OK with respect to `dotnet build` use case.
