### PR TITLE
Fix import of x86 COM Component in ClickOnce Publish

### DIFF
--- a/src/Tasks/ManifestUtil/ComImporter.cs
+++ b/src/Tasks/ManifestUtil/ComImporter.cs
@@ -161,16 +161,38 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private ClassInfo GetRegisteredClassInfo(Guid clsid)
         {
             ClassInfo info = null;
-            RegistryKey userKey = Registry.CurrentUser.OpenSubKey("SOFTWARE\\CLASSES\\CLSID");
-            if (GetRegisteredClassInfo(userKey, clsid, ref info))
+
+            using (RegistryKey userKey = Registry.CurrentUser.OpenSubKey("SOFTWARE\\CLASSES\\CLSID"))
             {
-                return info;
+               if (GetRegisteredClassInfo(userKey, clsid, ref info))
+               {
+                   return info;
+               }
             }
-            RegistryKey machineKey = Registry.ClassesRoot.OpenSubKey("CLSID");
-            if (GetRegisteredClassInfo(machineKey, clsid, ref info))
+
+            using (RegistryKey machineKey = Registry.ClassesRoot.OpenSubKey("CLSID"))
             {
-                return info;
+               if (GetRegisteredClassInfo(machineKey, clsid, ref info))
+               {
+                  return info;
+               }
             }
+
+            // Check Wow6432Node of HKCR incase the COM reference is to a 32-bit binary.
+            if (Environment.Is64BitProcess)
+            {
+                using (RegistryKey classesRootKey = RegistryKey.OpenBaseKey(RegistryHive.ClassesRoot, RegistryView.Registry32))
+                {
+                    using (RegistryKey clsidKey = classesRootKey.OpenSubKey("CLSID"))
+                    {
+                        if (GetRegisteredClassInfo(clsidKey, clsid, ref info))
+                        {
+                            return info;
+                        }
+                    }
+                }
+            }
+
             return null;
         }
 


### PR DESCRIPTION
Fixes #
https://developercommunity.visualstudio.com/t/MSB3179:-Problem-isolating-COM-reference/1571958

### Customer Impact
Customer projects that reference a x86 COM binary cannot publish their project using ClickOnce provider.

### Regression?
Yes (Dev16 -> Dev17)

### Summary

ClickOnce's msbuild task to generate the application manifest has code that imports COM Component by reading their registration data from the registry. In this scenario, the COM reference is an x86 binary that is registered under HKCR\WOW6432Node\Clsid node. In dev17 with msbuild being an x64  process, the code is not reading from the WOW6432Node.

The fix is to update the code that's reads COM registration data to look under the WOW6432 node of HKCR as well.

### Testing
Verifed with customer provided repro project that x86 COM component is imported fine after the fix.
CTI team has run regression tests and signed off on the private.

### Risk
Low. The check to read from the WOW6432 node is a fallback when we cannot get registration info from the non-WOW location. 
