### PR TITLE
Enable feature flags for things enabled in .NET Core 2.0

### DIFF
--- a/src/Build.OM.UnitTests/Definition/ProjectCollection_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectCollection_Tests.cs
@@ -1062,11 +1062,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             }
 
             var collection = new ProjectCollection();
-#if STANDALONEBUILD
             Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, collection.DefaultToolsVersion);
-#else
-            Assert.Equal("2.0", collection.DefaultToolsVersion);
-#endif
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/Build.UnitTests/Construction/ElementLocation_Tests.cs
@@ -343,8 +343,6 @@ namespace Microsoft.Build.UnitTests.Construction
             Helpers.VerifyAssertLineByLine(readWriteLoadLocations, readOnlyLoadLocations);
         }
 
-        // Without save to file, this becomes identical to SaveReadOnly4
-#if FEATURE_XML_LOADPATH
         /// <summary>
         /// Save read only fails
         /// </summary>
@@ -360,7 +358,6 @@ namespace Microsoft.Build.UnitTests.Construction
             }
            );
         }
-#endif
 
         /// <summary>
         /// Save read only fails
@@ -371,17 +368,7 @@ namespace Microsoft.Build.UnitTests.Construction
         public void SaveReadOnly2()
         {
             var doc = new XmlDocumentWithLocation(loadAsReadOnly: true);
-#if FEATURE_XML_LOADPATH
             doc.Load(_pathToCommonTargets);
-#else
-            using (
-                XmlReader xmlReader = XmlReader.Create(
-                    _pathToCommonTargets,
-                    new XmlReaderSettings {DtdProcessing = DtdProcessing.Ignore}))
-            {
-                doc.Load(xmlReader);
-            }
-#endif
             Assert.True(doc.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() => {
                 doc.Save(new MemoryStream());
@@ -397,17 +384,7 @@ namespace Microsoft.Build.UnitTests.Construction
         public void SaveReadOnly3()
         {
             var doc = new XmlDocumentWithLocation(loadAsReadOnly: true);
-#if FEATURE_XML_LOADPATH
             doc.Load(_pathToCommonTargets);
-#else
-            using (
-                XmlReader xmlReader = XmlReader.Create(
-                    _pathToCommonTargets,
-                    new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore }))
-            {
-                doc.Load(xmlReader);
-            }
-#endif
             Assert.True(doc.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -424,17 +401,7 @@ namespace Microsoft.Build.UnitTests.Construction
         public void SaveReadOnly4()
         {
             var doc = new XmlDocumentWithLocation(loadAsReadOnly: true);
-#if FEATURE_XML_LOADPATH
             doc.Load(_pathToCommonTargets);
-#else
-            using (
-                XmlReader xmlReader = XmlReader.Create(
-                    _pathToCommonTargets,
-                    new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore }))
-            {
-                doc.Load(xmlReader);
-            }
-#endif
             Assert.True(doc.IsReadOnly);
             using (XmlWriter wr = XmlWriter.Create(new FileStream(FileUtilities.GetTemporaryFile(), FileMode.Create)))
             {
@@ -457,17 +424,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 file = FileUtilities.GetTemporaryFile();
                 File.WriteAllText(file, content);
                 var doc = new XmlDocumentWithLocation(loadAsReadOnly: readOnly);
-#if FEATURE_XML_LOADPATH
                 doc.Load(file);
-#else
-                using (
-                    XmlReader xmlReader = XmlReader.Create(
-                        file,
-                        new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore }))
-                {
-                    doc.Load(xmlReader);
-                }
-#endif
                 Assert.Equal(readOnly, doc.IsReadOnly);
                 var allNodes = doc.SelectNodes("//*|//@*");
 

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -1571,11 +1571,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
             xmlattribute.Value = "abc123" + new Random().Next();
             string expandedString = expander.ExpandIntoStringLeaveEscaped(xmlattribute.Value, ExpanderOptions.ExpandAll, MockElementLocation.Instance);
 
-#if FEATURE_STRING_INTERN
             // Verify neither string got interned, so that this test is meaningful
             Assert.Null(string.IsInterned(xmlattribute.Value));
             Assert.Null(string.IsInterned(expandedString));
-#endif
 
             // Finally verify Expander indeed didn't create a new string.
             Assert.True(Object.ReferenceEquals(xmlattribute.Value, expandedString));

--- a/src/Build.UnitTests/Evaluation/ProjectStringCache_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectStringCache_Tests.cs
@@ -44,26 +44,11 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
                 ProjectStringCache cache = new ProjectStringCache();
                 XmlDocumentWithLocation document1 = new XmlDocumentWithLocation();
                 document1.StringCache = cache;
-#if FEATURE_XML_LOADPATH
                 document1.Load(path);
-#else
-                var xmlReadSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                using (XmlReader xmlReader = XmlReader.Create(path, xmlReadSettings))
-                {
-                    document1.Load(xmlReader);
-                }
-#endif
 
                 XmlDocumentWithLocation document2 = new XmlDocumentWithLocation();
                 document2.StringCache = cache;
-#if FEATURE_XML_LOADPATH
                 document2.Load(path);
-#else
-                using (XmlReader xmlReader = XmlReader.Create(path, xmlReadSettings))
-                {
-                    document2.Load(xmlReader);
-                }
-#endif
 
                 XmlNodeList nodes1 = document1.GetElementsByTagName("ItemGroup");
                 XmlNodeList nodes2 = document2.GetElementsByTagName("ItemGroup");
@@ -109,26 +94,11 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
                 ProjectStringCache cache = new ProjectStringCache();
                 XmlDocumentWithLocation document1 = new XmlDocumentWithLocation();
                 document1.StringCache = cache;
-#if FEATURE_XML_LOADPATH
                 document1.Load(path);
-#else
-                var xmlReadSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                using (XmlReader xmlReader = XmlReader.Create(path, xmlReadSettings))
-                {
-                    document1.Load(xmlReader);
-                }
-#endif
 
                 XmlDocumentWithLocation document2 = new XmlDocumentWithLocation();
                 document2.StringCache = cache;
-#if FEATURE_XML_LOADPATH
                 document2.Load(path);
-#else
-                using (XmlReader xmlReader = XmlReader.Create(path, xmlReadSettings))
-                {
-                    document2.Load(xmlReader);
-                }
-#endif
 
                 string outerXml1 = document1.OuterXml;
                 string outerXml2 = document2.OuterXml;
@@ -198,15 +168,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
                 ProjectRootElement pre1 = ProjectRootElement.Create(collection);
                 pre1.XmlDocument.StringCache = cache;
                 pre1.FullPath = path;
-#if FEATURE_XML_LOADPATH
                 pre1.XmlDocument.Load(path);
-#else
-                var xmlReadSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                using (XmlReader xmlReader = XmlReader.Create(path, xmlReadSettings))
-                {
-                    pre1.XmlDocument.Load(xmlReader);
-                }
-#endif
 
                 entryCount = cache.Count;
                 Assert.True(entryCount > 0);
@@ -214,14 +176,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
                 ProjectRootElement pre2 = ProjectRootElement.Create(collection);
                 pre2.XmlDocument.StringCache = cache;
                 pre2.FullPath = path;
-#if FEATURE_XML_LOADPATH
                 pre2.XmlDocument.Load(path);
-#else
-                using (XmlReader xmlReader = XmlReader.Create(path, xmlReadSettings))
-                {
-                    pre2.XmlDocument.Load(xmlReader);
-                }
-#endif
 
                 // Entry count should not have changed
                 Assert.Equal(entryCount, cache.Count);

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -278,9 +278,7 @@ namespace Microsoft.Build.Execution
             _nodeExeLocation = other._nodeExeLocation;
             NodeId = other.NodeId;
             _onlyLogCriticalEvents = other._onlyLogCriticalEvents;
-#if FEATURE_THREAD_PRIORITY
             BuildThreadPriority = other.BuildThreadPriority;
-#endif
             _toolsetProvider = other._toolsetProvider;
             ToolsetDefinitionLocations = other.ToolsetDefinitionLocations;
             _toolsetProvider = other._toolsetProvider;
@@ -307,13 +305,10 @@ namespace Microsoft.Build.Execution
             ProjectCacheDescriptor = other.ProjectCacheDescriptor;
         }
 
-#if FEATURE_THREAD_PRIORITY
         /// <summary>
         /// Gets or sets the desired thread priority for building.
         /// </summary>
         public ThreadPriority BuildThreadPriority { get; set; } = ThreadPriority.Normal;
-
-#endif
 
         /// <summary>
         /// By default if the number of processes is set to 1 we will use Asynchronous logging. However if we want to use synchronous logging when the number of cpu's is set to 1

--- a/src/Build/BackEnd/Components/Communications/TranslatorExtensions.cs
+++ b/src/Build/BackEnd/Components/Communications/TranslatorExtensions.cs
@@ -85,15 +85,7 @@ namespace Microsoft.Build.BackEnd
                 t =>
                 {
                     ConstructorInfo constructor = null;
-#if FEATURE_TYPE_GETCONSTRUCTOR
                     constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, Type.EmptyTypes, null);
-#else
-                    constructor =
-                        type
-                            .GetTypeInfo()
-                            .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
-                            .FirstOrDefault(c => c.GetParameters().Length == 0);
-#endif
                     ErrorUtilities.VerifyThrowInvalidOperation(
                         constructor != null,
                         $"{typeName} must have a private parameterless constructor");

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -714,9 +714,7 @@ namespace Microsoft.Build.BackEnd
             CultureInfo.CurrentCulture = _componentHost.BuildParameters.Culture;
             CultureInfo.CurrentUICulture = _componentHost.BuildParameters.UICulture;
 
-#if FEATURE_THREAD_PRIORITY
             Thread.CurrentThread.Priority = _componentHost.BuildParameters.BuildThreadPriority;
-#endif
             Thread.CurrentThread.IsBackground = true;
 
             // NOTE: This is safe to do because we have specified long-running so we get our own new thread.

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -410,13 +410,6 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal async Task ExecuteTarget(ITaskBuilder taskBuilder, BuildRequestEntry requestEntry, ProjectLoggingContext projectLoggingContext, CancellationToken cancellationToken)
         {
-#if MSBUILDENABLEVSPROFILING 
-            try
-            {
-                string beginTargetBuild = String.Format(CultureInfo.CurrentCulture, "Build Target {0} in Project {1} - Start", this.Name, projectFullPath);
-                DataCollection.CommentMarkProfile(8800, beginTargetBuild);
-#endif 
-
             try
             {
                 VerifyState(_state, TargetEntryState.Execution);
@@ -668,14 +661,6 @@ namespace Microsoft.Build.BackEnd
             {
                 _isExecuting = false;
             }
-#if MSBUILDENABLEVSPROFILING 
-            }
-            finally
-            {
-                string endTargetBuild = String.Format(CultureInfo.CurrentCulture, "Build Target {0} in Project {1} - End", this.Name, projectFullPath);
-                DataCollection.CommentMarkProfile(8801, endTargetBuild);
-            }
-#endif
         }
 
         /// <summary>

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -647,11 +647,7 @@ namespace Microsoft.Build.BackEnd
 
             // Let the task finish now.  If cancellation worked, hopefully it finishes sooner than it would have otherwise.
             // If the task builder crashed, this could have already been disposed
-#if FEATURE_HANDLE_SAFEWAITHANDLE
             if (!_taskExecutionIdle.SafeWaitHandle.IsClosed)
-#else
-            if (!_taskExecutionIdle.GetSafeWaitHandle().IsClosed)
-#endif
             {
                 // Kick off a task to log the message so that we don't block the calling thread.
                 Task.Run(async delegate

--- a/src/Build/ElementLocation/XmlDocumentWithLocation.cs
+++ b/src/Build/ElementLocation/XmlDocumentWithLocation.cs
@@ -165,7 +165,6 @@ namespace Microsoft.Build.Construction
             _reader = null;
         }
 
-#if FEATURE_XML_LOADPATH
         /// <summary>
         /// Grab the path to the file, for use in our location information.
         /// </summary>
@@ -180,7 +179,6 @@ namespace Microsoft.Build.Construction
                 this.Load(xtr.Reader);
             }
         }
-#endif
 
         /// <summary>
         /// Called during load, to add an element.
@@ -281,7 +279,6 @@ namespace Microsoft.Build.Construction
             base.Save(outStream);
         }
 
-#if FEATURE_XML_LOADPATH
         /// <summary>
         /// Override Save to verify file was not loaded as readonly
         /// </summary>
@@ -290,7 +287,6 @@ namespace Microsoft.Build.Construction
             VerifyThrowNotReadOnly();
             base.Save(filename);
         }
-#endif
 
         /// <summary>
         /// Override Save to verify file was not loaded as readonly

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2597,19 +2597,8 @@ namespace Microsoft.Build.Execution
                         clearedVariables.Add(environmentVariable);
                     }
                 }
-#if (!STANDALONEBUILD)
-                wrapperProjectXml = Microsoft.Build.BuildEngine.SolutionWrapperProject.Generate(projectFile, toolsVersion, projectBuildEventContext);
-#else
                 wrapperProjectXml = "";
-#endif
             }
-#if (!STANDALONEBUILD)
-            catch (Microsoft.Build.BuildEngine.InvalidProjectFileException ex)
-            {
-                // Whenever calling the old engine, we must translate its exception types into ours
-                throw new InvalidProjectFileException(ex.ProjectFile, ex.LineNumber, ex.ColumnNumber, ex.EndLineNumber, ex.EndColumnNumber, ex.Message, ex.ErrorSubcategory, ex.ErrorCode, ex.HelpKeyword, ex.InnerException);
-            }
-#endif
             finally
             {
                 // Set the cleared environment variables back to what they were.

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -83,7 +83,6 @@ namespace Microsoft.Build.BackEnd.Logging
             // If forceNoAlign is set there is no point getting the console width as there will be no aligning of the text
             if (!_forceNoAlign)
             {
-#if FEATURE_CONSOLE_BUFFERWIDTH
                 if (runningWithCharacterFileType)
                 {
                     // Get the size of the console buffer so messages can be formatted to the console width
@@ -100,7 +99,6 @@ namespace Microsoft.Build.BackEnd.Logging
                     }
                 }
                 else
-#endif
                 {
                     _alignMessages = false;
                 }

--- a/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.get -> Microsoft.Build.FileSystem.IDirectoryCacheFactory
 Microsoft.Build.Definition.ProjectOptions.DirectoryCacheFactory.set -> void
+Microsoft.Build.Execution.BuildParameters.BuildThreadPriority.get -> System.Threading.ThreadPriority
+Microsoft.Build.Execution.BuildParameters.BuildThreadPriority.set -> void
 Microsoft.Build.Experimental.ProjectCache.PluginLoggerBase.PluginLoggerBase() -> void
 Microsoft.Build.FileSystem.FindPredicate
 Microsoft.Build.FileSystem.FindTransform<TResult>

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -309,9 +309,7 @@ namespace Microsoft.Build.Internal
 #endif
 
                         availableStaticMethods.TryAdd("System.Environment::MachineName", environmentType);
-#if FEATURE_OSVERSION
                         availableStaticMethods.TryAdd("System.Environment::OSVersion", environmentType);
-#endif
                         availableStaticMethods.TryAdd("System.Environment::ProcessorCount", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::StackTrace", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::SystemDirectory", environmentType);

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -302,9 +302,7 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.Environment::GetLogicalDrives", environmentType);
 
 // All the following properties only have getters
-#if FEATURE_GET_COMMANDLINE
                         availableStaticMethods.TryAdd("System.Environment::CommandLine", environmentType);
-#endif
 #if FEATURE_64BIT_ENVIRONMENT_QUERY
                         availableStaticMethods.TryAdd("System.Environment::Is64BitOperatingSystem", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::Is64BitProcess", environmentType);
@@ -317,23 +315,13 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.Environment::ProcessorCount", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::StackTrace", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::SystemDirectory", environmentType);
-#if FEATURE_SYSTEMPAGESIZE
                         availableStaticMethods.TryAdd("System.Environment::SystemPageSize", environmentType);
-#endif
                         availableStaticMethods.TryAdd("System.Environment::TickCount", environmentType);
-#if FEATURE_USERDOMAINNAME
                         availableStaticMethods.TryAdd("System.Environment::UserDomainName", environmentType);
-#endif
-#if FEATURE_USERINTERACTIVE
                         availableStaticMethods.TryAdd("System.Environment::UserInteractive", environmentType);
-#endif
                         availableStaticMethods.TryAdd("System.Environment::UserName", environmentType);
-#if FEATURE_DOTNETVERSION
                         availableStaticMethods.TryAdd("System.Environment::Version", environmentType);
-#endif
-#if FEATURE_WORKINGSET
                         availableStaticMethods.TryAdd("System.Environment::WorkingSet", environmentType);
-#endif
 
                         availableStaticMethods.TryAdd("System.IO.Directory::GetDirectories", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetFiles", directoryType);
@@ -347,9 +335,7 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.IO.File::GetLastWriteTime", fileType);
                         availableStaticMethods.TryAdd("System.IO.File::ReadAllText", fileType);
 
-#if FEATURE_CULTUREINFO_GETCULTUREINFO
                         availableStaticMethods.TryAdd("System.Globalization.CultureInfo::GetCultureInfo", new Tuple<string, Type>(null, typeof(CultureInfo))); // user request
-#endif
                         availableStaticMethods.TryAdd("System.Globalization.CultureInfo::new", new Tuple<string, Type>(null, typeof(CultureInfo))); // user request
                         availableStaticMethods.TryAdd("System.Globalization.CultureInfo::CurrentUICulture", new Tuple<string, Type>(null, typeof(CultureInfo))); // user request
 

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -303,10 +303,8 @@ namespace Microsoft.Build.Internal
 
 // All the following properties only have getters
                         availableStaticMethods.TryAdd("System.Environment::CommandLine", environmentType);
-#if FEATURE_64BIT_ENVIRONMENT_QUERY
                         availableStaticMethods.TryAdd("System.Environment::Is64BitOperatingSystem", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::Is64BitProcess", environmentType);
-#endif
 
                         availableStaticMethods.TryAdd("System.Environment::MachineName", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::OSVersion", environmentType);

--- a/src/Deprecated/Engine/Engine/Engine.cs
+++ b/src/Deprecated/Engine/Engine/Engine.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Build.BuildEngine
         // this seed is used to generate unique logger ids for each distributed logger
         private int lastUsedLoggerId;
 
-        // this boolean is true if central logging is enabled 
+        // this boolean is true if central logging is enabled
         private bool enabledCentralLogging;
 
         // The class used to observe engine operation to collect data and detect errors
@@ -205,7 +205,7 @@ namespace Microsoft.Build.BuildEngine
         // Number of CPUs this engine is instantiated with
         private int numberOfCpus;
 
-        // The current directory at the time the Engine was constructed -- 
+        // The current directory at the time the Engine was constructed --
         // if msbuild.exe is hosting, this is the current directory when
         // msbuild.exe was started
         private string startupDirectory;
@@ -343,7 +343,7 @@ namespace Microsoft.Build.BuildEngine
             ToolsetDefinitionLocations locations
         )
         {
-            // No need to check whether locations parameter 
+            // No need to check whether locations parameter
             // is null, because it is a value type
 
             this.startupDirectory = Environment.CurrentDirectory;
@@ -901,8 +901,8 @@ namespace Microsoft.Build.BuildEngine
                 // It already exists: replace it with the new toolset
                 toolsetStateMap[toolset.ToolsVersion] = new ToolsetState(this, toolset);
 
-                // We must be sure to notify all of the loaded projects with this 
-                // tools version that they are dirty so they will later pick up any changes 
+                // We must be sure to notify all of the loaded projects with this
+                // tools version that they are dirty so they will later pick up any changes
                 // to the ToolsetState.
                 DirtyProjectsUsingToolsVersion(toolset.ToolsVersion);
             }
@@ -975,7 +975,7 @@ namespace Microsoft.Build.BuildEngine
                     if (pathTo20Framework == null)
                     {
                         // We have been given no default, so we want to choose 2.0, but .NET 2.0 is not installed.
-                        // In general we do not verify that MSBuildToolsPath's point to a valid location, 
+                        // In general we do not verify that MSBuildToolsPath's point to a valid location,
                         // so failing here would be inconsistent. The build might not even use this toolset.
                         // Instead, synthesize what would be the path to the .NET 2.0 install location.
                         // If the build tries to use the default toolset, the problem will be discovered then.
@@ -1119,7 +1119,7 @@ namespace Microsoft.Build.BuildEngine
             lastUsedLoggerId++;
             forwardingLogger.LoggerId = loggerId;
 
-            //Create and configure the local node logger 
+            //Create and configure the local node logger
             IForwardingLogger localForwardingLogger = null;
             try
             {
@@ -1129,7 +1129,7 @@ namespace Microsoft.Build.BuildEngine
                 {
                     InternalLoggerException.Throw(null, null, "LoggerNotFoundError", true, forwardingLogger.Name);
                 }
-                // Configure the object 
+                // Configure the object
                 EventRedirector newRedirector = new EventRedirector(forwardingLogger.LoggerId, primaryLoggingServices);
                 localForwardingLogger.BuildEventRedirector = newRedirector;
                 localForwardingLogger.Parameters = forwardingLogger.LoggerSwitchParameters;
@@ -1156,7 +1156,7 @@ namespace Microsoft.Build.BuildEngine
             // Register the local forwarding logger to listen for all local events
             RegisterLoggerInternal(localForwardingLogger, eventSourceForForwarding, true);
 
-            //Register this logger's node logger with the node manager so that all 
+            //Register this logger's node logger with the node manager so that all
             //the nodes instantiate this node logger and forward the events
             nodeManager.RegisterNodeLogger(forwardingLogger);
 
@@ -1272,7 +1272,7 @@ namespace Microsoft.Build.BuildEngine
                     // Post the event to old style loggers and forwarding loggers on parent node
                     LoggingServices.LogBuildFinished(buildResult);
 
-                    // Cause the forwarding loggers to process BuildFinished event and whatever other events 
+                    // Cause the forwarding loggers to process BuildFinished event and whatever other events
                     // were in the queue (on the child the event are flushed to the level of the outofproc logging service)
                     LoggingServices.ProcessPostedLoggingEvents();
 
@@ -1289,15 +1289,15 @@ namespace Microsoft.Build.BuildEngine
                 // For each of the projects that the host has actually loaded (and holding on to),
                 // remove all projects with that same fullpath from the ProjectManager.  There are
                 // a couple of reasons for this:
-                // 1.   Because the host is hanging on to this projects, during design-time the host 
+                // 1.   Because the host is hanging on to this projects, during design-time the host
                 //      might decide to change the GlobalProperties on one of these projects.  He might
                 //      change the GlobalProperties such that they now are equivalent to the GlobalProperties
-                //      for one of the projects in the ProjectManager.  That would get weird because 
+                //      for one of the projects in the ProjectManager.  That would get weird because
                 //      we'd end up with two projects with the same fullpath and same GlobalProperties,
                 //      and we wouldn't know which one to choose (on the next build).
-                // 2.   Because the host is hanging on to the projects, it may decide to make in-memory 
+                // 2.   Because the host is hanging on to the projects, it may decide to make in-memory
                 //      changes to the project.  On next build, we need to take those changes into
-                //      account, and any instances of Project in the ProjectManager won't have those 
+                //      account, and any instances of Project in the ProjectManager won't have those
                 //      changes.
                 this.cacheOfBuildingProjects.RemoveProjects(loadedProjectFullPath);
             }
@@ -1369,7 +1369,7 @@ namespace Microsoft.Build.BuildEngine
 
             // Host is mucking with this project.  Remove the cached versions of
             // all projects with this same full path.  Over aggressively getting rid
-            // of stuff from the cache is better than accidentally leaving crud in 
+            // of stuff from the cache is better than accidentally leaving crud in
             // there.
             UnloadProject(project, true /* Unload all versions */);
         }
@@ -1426,7 +1426,7 @@ namespace Microsoft.Build.BuildEngine
 
                 // Host is mucking with this project.  Remove the cached versions of
                 // all projects with this same full path.  Over aggressively getting rid
-                // of stuff from the cache is better than accidentally leaving crud in 
+                // of stuff from the cache is better than accidentally leaving crud in
                 // there.
                 this.cacheOfBuildingProjects.RemoveProjects(oldFullFileName);
             }
@@ -1447,7 +1447,7 @@ namespace Microsoft.Build.BuildEngine
 
                 // Host is mucking with this project.  Remove the cached versions of
                 // all projects with this same full path.  Over aggressively getting rid
-                // of stuff from the cache is better than accidentally leaving crud in 
+                // of stuff from the cache is better than accidentally leaving crud in
                 // there.
                 this.cacheOfBuildingProjects.RemoveProjects(newFullFileName);
             }
@@ -1456,7 +1456,7 @@ namespace Microsoft.Build.BuildEngine
             {
                 // MSBuild projects keep track of PropertyGroups that are imported from other
                 // files.  It does this tracking by using the project file name of the imported
-                // file.  So when a project gets renamed, as is being done here, we need 
+                // file.  So when a project gets renamed, as is being done here, we need
                 // to go update all those imported PropertyGroup records with the new filename.
 
                 // Loop through every loaded project, and inform it about the newly named
@@ -1625,7 +1625,7 @@ namespace Microsoft.Build.BuildEngine
             {
                 int eventType;
 
-                // See if we have anything to do without waiting on the handles which is expensive 
+                // See if we have anything to do without waiting on the handles which is expensive
                 // for kernel mode objects.
                 if (this.engineAbortCachedValue)
                 {
@@ -1686,7 +1686,7 @@ namespace Microsoft.Build.BuildEngine
                     // Execute the command
                     engineCommand.Execute(this);
 
-                    // Don't consider node status request to be activity 
+                    // Don't consider node status request to be activity
                     if (!(engineCommand is RequestStatusEngineCommand))
                     {
                         lastLoopActivity = DateTime.Now.Ticks;
@@ -1856,11 +1856,6 @@ namespace Microsoft.Build.BuildEngine
                 SetBuildItemCurrentDirectory(project);
                 if (initialCall)
                 {
-#if MSBUILDENABLEVSPROFILING 
-                    string beginProjectBuild = String.Format(CultureInfo.CurrentCulture, "Build Project {0} Using Old OM - Start", project.FullFileName);
-                    DataCollection.CommentMarkProfile(8802, beginProjectBuild);
-#endif 
-
                     // Make sure we were passed in a project object.
                     error.VerifyThrowArgument(project != null, "MissingProject", "Project");
 
@@ -1931,10 +1926,6 @@ namespace Microsoft.Build.BuildEngine
 
                 if (buildRequest?.BuildCompleted == true || exitedDueToError)
                 {
-#if MSBUILDENABLEVSPROFILING 
-                    string endProjectBuild = String.Format(CultureInfo.CurrentCulture, "Build Project {0} Using Old OM - End", project.FullFileName);
-                    DataCollection.CommentMarkProfile(8803, endProjectBuild);
-#endif 
                 }
             }
         }
@@ -2075,7 +2066,7 @@ namespace Microsoft.Build.BuildEngine
 
             if (0 == (buildRequest.BuildSettings & BuildSettings.DoNotResetPreviouslyBuiltTargets))
             {
-                // Reset the build state for all projects that are still cached from the 
+                // Reset the build state for all projects that are still cached from the
                 // last build and the currently loaded projects that we just added to
                 // the ProjectManager.
                 this.cacheOfBuildingProjects.ResetBuildStatusForAllProjects();
@@ -2340,7 +2331,7 @@ namespace Microsoft.Build.BuildEngine
             Hashtable[] targetOutputsWorkingCopy = new Hashtable[buildRequests.Length];
             for (int i = 0; i < buildRequests.Length; i++)
             {
-                // if the caller wants to retrieve target outputs, create a working copy to avoid clobbering 
+                // if the caller wants to retrieve target outputs, create a working copy to avoid clobbering
                 // other data in the hashtable
                 if (targetOutputsPerProject[i] != null)
                 {
@@ -2408,10 +2399,10 @@ namespace Microsoft.Build.BuildEngine
             {
                 // Post build finished event if the finally is not being executed due to an exception
                 EndingEngineExecution(overallResult, exitedDueToError);
-                // Reset the current directory to the value before this 
+                // Reset the current directory to the value before this
                 // project built
                 Environment.CurrentDirectory = currentDirectory;
-                // We reset the path back to the original value in case the 
+                // We reset the path back to the original value in case the
                 // host is depending on the current directory to find projects
                 Project.PerThreadProjectDirectory = currentPerThreadProjectDirectory;
             }
@@ -2439,7 +2430,7 @@ namespace Microsoft.Build.BuildEngine
             buildRequest.ProjectToBuild = project;
             // Set the request build flags
             buildRequest.BuildSettings = buildFlags;
-            // Set the boolean requesting the project start/finish events 
+            // Set the boolean requesting the project start/finish events
             buildRequest.FireProjectStartedFinishedEvents = true;
             // Set the dictionary to return target outputs in, if any
             buildRequest.OutputsByTarget = targetOutputs;
@@ -2508,7 +2499,7 @@ namespace Microsoft.Build.BuildEngine
                 {
                     // There's no cached result: we have to build it. Figure out which node to build it on.
                     Project matchingProjectCurrentlyLoaded = null;
-                    
+
                     // See if we have a project loaded by the host already that matches the full path, in the
                     // list of projects which were loaded at the beginning of the build.
                     Project projectCurrentlyLoaded = (Project)this.projectsLoadedByHost[projectFileInfo.FullName];
@@ -2581,7 +2572,7 @@ namespace Microsoft.Build.BuildEngine
 
                     if (evaluationNode != EngineCallback.inProcNode)
                     {
-                        // The project will be evaluated remotely so add a record 
+                        // The project will be evaluated remotely so add a record
                         // indicating where this project is being evaluated
                         if (evaluationNode != EngineCallback.parentNode)
                         {
@@ -2604,7 +2595,7 @@ namespace Microsoft.Build.BuildEngine
                     }
                     else
                     {
-                        // Increment number of projects in progress 
+                        // Increment number of projects in progress
                         if (!buildRequest.IsGeneratedRequest)
                         {
                             IncrementProjectsInProgress();
@@ -2746,7 +2737,7 @@ namespace Microsoft.Build.BuildEngine
                         // If a user customized his build process and is explicitly passing in Properties to the
                         // <MSBuild> task, then we would be entering this codepath for a totally legitimate
                         // scenario, so we don't want to disallow it.  We just want to know about it if it happens
-                        // to anyone before we ship, just so we can investigate to see if there may be a bug 
+                        // to anyone before we ship, just so we can investigate to see if there may be a bug
                         // somewhere.
                         if (this.projectsLoadedByHost.Count > 1)
                         {
@@ -3057,7 +3048,7 @@ namespace Microsoft.Build.BuildEngine
         /// </summary>
         internal void ResetPerBuildDataStructures()
         {
-            // Reset the build state for all projects that are still cached from the 
+            // Reset the build state for all projects that are still cached from the
             // last build and the currently loaded projects that we just added to
             // the ProjectManager.
             this.cacheOfBuildingProjects.ResetBuildStatusForAllProjects();

--- a/src/Deprecated/Engine/Engine/Engine.cs
+++ b/src/Deprecated/Engine/Engine/Engine.cs
@@ -11,13 +11,6 @@ using System.Reflection;
 using System.Globalization;
 using System.Threading;
 
-#if (!STANDALONEBUILD)
-using Microsoft.Internal.Performance;
-#if MSBUILDENABLEVSPROFILING 
-using Microsoft.VisualStudio.Profiler;
-#endif
-#endif
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.BuildEngine.Shared;
 
@@ -1863,9 +1856,6 @@ namespace Microsoft.Build.BuildEngine
                 SetBuildItemCurrentDirectory(project);
                 if (initialCall)
                 {
-#if (!STANDALONEBUILD)
-                    CodeMarkers.Instance.CodeMarker(CodeMarkerEvent.perfMSBuildEngineBuildProjectBegin);
-#endif
 #if MSBUILDENABLEVSPROFILING 
                     string beginProjectBuild = String.Format(CultureInfo.CurrentCulture, "Build Project {0} Using Old OM - Start", project.FullFileName);
                     DataCollection.CommentMarkProfile(8802, beginProjectBuild);
@@ -1941,9 +1931,6 @@ namespace Microsoft.Build.BuildEngine
 
                 if (buildRequest?.BuildCompleted == true || exitedDueToError)
                 {
-#if (!STANDALONEBUILD)
-                    CodeMarkers.Instance.CodeMarker(CodeMarkerEvent.perfMSBuildEngineBuildProjectEnd);
-#endif
 #if MSBUILDENABLEVSPROFILING 
                     string endProjectBuild = String.Format(CultureInfo.CurrentCulture, "Build Project {0} Using Old OM - End", project.FullFileName);
                     DataCollection.CommentMarkProfile(8803, endProjectBuild);

--- a/src/Deprecated/Engine/Engine/Project.cs
+++ b/src/Deprecated/Engine/Engine/Project.cs
@@ -10,12 +10,6 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Text;
 using System.Globalization;
-#if (!STANDALONEBUILD)
-using Microsoft.Internal.Performance;
-#if MSBUILDENABLEVSPROFILING 
-using Microsoft.VisualStudio.Profiler;
-#endif
-#endif
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.BuildEngine.Shared;
@@ -349,9 +343,6 @@ namespace Microsoft.Build.BuildEngine
             {
                 DataCollection.CommentMarkProfile(8808, "Construct Project Using Old OM - Start");
 #endif 
-#if (!STANDALONEBUILD)
-            using (new CodeMarkerStartEnd(CodeMarkerEvent.perfMSBuildProjectConstructBegin, CodeMarkerEvent.perfMSBuildProjectConstructEnd))
-#endif
             {
                 if (engine == null)
                 {
@@ -1779,9 +1770,6 @@ namespace Microsoft.Build.BuildEngine
             ErrorUtilities.VerifyThrowArgument(projectFileName.Length > 0, "EmptyProjectFileName");
             ErrorUtilities.VerifyThrowArgument(File.Exists(projectFileName), "ProjectFileNotFound", projectFileName);
 
-#if (!STANDALONEBUILD)
-            using (new CodeMarkerStartEnd(CodeMarkerEvent.perfMSBuildProjectLoadFromFileBegin, CodeMarkerEvent.perfMSBuildProjectLoadFromFileEnd))
-#endif
             {
                 string projectFullFileName = Path.GetFullPath(projectFileName);
 
@@ -2116,9 +2104,6 @@ namespace Microsoft.Build.BuildEngine
             Encoding encoding
             )
         {
-#if (!STANDALONEBUILD)
-            using (new CodeMarkerStartEnd(CodeMarkerEvent.perfMSBuildProjectSaveToFileBegin, CodeMarkerEvent.perfMSBuildProjectSaveToFileEnd))
-#endif
             {
 #if MSBUILDENABLEVSPROFILING 
             try
@@ -4268,9 +4253,6 @@ namespace Microsoft.Build.BuildEngine
         /// <owner>RGoel</owner>
         private void EvaluateProject(bool currentlyLoading)
         {
-#if (!STANDALONEBUILD)
-            using (new CodeMarkerStartEnd(CodeMarkerEvent.perfMSBuildProjectEvaluateBegin, CodeMarkerEvent.perfMSBuildProjectEvaluateEnd))
-#endif
             {
 #if MSBUILDENABLEVSPROFILING 
                 try

--- a/src/Deprecated/Engine/Engine/Project.cs
+++ b/src/Deprecated/Engine/Engine/Project.cs
@@ -338,11 +338,6 @@ namespace Microsoft.Build.BuildEngine
             string toolsVersion
         )
         {
-#if MSBUILDENABLEVSPROFILING 
-            try
-            {
-                DataCollection.CommentMarkProfile(8808, "Construct Project Using Old OM - Start");
-#endif 
             {
                 if (engine == null)
                 {
@@ -429,13 +424,6 @@ namespace Microsoft.Build.BuildEngine
                 this.GlobalProperties = this.parentEngine.GlobalProperties;
                 this.EnvironmentProperties = this.parentEngine.EnvironmentProperties;
             }
-#if MSBUILDENABLEVSPROFILING 
-            }
-            finally
-            {
-                DataCollection.CommentMarkProfile(8809, "Construct Project Using Old OM - End");
-            }
-#endif
         }
 
         /// <summary>
@@ -1775,10 +1763,6 @@ namespace Microsoft.Build.BuildEngine
 
                 try
                 {
-#if MSBUILDENABLEVSPROFILING 
-                string beginProjectLoad = String.Format(CultureInfo.CurrentCulture, "Load Project {0} Using Old OM - Start", projectFullFileName);
-                DataCollection.CommentMarkProfile(8806, beginProjectLoad);
-#endif
                     XmlDocument projectDocument = null;
                     if (IsSolutionFilename(projectFileName))
                     {
@@ -1880,9 +1864,6 @@ namespace Microsoft.Build.BuildEngine
                 {
                     // Flush the logging queue
                     ParentEngine.LoggingServices.ProcessPostedLoggingEvents();
-#if MSBUILDENABLEVSPROFILING 
-                DataCollection.CommentMarkProfile(8807, "Load Project Using Old OM - End");
-#endif
                 }
             }
         }
@@ -2105,13 +2086,6 @@ namespace Microsoft.Build.BuildEngine
             )
         {
             {
-#if MSBUILDENABLEVSPROFILING 
-            try
-            {
-                string beginProjectSave = String.Format(CultureInfo.CurrentCulture, "Save Project {0} Using Old OM - Start", projectFileName);
-                DataCollection.CommentMarkProfile(8810, beginProjectSave);
-#endif
-
                 // HIGHCHAR: Project.SaveToFileWithEncoding accepts encoding from caller.
                 using (ProjectWriter projectWriter = new ProjectWriter(projectFileName, encoding))
                 {
@@ -2128,14 +2102,6 @@ namespace Microsoft.Build.BuildEngine
 
                 // reset the dirty flag
                 dirtyNeedToSaveProjectFile = false;
-#if MSBUILDENABLEVSPROFILING 
-            }
-            finally
-            {
-                string endProjectSave = String.Format(CultureInfo.CurrentCulture, "Save Project {0} Using Old OM - End", projectFileName);
-                DataCollection.CommentMarkProfile(8810, endProjectSave);
-            }
-#endif
             }
         }
 
@@ -4254,12 +4220,6 @@ namespace Microsoft.Build.BuildEngine
         private void EvaluateProject(bool currentlyLoading)
         {
             {
-#if MSBUILDENABLEVSPROFILING 
-                try
-                {
-                    string beginProjectEvaluate = String.Format(CultureInfo.CurrentCulture, "Evaluate Project {0} Using Old OM - Start", this.FullFileName);
-                    DataCollection.CommentMarkProfile(8812, beginProjectEvaluate);
-#endif
                 string currentPerThreadProjectDirectory = Project.PerThreadProjectDirectory;
 
                 try
@@ -4315,14 +4275,6 @@ namespace Microsoft.Build.BuildEngine
                     // host is depending on the current directory to find projects
                     Project.PerThreadProjectDirectory = currentPerThreadProjectDirectory;
                 }
-#if MSBUILDENABLEVSPROFILING 
-                }
-                finally
-                {
-                    string beginProjectEvaluate = String.Format(CultureInfo.CurrentCulture, "Evaluate Project {0} Using Old OM - End", this.FullFileName);
-                    DataCollection.CommentMarkProfile(8813, beginProjectEvaluate);
-                }
-#endif
             }
         }
 

--- a/src/Deprecated/Engine/Engine/TargetCollection.cs
+++ b/src/Deprecated/Engine/Engine/TargetCollection.cs
@@ -5,10 +5,6 @@ using System;
 using System.Xml;
 using System.Collections;
 
-#if (!STANDALONEBUILD)
-using Microsoft.Internal.Performance;
-#endif
-
 using Microsoft.Build.BuildEngine.Shared;
 
 using error = Microsoft.Build.BuildEngine.Shared.ErrorUtilities;

--- a/src/Deprecated/Engine/Items/BuildItem.cs
+++ b/src/Deprecated/Engine/Items/BuildItem.cs
@@ -8,9 +8,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 
-#if (!STANDALONEBUILD)
-using Microsoft.Internal.Performance;
-#endif
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.BuildEngine.Shared;

--- a/src/Deprecated/Engine/Microsoft.Build.Engine.csproj
+++ b/src/Deprecated/Engine/Microsoft.Build.Engine.csproj
@@ -8,7 +8,6 @@
     <AdditionalTlbExpAsmPaths>$(XMakeRefPath)</AdditionalTlbExpAsmPaths>
     <PublishTlbPath>$(XMakeRefPath)</PublishTlbPath>
     <GenerateAssemblyRefs>true</GenerateAssemblyRefs>
-    <DefineConstants Condition="'$(MSBUILDENABLEVSPROFILING)' != ''">$(DefineConstants);MSBUILDENABLEVSPROFILING</DefineConstants>
     <CopyToSuiteBin>true</CopyToSuiteBin>
     <IsPackable>true</IsPackable>
     <PackageDescription>This package contains the $(MSBuildProjectName) assembly which contains the legacy compatibility shim for the MSBuild engine.  NOTE: This assembly is deprecated.</PackageDescription>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -51,7 +51,6 @@
     <!-- Path.GetFullPath The pre .Net 4.6.2 implementation of Path.GetFullPath is slow and creates strings in its work. -->
     <DefineConstants>$(DefineConstants);FEATURE_LEGACY_GETFULLPATH</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPE_SECURITY_CONSTRUCTOR</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_OSVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PERFORMANCE_COUNTERS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PIPE_SECURITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PFX_SIGNING</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -56,8 +56,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_RESGEN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESGENCACHE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESOURCE_EXPOSURE</DefineConstants>
-    <!-- System.Resources.ResourceManager.GetResourceSet() method is currently only in full framework -->
-    <DefineConstants>$(DefineConstants);FEATURE_RESOURCEMANAGER_GETRESOURCESET</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESXREADER_LIVEDESERIALIZATION</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_RTLMOVEMEMORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUN_EXE_IN_TESTS</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -39,7 +39,6 @@
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_GAC</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_GET_COMMANDLINE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HANDLEPROCESSCORRUPTEDSTATEEXCEPTIONS</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_HANDLEREF</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HTTP_LISTENER</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_INSTALLED_MSBUILD</DefineConstants>
     <!-- Directory.GetCurrentDirectory The pre .Net 4.6.2 implementation of Directory.GetCurrentDirectory is slow and creates strings in its work. -->

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -19,10 +19,8 @@
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_APM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN</DefineConstants>
     <FeatureAppDomain>true</FeatureAppDomain>
-    <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASPNET_COMPILER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOCATION</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETCONSTRUCTOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_COM_INTEROP</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILED_XSL</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILE_IN_TESTS</DefineConstants>
@@ -72,7 +70,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_XAML_TYPES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XAMLTASKFACTORY</DefineConstants>
     <FeatureXamlTypes>true</FeatureXamlTypes>
-    <DefineConstants>$(DefineConstants);FEATURE_XML_LOADPATH</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_XML_SCHEMA_VALIDATION</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true' and '$(MachineIndependentBuild)' != 'true' and '$(TargetFrameworkVersion)' != 'v3.5' and '$(DotNetBuildFromSource)' != 'true'">$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net3'))">
-    <DefineConstants>$(DefineConstants);FEATURE_64BIT_ENVIRONMENT_QUERY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APARTMENT_STATE</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_APM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -69,7 +69,6 @@
     <DefineConstants Condition="'$(MonoBuild)' != 'true' and '$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_SECURITY_PERMISSIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SECURITY_PRINCIPAL_WINDOWS</DefineConstants>
     <FeatureSpecialFolders>true</FeatureSpecialFolders>
-    <DefineConstants>$(DefineConstants);FEATURE_STRING_INTERN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRONG_NAMES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_CONFIGURATION</DefineConstants>
     <FeatureSystemConfiguration>true</FeatureSystemConfiguration>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -11,8 +11,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);STANDALONEBUILD</DefineConstants>
-
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_DEBUG_LAUNCH</DefineConstants>
   </PropertyGroup>
 

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -62,7 +62,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_TASK_GENERATERESOURCES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ABORT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_CULTURE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_THREAD_PRIORITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MULTIPLE_TOOLSETS</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NET35_TASKHOST</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -72,7 +72,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_XAML_TYPES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XAMLTASKFACTORY</DefineConstants>
     <FeatureXamlTypes>true</FeatureXamlTypes>
-    <DefineConstants>$(DefineConstants);FEATURE_XML_SOURCE_URI</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XML_LOADPATH</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_XML_SCHEMA_VALIDATION</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -38,7 +38,6 @@
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_FILE_TRACKER</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_GAC</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_GET_COMMANDLINE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_HANDLE_SAFEWAITHANDLE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HANDLEPROCESSCORRUPTEDSTATEEXCEPTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HANDLEREF</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HTTP_LISTENER</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -22,7 +22,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASPNET_COMPILER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOCATION</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_GETENTRYASSEMBLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETCONSTRUCTOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_COM_INTEROP</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILED_XSL</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -25,7 +25,6 @@
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILED_XSL</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILE_IN_TESTS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONSTRAINED_EXECUTION</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_CHARSET_AUTO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CODETASKFACTORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_GETCULTURES</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true' and '$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_ENCODING_DEFAULT</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -24,7 +24,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_COM_INTEROP</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILED_XSL</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILE_IN_TESTS</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_CONSOLE_BUFFERWIDTH</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONSTRAINED_EXECUTION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CHARSET_AUTO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CODETASKFACTORY</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -35,9 +35,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_CONSTRAINED_EXECUTION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CHARSET_AUTO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CODETASKFACTORY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_GETCULTUREINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_GETCULTURES</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_DOTNETVERSION</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true' and '$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_ENCODING_DEFAULT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ENVIRONMENT_SYSTEMDIRECTORY</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_FILE_TRACKER</DefineConstants>
@@ -76,7 +74,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_STRING_INTERN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRONG_NAMES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_CONFIGURATION</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_SYSTEMPAGESIZE</DefineConstants>
     <FeatureSystemConfiguration>true</FeatureSystemConfiguration>
     <DefineConstants>$(DefineConstants);FEATURE_TASK_GENERATERESOURCES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ABORT</DefineConstants>
@@ -85,8 +82,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_MULTIPLE_TOOLSETS</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NET35_TASKHOST</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_USERINTERACTIVE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_USERDOMAINNAME</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XAML_TYPES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XAMLTASKFACTORY</DefineConstants>
     <FeatureXamlTypes>true</FeatureXamlTypes>
@@ -95,7 +90,6 @@
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_XML_SCHEMA_VALIDATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DEBUGGER</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_WORKINGSET</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true' and '$(MachineIndependentBuild)' != 'true' and '$(TargetFrameworkVersion)' != 'v3.5' and '$(DotNetBuildFromSource)' != 'true'">$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MSCOREE</DefineConstants>
   </PropertyGroup>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -23,7 +23,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_ASPNET_COMPILER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOCATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_GETENTRYASSEMBLY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYNAME_CLONE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETCONSTRUCTOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_COM_INTEROP</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILED_XSL</DefineConstants>
@@ -57,12 +56,10 @@
     <DefineConstants>$(DefineConstants);FEATURE_RESGENCACHE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESOURCE_EXPOSURE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESXREADER_LIVEDESERIALIZATION</DefineConstants>
-    <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_RTLMOVEMEMORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUN_EXE_IN_TESTS</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' == 'true'">$(DefineConstants);USE_MSBUILD_DLL_EXTN</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true' and '$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_SECURITY_PERMISSIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SECURITY_PRINCIPAL_WINDOWS</DefineConstants>
-    <FeatureSpecialFolders>true</FeatureSpecialFolders>
     <DefineConstants>$(DefineConstants);FEATURE_STRONG_NAMES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_CONFIGURATION</DefineConstants>
     <FeatureSystemConfiguration>true</FeatureSystemConfiguration>
@@ -79,7 +76,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_XML_SOURCE_URI</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XML_LOADPATH</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_XML_SCHEMA_VALIDATION</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_DEBUGGER</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true' and '$(MachineIndependentBuild)' != 'true' and '$(TargetFrameworkVersion)' != 'v3.5' and '$(DotNetBuildFromSource)' != 'true'">$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MSCOREE</DefineConstants>

--- a/src/Framework/AssemblyUtilities.cs
+++ b/src/Framework/AssemblyUtilities.cs
@@ -147,15 +147,7 @@ namespace Microsoft.Build.Shared
 
         private static Assembly GetEntryAssembly()
         {
-#if FEATURE_ASSEMBLY_GETENTRYASSEMBLY
             return System.Reflection.Assembly.GetEntryAssembly();
-#else
-            var getEntryAssembly = typeof(Assembly).GetMethod("GetEntryAssembly");
-
-            FrameworkErrorUtilities.VerifyThrowInternalNull(getEntryAssembly, "Assembly does not have the method GetEntryAssembly");
-
-            return (Assembly) getEntryAssembly.Invoke(null, Array.Empty<object>());
-#endif
         }
 
 #if !FEATURE_CULTUREINFO_GETCULTURES

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -55,9 +55,7 @@ internal static class NativeMethods
 
     internal static DateTime MinFileDate { get; } = DateTime.FromFileTimeUtc(0);
 
-#if FEATURE_HANDLEREF
     internal static HandleRef NullHandleRef = new HandleRef(null, IntPtr.Zero);
-#endif
 
     internal static IntPtr NullIntPtr = new IntPtr(0);
 
@@ -1515,11 +1513,7 @@ internal static class NativeMethods
     /// </summary>
     [DllImport(kernel32Dll, SetLastError = true, CharSet = CharSet.Unicode)]
     internal static extern int GetModuleFileName(
-#if FEATURE_HANDLEREF
             HandleRef hModule,
-#else
-            IntPtr hModule,
-#endif
             [Out] StringBuilder buffer, int length);
 
     [DllImport("kernel32.dll")]

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1655,11 +1655,7 @@ internal static class NativeMethods
         // VS needs this in order to allow the in-proc compilers to properly initialize, since they will make calls from the
         // build thread which the main thread (blocked on BuildSubmission.Execute) must service.
         int waitIndex;
-#if FEATURE_HANDLE_SAFEWAITHANDLE
         IntPtr handlePtr = handle.SafeWaitHandle.DangerousGetHandle();
-#else
-            IntPtr handlePtr = handle.GetSafeWaitHandle().DangerousGetHandle();
-#endif
         int returnValue = CoWaitForMultipleHandles(COWAIT_FLAGS.COWAIT_NONE, timeout, 1, new IntPtr[] { handlePtr }, out waitIndex);
 
         if (!(returnValue == 0 || ((uint)returnValue == RPC_S_CALLPENDING && timeout != Timeout.Infinite)))

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -71,12 +71,6 @@ internal static class NativeMethods
     internal const uint WAIT_OBJECT_0 = 0x00000000;
     internal const uint WAIT_TIMEOUT = 0x00000102;
 
-#if FEATURE_CHARSET_AUTO
-    internal const CharSet AutoOrUnicode = CharSet.Auto;
-#else
-        internal const CharSet AutoOrUnicode = CharSet.Unicode;
-#endif
-
     #endregion
 
     #region Enums
@@ -251,7 +245,7 @@ internal static class NativeMethods
     /// <summary>
     /// Contains information about the current state of both physical and virtual memory, including extended memory
     /// </summary>
-    [StructLayout(LayoutKind.Sequential, CharSet = AutoOrUnicode)]
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
     internal class MemoryStatus
     {
         /// <summary>
@@ -1559,7 +1553,7 @@ internal static class NativeMethods
     private static extern int NtQueryInformationProcess(SafeProcessHandle hProcess, PROCESSINFOCLASS pic, ref PROCESS_BASIC_INFORMATION pbi, uint cb, ref int pSize);
 
     [return: MarshalAs(UnmanagedType.Bool)]
-    [DllImport("kernel32.dll", CharSet = AutoOrUnicode, SetLastError = true)]
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     private static extern bool GlobalMemoryStatusEx([In, Out] MemoryStatus lpBuffer);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, BestFitMapping = false)]
@@ -1568,10 +1562,10 @@ internal static class NativeMethods
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, BestFitMapping = false)]
     internal static extern int GetLongPathName([In] string path, [Out] StringBuilder fullpath, [In] int length);
 
-    [DllImport("kernel32.dll", CharSet = AutoOrUnicode, SetLastError = true)]
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     internal static extern bool CreatePipe(out SafeFileHandle hReadPipe, out SafeFileHandle hWritePipe, SecurityAttributes lpPipeAttributes, int nSize);
 
-    [DllImport("kernel32.dll", CharSet = AutoOrUnicode, SetLastError = true)]
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     internal static extern bool ReadFile(SafeFileHandle hFile, byte[] lpBuffer, uint nNumberOfBytesToRead, out uint lpNumberOfBytesRead, IntPtr lpOverlapped);
 
     /// <summary>
@@ -1588,7 +1582,7 @@ internal static class NativeMethods
     internal const uint FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
     internal const uint OPEN_EXISTING = 3;
 
-    [DllImport("kernel32.dll", CharSet = AutoOrUnicode, CallingConvention = CallingConvention.StdCall,
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall,
         SetLastError = true)]
     internal static extern SafeFileHandle CreateFile(
         string lpFileName,

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1334,7 +1334,6 @@ namespace Microsoft.Build.UnitTests
             yield return new object[] { $"C:\\a_path\\with{Path.GetInvalidPathChars().First()}invalid\\chars" };
         }
 
-#if FEATURE_RESOURCEMANAGER_GETRESOURCESET
         /// <summary>
         /// Verifies that help messages are correctly formed with the right width and leading spaces.
         /// </summary>
@@ -1398,7 +1397,6 @@ namespace Microsoft.Build.UnitTests
                 }
             }
         }
-#endif
 
         /// <summary>
         /// Verifies that a switch collection has an error registered for the given command line arg.

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -44,9 +44,6 @@ namespace Microsoft.Build.CommandLine
             FileLogger7,
             FileLogger8,
             FileLogger9,
-#if (!STANDALONEBUILD)
-            OldOM,
-#endif
             DistributedFileLogger,
 #if DEBUG
             WaitForDebugger,
@@ -219,9 +216,6 @@ namespace Microsoft.Build.CommandLine
             new ParameterlessSwitchInfo(  new string[] { "filelogger7", "fl7" },            ParameterlessSwitch.FileLogger7,           null),
             new ParameterlessSwitchInfo(  new string[] { "filelogger8", "fl8" },            ParameterlessSwitch.FileLogger8,           null),
             new ParameterlessSwitchInfo(  new string[] { "filelogger9", "fl9" },            ParameterlessSwitch.FileLogger9,           null),
-#if (!STANDALONEBUILD)
-            new ParameterlessSwitchInfo(  new string[] { "oldom" },                         ParameterlessSwitch.OldOM,                 null),
-#endif
             new ParameterlessSwitchInfo(  new string[] { "distributedfilelogger", "dfl" },  ParameterlessSwitch.DistributedFileLogger, null),
 #if DEBUG
             new ParameterlessSwitchInfo(  new string[] { "waitfordebugger", "wfd" },        ParameterlessSwitch.WaitForDebugger,       null),

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -501,9 +501,7 @@ namespace Microsoft.Build.CommandLine
             ErrorUtilities.VerifyThrowArgumentLength(commandLine, nameof(commandLine));
 #endif
 
-#if FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION
             AppDomain.CurrentDomain.UnhandledException += ExceptionHandling.UnhandledExceptionHandler;
-#endif
 
             ExitType exitType = ExitType.Success;
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -640,42 +640,40 @@ namespace Microsoft.Build.CommandLine
                     }
                     else // regular build
                     {
-                        {
-                            // if everything checks out, and sufficient information is available to start building
-                            if (
-                                !BuildProject(
-                                    projectFile,
-                                    targets,
-                                    toolsVersion,
-                                    globalProperties,
-                                    restoreProperties,
-                                    loggers,
-                                    verbosity,
-                                    distributedLoggerRecords.ToArray(),
+                        // if everything checks out, and sufficient information is available to start building
+                        if (
+                            !BuildProject(
+                                projectFile,
+                                targets,
+                                toolsVersion,
+                                globalProperties,
+                                restoreProperties,
+                                loggers,
+                                verbosity,
+                                distributedLoggerRecords.ToArray(),
 #if FEATURE_XML_SCHEMA_VALIDATION
-                                    needToValidateProject, schemaFile,
+                                needToValidateProject, schemaFile,
 #endif
-                                    cpuCount,
-                                    enableNodeReuse,
-                                    preprocessWriter,
-                                    targetsWriter,
-                                    detailedSummary,
-                                    warningsAsErrors,
-                                    warningsAsMessages,
-                                    enableRestore,
-                                    profilerLogger,
-                                    enableProfiler,
-                                    interactive,
-                                    isolateProjects,
-                                    graphBuildOptions,
-                                    lowPriority,
-                                    inputResultsCaches,
-                                    outputResultsCache,
-                                    commandLine
-                                    ))
-                            {
-                                exitType = ExitType.BuildError;
-                            }
+                                cpuCount,
+                                enableNodeReuse,
+                                preprocessWriter,
+                                targetsWriter,
+                                detailedSummary,
+                                warningsAsErrors,
+                                warningsAsMessages,
+                                enableRestore,
+                                profilerLogger,
+                                enableProfiler,
+                                interactive,
+                                isolateProjects,
+                                graphBuildOptions,
+                                lowPriority,
+                                inputResultsCaches,
+                                outputResultsCache,
+                                commandLine
+                                ))
+                        {
+                            exitType = ExitType.BuildError;
                         }
                     } // end of build
 
@@ -2533,46 +2531,44 @@ namespace Microsoft.Build.CommandLine
                 CommandLineSwitchException.VerifyThrow(nodeModeNumber >= 0, "InvalidNodeNumberValueIsNegative", input[0]);
             }
 
+            bool restart = true;
+            while (restart)
             {
-                bool restart = true;
-                while (restart)
+                Exception nodeException = null;
+                NodeEngineShutdownReason shutdownReason = NodeEngineShutdownReason.Error;
+                // normal OOP node case
+                if (nodeModeNumber == 1)
                 {
-                    Exception nodeException = null;
-                    NodeEngineShutdownReason shutdownReason = NodeEngineShutdownReason.Error;
-                    // normal OOP node case
-                    if (nodeModeNumber == 1)
-                    {
-                        OutOfProcNode node = new OutOfProcNode();
+                    OutOfProcNode node = new OutOfProcNode();
 
-                        // If FEATURE_NODE_REUSE is OFF, just validates that the switch is OK, and always returns False
-                        bool nodeReuse = ProcessNodeReuseSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.NodeReuse]);
-                        string[] lowPriorityInput = commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.LowPriority];
-                        bool lowpriority = lowPriorityInput.Length > 0 && lowPriorityInput[0].Equals("true");
+                    // If FEATURE_NODE_REUSE is OFF, just validates that the switch is OK, and always returns False
+                    bool nodeReuse = ProcessNodeReuseSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.NodeReuse]);
+                    string[] lowPriorityInput = commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.LowPriority];
+                    bool lowpriority = lowPriorityInput.Length > 0 && lowPriorityInput[0].Equals("true");
 
-                        shutdownReason = node.Run(nodeReuse, lowpriority, out nodeException);
+                    shutdownReason = node.Run(nodeReuse, lowpriority, out nodeException);
 
-                        FileUtilities.ClearCacheDirectory();
-                    }
-                    else if (nodeModeNumber == 2)
-                    {
-                        OutOfProcTaskHostNode node = new OutOfProcTaskHostNode();
-                        shutdownReason = node.Run(out nodeException);
-                    }
-                    else
-                    {
-                        CommandLineSwitchException.Throw("InvalidNodeNumberValue", nodeModeNumber.ToString());
-                    }
+                    FileUtilities.ClearCacheDirectory();
+                }
+                else if (nodeModeNumber == 2)
+                {
+                    OutOfProcTaskHostNode node = new OutOfProcTaskHostNode();
+                    shutdownReason = node.Run(out nodeException);
+                }
+                else
+                {
+                    CommandLineSwitchException.Throw("InvalidNodeNumberValue", nodeModeNumber.ToString());
+                }
 
-                    if (shutdownReason == NodeEngineShutdownReason.Error)
-                    {
-                        Debug.WriteLine("An error has happened, throwing an exception");
-                        throw nodeException;
-                    }
+                if (shutdownReason == NodeEngineShutdownReason.Error)
+                {
+                    Debug.WriteLine("An error has happened, throwing an exception");
+                    throw nodeException;
+                }
 
-                    if (shutdownReason != NodeEngineShutdownReason.BuildCompleteReuse)
-                    {
-                        restart = false;
-                    }
+                if (shutdownReason != NodeEngineShutdownReason.BuildCompleteReuse)
+                {
+                    restart = false;
                 }
             }
         }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1557,16 +1557,15 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private static void VerifyThrowSupportedOS()
         {
-#if FEATURE_OSVERSION
-            if (Environment.OSVersion.Platform != PlatformID.Win32NT ||
-                Environment.OSVersion.Version.Major < 6 ||
-                (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor < 1)) // Windows 7 is minimum
+            if (NativeMethodsShared.IsWindows &&
+                (Environment.OSVersion.Platform != PlatformID.Win32NT ||
+                 Environment.OSVersion.Version.Major < 6 ||
+                 (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor < 1))) // Windows 7 is minimum
             {
                 // If we're running on any of the unsupported OS's, fail immediately.  This way,
                 // we don't run into some obscure error down the line, totally confusing the user.
                 InitializationException.Throw("UnsupportedOS", null, null, false);
             }
-#endif
         }
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -28,9 +28,6 @@ using Microsoft.Build.Graph;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
-#if MSBUILDENABLEVSPROFILING 
-using Microsoft.VisualStudio.Profiler;
-#endif
 
 using FileLogger = Microsoft.Build.Logging.FileLogger;
 using ConsoleLogger = Microsoft.Build.Logging.ConsoleLogger;
@@ -1168,9 +1165,6 @@ namespace Microsoft.Build.CommandLine
 
                     BuildManager buildManager = BuildManager.DefaultBuildManager;
 
-#if MSBUILDENABLEVSPROFILING
-                    DataCollection.CommentMarkProfile(8800, "Pending Build Request from MSBuild.exe");
-#endif
                     BuildResultCode? result = null;
 
                     IEnumerable<BuildManager.DeferredBuildMessage> messagesToLogInBuildLoggers = null;

--- a/src/Shared/BuildEventFileInfo.cs
+++ b/src/Shared/BuildEventFileInfo.cs
@@ -85,11 +85,7 @@ namespace Microsoft.Build.Shared
         internal BuildEventFileInfo(XmlException e)
         {
             ErrorUtilities.VerifyThrow(e != null, "Need exception context.");
-#if FEATURE_XML_SOURCE_URI
             _file = (e.SourceUri.Length == 0) ? String.Empty : new Uri(e.SourceUri).LocalPath;
-#else
-            _file = String.Empty;
-#endif
             _line = e.LineNumber;
             _column = e.LinePosition;
             _endLine = 0;

--- a/src/Shared/EnvironmentUtilities.cs
+++ b/src/Shared/EnvironmentUtilities.cs
@@ -13,11 +13,6 @@ namespace Microsoft.Build.Shared
         public static bool Is64BitProcess => Marshal.SizeOf<IntPtr>() == 8;
 
         public static bool Is64BitOperatingSystem =>
-#if FEATURE_64BIT_ENVIRONMENT_QUERY
             Environment.Is64BitOperatingSystem;
-#else
-            RuntimeInformation.OSArchitecture == Architecture.Arm64 ||
-            RuntimeInformation.OSArchitecture == Architecture.X64;
-#endif
     }
 }

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -9,9 +9,7 @@ namespace Microsoft.Build.AppxPackage.Shared
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-#if FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -304,7 +302,6 @@ namespace Microsoft.Build.Shared
             return true;
         }
 
-#if FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION
         /// <summary>
         /// Dump any unhandled exceptions to a file so they can be diagnosed
         /// </summary>
@@ -314,7 +311,6 @@ namespace Microsoft.Build.Shared
             Exception ex = (Exception)e.ExceptionObject;
             DumpExceptionToFile(ex);
         }
-#endif
 
         /// <summary>
         /// Dump the exception information to a file

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -141,21 +141,10 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal abstract class LogMessagePacketBase : INodePacket
     {
-#if FEATURE_DOTNETVERSION
         /// <summary>
         /// The packet version, which is based on the CLR version. Cached because querying Environment.Version each time becomes an allocation bottleneck.
         /// </summary>
         private static readonly int s_defaultPacketVersion = (Environment.Version.Major * 10) + Environment.Version.Minor;
-#else
-        private static readonly int s_defaultPacketVersion = GetDefaultPacketVersion();
-
-        private static int GetDefaultPacketVersion()
-        {
-            Assembly coreAssembly = typeof(object).GetTypeInfo().Assembly;
-            Version coreAssemblyVersion = coreAssembly.GetName().Version;
-            return 1000 + (coreAssemblyVersion.Major * 10) + coreAssemblyVersion.Minor;
-        }
-#endif
 
         /// <summary>
         /// Dictionary of methods used to read BuildEventArgs.

--- a/src/Shared/TaskLoader.cs
+++ b/src/Shared/TaskLoader.cs
@@ -110,10 +110,8 @@ namespace Microsoft.Build.Shared
                             taskAppDomain.Load(loadedType.LoadedAssembly.GetName());
                         }
 
-#if FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION
                         // Hook up last minute dumping of any exceptions 
                         taskAppDomain.UnhandledException += ExceptionHandling.UnhandledExceptionHandler;
-#endif
                     }
                 }
                 else


### PR DESCRIPTION
Enable many `FEATURE_*` flags that were disabled in the initial port to .NET Core but are now unifiable because the APIs were added in .NET Core 2.0.

Fixes #7329 and many more like it.