### PR TITLE
Revert to arcade without merged manifest bug

### DIFF
--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.22054.3"
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21614.2"
   }
 }


### PR DESCRIPTION
This is a workaround for https://github.com/dotnet/arcade/issues/8393

### Context
This reverts the version of the Arcade SDK to work around a bug in the merged manifest generation that is merging the manifests with incorrect values, which breaks the publishing infrastructure.

### Changes Made
Reverted to the last version of the Arcade SDK that doesn't have the problematic changes.

### Testing
Ran this test build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5673773&view=results with this exact change, and then published that build to the testing channel: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=5673847&view=results. The publishing build created the isolated feeds that were expected. 
