### PR TITLE
Revert "xcopy-msbuild": "none"

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,9 +6,7 @@
     "dotnet": "6.0.100",
     "vs": {
       "version": "17.0"
-    },
-    "$comment1": "Disable the packaged version of MSBuild; require a VS installation",
-    "xcopy-msbuild": "none"
+    }
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
### Context

#7304 broke main builds as xcopy-msbuild appears to be required for signing validation.

### Changes Made

Reverted the problematic part of #7304.

### Testing

Build.
