### PR TITLE
Fix handling of relative paths when using graph builds with implicit restore

### DIFF
--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Build.Graph
                 valueComparer: StringComparer.OrdinalIgnoreCase,
                 items: solutionEntryPoint.GlobalProperties ?? ImmutableDictionary<string, string>.Empty);
 
-            var solution = SolutionFile.Parse(FileUtilities.NormalizePath(solutionEntryPoint.ProjectFile));
+            var solution = SolutionFile.Parse(solutionEntryPoint.ProjectFile);
 
             if (solution.SolutionParserWarnings.Count != 0 || solution.SolutionParserErrorCodes.Count != 0)
             {
@@ -410,7 +410,7 @@ namespace Microsoft.Build.Graph
 
                     AddGraphBuildGlobalVariable(globalPropertyDictionary);
 
-                    var configurationMetadata = new ConfigurationMetadata(FileUtilities.NormalizePath(entryPoint.ProjectFile), globalPropertyDictionary);
+                    var configurationMetadata = new ConfigurationMetadata(entryPoint.ProjectFile, globalPropertyDictionary);
                     entryPointConfigurationMetadata.Add(configurationMetadata);
                 }
 

--- a/src/Build/Graph/ProjectGraphEntryPoint.cs
+++ b/src/Build/Graph/ProjectGraphEntryPoint.cs
@@ -31,12 +31,12 @@ namespace Microsoft.Build.Graph
         {
             ErrorUtilities.VerifyThrowArgumentLength(projectFile, nameof(projectFile));
 
-            ProjectFile = projectFile;
+            ProjectFile = FileUtilities.NormalizePath(projectFile);
             GlobalProperties = globalProperties;
         }
 
         /// <summary>
-        /// Gets the project file to use for this entry point.
+        /// Gets the full path to the project file to use for this entry point.
         /// </summary>
         public string ProjectFile { get; }
 


### PR DESCRIPTION
Fixes #5898

### Context
Executing projects changes the cwd, which makes relative paths behave unexpectedly. So when an implicit restore happens (`/restore`), then the cwd is different than what it was originally. For non-graph builds, this isn't a problem as the `BuildRequestData` gets the full path of the project file before the implicit restore, so there effectively are no relative paths to deal with. However, this was not the case for `GraphBuildRequestData`, so doing a build with `/retore`, `/graph`, and a relative path to a project file was erroring incorrectly.

### Changes Made
The `ProjectGraphEntryPoint` constructor will now get the full path of the project file, similar to what `BuildRequestData` does today.

I also followed all uses of `ProjectGraphEntryPoint.ProjectFile` and removed any normalization since it's now always done already.

### Testing
I tested this change calling msbuild on a relative path with graph on/off and restore on/off. It now behaves as expected.