### PR TITLE
Better evaluator errors Fixes #6460

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -823,6 +823,18 @@ namespace Microsoft.Build.BackEnd
             catch (Exception ex)
             {
                 thrownException = ex;
+                if (ex is BuildAbortedException)
+                {
+                    // The build was likely cancelled. We do not need to log an error in this case.
+                }
+                else if (_projectLoggingContext is null)
+                {
+                    _nodeLoggingContext.LogError(BuildEventFileInfo.Empty, "UnhandledMSBuildError", ex.ToString());
+                }
+                else
+                {
+                    _projectLoggingContext.LogError(BuildEventFileInfo.Empty, "UnhandledMSBuildError", ex.ToString());
+                }
 
                 if (ExceptionHandling.IsCriticalException(ex))
                 {

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -450,7 +450,8 @@ namespace Microsoft.Build.Evaluation
                 {
                     for (int i = 0; i < items.Count; i++)
                     {
-                        if (itemsWithNoWildcards.TryGetValue(FileUtilities.GetFullPath(items[i].Item.EvaluatedInclude, items[i].Item.ProjectDirectory), out UpdateOperation op))
+                        string fullPath = FileUtilities.GetFullPath(items[i].Item.EvaluatedIncludeEscaped, items[i].Item.ProjectDirectory);
+                        if (itemsWithNoWildcards.TryGetValue(fullPath, out UpdateOperation op))
                         {
                             items[i] = op.UpdateItem(items[i]);
                         }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -463,6 +463,10 @@
     <value>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</value>
     <comment>{StrBegin="MSB4187: "}</comment>
   </data>
+  <data name="UnhandledMSBuildError" xml:space="preserve">
+    <value>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</value>
+  </data>
   <data name="IllFormedCondition" xml:space="preserve">
     <value>MSB4088: Condition "{0}" is improperly constructed.</value>
     <comment>{StrBegin="MSB4088: "}</comment>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">Číst neinicializovanou vlastnost {0}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">Nicht initialisierte Eigenschaft "{0}" lesen</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">Leer la propiedad no inicializada "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">Lire la propriété non initialisée "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">Legge la proprietà non inizializzata "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">初期化されていないプロパティ "{0}" の読み取り</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">초기화되지 않은 속성 "{0}" 읽기</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">Odczytaj niezainicjowaną właściwość „{0}”</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">Ler a propriedade não inicializada "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">Чтение неинициализированного свойства "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">"{0}" başlatılmamış özelliğini oku</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">读取未初始化的属性“{0}”</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -419,6 +419,13 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
       </trans-unit>
+      <trans-unit id="UnhandledMSBuildError">
+        <source>This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</source>
+        <target state="new">This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISSUE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled.
+    {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
         <source>Read uninitialized property "{0}"</source>
         <target state="translated">讀取未初始化的屬性 "{0}"</target>


### PR DESCRIPTION
Fixes #6460

### Context
Errors from Evaluate could appear as just BUILD FAILED 0 Warnings 0 Errors, which is no good. This makes the errors appear in a fairly generic way.

It also fixes the motivating issue.

### Changes Made
Logs an error including a full stack and the original error message with errors in Evaluate.
Fixes a bug with GetFullPath being passed an unescaped string instead of an escaped string.
Changes the error formatting such that only the first line gets reformatted.

### Testing
Tried it out before and after the changes. It now prints:

```
Build FAILED.

"C:\Users\forgind\Desktop\Archives\Bug-specific\6460\1.csproj" (default target) (1) ->
"C:\Users\forgind\Desktop\Archives\Bug-specific\6460\1.csproj" (Inner target) (1:2) ->
  MSBUILD : error : "This is an unhandled exception in MSBuild -- PLEASE FILE AN ISSUE AT https://github.com/dotnet/msb
uild/issues/new. [C:\Users\forgind\Desktop\Archives\Bug-specific\6460\1.csproj]    Message:
    Illegal characters in path.
    Stack:
       at System.IO.Path.CheckInvalidPathChars(String path, Boolean checkAdditional)
   at System.IO.Path.Combine(String path1, String path2)
   at Microsoft.Build.Shared.FileUtilities.GetFullPath(String fileSpec, String currentDirectory) in C:\Users\forgind\D
ocuments\GitHub\msbuild\src\Shared\FileUtilities.cs:line 669
   at Microsoft.Build.Evaluation.LazyItemEvaluator`4.LazyItemList.ProcessNonWildCardItemUpdates(Dictionary`2 itemsWithN
oWildcards, Builder items) in C:\Users\forgind\Documents\GitHub\msbuild\src\Build\Evaluation\LazyItemEvaluator.cs:line
 453
   at Microsoft.Build.Evaluation.LazyItemEvaluator`4.LazyItemList.ComputeItems(LazyItemList lazyItemList, ImmutableHash
Set`1 globsToIgnore) in C:\Users\forgind\Documents\GitHub\msbuild\src\Build\Evaluation\LazyItemEvaluator.cs:line 439
   at Microsoft.Build.Evaluation.LazyItemEvaluator`4.LazyItemList.GetItemData(ImmutableHashSet`1 globsToIgnore) in C:\U
sers\forgind\Documents\GitHub\msbuild\src\Build\Evaluation\LazyItemEvaluator.cs:line 312
   at Microsoft.Build.Evaluation.LazyItemEvaluator`4.<>c.<GetAllItemsDeferred>b__27_0(LazyItemList itemList) in C:\User
s\forgind\Documents\GitHub\msbuild\src\Build\Evaluation\LazyItemEvaluator.cs:line 511
   at System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.OrderedEnumerable`1.<GetEnumerator>d__1.MoveNext()
   at Microsoft.Build.Evaluation.Evaluator`4.Evaluate() in C:\Users\forgind\Documents\GitHub\msbuild\src\Build\Evaluat
ion\Evaluator.cs:line 681
   at Microsoft.Build.Evaluation.Evaluator`4.Evaluate(IEvaluatorData`4 data, Project project, ProjectRootElement root,
ProjectLoadSettings loadSettings, Int32 maxNodeCount, PropertyDictionary`1 environmentProperties, ILoggingService loggi
ngService, IItemFactory`2 itemFactory, IToolsetProvider toolsetProvider, ProjectRootElementCacheBase projectRootElement
Cache, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService, Int32 submissionId, EvaluationConte
xt evaluationContext, Boolean interactive) in C:\Users\forgind\Documents\GitHub\msbuild\src\Build\Evaluation\Evaluator
.cs:line 336
   at Microsoft.Build.Execution.ProjectInstance.Initialize(ProjectRootElement xml, IDictionary`2 globalProperties, Stri
ng explicitToolsVersion, String explicitSubToolsetVersion, Int32 visualStudioVersionFromSolution, BuildParameters build
Parameters, ILoggingService loggingService, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService
, Int32 submissionId, Nullable`1 projectLoadSettings, EvaluationContext evaluationContext) in C:\Users\forgind\Documen
ts\GitHub\msbuild\src\Build\Instance\ProjectInstance.cs:line 2771
   at Microsoft.Build.Execution.ProjectInstance..ctor(String projectFile, IDictionary`2 globalProperties, String toolsV
ersion, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext buildEventContext, ISdkResol
verService sdkResolverService, Int32 submissionId, Nullable`1 projectLoadSettings) in C:\Users\forgind\Documents\GitHu
b\msbuild\src\Build\Instance\ProjectInstance.cs:line 486
   at Microsoft.Build.BackEnd.BuildRequestConfiguration.<>c__DisplayClass60_0.<LoadProjectIntoConfiguration>b__0() in C
:\Users\forgind\Documents\GitHub\msbuild\src\Build\BackEnd\Shared\BuildRequestConfiguration.cs:line 469
   at Microsoft.Build.BackEnd.BuildRequestConfiguration.InitializeProject(BuildParameters buildParameters, Func`1 loadP
rojectFromFile) in C:\Users\forgind\Documents\GitHub\msbuild\src\Build\BackEnd\Shared\BuildRequestConfiguration.cs:lin
e 495
   at Microsoft.Build.BackEnd.BuildRequestConfiguration.LoadProjectIntoConfiguration(IBuildComponentHost componentHost,
 BuildRequestDataFlags buildRequestDataFlags, Int32 submissionId, Int32 nodeId) in C:\Users\forgind\Documents\GitHub\m
sbuild\src\Build\BackEnd\Shared\BuildRequestConfiguration.cs:line 429
   at Microsoft.Build.BackEnd.RequestBuilder.<BuildProject>d__68.MoveNext() in C:\Users\forgind\Documents\GitHub\msbui
ld\src\Build\BackEnd\Components\RequestBuilder\RequestBuilder.cs:line 1117
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.Build.BackEnd.RequestBuilder.<BuildAndReport>d__59.MoveNext() in C:\Users\forgind\Documents\GitHub\msb
uild\src\Build\BackEnd\Components\RequestBuilder\RequestBuilder.cs:line 808"

    0 Warning(s)
    1 Error(s)
```
