### PR TITLE
Fixes dotnet / msbuild#6313 FormatUrl

### DIFF
--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -48,6 +48,19 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// No InputUrl value is provided. InputUrl is not a required parameter for the task.
+        /// </summary>
+        [Fact]
+        public void NoInputTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(string.Empty);
+        }
+
+        /// <summary>
         /// The URL to format is white space.
         /// FormatUrl depends on Path.GetFullPath.
         /// From the documentation, Path.GetFullPath(" ") should throw an ArgumentException, but it doesn't on macOS and Linux

--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -117,11 +117,9 @@ namespace Microsoft.Build.UnitTests
             var t = new FormatUrl();
             t.BuildEngine = new MockEngine(_out);
 
-            var uriBuilder = new UriBuilder(Uri.UriSchemeHttps, "localhost") { Path = "Example/Path" };
-            t.InputUrl = uriBuilder.ToString();
+            t.InputUrl = @"https://localhost/Example/Path";
             t.Execute().ShouldBeTrue();
-            uriBuilder.Host = Environment.MachineName.ToLowerInvariant();
-            t.OutputUrl.ShouldBe(uriBuilder.ToString());
+            t.OutputUrl.ShouldBe(@"https://" + Environment.MachineName.ToLowerInvariant() + "/Example/Path");
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -68,13 +68,14 @@ namespace Microsoft.Build.UnitTests
         /// The URL to format is white space.
         /// </summary>
         [Fact]
-        public void WhitespaceTest()
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void WhitespaceTestOnUnix()
         {
             var t = new FormatUrl();
             t.BuildEngine = new MockEngine(_out);
 
             t.InputUrl = " ";
-            // From the documentation, Path.GetFullPath(" ") should throw an ArgumentException but it doesn't.
+            // From the documentation, Path.GetFullPath(" ") should throw an ArgumentException but it doesn't on macOS and Linux.
             // If the behavior of Path.GetFullPath(string) changes, this unit test will need to be updated.
             var expected = new Uri(Path.GetFullPath(t.InputUrl)).AbsoluteUri;
 

--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -3,14 +3,10 @@
 
 using System;
 using System.IO;
-using Microsoft.Build.Framework;
-using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
-using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
-
-#nullable disable
 
 namespace Microsoft.Build.UnitTests
 {
@@ -33,15 +29,8 @@ namespace Microsoft.Build.UnitTests
             t.BuildEngine = new MockEngine(_out);
 
             t.InputUrl = null;
-            var expected = string.Empty;
-
-            Assert.True(t.Execute()); // "success"
-#if DEBUG
-            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
-            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
-            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
-#endif
-            Assert.Equal(expected, t.OutputUrl);
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(string.Empty);
         }
 
         /// <summary>
@@ -53,19 +42,16 @@ namespace Microsoft.Build.UnitTests
             var t = new FormatUrl();
             t.BuildEngine = new MockEngine(_out);
 
-            var expected = t.InputUrl = string.Empty;
-
-            Assert.True(t.Execute()); // "success"
-#if DEBUG
-            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
-            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
-            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
-#endif
-            Assert.Equal(expected, t.OutputUrl);
+            t.InputUrl = string.Empty;
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(t.InputUrl);
         }
 
         /// <summary>
         /// The URL to format is white space.
+        /// FormatUrl depends on Path.GetFullPath.
+        /// From the documentation, Path.GetFullPath(" ") should throw an ArgumentException, but it doesn't on macOS and Linux
+        /// where whitespace characters are valid characters for filenames.
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
@@ -75,17 +61,8 @@ namespace Microsoft.Build.UnitTests
             t.BuildEngine = new MockEngine(_out);
 
             t.InputUrl = " ";
-            // From the documentation, Path.GetFullPath(" ") should throw an ArgumentException but it doesn't on macOS and Linux.
-            // If the behavior of Path.GetFullPath(string) changes, this unit test will need to be updated.
-            var expected = new Uri(Path.GetFullPath(t.InputUrl)).AbsoluteUri;
-
-            Assert.True(t.Execute()); // "success"
-#if DEBUG
-            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
-            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
-            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
-#endif
-            Assert.Equal(expected, t.OutputUrl);
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(new Uri(Path.Combine(Environment.CurrentDirectory, t.InputUrl)).AbsoluteUri);
         }
 
         /// <summary>
@@ -99,8 +76,7 @@ namespace Microsoft.Build.UnitTests
             t.BuildEngine = new MockEngine(_out);
 
             t.InputUrl = " ";
-            // Path.GetFullPath(" ") should throw an ArgumentException.
-            Assert.Throws<ArgumentException>(() => t.Execute());
+            Should.Throw<ArgumentException>(() => t.Execute());
         }
 
         /// <summary>
@@ -113,19 +89,13 @@ namespace Microsoft.Build.UnitTests
             t.BuildEngine = new MockEngine(_out);
 
             t.InputUrl = @"\\server\filename.ext";
-            var expected = new Uri(t.InputUrl).AbsoluteUri;
-
-            Assert.True(t.Execute()); // "success"
-#if DEBUG
-            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
-            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
-            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
-#endif
-            Assert.Equal(expected, t.OutputUrl);
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(@"file://server/filename.ext");
         }
 
         /// <summary>
         /// The URL to format is a local file path.
+        /// This test uses Environment.CurrentDirectory to have a file path value appropriate to the current OS/filesystem. 
         /// </summary>
         [Fact]
         public void LocalPathTest()
@@ -134,15 +104,8 @@ namespace Microsoft.Build.UnitTests
             t.BuildEngine = new MockEngine(_out);
 
             t.InputUrl = Environment.CurrentDirectory;
-            var expected = new Uri(t.InputUrl).AbsoluteUri;
-
-            Assert.True(t.Execute()); // "success"
-#if DEBUG
-            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
-            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
-            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
-#endif
-            Assert.Equal(expected, t.OutputUrl);
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(new Uri(t.InputUrl).AbsoluteUri);
         }
 
         /// <summary>
@@ -155,18 +118,10 @@ namespace Microsoft.Build.UnitTests
             t.BuildEngine = new MockEngine(_out);
 
             var uriBuilder = new UriBuilder(Uri.UriSchemeHttps, "localhost") { Path = "Example/Path" };
-
             t.InputUrl = uriBuilder.ToString();
+            t.Execute().ShouldBeTrue();
             uriBuilder.Host = Environment.MachineName.ToLowerInvariant();
-            var expected = uriBuilder.ToString();
-
-            Assert.True(t.Execute()); // "success"
-#if DEBUG
-            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
-            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
-            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
-#endif
-            Assert.Equal(expected, t.OutputUrl);
+            t.OutputUrl.ShouldBe(uriBuilder.ToString());
         }
 
         /// <summary>
@@ -178,17 +133,9 @@ namespace Microsoft.Build.UnitTests
             var t = new FormatUrl();
             t.BuildEngine = new MockEngine(_out);
 
-            var uriBuilder = new UriBuilder(Uri.UriSchemeHttps, "example.com") { Path = "Example/Path" };
-
-            var expected = t.InputUrl = uriBuilder.ToString();
-
-            Assert.True(t.Execute()); // "success"
-#if DEBUG
-            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
-            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
-            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
-#endif
-            Assert.Equal(expected, t.OutputUrl);
+            t.InputUrl = @"https://example.com/Example/Path";
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(t.InputUrl);
         }
 
         /// <summary>
@@ -200,18 +147,9 @@ namespace Microsoft.Build.UnitTests
             var t = new FormatUrl();
             t.BuildEngine = new MockEngine(_out);
 
-            var uriBuilder = new UriBuilder(Uri.UriSchemeHttps, "example.com") { Path = "Example/../Path" };
-
-            t.InputUrl = uriBuilder.ToString();
-            var expected = uriBuilder.Uri.AbsoluteUri;
-
-            Assert.True(t.Execute()); // "success"
-#if DEBUG
-            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
-            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
-            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
-#endif
-            Assert.Equal(expected, t.OutputUrl);
+            t.InputUrl = @"https://example.com/Example/../Path";
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(@"https://example.com/Path");
         }
     }
 }

--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -89,6 +89,21 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// The URL to format is white space.
+        /// </summary>
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void WhitespaceTestOnWindows()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            t.InputUrl = " ";
+            // Path.GetFullPath(" ") should throw an ArgumentException.
+            Assert.Throws<ArgumentException>(() => t.Execute());
+        }
+
+        /// <summary>
         /// The URL to format is a UNC.
         /// </summary>
         [Fact]

--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -94,11 +94,11 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// The URL to format is a local file path.
+        /// The URL to format is a local absolute file path.
         /// This test uses Environment.CurrentDirectory to have a file path value appropriate to the current OS/filesystem. 
         /// </summary>
         [Fact]
-        public void LocalPathTest()
+        public void LocalAbsolutePathTest()
         {
             var t = new FormatUrl();
             t.BuildEngine = new MockEngine(_out);
@@ -106,6 +106,51 @@ namespace Microsoft.Build.UnitTests
             t.InputUrl = Environment.CurrentDirectory;
             t.Execute().ShouldBeTrue();
             t.OutputUrl.ShouldBe(new Uri(t.InputUrl).AbsoluteUri);
+        }
+
+        /// <summary>
+        /// The URL to format is a local relative file path.
+        /// This test uses Environment.CurrentDirectory to have a file path value appropriate to the current OS/filesystem. 
+        /// </summary>
+        [Fact]
+        public void LocalRelativePathTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            t.InputUrl = @".";
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(new Uri(Environment.CurrentDirectory).AbsoluteUri);
+        }
+
+        /// <summary>
+        /// The URL to format is a *nix-style (macOS, Linux) local absolute file path.
+        /// </summary>
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void LocalUnixAbsolutePathTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            t.InputUrl = @"/usr/local/share";
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(@"file:///usr/local/share");
+        }
+
+        /// <summary>
+        /// The URL to format is a Windows-style local absolute file path.
+        /// </summary>
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void LocalWindowsAbsolutePathTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            t.InputUrl = @"c:\folder\filename.ext";
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(@"file:///c:/folder/filename.ext");
         }
 
         /// <summary>
@@ -137,7 +182,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// The URL to format is a URL.
+        /// The URL to format is a URL with a 'parent' element (..) in the path.
         /// </summary>
         [Fact]
         public void UrlParentPathTest()

--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Tasks;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests
+{
+    sealed public class FormatUrl_Tests
+    {
+        private readonly ITestOutputHelper _out;
+
+        public FormatUrl_Tests(ITestOutputHelper testOutputHelper)
+        {
+            _out = testOutputHelper;
+        }
+
+        /// <summary>
+        /// The URL to format is null.
+        /// </summary>
+        [Fact]
+        public void NullTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            t.InputUrl = null;
+            var expected = string.Empty;
+
+            Assert.True(t.Execute()); // "success"
+#if DEBUG
+            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
+            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
+            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
+#endif
+            Assert.Equal(expected, t.OutputUrl);
+        }
+
+        /// <summary>
+        /// The URL to format is empty.
+        /// </summary>
+        [Fact]
+        public void EmptyTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            var expected = t.InputUrl = string.Empty;
+
+            Assert.True(t.Execute()); // "success"
+#if DEBUG
+            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
+            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
+            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
+#endif
+            Assert.Equal(expected, t.OutputUrl);
+        }
+
+        /// <summary>
+        /// The URL to format is white space.
+        /// </summary>
+        [Fact]
+        public void WhitespaceTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            t.InputUrl = " ";
+            // From the documentation, Path.GetFullPath(" ") should throw an ArgumentException but it doesn't.
+            // If the behavior of Path.GetFullPath(string) changes, this unit test will need to be updated.
+            var expected = new Uri(Path.GetFullPath(t.InputUrl)).AbsoluteUri;
+
+            Assert.True(t.Execute()); // "success"
+#if DEBUG
+            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
+            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
+            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
+#endif
+            Assert.Equal(expected, t.OutputUrl);
+        }
+
+        /// <summary>
+        /// The URL to format is a UNC.
+        /// </summary>
+        [Fact]
+        public void UncPathTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            t.InputUrl = @"\\server\filename.ext";
+            var expected = new Uri(t.InputUrl).AbsoluteUri;
+
+            Assert.True(t.Execute()); // "success"
+#if DEBUG
+            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
+            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
+            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
+#endif
+            Assert.Equal(expected, t.OutputUrl);
+        }
+
+        /// <summary>
+        /// The URL to format is a local file path.
+        /// </summary>
+        [Fact]
+        public void LocalPathTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            t.InputUrl = Environment.CurrentDirectory;
+            var expected = new Uri(t.InputUrl).AbsoluteUri;
+
+            Assert.True(t.Execute()); // "success"
+#if DEBUG
+            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
+            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
+            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
+#endif
+            Assert.Equal(expected, t.OutputUrl);
+        }
+
+        /// <summary>
+        /// The URL to format is a URL using localhost.
+        /// </summary>
+        [Fact]
+        public void UrlLocalHostTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            var uriBuilder = new UriBuilder(Uri.UriSchemeHttps, "localhost") { Path = "Example/Path" };
+
+            t.InputUrl = uriBuilder.ToString();
+            uriBuilder.Host = Environment.MachineName.ToLowerInvariant();
+            var expected = uriBuilder.ToString();
+
+            Assert.True(t.Execute()); // "success"
+#if DEBUG
+            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
+            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
+            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
+#endif
+            Assert.Equal(expected, t.OutputUrl);
+        }
+
+        /// <summary>
+        /// The URL to format is a URL.
+        /// </summary>
+        [Fact]
+        public void UrlTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            var uriBuilder = new UriBuilder(Uri.UriSchemeHttps, "example.com") { Path = "Example/Path" };
+
+            var expected = t.InputUrl = uriBuilder.ToString();
+
+            Assert.True(t.Execute()); // "success"
+#if DEBUG
+            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
+            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
+            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
+#endif
+            Assert.Equal(expected, t.OutputUrl);
+        }
+
+        /// <summary>
+        /// The URL to format is a URL.
+        /// </summary>
+        [Fact]
+        public void UrlParentPathTest()
+        {
+            var t = new FormatUrl();
+            t.BuildEngine = new MockEngine(_out);
+
+            var uriBuilder = new UriBuilder(Uri.UriSchemeHttps, "example.com") { Path = "Example/../Path" };
+
+            t.InputUrl = uriBuilder.ToString();
+            var expected = uriBuilder.Uri.AbsoluteUri;
+
+            Assert.True(t.Execute()); // "success"
+#if DEBUG
+            _out.WriteLine("InputUrl " + ((null == t.InputUrl) ? "is null." : $"= '{t.InputUrl}'."));
+            _out.WriteLine("expected " + ((null == expected) ? "is null." : $"= '{expected}'."));
+            _out.WriteLine("OutputUrl " + ((null == t.OutputUrl) ? "is null." : $"= '{t.OutputUrl}'."));
+#endif
+            Assert.Equal(expected, t.OutputUrl);
+        }
+    }
+}

--- a/src/Tasks/FormatUrl.cs
+++ b/src/Tasks/FormatUrl.cs
@@ -21,13 +21,8 @@ namespace Microsoft.Build.Tasks
 
         public override bool Execute()
         {
-#if RUNTIME_TYPE_NETCORE
-            Log.LogErrorFromResources("TaskRequiresFrameworkFailure", nameof(FormatUrl));
-            return false;
-#else
             OutputUrl = InputUrl != null ? PathUtil.Format(InputUrl) : String.Empty;
             return true;
-#endif
         }
     }
 }

--- a/src/Tasks/FormatUrl.cs
+++ b/src/Tasks/FormatUrl.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !RUNTIME_TYPE_NETCORE
 using System;
-using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
-#endif
 using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
 
 #nullable disable
 

--- a/src/Tasks/LC.cs
+++ b/src/Tasks/LC.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Build.Tasks
         /// </remarks>
         public override bool Execute()
         {
-            Log.LogErrorFromResources("TaskRequiresFrameworkFailure", nameof(LC));
+            Log.LogErrorWithCodeFromResources("TaskRequiresFrameworkFailure", nameof(LC));
             return false;
         }
 #endif

--- a/src/Tasks/ManifestUtil/PathUtil.cs
+++ b/src/Tasks/ManifestUtil/PathUtil.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 var u = new Uri(path);
                 if (String.Equals(u.Host, localHost, StringComparison.OrdinalIgnoreCase))
                 {
-                    // Unfortunatly Uri.Host is read-only, so we need to reconstruct it manually...
+                    // Unfortunately Uri.Host is read-only, so we need to reconstruct it manually...
                     int i = path.IndexOf(localHost, StringComparison.OrdinalIgnoreCase);
                     return i >= 0 ? path.Substring(0, i) + Environment.MachineName.ToLowerInvariant() + path.Substring(i + localHost.Length) : path;
                 }

--- a/src/Tasks/ResolveComReference.cs
+++ b/src/Tasks/ResolveComReference.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         public override bool Execute()
         {
-            Log.LogErrorFromResources("TaskRequiresFrameworkFailure", nameof(ResolveComReference));
+            Log.LogErrorWithCodeFromResources("TaskRequiresFrameworkFailure", nameof(ResolveComReference));
             return false;
         }
 


### PR DESCRIPTION
Fixes #6313

### Context
The standard task [FormatUrl](https://docs.microsoft.com/en-us/visualstudio/msbuild/formaturl-task) was disabled for .Net Core. 

### Changes Made

- Removed the 'TaskRequiresFrameworkFailure' error for .Net Core for the FormatUrl task.
- Added a new unit test class for the FormatUrl class.

#### Additional related changes:
When testing with a debug build before making any changes, the debug build would report
```
Called LogErrorFromResources instead of LogErrorWithCodeFromResources, but message 'The task "FormatUrl" is not supported on the .NET Core version of MSBuild. Please use the .NET Framework version of MSBuild. See https://aka.ms/msbuild/MSB4803 for further details.' does have an error code 'MSB4803'
```

Two other tasks use the 'TaskRequiresFrameworkFailure' error: LC and ResolveComReference. Both were using `LogErrorFromResources`. Both have been changed to use `LogErrorWithCodeFromResources`.

A minor spelling error was corrected in a comment in the `PathUtil.Resolve(string)` method. This method is used by the `FormatUrl` class.

### Testing
#### FormatUrl Task
Initially before making any changes, tested manually with a test project file.

With the changes, built the code and ran the unit tests on .Net 6.0.

Also repeated the manual test.

'FormatUrlTest.proj' test project file:
```
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <Target Name="Test">
        <FormatUrl InputUrl="https://localhost/test">
            <Output TaskParameter="OutputUrl" PropertyName="out" />
        </FormatUrl>
        <Message Text="out = $(out)" Importance="high" />
        <FormatUrl InputUrl="formarlurltest.proj">
            <Output TaskParameter="OutputUrl" PropertyName="out" />
        </FormatUrl>
        <Message Text="out = $(out)" Importance="high" />
        <FormatUrl InputUrl="https://www.microsoft.com/foo/../bar">
            <Output TaskParameter="OutputUrl" PropertyName="out" />
        </FormatUrl>
        <Message Text="out = $(out)" Importance="high" />
    </Target>
</Project>
```

Executed with the command:
```
dotnet ./artifacts/bin/bootstrap/net6.0/MSBuild/MSBuild.dll FormatUrlTest.proj /t:Test
```

#### LC and ResolveComReference Tasks
Manually tested with test project files before and after changing the LogError* method.

LcTest.proj
```
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <Target Name="Test">
        <LC Sources="" LicenseTarget="foo" TargetFrameworkVersion="net5.0-windows" />
    </Target>
</Project>
```
```
dotnet ./artifacts/bin/bootstrap/net6.0/MSBuild/MSBuild.dll LcTest.proj /t:Test
```

ResolveComReferenceTest.proj
```
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <Target Name="Test">
        <ResolveComReference />
    </Target>
</Project>
```

```
dotnet ./artifacts/bin/bootstrap/net6.0/MSBuild/MSBuild.dll ResolveComReferenceTest.proj /t:Test
```

(There are unit test classes for the LC and ResolveComReference tasks but the classes are explicitly excluded from compilation within the Microsoft.Build.Tasks.UnitTests.csproj project file.)