### PR TITLE
Revert "Loosen version comparisons in loading assemblies (#7042)"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.1.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.1.1</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -165,10 +165,12 @@ namespace Microsoft.Build.Shared
                     }
 
                     AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
-                    if (candidateAssemblyName.Version >= assemblyName.Version)
+                    if (candidateAssemblyName.Version != assemblyName.Version)
                     {
-                        return LoadAndCache(context, candidatePath);
+                        continue;
                     }
+
+                    return LoadAndCache(context, candidatePath);
                 }
             }
 

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -53,20 +53,22 @@ namespace Microsoft.Build.Shared
                 // bare search directory if that fails.
                 : new[] { assemblyName.CultureName, string.Empty })
             {
-                var candidatePath = Path.Combine(_directory,
-                    cultureSubfolder,
-                    $"{assemblyName.Name}.dll");
+                    var candidatePath = Path.Combine(_directory,
+                        cultureSubfolder,
+                        $"{assemblyName.Name}.dll");
 
-                if (!FileSystems.Default.FileExists(candidatePath))
-                {
-                    continue;
-                }
+                    if (!FileSystems.Default.FileExists(candidatePath))
+                    {
+                        continue;
+                    }
 
-                AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
-                if (candidateAssemblyName.Version >= assemblyName.Version)
-                {
+                    AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
+                    if (candidateAssemblyName.Version != assemblyName.Version)
+                    {
+                        continue;
+                    }
+
                     return LoadFromAssemblyPath(candidatePath);
-                }
             }
 
             // If the Assembly is provided via a file path, the following rules are used to load the assembly:


### PR DESCRIPTION
This reverts commit 3bb10b76c5a345b30d6bf55facacbbce47446358.

Fixes https://github.com/dotnet/sdk/issues/23498

Work item (Internal use): 

### Summary

The linked commit changed MSBuild Assembly resolution to be in line with .NET Assembly resolution, but this had adverse impact on an SDK scenario that led to the wrong version of certain pre-packaged DLLs being loaded compared to previous versions of the runtime. In this case, System.Security.Cryptography.ProtectedData triggered the incorrect loading behavior.

### Customer Impact

Restore operations that use NuGet feeds with encrypted passwords began failing. There are workarounds like saving the passwords in cleartext, but this is not an ideal workaround.

### Regression?

This regressed behavior from 6.0.1xx and earlier series SDKs.

### Testing

We still need to work with impacted customers to verify that this change fixes the underlying issue, but investigations point to yes.

### Risk

Per @rainersigwald this is low risk. It was a nice-to-have that addressed a couple annoying issues, but we can regroup and take another pass at it for a later release.
