### PR TITLE
Update official build references to tasks and pools that recently started failing

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -253,7 +253,7 @@ stages:
         - Windows_NT
         - Source_Build_Managed
       pool:
-        vmImage: vs2017-win2016
+        vmImage: windows-latest
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -138,7 +138,7 @@ stages:
 
     # Build VS bootstrapper
     # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-    - task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
+    - task: MicroBuildBuildVSBootstrapper@2
       inputs:
         vsMajorVersion: $(VisualStudio.MajorVersion)
         channelName: $(VisualStudio.ChannelName)


### PR DESCRIPTION
The official build started failing, but appears to be happy with this GUID-less invocation (of what should be the same task):

https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=5796249