### PR TITLE
Infer MSBuildWarnNotAsError from WarnNotAsError Fixes #7423

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -648,6 +648,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <MSBuildWarningsAsMessages Condition="'$(MSBuildWarningsAsMessages)'==''">$(NoWarn)</MSBuildWarningsAsMessages>
     <MSBuildWarningsAsErrors Condition="'$(MSBuildWarningsAsErrors)'==''">$(WarningsAsErrors)</MSBuildWarningsAsErrors>
+    <MSBuildWarningsNotAsErrors Condition="'$(MSBuildWarningsNotAsErrors)'==''">$(WarningsNotAsErrors)</MSBuildWarningsNotAsErrors>
   </PropertyGroup>
 
   <!-- Common Project System support -->


### PR DESCRIPTION
Fixes #7423

### Context
We infer MSBuildWarningsAsMessages and MSBuildWarningsAsErrors if they aren't defined based on values used by csc; we should do the same with MSBuildWarningsNotAsErrors.