### PR TITLE
Fix dotnet/msbuild#7428 Enhancement: Add System.Environment::NewLine as a supported static property

### DIFF
--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -301,12 +301,12 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.Environment::GetFolderPath", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::GetLogicalDrives", environmentType);
 
-// All the following properties only have getters
+                        // All the following properties only have getters
                         availableStaticMethods.TryAdd("System.Environment::CommandLine", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::Is64BitOperatingSystem", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::Is64BitProcess", environmentType);
-
                         availableStaticMethods.TryAdd("System.Environment::MachineName", environmentType);
+                        availableStaticMethods.TryAdd("System.Environment::NewLine", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::OSVersion", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::ProcessorCount", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::StackTrace", environmentType);


### PR DESCRIPTION
Fixes #7428

### Context
Provide the 'native' line ending for the current OS in a portable fashion.

### Changes Made

- Added one line in Constants.cs to add `System.Environment::NewLine` to `availableStaticMethods`.
- Minor whitespace clean up to adjust the indent of a comment and to remove a blank line in the set of `System.Environment` properties.

### Testing
Built the bootstrap and tested with the following 'NewlinePropFunc.proj' project file:
```
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <Target Name="Test">
        <ItemGroup>
            <stuff Include="apple;boat;cat;dog" />
        </ItemGroup>
        <Message Text="@(stuff, '$([System.Environment]::NewLine)')" />
    </Target>
</Project>
```

When the project is run with `/v:n`, the Message task is expected to output one item per line, e.g.:
```
apple
boat
cat
dog
```

(Without the change, an MSB4185 error is generated as described in the issue.)