### PR TITLE
Enable LockCheck on .NET on Windows

### DIFF
--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -822,9 +822,11 @@ namespace Microsoft.Build.UnitTests
                     engine.AssertLogContains("MSB3021"); // copy failed
                     engine.AssertLogContains("MSB3026"); // DID retry
 
-#if !RUNTIME_TYPE_NETCORE && !MONO
-                    engine.AssertLogContains(Process.GetCurrentProcess().Id.ToString()); // the file is locked by the current process
-#endif
+                    if (NativeMethodsShared.IsWindows)
+                    {
+                        engine.AssertLogContains(Process.GetCurrentProcess().Id.ToString()); // the file is locked by the current process
+                    }
+
                     Assert.Equal(2, engine.Errors); // retries failed and the actual failure
                     Assert.Equal(10, engine.Warnings);
                 }

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -899,20 +899,22 @@ namespace Microsoft.Build.Tasks
         private static string GetLockedFileMessage(string file)
         {
             string message = string.Empty;
-#if !RUNTIME_TYPE_NETCORE && !MONO
 
             try
             {
-                var processes = LockCheck.GetProcessesLockingFile(file);
-                message = !string.IsNullOrEmpty(processes)
-                    ? ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("Copy.FileLocked", processes)
-                    : String.Empty;
+                if (NativeMethodsShared.IsWindows && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4))
+                {
+                    var processes = LockCheck.GetProcessesLockingFile(file);
+                    message = !string.IsNullOrEmpty(processes)
+                        ? ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("Copy.FileLocked", processes)
+                        : String.Empty;
+                }
             }
             catch (Exception)
             {
                 // Never throw if we can't get the processes locking the file.
             }
-#endif
+
             return message;
         }
 

--- a/src/Tasks/LockCheck.cs
+++ b/src/Tasks/LockCheck.cs
@@ -1,19 +1,19 @@
 ﻿// Taken from https://github.com/cklutz/LockCheck, MIT license.
 // Copyright (C) Christian Klutz
 
-#if !RUNTIME_TYPE_NETCORE && !MONO
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 
 #nullable disable
 
 namespace Microsoft.Build.Tasks
 {
+    [SupportedOSPlatform("windows")]
     internal class LockCheck
     {
         [Flags]
@@ -355,5 +355,3 @@ namespace Microsoft.Build.Tasks
         }
     }
 }
-
-#endif


### PR DESCRIPTION
Improves understandability of build issues like dotnet/sdk#9585. Fixes #7327