### PR TITLE
Deep copy metadata Fixes #7435

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Xml;
 
 using Microsoft.Build.Construction;
+using Shouldly;
 using Xunit;
 
 #nullable disable
@@ -68,6 +69,49 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Equal(2, items.Count);
             Assert.Equal("i1", items[0].Include);
             Assert.Equal("i2", items[1].Include);
+        }
+
+        [Fact]
+        public void DeepCopyFromItemGroupWithMetadata()
+        {
+            string content = @"
+                    <Project>
+                        <ItemGroup>
+                            <i Include='i1'>
+                              <M>metadataValue</M>
+                            </i>
+                            <i Include='i2'>
+                              <M>
+                                <Some>
+                                    <Xml With='Nesting' />
+                                </Some>
+                              </M>
+                            </i>
+                        </ItemGroup>
+                    </Project>
+                ";
+
+            ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
+            ProjectItemGroupElement group = (ProjectItemGroupElement)Helpers.GetFirst(project.Children);
+
+            ProjectRootElement newProject = ProjectRootElement.Create();
+            ProjectItemGroupElement newItemGroup = project.AddItemGroup();
+
+            newItemGroup.DeepCopyFrom(group);
+
+            var items = Helpers.MakeList(newItemGroup.Items);
+
+            items.Count.ShouldBe(2);
+
+            items[0].Include.ShouldBe("i1");
+            ProjectMetadataElement metadataElement = items[0].Metadata.ShouldHaveSingleItem();
+            metadataElement.Name.ShouldBe("M");
+            metadataElement.Value.ShouldBe("metadataValue");
+
+            items[1].Include.ShouldBe("i2");
+            metadataElement = items[1].Metadata.ShouldHaveSingleItem();
+            metadataElement.Name.ShouldBe("M");
+            metadataElement.Value.ShouldBe("<Some><Xml With=\"Nesting\" /></Some>");
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectElement.cs
+++ b/src/Build/Construction/ProjectElement.cs
@@ -394,43 +394,26 @@ namespace Microsoft.Build.Construction
             }
             else
             {
-                AppendAttributesAndChildren(XmlElement, element.XmlElement);
+                // Copy over the attributes from the template element.
+                foreach (XmlAttribute attribute in element.XmlElement.Attributes)
+                {
+                    if (ShouldCloneXmlAttribute(attribute))
+                    {
+                        XmlElement.SetAttribute(attribute.LocalName, attribute.NamespaceURI, attribute.Value);
+                    }
+                }
+
+                // If this element has pure text content, copy that over.
+                if (element.XmlElement.ChildNodes.Count == 1 && element.XmlElement.FirstChild.NodeType == XmlNodeType.Text)
+                {
+                    XmlElement.AppendChild(XmlElement.OwnerDocument.CreateTextNode(element.XmlElement.FirstChild.Value));
+                }
 
                 _expressedAsAttribute = element._expressedAsAttribute;
             }
 
             MarkDirty("CopyFrom", null);
             ClearAttributeCache();
-        }
-
-        private void AppendAttributesAndChildren(XmlNode appendTo, XmlNode appendFrom)
-        {
-            // Copy over the attributes from the template element.
-            if (appendFrom.Attributes is not null)
-            {
-                foreach (XmlAttribute attribute in appendFrom.Attributes)
-                {
-                    if (ShouldCloneXmlAttribute(attribute))
-                    {
-                        XmlAttribute attr = appendTo.OwnerDocument.CreateAttribute(attribute.LocalName, attribute.NamespaceURI);
-                        attr.Value = attribute.Value;
-                        appendTo.Attributes.Append(attr);
-                    }
-                }
-            }
-
-            // If this element has pure text content, copy that over.
-            if (appendFrom.ChildNodes.Count == 1 && appendFrom.FirstChild.NodeType == XmlNodeType.Text)
-            {
-                appendTo.AppendChild(appendTo.OwnerDocument.CreateTextNode(appendFrom.FirstChild.Value));
-            }
-
-            foreach (XmlNode child in appendFrom.ChildNodes)
-            {
-                XmlNode childClone = XmlElement.OwnerDocument.CreateNode(child.NodeType, child.Prefix, child.Name, child.NamespaceURI);
-                AppendAttributesAndChildren(childClone, child);
-                appendTo.AppendChild(childClone);
-            }
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectElement.cs
+++ b/src/Build/Construction/ProjectElement.cs
@@ -394,26 +394,43 @@ namespace Microsoft.Build.Construction
             }
             else
             {
-                // Copy over the attributes from the template element.
-                foreach (XmlAttribute attribute in element.XmlElement.Attributes)
-                {
-                    if (ShouldCloneXmlAttribute(attribute))
-                    {
-                        XmlElement.SetAttribute(attribute.LocalName, attribute.NamespaceURI, attribute.Value);
-                    }
-                }
-
-                // If this element has pure text content, copy that over.
-                if (element.XmlElement.ChildNodes.Count == 1 && element.XmlElement.FirstChild.NodeType == XmlNodeType.Text)
-                {
-                    XmlElement.AppendChild(XmlElement.OwnerDocument.CreateTextNode(element.XmlElement.FirstChild.Value));
-                }
+                AppendAttributesAndChildren(XmlElement, element.XmlElement);
 
                 _expressedAsAttribute = element._expressedAsAttribute;
             }
 
             MarkDirty("CopyFrom", null);
             ClearAttributeCache();
+        }
+
+        private void AppendAttributesAndChildren(XmlNode appendTo, XmlNode appendFrom)
+        {
+            // Copy over the attributes from the template element.
+            if (appendFrom.Attributes is not null)
+            {
+                foreach (XmlAttribute attribute in appendFrom.Attributes)
+                {
+                    if (ShouldCloneXmlAttribute(attribute))
+                    {
+                        XmlAttribute attr = appendTo.OwnerDocument.CreateAttribute(attribute.LocalName, attribute.NamespaceURI);
+                        attr.Value = attribute.Value;
+                        appendTo.Attributes.Append(attr);
+                    }
+                }
+            }
+
+            // If this element has pure text content, copy that over.
+            if (appendFrom.ChildNodes.Count == 1 && appendFrom.FirstChild.NodeType == XmlNodeType.Text)
+            {
+                appendTo.AppendChild(appendTo.OwnerDocument.CreateTextNode(appendFrom.FirstChild.Value));
+            }
+
+            foreach (XmlNode child in appendFrom.ChildNodes)
+            {
+                XmlNode childClone = XmlElement.OwnerDocument.CreateNode(child.NodeType, child.Prefix, child.Name, child.NamespaceURI);
+                AppendAttributesAndChildren(childClone, child);
+                appendTo.AppendChild(childClone);
+            }
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -343,17 +343,20 @@ namespace Microsoft.Build.Construction
             }
 
             RemoveAllChildren();
-            CopyFrom(element);
+            CopyFrom(element, true);
 
-            foreach (ProjectElement child in element.Children)
+            if (Link is not null)
             {
-                if (child is ProjectElementContainer childContainer)
+                foreach (ProjectElement child in element.Children)
                 {
-                    childContainer.DeepClone(ContainingProject, this);
-                }
-                else
-                {
-                    AppendChild(child.Clone(ContainingProject));
+                    if (child is ProjectElementContainer childContainer)
+                    {
+                        childContainer.DeepClone(ContainingProject, this);
+                    }
+                    else
+                    {
+                        AppendChild(child.Clone(ContainingProject));
+                    }
                 }
             }
         }
@@ -396,9 +399,7 @@ namespace Microsoft.Build.Construction
         /// <returns>The cloned element.</returns>
         protected internal virtual ProjectElementContainer DeepClone(ProjectRootElement factory, ProjectElementContainer parent)
         {
-            var clone = (ProjectElementContainer)Clone(factory);
-            parent?.AppendChild(clone);
-
+            ProjectElementContainer clone = (ProjectElementContainer)Clone(factory, parent);
             foreach (ProjectElement child in Children)
             {
                 if (child is ProjectElementContainer childContainer)
@@ -407,7 +408,7 @@ namespace Microsoft.Build.Construction
                 }
                 else
                 {
-                    clone.AppendChild(child.Clone(clone.ContainingProject));
+                    clone.AppendChild(child.Clone(clone.ContainingProject, deepCopy: true));
                 }
             }
 

--- a/src/Build/Construction/ProjectItemGroupElement.cs
+++ b/src/Build/Construction/ProjectItemGroupElement.cs
@@ -158,6 +158,15 @@ namespace Microsoft.Build.Construction
             _definitelyAreNoChildrenWithWildcards = false;
         }
 
+        /// <inheritdoc />
+        internal override void CopyFrom(ProjectElement element, bool deepCopy)
+        {
+            base.CopyFrom(element, deepCopy);
+
+            // clear out caching fields.
+            _definitelyAreNoChildrenWithWildcards = false;
+        }
+
         /// <summary>
         /// Creates an unparented ProjectItemGroupElement, wrapping an unparented XmlElement.
         /// Caller should then ensure the element is added to the XmlDocument in the appropriate location.

--- a/src/Build/ObjectModelRemoting/ConstructionObjectLinks/ProjectElementLink.cs
+++ b/src/Build/ObjectModelRemoting/ConstructionObjectLinks/ProjectElementLink.cs
@@ -86,12 +86,12 @@ namespace Microsoft.Build.ObjectModelRemoting
         public abstract ElementLocation Location { get; }
 
         /// <summary>
-        /// Supports <see cref="ProjectElement.CopyFrom"/>.
+        /// Supports <see cref="ProjectElement.CopyFrom(ProjectElement)"/>.
         /// </summary>
         public abstract IReadOnlyCollection<XmlAttributeLink> Attributes { get; }
 
         /// <summary>
-        /// Supports <see cref="ProjectElement.CopyFrom"/>.
+        /// Supports <see cref="ProjectElement.CopyFrom(ProjectElement)"/>.
         /// return raw xml content of the element if it has exactly 1 text child
         /// </summary>
         public abstract string PureText { get; }
@@ -112,7 +112,7 @@ namespace Microsoft.Build.ObjectModelRemoting
         public abstract void SetOrRemoveAttribute(string name, string value, bool clearAttributeCache, string reason, string param);
 
         /// <summary>
-        /// Facilitate remoting to remote <see cref="ProjectElement.CopyFrom"/>.
+        /// Facilitate remoting to remote <see cref="ProjectElement.CopyFrom(ProjectElement)"/>.
         /// </summary>
         public abstract void CopyFrom(ProjectElement element);
 


### PR DESCRIPTION
Fixes #7435

### Context
When "DeepCopy"ing ProjectItemGroupElements, we copied attributes but not children, which meant we would lose them if present.

### Changes Made
Recursively copy children as well.

### Testing
Ran (and passed) rainersigwald's unit test.