### PR TITLE
Make DeepCopyFrom (for ProjectElementContainers) copy all descendants instead of just the direct children

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Xml;
 
 using Microsoft.Build.Construction;
+using Shouldly;
 using Xunit;
 
 #nullable disable
@@ -68,6 +69,49 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Equal(2, items.Count);
             Assert.Equal("i1", items[0].Include);
             Assert.Equal("i2", items[1].Include);
+        }
+
+        [Fact]
+        public void DeepCopyFromItemGroupWithMetadata()
+        {
+            string content = @"
+                    <Project>
+                        <ItemGroup>
+                            <i Include='i1'>
+                              <M>metadataValue</M>
+                            </i>
+                            <i Include='i2'>
+                              <M>
+                                <Some>
+                                    <Xml With='Nesting' />
+                                </Some>
+                              </M>
+                            </i>
+                        </ItemGroup>
+                    </Project>
+                ";
+
+            ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
+            ProjectItemGroupElement group = (ProjectItemGroupElement)Helpers.GetFirst(project.Children);
+
+            ProjectRootElement newProject = ProjectRootElement.Create();
+            ProjectItemGroupElement newItemGroup = project.AddItemGroup();
+
+            newItemGroup.DeepCopyFrom(group);
+
+            var items = Helpers.MakeList(newItemGroup.Items);
+
+            items.Count.ShouldBe(2);
+
+            items[0].Include.ShouldBe("i1");
+            ProjectMetadataElement metadataElement = items[0].Metadata.ShouldHaveSingleItem();
+            metadataElement.Name.ShouldBe("M");
+            metadataElement.Value.ShouldBe("metadataValue");
+
+            items[1].Include.ShouldBe("i2");
+            metadataElement = items[1].Metadata.ShouldHaveSingleItem();
+            metadataElement.Name.ShouldBe("M");
+            metadataElement.Value.ShouldBe("<Some><Xml With=\"Nesting\" /></Some>");
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -407,11 +407,44 @@ namespace Microsoft.Build.Construction
                 }
                 else
                 {
-                    clone.AppendChild(child.Clone(clone.ContainingProject));
+                    ProjectElement childClone = child.Clone(clone.ContainingProject);
+                    clone.AppendChild(childClone);
+                    if (childClone.XmlElement is not null)
+                    {
+                        AppendAttributesAndChildren(childClone.XmlElement, child.XmlElement);
+                    }
                 }
             }
 
             return clone;
+        }
+
+        private void AppendAttributesAndChildren(XmlNode appendTo, XmlNode appendFrom)
+        {
+            appendTo.RemoveAll();
+            // Copy over the attributes from the template element.
+            if (appendFrom.Attributes is not null)
+            {
+                foreach (XmlAttribute attribute in appendFrom.Attributes)
+                {
+                    XmlAttribute attr = appendTo.OwnerDocument.CreateAttribute(attribute.LocalName, attribute.NamespaceURI);
+                    attr.Value = attribute.Value;
+                    appendTo.Attributes.Append(attr);
+                }
+            }
+
+            // If this element has pure text content, copy that over.
+            if (appendFrom.ChildNodes.Count == 1 && appendFrom.FirstChild.NodeType == XmlNodeType.Text)
+            {
+                appendTo.AppendChild(appendTo.OwnerDocument.CreateTextNode(appendFrom.FirstChild.Value));
+            }
+
+            foreach (XmlNode child in appendFrom.ChildNodes)
+            {
+                XmlNode childClone = appendTo.OwnerDocument.CreateNode(child.NodeType, child.Prefix, child.Name, child.NamespaceURI);
+                appendTo.AppendChild(childClone);
+                AppendAttributesAndChildren(childClone, child);
+            }
         }
 
         internal static ProjectElementContainer DeepClone(ProjectElementContainer xml, ProjectRootElement factory, ProjectElementContainer parent)


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/7435

Context
When "DeepCopy"ing ProjectItemGroupElements, we copied attributes but not children, which meant we would lose them if present.

Changes Made
Recursively copy children as well.

Testing
Ran (and passed) rainersigwald's unit test.