### PR TITLE
Stop disabling CA1416 Fixes #6376

### DIFF
--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -633,7 +633,6 @@ internal static class NativeMethods
             return fileSystemKey != null && Convert.ToInt32(longPathsEnabledValue) == 1;
         }
     }
-#pragma warning restore CA1416
 
     /// <summary>
     /// Cached value for IsUnixLike (this method is called frequently during evaluation).

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -624,9 +624,7 @@ internal static class NativeMethods
         }
     }
 
-    // CA1416 warns about code that can only run on Windows, but we verified we're running on Windows before this.
-    // This is the most reasonable way to resolve this part because other ways would require ifdef'ing on NET472.
-#pragma warning disable CA1416
+    [SupportedOSPlatform("windows")]
     private static bool IsLongPathsEnabledRegistry()
     {
         using (RegistryKey fileSystemKey = Registry.LocalMachine.OpenSubKey(WINDOWS_FILE_SYSTEM_REGISTRY_KEY))

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -15,6 +15,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 using NativeMethods = Microsoft.Build.Tasks.NativeMethods;
+using System.Runtime.Versioning;
 
 #nullable disable
 
@@ -2491,10 +2492,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             };
         }
 
-#pragma warning disable CA1416
         /// <summary>
         /// Registry access delegate. Given a hive and a view, return the registry base key.
         /// </summary>
+        [SupportedOSPlatform("windows")]
         private static RegistryKey GetBaseKey(RegistryHive hive, RegistryView view)
         {
             if (hive == RegistryHive.CurrentUser)
@@ -2516,6 +2517,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <param name="baseKey">The base registry key.</param>
         /// <param name="subKey">The subkey</param>
         /// <returns>An enumeration of strings.</returns>
+        [SupportedOSPlatform("windows")]
         private static IEnumerable<string> GetRegistrySubKeyNames(RegistryKey baseKey, string subKey)
         {
             if (baseKey == Registry.CurrentUser)
@@ -2765,6 +2767,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <param name="baseKey">The base registry key.</param>
         /// <param name="subKey">The subkey</param>
         /// <returns>A string containing the default value.</returns>
+        [SupportedOSPlatform("windows")]
         private static string GetRegistrySubKeyDefaultValue(RegistryKey baseKey, string subKey)
         {
             if (baseKey == Registry.CurrentUser)

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -2903,7 +2903,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.True(false, $"New GetRegistrySubKeyDefaultValue parameters encountered, need to add unittesting support for subKey={subKey}");
             return null;
         }
-#pragma warning restore CA1416
 
         /// <summary>
         /// Delegate for System.IO.File.GetLastWriteTime

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2399,9 +2399,7 @@ namespace Microsoft.Build.UnitTests
 
             if (NativeMethodsShared.IsWindows)
             {
-#pragma warning disable CA1416 // Suppress Warning saying that WindowsPrincipal might not be compatible on Windows (Which shouldn't be an issue...)
                 if (!new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null)))
-#pragma warning restore CA1416 // Suppress Warning saying that WindowsPrincipal might not be compatible on Windows (Which shouldn't be an issue...)
                 {
                     isPrivileged = false;
                     Assert.True(true, "It seems that you don't have the permission to create symbolic links. Try to run this test again with higher privileges");


### PR DESCRIPTION
Fixes #6376

### Context
We had disabled these before we had the more convenient SupportedOSPlatformGuard. Now we can use that instead.

### Changes Made
Replaced #pragma warning disable CA1416s with SupportedOSPlatform("windows")

### Testing
Built