### PR TITLE
Fix missing transitive dependencies

### DIFF
--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -126,7 +126,9 @@ namespace Microsoft.Build.Graph
 
         private void AddEdgesFromProjectReferenceItems(Dictionary<ConfigurationMetadata, ParsedProject> allParsedProjects, GraphEdges edges)
         {
-            var transitiveReferenceCache = new Dictionary<ProjectGraphNode, HashSet<ProjectGraphNode>>(allParsedProjects.Count);
+            Dictionary<ProjectGraphNode, HashSet<ProjectGraphNode>> transitiveReferenceCache = new(allParsedProjects.Count);
+            HashSet<ProjectGraphNode> traversedReferences = new();
+            HashSet<ProjectGraphNode> emptyHashSet = new(0);
 
             foreach (var parsedProject in allParsedProjects)
             {
@@ -145,7 +147,7 @@ namespace Microsoft.Build.Graph
                     // Add transitive references only if the project requires it.
                     if (requiresTransitiveProjectReferences)
                     {
-                        foreach (var transitiveProjectReference in GetTransitiveProjectReferencesExcludingSelf(allParsedProjects[referenceInfo.ReferenceConfiguration]))
+                        foreach (var transitiveProjectReference in GetTransitiveProjectReferencesExcludingSelf(allParsedProjects[referenceInfo.ReferenceConfiguration], traversedReferences))
                         {
                             currentNode.AddProjectReference(
                                 transitiveProjectReference,
@@ -162,54 +164,31 @@ namespace Microsoft.Build.Graph
                 }
             }
 
-            HashSet<ProjectGraphNode> GetTransitiveProjectReferencesExcludingSelf(ParsedProject parsedProject)
+            HashSet<ProjectGraphNode> GetTransitiveProjectReferencesExcludingSelf(ParsedProject parsedProject, HashSet<ProjectGraphNode> traversedReferences)
             {
-                HashSet<ProjectGraphNode> references = new();
-                GetTransitiveProjectReferencesExcludingSelfHelper(parsedProject, references, null);
-                return references;
-            }
-
-            // transitiveReferences contains all of the references we've found so far from the initial GetTransitiveProjectReferencesExcludingSelf call.
-            // referencesFromHere is essentially "reset" at each level of the recursion.
-            // The first is important because if we find a cycle at some point, we need to know not to keep recursing. We wouldn't have added to transitiveReferenceCache yet, since we haven't finished
-            // finding all the transitive references yet.
-            // On the other hand, the second is important to help us fill that cache afterwards. The cache is from a particular node to all of its references, including transitive references
-            // but not including itself, which means we can't include parents as we would if we used transitiveReferences. You can see that for any particular call, it creates a new "toCache"
-            // HashSet that we fill with direct references and pass as referencesFromHere in recursive calls to fill it with transitive references. It is then used to populate the cache.
-            // Meanwhile, we avoid going into the recursive step at all if transitiveReferences already includes a particular node to avoid a StackOverflowException if there's a loop.
-            void GetTransitiveProjectReferencesExcludingSelfHelper(ParsedProject parsedProject, HashSet<ProjectGraphNode> traversedReferences, HashSet<ProjectGraphNode> incompleteReferencesOfDirectlyReferencingNode)
-            {
-                if (transitiveReferenceCache.TryGetValue(parsedProject.GraphNode, out HashSet<ProjectGraphNode> cachedTransitiveReferences))
+                if (transitiveReferenceCache.TryGetValue(parsedProject.GraphNode, out HashSet<ProjectGraphNode> transitiveReferences))
                 {
-                    traversedReferences.UnionWith(cachedTransitiveReferences);
+                    return transitiveReferences;
                 }
-                else
-                {
-                    HashSet<ProjectGraphNode> referencesFromThisNode = new();
-                    foreach (ProjectInterpretation.ReferenceInfo referenceInfo in parsedProject.ReferenceInfos)
-                    {
-                        ParsedProject reference = allParsedProjects[referenceInfo.ReferenceConfiguration];
-                        if (traversedReferences.Add(reference.GraphNode))
-                        {
-                            GetTransitiveProjectReferencesExcludingSelfHelper(reference, traversedReferences, referencesFromThisNode);
-                        }
-                        else if (transitiveReferenceCache.TryGetValue(reference.GraphNode, out cachedTransitiveReferences))
-                        {
-                            referencesFromThisNode.UnionWith(cachedTransitiveReferences);
-                        }
-                        referencesFromThisNode.Add(reference.GraphNode);
-                    }
 
-                    // We've returned from recursing through all transitive references
-                    // of this node, so add that set to the cache
-                    transitiveReferenceCache[parsedProject.GraphNode] = referencesFromThisNode;
-                    if (incompleteReferencesOfDirectlyReferencingNode is not null)
-                    {
-                        // Also add it to the set of transitive dependencies of
-                        // the referencing node (which are probably still incomplete)
-                        incompleteReferencesOfDirectlyReferencingNode.UnionWith(referencesFromThisNode);
-                    }
+                // If the node was not already in the cache but has been traversed already, then we're in a cycle. Just return an empty set in that case.
+                // This makes transitive references incorrect in the case of a cycle, but direct dependencies are always added so a cycle will still be detected and an exception will still be thrown.
+                if (!traversedReferences.Add(parsedProject.GraphNode))
+                {
+                    return emptyHashSet;
                 }
+
+                transitiveReferences = new();
+
+                foreach (ProjectInterpretation.ReferenceInfo referenceInfo in parsedProject.ReferenceInfos)
+                {
+                    ParsedProject reference = allParsedProjects[referenceInfo.ReferenceConfiguration];
+                    transitiveReferences.Add(reference.GraphNode);
+                    transitiveReferences.UnionWith(GetTransitiveProjectReferencesExcludingSelf(reference, traversedReferences));
+                }
+
+                transitiveReferenceCache[parsedProject.GraphNode] = transitiveReferences;
+                return transitiveReferences;
             }
         }
 

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -127,7 +127,6 @@ namespace Microsoft.Build.Graph
         private void AddEdgesFromProjectReferenceItems(Dictionary<ConfigurationMetadata, ParsedProject> allParsedProjects, GraphEdges edges)
         {
             Dictionary<ProjectGraphNode, HashSet<ProjectGraphNode>> transitiveReferenceCache = new(allParsedProjects.Count);
-            HashSet<ProjectGraphNode> emptyHashSet = new(0);
 
             foreach (var parsedProject in allParsedProjects)
             {

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -127,7 +127,6 @@ namespace Microsoft.Build.Graph
         private void AddEdgesFromProjectReferenceItems(Dictionary<ConfigurationMetadata, ParsedProject> allParsedProjects, GraphEdges edges)
         {
             Dictionary<ProjectGraphNode, HashSet<ProjectGraphNode>> transitiveReferenceCache = new(allParsedProjects.Count);
-            HashSet<ProjectGraphNode> traversedReferences = new();
             HashSet<ProjectGraphNode> emptyHashSet = new(0);
 
             foreach (var parsedProject in allParsedProjects)
@@ -147,7 +146,7 @@ namespace Microsoft.Build.Graph
                     // Add transitive references only if the project requires it.
                     if (requiresTransitiveProjectReferences)
                     {
-                        foreach (var transitiveProjectReference in GetTransitiveProjectReferencesExcludingSelf(allParsedProjects[referenceInfo.ReferenceConfiguration], traversedReferences))
+                        foreach (var transitiveProjectReference in GetTransitiveProjectReferencesExcludingSelf(allParsedProjects[referenceInfo.ReferenceConfiguration]))
                         {
                             currentNode.AddProjectReference(
                                 transitiveProjectReference,
@@ -164,30 +163,31 @@ namespace Microsoft.Build.Graph
                 }
             }
 
-            HashSet<ProjectGraphNode> GetTransitiveProjectReferencesExcludingSelf(ParsedProject parsedProject, HashSet<ProjectGraphNode> traversedReferences)
+            HashSet<ProjectGraphNode> GetTransitiveProjectReferencesExcludingSelf(ParsedProject parsedProject)
             {
                 if (transitiveReferenceCache.TryGetValue(parsedProject.GraphNode, out HashSet<ProjectGraphNode> transitiveReferences))
                 {
                     return transitiveReferences;
                 }
 
-                // If the node was not already in the cache but has been traversed already, then we're in a cycle. Just return an empty set in that case.
-                // This makes transitive references incorrect in the case of a cycle, but direct dependencies are always added so a cycle will still be detected and an exception will still be thrown.
-                if (!traversedReferences.Add(parsedProject.GraphNode))
-                {
-                    return emptyHashSet;
-                }
-
                 transitiveReferences = new();
+
+                // Add the results to the cache early, even though it'll be incomplete until the loop below finishes. This helps handle cycles by not allowing them to recurse infinitely.
+                // Note that this makes transitive references incomplete in the case of a cycle, but direct dependencies are always added so a cycle will still be detected and an exception will still be thrown.
+                transitiveReferenceCache[parsedProject.GraphNode] = transitiveReferences;
 
                 foreach (ProjectInterpretation.ReferenceInfo referenceInfo in parsedProject.ReferenceInfos)
                 {
                     ParsedProject reference = allParsedProjects[referenceInfo.ReferenceConfiguration];
                     transitiveReferences.Add(reference.GraphNode);
-                    transitiveReferences.UnionWith(GetTransitiveProjectReferencesExcludingSelf(reference, traversedReferences));
+
+                    // Perf note: avoiding UnionWith to avoid boxing the HashSet enumerator.
+                    foreach (ProjectGraphNode transitiveReference in GetTransitiveProjectReferencesExcludingSelf(reference))
+                    {
+                        transitiveReferences.Add(transitiveReference);
+                    }
                 }
 
-                transitiveReferenceCache[parsedProject.GraphNode] = transitiveReferences;
                 return transitiveReferences;
             }
         }


### PR DESCRIPTION
Fixes #7475

### Context
In #7053 there's a subtle bug which is highly dependent on node ordering (which makes it even repro differently or not at all on different machines...).

Specifically, `traversedReferences` is "reset" every time `GetTransitiveProjectReferencesExcludingSelf` is called. So we can end up in a state where a node is in the `transitiveReferenceCache` but not in `traversedReferences`. In that case, `GetTransitiveProjectReferencesExcludingSelfHelper` will add the cached transitive references to the `traversedReferences` set, but *not* `incompleteReferencesOfDirectlyReferencingNode`, so the referencing node loses these transitive references.

### Changes Made
I reworked the `GetTransitiveProjectReferencesExcludingSelf` method to a more straightforward approach. First it checks the cache. Then it creates a new set for the transitive references for this node and immediately adds it to the cache (note the set will be mutated later). This helps cycle handling (this avoids the StackOverflow from #6925, but does make the transitive references incorrect in the cycle case, but that's fine since we'll error later anyway when doing proper cycle detection). Then just iterate the references, add them and add the recursion into their transitive references.

### Testing
Covered by existing UTs and manually tested on a local repro I had. Unfortunately I can't add UTs for this since the repro is dependent on ordering and is seemingly machine-dependent.