### PR TITLE
Allow overriding MSBuildRuntimeType to "Full" on RUNTIME_TYPE_NETCORE

### DIFF
--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -921,7 +921,7 @@ namespace Microsoft.Build.Evaluation
 
                     reservedProperties.Add(ProjectPropertyInstance.Create(ReservedPropertyNames.msbuildRuntimeType,
 #if RUNTIME_TYPE_NETCORE
-                        !Traits.Instance.ForceEvaluateAsFullFramework ? "Core" : "Full",
+                        Traits.Instance.ForceEvaluateAsFullFramework ? "Full" : "Core",
 #elif MONO
                         NativeMethodsShared.IsMono ? "Mono" : "Full");
 #else

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -921,7 +921,7 @@ namespace Microsoft.Build.Evaluation
 
                     reservedProperties.Add(ProjectPropertyInstance.Create(ReservedPropertyNames.msbuildRuntimeType,
 #if RUNTIME_TYPE_NETCORE
-                        "Core",
+                        !Traits.Instance.ForceEvaluateAsFullFramework ? "Core" : "Full",
 #elif MONO
                         NativeMethodsShared.IsMono ? "Mono" : "Full");
 #else

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1149,7 +1149,7 @@ namespace Microsoft.Build.Evaluation
 
 #if RUNTIME_TYPE_NETCORE
             SetBuiltInProperty(ReservedPropertyNames.msbuildRuntimeType,
-                !Traits.Instance.ForceEvaluateAsFullFramework ? "Core" : "Full");
+                Traits.Instance.ForceEvaluateAsFullFramework ? "Full" : "Core");
 #elif MONO
             SetBuiltInProperty(ReservedPropertyNames.msbuildRuntimeType,
                                                         NativeMethodsShared.IsMono ? "Mono" : "Full");

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1148,7 +1148,8 @@ namespace Microsoft.Build.Evaluation
             }
 
 #if RUNTIME_TYPE_NETCORE
-            SetBuiltInProperty(ReservedPropertyNames.msbuildRuntimeType, "Core");
+            SetBuiltInProperty(ReservedPropertyNames.msbuildRuntimeType,
+                !Traits.Instance.ForceEvaluateAsFullFramework ? "Core" : "Full");
 #elif MONO
             SetBuiltInProperty(ReservedPropertyNames.msbuildRuntimeType,
                                                         NativeMethodsShared.IsMono ? "Mono" : "Full");

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -70,6 +70,11 @@ namespace Microsoft.Build.Framework
         public static readonly string MSBuildNodeHandshakeSalt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT");
 
         /// <summary>
+        /// Override property "MSBuildRuntimeType" to "Full", ignoring the actual runtime type of MSBuild.
+        /// </summary>
+        public readonly bool ForceEvaluateAsFullFramework = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildForceEvaluateAsFullFramework"));
+
+        /// <summary>
         /// Setting the associated environment variable to 1 restores the pre-15.8 single
         /// threaded (slower) copy behavior. Zero implies Int32.MaxValue, less than zero
         /// (default) uses the empirical default in Copy.cs, greater than zero can allow


### PR DESCRIPTION
### Context
We have scenarios in internal build tools where MSBuild evaluation is executed in the parse phase under a .NET 6.0 process, prior the build phase which builds projects using full framework ```msbuild.exe```. As evaluation results in the parse phase must match the build phase for prediction to be accurate, ```MSBuildRuntimeType``` must be set to ```"Full"``` in both cases - so we currently solve this by launching a separate process under full framework which runs evaluation / parsing and serializes results back to the main process.

However, this serialization incurs a significant amount of overhead on large repos. Instead, by having the option of forcing ```MSBuildRuntimeType=Full``` when on ```RUNTIME_TYPE_NETCORE```, we would be able to evaluate these projects in-process for the majority of repos.

### Changes Made
- Added a new environment variable
```MsBuildForceEvaluateAsFullFramework```
- Added conditions to set ```MSBuildRuntimeType="Full"``` when this env var is set

### Testing
Ran multiple validation runs across all repos on internal build tools to validate this approach works, comparing evaluation / parser results of the "forced" runtime vs "actual".
