### PR TITLE
Log environment-derived properties

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1469,7 +1469,9 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             private static object LookupProperty(IPropertyProvider<T> properties, string propertyName, int startIndex, int endIndex, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties)
             {
-                T property = properties.GetProperty(propertyName, startIndex, endIndex);
+                string propertyNameValue = propertyName.Substring(startIndex, endIndex - startIndex + 1);
+                T property = properties.GetProperty(propertyNameValue, 0, propertyNameValue.Length - 1);
+                EnvironmentUtilities.EnvironmentVariablesUsedAsProperties[propertyNameValue] = Environment.GetEnvironmentVariable(propertyNameValue);
 
                 object propertyValue;
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -53,7 +53,9 @@ namespace Microsoft.Build.Logging
         //   - TargetSkippedEventArgs: added OriginallySucceeded, Condition, EvaluatedCondition
         // version 14:
         //   - TargetSkippedEventArgs: added SkipReason, OriginalBuildEventContext
-        internal const int FileFormatVersion = 14;
+        // version 15:
+        //   - Log only environment variables accessed as properties
+        internal const int FileFormatVersion = 15;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -362,12 +362,14 @@ namespace Microsoft.Build.Logging
         {
             var fields = ReadBuildEventArgsFields();
             var succeeded = ReadBoolean();
+            var environmentProperties = ReadStringDictionary();
 
             var e = new BuildFinishedEventArgs(
                 fields.Message,
                 fields.HelpKeyword,
                 succeeded,
-                fields.Timestamp);
+                fields.Timestamp,
+                environmentVariables: environmentProperties);
             SetCommonFields(e, fields);
             return e;
         }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -4,18 +4,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
-using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
-using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 
 #nullable disable
@@ -251,7 +247,14 @@ Build
         {
             Write(BinaryLogRecordKind.BuildStarted);
             WriteBuildEventArgsFields(e);
-            Write(e.BuildEnvironment);
+            if (Traits.Instance.LogAllEnvironmentVariables)
+            {
+                Write(e.BuildEnvironment);
+            }
+            else
+            {
+                Write(new Dictionary<string, string>(0));
+            }
         }
 
         private void Write(BuildFinishedEventArgs e)

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -259,6 +259,7 @@ Build
             Write(BinaryLogRecordKind.BuildFinished);
             WriteBuildEventArgsFields(e);
             Write(e.Succeeded);
+            Write(EnvironmentUtilities.EnvironmentVariablesUsedAsProperties);
         }
 
         private void Write(ProjectEvaluationStartedEventArgs e)

--- a/src/Framework.UnitTests/BuildFinishedEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/BuildFinishedEventArgs_Tests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.UnitTests
             buildFinishedEvent = new BuildFinishedEventArgs("{0}", "HelpKeyword", true, new DateTime(), "Message");
             buildFinishedEvent = new BuildFinishedEventArgs(null, null, true);
             buildFinishedEvent = new BuildFinishedEventArgs(null, null, true, new DateTime());
-            buildFinishedEvent = new BuildFinishedEventArgs(null, null, true, new DateTime(), null);
+            buildFinishedEvent = new BuildFinishedEventArgs(null, null, true, new DateTime(), messageArgs: null);
         }
 
         /// <summary>

--- a/src/Framework/BuildFinishedEventArgs.cs
+++ b/src/Framework/BuildFinishedEventArgs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 #nullable disable
@@ -24,6 +25,11 @@ namespace Microsoft.Build.Framework
         /// Whether the build succeeded
         /// </summary>
         private bool succeeded;
+
+        /// <summary>
+        /// Environment variable-derived properties
+        /// </summary>
+        private IDictionary<string, string> environmentVariables;
 
         /// <summary>
         /// Default constructor
@@ -65,7 +71,7 @@ namespace Microsoft.Build.Framework
             bool succeeded,
             DateTime eventTimestamp
         )
-            : this(message, helpKeyword, succeeded, eventTimestamp, null)
+            : this(message, helpKeyword, succeeded, eventTimestamp, messageArgs: null)
         {
             // do nothing
         }
@@ -89,6 +95,30 @@ namespace Microsoft.Build.Framework
             : base(message, helpKeyword, "MSBuild", eventTimestamp, messageArgs)
         {
             this.succeeded = succeeded;
+        }
+
+        /// <summary>
+        /// Constructor which allows environment variable-derived properties to be set
+        /// </summary>
+        /// <param name="message">text message</param>
+        /// <param name="helpKeyword">help keyword </param>
+        /// <param name="succeeded">True indicates a successful build</param>
+        /// <param name="eventTimestamp">Timestamp when the event was created</param>
+        /// <param name="environmentVariables">Properties derived from environment variables</param>
+        /// <param name="messageArgs">message arguments</param>
+        public BuildFinishedEventArgs
+        (
+            string message,
+            string helpKeyword,
+            bool succeeded,
+            DateTime eventTimestamp,
+            IDictionary<string, string> environmentVariables,
+            params object[] messageArgs
+        )
+            : base(message, helpKeyword, "MSBuild", eventTimestamp, messageArgs)
+        {
+            this.succeeded = succeeded;
+            this.environmentVariables = environmentVariables;
         }
 
 
@@ -123,6 +153,17 @@ namespace Microsoft.Build.Framework
             get
             {
                 return succeeded;
+            }
+        }
+
+        /// <summary>
+        /// Gets all environment variables read when trying to evaluate properties along with their values.
+        /// </summary>
+        public IDictionary<string, string> EnvironmentVariables
+        {
+            get
+            {
+                return environmentVariables;
             }
         }
     }

--- a/src/Framework/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Framework/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Build.Framework.BuildFinishedEventArgs.BuildFinishedEventArgs(string message, string helpKeyword, bool succeeded, System.DateTime eventTimestamp, System.Collections.Generic.IDictionary<string, string> environmentVariables, params object[] messageArgs) -> void
+Microsoft.Build.Framework.BuildFinishedEventArgs.EnvironmentVariables.get -> System.Collections.Generic.IDictionary<string, string>

--- a/src/Framework/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Framework/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Build.Framework.BuildFinishedEventArgs.BuildFinishedEventArgs(string message, string helpKeyword, bool succeeded, System.DateTime eventTimestamp, System.Collections.Generic.IDictionary<string, string> environmentVariables, params object[] messageArgs) -> void
+Microsoft.Build.Framework.BuildFinishedEventArgs.EnvironmentVariables.get -> System.Collections.Generic.IDictionary<string, string>

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -93,6 +93,11 @@ namespace Microsoft.Build.Framework
         public readonly bool LogPropertyFunctionsRequiringReflection = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBuildLogPropertyFunctionsRequiringReflection"));
 
         /// <summary>
+        /// Log all environment variables whether or not they are used in a build in the binary log.
+        /// </summary>
+        public readonly bool LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES"));
+
+        /// <summary>
         /// Log property tracking information.
         /// </summary>
         public readonly int LogPropertyTracking = ParseIntFromEnvironmentVariableOrDefault("MsBuildLogPropertyTracking", 0); // Default to logging nothing via the property tracker.

--- a/src/Shared/EnvironmentUtilities.cs
+++ b/src/Shared/EnvironmentUtilities.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 #nullable disable
@@ -14,5 +15,7 @@ namespace Microsoft.Build.Shared
 
         public static bool Is64BitOperatingSystem =>
             Environment.Is64BitOperatingSystem;
+
+        public static Dictionary<string, string> EnvironmentVariablesUsedAsProperties { get; } = new();
     }
 }


### PR DESCRIPTION
### Context
We currently log all environment variables, which is useful in giving you a sense of where things come from sometimes but doesn't really tell you if those environment variables are used or what other environment variables we might have expected. This shifts to logging only those environment variables we actually used. This also partially mitigates potential privacy issues, as random environment variables with secrets aren't logged unless they happen to correspond to something MSBuild actually needs.

### Changes Made
Keep track of environment variable usages for looking at properties. Log those in the binlog instead of all environment variables.

### Testing
Not yet