### PR TITLE
Always make bootstrap

### DIFF
--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -21,7 +21,7 @@
 
   <Target Name="Bootstrap" DependsOnTargets="$(BootstrapDependsOn)"
           AfterTargets="AfterBuild"
-          Condition="'$(CreateBootstrap)' == 'true'"/>
+          Condition="'$(CreateBootstrap)' != 'false'"/>
 
   <Target Name="CleanBootstrapFolder">
     <!-- This sometimes fails so it might need be retried. -->


### PR DESCRIPTION
### Context
Always creates a bootstrap MSBuild when building from the command line.

### Changes Made
Added /p:CreateBootstrap=true in two places

### Testing
Tested `build.cmd` on windows, and it made a bootstrap version.