### PR TITLE
Respect deps json

### DIFF
--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Build.Framework
     {
         internal static readonly Version Wave16_10 = new Version(16, 10);
         internal static readonly Version Wave17_0 = new Version(17, 0);
-        internal static readonly Version[] AllWaves = { Wave16_10, Wave17_0 };
-
+        internal static readonly Version Wave17_2 = new Version(17, 2);
+        internal static readonly Version[] AllWaves = { Wave16_10, Wave17_0, Wave17_2 };
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.
         /// </summary>

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared.FileSystem;
+
+using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
@@ -15,6 +18,8 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal class MSBuildLoadContext : AssemblyLoadContext
     {
+        private AssemblyDependencyResolver _resolver;
+
         private readonly string _directory;
 
         internal static readonly ImmutableHashSet<string> WellKnownAssemblyNames =
@@ -31,6 +36,8 @@ namespace Microsoft.Build.Shared
             : base($"MSBuild plugin {assemblyPath}")
         {
             _directory = Directory.GetParent(assemblyPath)!.FullName;
+
+            _resolver = new AssemblyDependencyResolver(assemblyPath);
         }
 
         protected override Assembly? Load(AssemblyName assemblyName)
@@ -41,6 +48,19 @@ namespace Microsoft.Build.Shared
                 // and unify to the current version.
                 return null;
             }
+
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_2))
+            {
+                // respect plugin.dll.json with the AssemblyDependencyResolver
+                string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+                if (assemblyPath != null)
+                {
+                    return LoadFromAssemblyPath(assemblyPath);
+                }
+            }
+
+            // Fall back to the older MSBuild-on-Core behavior to continue to support
+            // plugins that don't ship a .deps.json
 
             foreach (var cultureSubfolder in string.IsNullOrEmpty(assemblyName.CultureName)
                 // If no culture is specified, attempt to load directly from
@@ -83,6 +103,20 @@ namespace Microsoft.Build.Shared
             }
 
             return null;
+        }
+
+        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        {
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_2))
+            {
+                string? libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+                if (libraryPath != null)
+                {
+                    return LoadUnmanagedDllFromPath(libraryPath);
+                }
+            }
+
+            return base.LoadUnmanagedDll(unmanagedDllName);
         }
     }
 }

--- a/src/Shared/UnitTests/TypeLoader_Tests.cs
+++ b/src/Shared/UnitTests/TypeLoader_Tests.cs
@@ -6,8 +6,10 @@ using System;
 using System.IO;
 using Microsoft.Build.Shared;
 using System.Reflection;
-using Xunit;
 using Microsoft.Build.UnitTests.Shared;
+using Xunit;
+using Xunit.Abstractions;
+using Shouldly;
 
 #nullable disable
 
@@ -18,6 +20,13 @@ namespace Microsoft.Build.UnitTests
         private static readonly string ProjectFileFolder = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, "PortableTask");
         private const string ProjectFileName = "portableTaskTest.proj";
         private const string DLLFileName = "PortableTask.dll";
+
+        private readonly ITestOutputHelper _output;
+
+        public TypeLoader_Tests(ITestOutputHelper testOutputHelper)
+        {
+            _output = testOutputHelper;
+        }
 
         [Fact]
         public void Basic()
@@ -50,19 +59,18 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void LoadNonExistingAssembly()
         {
-            using (var dir = new FileUtilities.TempWorkingDirectory(ProjectFileFolder))
-            {
-                string projectFilePath = Path.Combine(dir.Path, ProjectFileName);
+            using var dir = new FileUtilities.TempWorkingDirectory(ProjectFileFolder);
 
-                string dllName = "NonExistent.dll";
+            string projectFilePath = Path.Combine(dir.Path, ProjectFileName);
 
-                bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(projectFilePath + " /v:diag /p:AssemblyPath=" + dllName, out successfulExit);
-                Assert.False(successfulExit);
+            string dllName = "NonExistent.dll";
 
-                string dllPath = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, dllName);
-                CheckIfCorrectAssemblyLoaded(output, dllPath, false);
-            }
+            bool successfulExit;
+            string output = RunnerUtilities.ExecMSBuild(projectFilePath + " /v:diag /p:AssemblyPath=" + dllName, out successfulExit, _output);
+            successfulExit.ShouldBeFalse();
+
+            string dllPath = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, dllName);
+            CheckIfCorrectAssemblyLoaded(output, dllPath, false);
         }
 
         [Fact]
@@ -73,7 +81,7 @@ namespace Microsoft.Build.UnitTests
                 string projectFilePath = Path.Combine(dir.Path, ProjectFileName);
 
                 bool successfulExit;
-                string output = RunnerUtilities.ExecMSBuild(projectFilePath + " /v:diag", out successfulExit);
+                string output = RunnerUtilities.ExecMSBuild(projectFilePath + " /v:diag", out successfulExit, _output);
                 Assert.True(successfulExit);
 
                 string dllPath = Path.Combine(dir.Path, DLLFileName);
@@ -95,7 +103,7 @@ namespace Microsoft.Build.UnitTests
                 try
                 {
                     bool successfulExit;
-                    string output = RunnerUtilities.ExecMSBuild(projectFilePath + " /v:diag /p:AssemblyPath=" + movedDLLPath, out successfulExit);
+                    string output = RunnerUtilities.ExecMSBuild(projectFilePath + " /v:diag /p:AssemblyPath=" + movedDLLPath, out successfulExit, _output);
                     Assert.True(successfulExit);
 
                     CheckIfCorrectAssemblyLoaded(output, movedDLLPath);
@@ -119,7 +127,7 @@ namespace Microsoft.Build.UnitTests
                 try
                 {
                     bool successfulExit;
-                    string output = RunnerUtilities.ExecMSBuild(projectFilePath + " /v:diag /p:AssemblyPath=" + copiedDllPath, out successfulExit);
+                    string output = RunnerUtilities.ExecMSBuild(projectFilePath + " /v:diag /p:AssemblyPath=" + copiedDllPath, out successfulExit, _output);
                     Assert.True(successfulExit);
 
                     CheckIfCorrectAssemblyLoaded(output, originalDLLPath);


### PR DESCRIPTION
Fixes #4081 and #1887; progress towards #5037

### Context
MSBuild doesn't currently respect .deps.json files for plugins (tasks). This can lead to incorrect versions of assemblies being found as finding the AnyCPU version of an assembly instead of the windows-specific version.

### Changes Made
Use AssemblyDependencyResolver as a second pass (after looking for "well-known assemblies") to automatically use the deps.json file to find the right assembly.

### Testing
Verified that for a task assembly with a rid-specific dependency, it finds the rid-specific dependency as specified by the deps.json file. Also verified that it can find native assemblies and that the issue that inspired this (https://github.com/dotnet/sdk/issues/23498) no longer reproduces after giving nuget a .deps.json file specifying the correct version.