### PR TITLE
Logs warning message when property AllowFailureWithoutError is set to…

### DIFF
--- a/src/Build.UnitTests/BackEnd/OnError_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/OnError_Tests.cs
@@ -583,6 +583,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             else
             {
                 logger.ErrorCount.ShouldBe(0);
+                logger.WarningCount.ShouldBe(1);
             }
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -960,11 +960,10 @@ namespace Microsoft.Build.BackEnd
                     && !taskResult // and it returned false
                     && !taskLoggingContext.HasLoggedErrors // and it didn't log any errors
                     && (be is TaskHost th ? th.BuildRequestsSucceeded : false)
-                    && (be is IBuildEngine7 be7 ? !be7.AllowFailureWithoutError : true) // and it's not allowed to fail unless it logs an error
                     && !(_cancellationToken.CanBeCanceled && _cancellationToken.IsCancellationRequested)) // and it wasn't cancelled
                 {
                     // Then decide how to log MSB4181
-                    if (_continueOnError == ContinueOnError.WarnAndContinue)
+                    if (_continueOnError == ContinueOnError.WarnAndContinue || (be is IBuildEngine7 be7 && be7.AllowFailureWithoutError))
                     {
                         taskLoggingContext.LogWarning(null,
                             new BuildEventFileInfo(_targetChildInstance.Location),


### PR DESCRIPTION
… True

Fixes #6633

### Context
 No messages are logged at all if the build fails and AllowFailureWithoutError is set to True.

### Changes Made
Moved the logic check for AllowFailureWithoutError to the nested if-else statement so that a warning message is logged if AllowFailureWithoutError is set to True and if AllowFailureWithoutError is set to False then an error is logged instead.

### Testing
Added line to relevant Unit Test to check for warning messages in cases where AllowFailureWithoutError is set to True.

### Notes
