### PR TITLE
Fix regex culture bug

### DIFF
--- a/src/Utilities.UnitTests/CommandLineBuilder_Tests.cs
+++ b/src/Utilities.UnitTests/CommandLineBuilder_Tests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
 using System.IO;
+using System.Threading;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
 using Shouldly;
@@ -52,6 +54,24 @@ namespace Microsoft.Build.UnitTests
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/animal:", "dog and pony");
             c.ShouldBe("/animal:\"dog and pony\"");
+        }
+
+        [Fact]
+        public void AppendSwitchWithIShouldNotNeedQuotingInTurkishLocale()
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR"); // Turkish
+
+                CommandLineBuilder c = new CommandLineBuilder();
+                c.AppendSwitchIfNotNull("/i:", "iI");
+                c.ShouldBe("/i:iI");
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = currentCulture;
+            }
         }
 
         /// <summary>

--- a/src/Utilities/CommandLineBuilder.cs
+++ b/src/Utilities/CommandLineBuilder.cs
@@ -156,13 +156,13 @@ namespace Microsoft.Build.Utilities
         /// Use a private property so that we can lazy initialize the regex
         /// </summary>
         private Regex DefinitelyNeedQuotes => _definitelyNeedQuotes
-            ?? (_definitelyNeedQuotes = new Regex(_quoteHyphens ? s_definitelyNeedQuotesRegexWithHyphen : s_definitelyNeedQuotesRegexNoHyphen, RegexOptions.None));
+            ?? (_definitelyNeedQuotes = new Regex(_quoteHyphens ? s_definitelyNeedQuotesRegexWithHyphen : s_definitelyNeedQuotesRegexNoHyphen, RegexOptions.CultureInvariant));
 
         /// <summary>
         /// Use a private getter property to we can lazy initialize the regex
         /// </summary>
         private Regex AllowedUnquoted => _allowedUnquoted
-            ?? (_allowedUnquoted = new Regex(_quoteHyphens ? s_allowedUnquotedRegexNoHyphen : s_allowedUnquotedRegexWithHyphen, RegexOptions.IgnoreCase));
+            ?? (_allowedUnquoted = new Regex(_quoteHyphens ? s_allowedUnquotedRegexNoHyphen : s_allowedUnquotedRegexWithHyphen, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));
 
         /// <summary>
         /// Checks the given switch parameter to see if it must/can be quoted.


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/7154

### Context

The CSC compiler does not unquote disabled warnings eg `/nowarn:1701,1702,1705,NETSDK1138,CS8969,"IDE0161",NU5105,RS0041,CA1416,1701,1702` will not disable `IDE0161`. MSBuild has logic to quote strings that it believes must be quoted to be passed on a command line. It has a bug causing it to do this over eagerly in the tr-TR culture, which exposes this compiler limitation.

To fix this Regex should use RegexOptions.CultureInvariant unless they are specifically intended to have culture specific  behavior. In this case the purpose is simply to determine whether a string needs to be quoted on a command line. An example is "SYSLIB0003". The `I` does not match `[a-z]` case insensitively in tr-TR culture because lower casing `I` does not produce `i` in this culture, it produces `ı`, which does not match the pattern. Assuming that it is safe to pass `I` on a command line in an OS set to Turkish culture -- I assume this is the case, but if it isn't, quoting will not help -- we can change the pattern to match in a culture invariant way. This causes the regex engine to operate more-or-less with en-US casing rules, so `I` and `i` are allowed. (Turkish `ı` or `İ` will still be quoted, see below.) 

### Changes Made

Added the option to the regex. Also added it to the other related one, even though it has no relevant parts in the pattern, for consistency. I did not add it to the place where MSBuild looks for "error" or "warning" -- it probably should be there, but as they don't include "i", it doesn't matter and can be changed separately.

### Testing

Added test.

### Notes

Note: this does not address the issue that a quoted warning is not unquoted by the compiler. The code will still add quotes if eg., the string has a space in, and most likely this will then fail to be unquoted by the compiler. If htis is an issue then we should have a separate issue for it against the compiler.

This change makes things strictly better and solves the reported issue.

BTW - this should be considered for backporting, as it makes it impossible for customers with their OS set to tr-TR (which I assume is most of our Turkish customers) to suppress any SYSLIBnnnn warnings, which many of our analyzers now emit.