### PR TITLE
Platform Negotiation: Platform is considered a referenced project's DEFAULT platform

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -26,6 +26,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 ### 17.4
 - [Respect deps.json when loading assemblies](https://github.com/dotnet/msbuild/pull/7520)
 - [Remove opt in for new schema for CombineTargetFrameworkInfoProperties](https://github.com/dotnet/msbuild/pull/6928)
+- [Consider `Platform` as default during Platform Negotiation](https://github.com/dotnet/msbuild/pull/7511)
 
 ### 17.0
 - [Scheduler should honor BuildParameters.DisableInprocNode](https://github.com/dotnet/msbuild/pull/6400)

--- a/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
+++ b/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Build.Tasks.UnitTests
             // It will continue and have no NearestPlatform metadata.
             TaskItem projectReference = new TaskItem("foo.bar");
             projectReference.SetMetadata("Platforms", string.Empty);
+            projectReference.SetMetadata("Platform", string.Empty);
 
             GetCompatiblePlatform task = new GetCompatiblePlatform()
             {
@@ -200,6 +201,30 @@ namespace Microsoft.Build.Tasks.UnitTests
             // it has an invalid format. The current project's PLT should be the next priority.
             task.AssignedProjectsWithPlatform[0].GetMetadata("NearestPlatform").ShouldBe("x86");
             ((MockEngine)task.BuildEngine).AssertLogContains("MSB3983");
+        }
+
+        // When `Platform` is retrieved in "GetTargetFrameworks" and that platform matches what's currently
+        // being built, build that project _without_ a global property for Platform.
+        [Theory]
+        [InlineData("x86;AnyCPU", "x64", "x64")] // Referenced platform matches current platform, build w/o global property
+        [InlineData("x64;x86;AnyCPU", "x64", "x64")] // Referenced platform overrides 'Platforms' being an option
+        public void PlatformIsChosenAsDefault(string referencedPlatforms, string referencedPlatform, string currentPlatform)
+        {
+            TaskItem projectReference = new TaskItem("foo.bar");
+            projectReference.SetMetadata("Platforms", referencedPlatforms);
+            projectReference.SetMetadata("Platform", referencedPlatform);
+
+            GetCompatiblePlatform task = new GetCompatiblePlatform()
+            {
+                BuildEngine = new MockEngine(_output),
+                CurrentProjectPlatform = currentPlatform,
+                AnnotatedProjects = new TaskItem[] { projectReference }
+            };
+
+            task.Execute().ShouldBeTrue();
+
+            task.AssignedProjectsWithPlatform[0].GetMetadata("NearestPlatform").ShouldBe(string.Empty);
+            task.Log.HasLoggedErrors.ShouldBeFalse();
         }
     }
 }

--- a/src/Tasks/GetCompatiblePlatform.cs
+++ b/src/Tasks/GetCompatiblePlatform.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Build.Tasks
                 // If the referenced project has a defined `Platform` it should always build as _and_ it's compatible, build it without passing any global properties to reuse the evaluation.
                 if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(CurrentProjectPlatform))
                 {
-                    Log.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", AssignedProjectsWithPlatform[i].ItemSpec);
+                    Log.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", AssignedProjectsWithPlatform[i].ItemSpec, referencedProjectPlatform);
                 }
                 // Prefer matching platforms
                 else if (projectReferencePlatforms.Contains(CurrentProjectPlatform))

--- a/src/Tasks/GetCompatiblePlatform.cs
+++ b/src/Tasks/GetCompatiblePlatform.cs
@@ -84,8 +84,7 @@ namespace Microsoft.Build.Tasks
                 // If the referenced project has a defined `Platform` it should always build as _and_ it's compatible, build it without passing any global properties to reuse the evaluation.
                 if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(CurrentProjectPlatform))
                 {
-                    // TODO: Add this resource
-                    Log.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform");
+                    Log.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", AssignedProjectsWithPlatform[i].ItemSpec);
                 }
                 // Prefer matching platforms
                 else if (projectReferencePlatforms.Contains(CurrentProjectPlatform))

--- a/src/Tasks/GetCompatiblePlatform.cs
+++ b/src/Tasks/GetCompatiblePlatform.cs
@@ -58,29 +58,37 @@ namespace Microsoft.Build.Tasks
             {
                 AssignedProjectsWithPlatform[i] = new TaskItem(AnnotatedProjects[i]);
 
-                string projectReferencePlatformMetadata = AssignedProjectsWithPlatform[i].GetMetadata("Platforms");
+                string referencedProjectPlatform = AssignedProjectsWithPlatform[i].GetMetadata("Platform");
+                string projectReferencePlatformsMetadata = AssignedProjectsWithPlatform[i].GetMetadata("Platforms");
+                string projectReferenceLookupTableMetadata = AssignedProjectsWithPlatform[i].GetMetadata("PlatformLookupTable");
 
-                if (string.IsNullOrEmpty(projectReferencePlatformMetadata))
+                if (string.IsNullOrEmpty(projectReferencePlatformsMetadata) && string.IsNullOrEmpty(referencedProjectPlatform))
                 {
+                    // TODO: This message should mean "We weren't given enough info to perform platform negotiation"
                     Log.LogWarningWithCodeFromResources("GetCompatiblePlatform.NoPlatformsListed", AssignedProjectsWithPlatform[i].ItemSpec);
                     continue;
                 }
 
-                string projectReferenceLookupTableMetadata = AssignedProjectsWithPlatform[i].GetMetadata("PlatformLookupTable");
                 // Pull platformlookuptable metadata from the referenced project. This allows custom
                 // mappings on a per-ProjectReference basis.
                 Dictionary<string, string>? projectReferenceLookupTable = ExtractLookupTable(projectReferenceLookupTableMetadata);
 
                 HashSet<string> projectReferencePlatforms = new HashSet<string>();
-                foreach (string s in projectReferencePlatformMetadata.Split(MSBuildConstants.SemicolonChar, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string s in projectReferencePlatformsMetadata.Split(MSBuildConstants.SemicolonChar, StringSplitOptions.RemoveEmptyEntries))
                 {
                     projectReferencePlatforms.Add(s);
                 }
 
                 string buildProjectReferenceAs = string.Empty;
 
+                // If the referenced project has a defined `Platform` it should always build as _and_ it's compatible, build it without passing any global properties to reuse the evaluation.
+                if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(CurrentProjectPlatform))
+                {
+                    // TODO: Add this resource
+                    Log.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform");
+                }
                 // Prefer matching platforms
-                if (projectReferencePlatforms.Contains(CurrentProjectPlatform))
+                else if (projectReferencePlatforms.Contains(CurrentProjectPlatform))
                 {
                     buildProjectReferenceAs = CurrentProjectPlatform;
                     Log.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.SamePlatform");

--- a/src/Tasks/GetCompatiblePlatform.cs
+++ b/src/Tasks/GetCompatiblePlatform.cs
@@ -64,7 +64,6 @@ namespace Microsoft.Build.Tasks
 
                 if (string.IsNullOrEmpty(projectReferencePlatformsMetadata) && string.IsNullOrEmpty(referencedProjectPlatform))
                 {
-                    // TODO: This message should mean "We weren't given enough info to perform platform negotiation"
                     Log.LogWarningWithCodeFromResources("GetCompatiblePlatform.NoPlatformsListed", AssignedProjectsWithPlatform[i].ItemSpec);
                     continue;
                 }

--- a/src/Tasks/GetCompatiblePlatform.cs
+++ b/src/Tasks/GetCompatiblePlatform.cs
@@ -80,8 +80,9 @@ namespace Microsoft.Build.Tasks
 
                 string buildProjectReferenceAs = string.Empty;
 
-                // If the referenced project has a defined `Platform` it should always build as _and_ it's compatible, build it without passing any global properties to reuse the evaluation.
-                if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(CurrentProjectPlatform))
+                // If the referenced project has a defined `Platform` that's compatible, it will build that way by default.
+                // Don't set `buildProjectReferenceAs` and the `_GetProjectReferencePlatformProperties` target will handle the rest.
+                if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(CurrentProjectPlatform, StringComparison.OrdinalIgnoreCase))
                 {
                     Log.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", AssignedProjectsWithPlatform[i].ItemSpec, referencedProjectPlatform);
                 }

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -49,7 +49,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- Extract necessary information for SetPlatform negotiation -->
         <!-- This target does not run for cpp projects. -->
         <IsVcxOrNativeProj>false</IsVcxOrNativeProj>
-        <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.3'))">$(Platform)</Platform>
+        <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.4'))">$(Platform)</Platform>
         <Platforms>$(Platforms)</Platforms>
       </_ThisProjectBuildMetadata>
     </ItemGroup>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -49,6 +49,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- Extract necessary information for SetPlatform negotiation -->
         <!-- This target does not run for cpp projects. -->
         <IsVcxOrNativeProj>false</IsVcxOrNativeProj>
+        <Platform>$(Platform)</Platform>
         <Platforms>$(Platforms)</Platforms>
       </_ThisProjectBuildMetadata>
     </ItemGroup>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -49,7 +49,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- Extract necessary information for SetPlatform negotiation -->
         <!-- This target does not run for cpp projects. -->
         <IsVcxOrNativeProj>false</IsVcxOrNativeProj>
-        <Platform>$(Platform)</Platform>
+        <Platform Condition="'$(MSBuildPlatformNegotiation_SkipPlatformProperty)' == ''">$(Platform)</Platform>
         <Platforms>$(Platforms)</Platforms>
       </_ThisProjectBuildMetadata>
     </ItemGroup>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -49,7 +49,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- Extract necessary information for SetPlatform negotiation -->
         <!-- This target does not run for cpp projects. -->
         <IsVcxOrNativeProj>false</IsVcxOrNativeProj>
-        <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.3')">$(Platform)</Platform>
+        <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.3'))">$(Platform)</Platform>
         <Platforms>$(Platforms)</Platforms>
       </_ThisProjectBuildMetadata>
     </ItemGroup>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -49,7 +49,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- Extract necessary information for SetPlatform negotiation -->
         <!-- This target does not run for cpp projects. -->
         <IsVcxOrNativeProj>false</IsVcxOrNativeProj>
-        <Platform Condition="'$(MSBuildPlatformNegotiation_SkipPlatformProperty)' == ''">$(Platform)</Platform>
+        <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.3')">$(Platform)</Platform>
         <Platforms>$(Platforms)</Platforms>
       </_ThisProjectBuildMetadata>
     </ItemGroup>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1888,7 +1888,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
         <!-- Extract necessary information for SetPlatform negotiation -->
         <IsVcxOrNativeProj Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.nativeproj'">true</IsVcxOrNativeProj>
-        <Platform>$(Platform)</Platform>
+        <Platform Condition="'$(MSBuildPlatformNegotiation_SkipPlatformProperty)' == ''">$(Platform)</Platform>
         <Platforms>$(Platforms)</Platforms>
         <!-- .vcxproj and .nativeproj contain a `ProjectConfiguration` item that have `Platform` metadata within.
              Build the `Platforms` property from that. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1888,7 +1888,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
         <!-- Extract necessary information for SetPlatform negotiation -->
         <IsVcxOrNativeProj Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.nativeproj'">true</IsVcxOrNativeProj>
-        <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.3'))">$(Platform)</Platform>
+        <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.4'))">$(Platform)</Platform>
         <Platforms>$(Platforms)</Platforms>
         <!-- .vcxproj and .nativeproj contain a `ProjectConfiguration` item that have `Platform` metadata within.
              Build the `Platforms` property from that. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1888,7 +1888,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
         <!-- Extract necessary information for SetPlatform negotiation -->
         <IsVcxOrNativeProj Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.nativeproj'">true</IsVcxOrNativeProj>
-        <Platform Condition="'$(MSBuildPlatformNegotiation_SkipPlatformProperty)' == ''">$(Platform)</Platform>
+        <Platform Condition="$([MSBuild]::AreFeaturesEnabled('17.3'))">$(Platform)</Platform>
         <Platforms>$(Platforms)</Platforms>
         <!-- .vcxproj and .nativeproj contain a `ProjectConfiguration` item that have `Platform` metadata within.
              Build the `Platforms` property from that. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1888,6 +1888,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</IsRidAgnostic>
         <!-- Extract necessary information for SetPlatform negotiation -->
         <IsVcxOrNativeProj Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.nativeproj'">true</IsVcxOrNativeProj>
+        <Platform>$(Platform)</Platform>
         <Platforms>$(Platforms)</Platforms>
         <!-- .vcxproj and .nativeproj contain a `ProjectConfiguration` item that have `Platform` metadata within.
              Build the `Platforms` property from that. -->

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2928,6 +2928,9 @@
   <data name="GetCompatiblePlatform.AnyCPUDefault">
     <value>Choosing AnyCPU by default.</value>
   </data>
+  <data name="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+    <value>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</value>
+  </data>
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2906,7 +2906,7 @@
     <comment>{StrBegin="MSB3981: "}</comment>
   </data>
   <data name="GetCompatiblePlatform.NoPlatformsListed">
-    <value>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</value>
+    <value>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</value>
     <comment>{StrBegin="MSB3982: "}</comment>
   </data>
   <data name="GetCompatiblePlatform.InvalidLookupTableFormat">

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution je true, ale odkazovaný projekt {0} nemá nastavená metadata pro platformy. Sestaví se bez zadané platformy.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference a aktuální projekt mají stejnou platformu.</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution je true, ale odkazovaný projekt {0} nemá nastavená metadata pro platformy. Sestaví se bez zadané platformy.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution je true, ale odkazovaný projekt {0} nemá nastavená metadata pro platformy. Sestaví se bez zadané platformy.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution ist "true". Das referenzierte Projekt "{0}" enthält jedoch keine Metadaten für "Platforms". Es wird ohne eine angegebene Plattform erstellt.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution ist "true". Das referenzierte Projekt "{0}" enthält jedoch keine Metadaten für "Platforms". Es wird ohne eine angegebene Plattform erstellt.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution ist "true". Das referenzierte Projekt "{0}" enthält jedoch keine Metadaten für "Platforms". Es wird ohne eine angegebene Plattform erstellt.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference und das aktuelle Projekt haben die gleiche Plattform.</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution es true, pero el proyecto al que se hace referencia, "{0}", no tiene establecido ningún conjunto de metadatos "Platforms". Se compilará sin una plataforma especificada.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference y el proyecto actual tienen la misma plataforma.</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution es true, pero el proyecto al que se hace referencia, "{0}", no tiene establecido ningún conjunto de metadatos "Platforms". Se compilará sin una plataforma especificada.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution es true, pero el proyecto al que se hace referencia, "{0}", no tiene establecido ningún conjunto de metadatos "Platforms". Se compilará sin una plataforma especificada.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution a la valeur true, mais le projet référencé '{0}' n’a pas de métadonnées ’Platforms’ définies. Il sera généré sans une plateforme spécifiée.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference et le projet actuel ont la même plateforme.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution a la valeur true, mais le projet référencé '{0}' n’a pas de métadonnées ’Platforms’ définies. Il sera généré sans une plateforme spécifiée.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution a la valeur true, mais le projet référencé '{0}' n’a pas de métadonnées ’Platforms’ définies. Il sera généré sans une plateforme spécifiée.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution è true ma il progetto di riferimento '{0}' non ha un set di metadati 'Platforms'. Verrà compilato senza una piattaforma specificata.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution è true ma il progetto di riferimento '{0}' non ha un set di metadati 'Platforms'. Verrà compilato senza una piattaforma specificata.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution è true ma il progetto di riferimento '{0}' non ha un set di metadati 'Platforms'. Verrà compilato senza una piattaforma specificata.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference e il progetto corrente hanno la stessa piattaforma.</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution は true ですが、参照対象プロジェクト '{0}' に 'プラットフォーム' メタデータが設定されていません。これは、指定されたプラットフォームなしでビルドされます。</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference と現在のプロジェクトに同じプラットフォームがあります。</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution は true ですが、参照対象プロジェクト '{0}' に 'プラットフォーム' メタデータが設定されていません。これは、指定されたプラットフォームなしでビルドされます。</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution は true ですが、参照対象プロジェクト '{0}' に 'プラットフォーム' メタデータが設定されていません。これは、指定されたプラットフォームなしでビルドされます。</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution이 true이지만 참조된 프로젝트 '{0}'에 '플랫폼' 메타데이터 세트가 없습니다. 지정된 플랫폼 없이 구축됩니다.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference와 현재 프로젝트는 동일한 플랫폼을 가지고 있습니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution이 true이지만 참조된 프로젝트 '{0}'에 '플랫폼' 메타데이터 세트가 없습니다. 지정된 플랫폼 없이 구축됩니다.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution이 true이지만 참조된 프로젝트 '{0}'에 '플랫폼' 메타데이터 세트가 없습니다. 지정된 플랫폼 없이 구축됩니다.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: element EnableDynamicPlatformResolution ma wartość true, ale projekt "{0}", do którego się odnosi, nie ma ustawionych metadanych "Platformy". Zostanie on skompilowany bez określonej platformy.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: element EnableDynamicPlatformResolution ma wartość true, ale projekt "{0}", do którego się odnosi, nie ma ustawionych metadanych "Platformy". Zostanie on skompilowany bez określonej platformy.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: element EnableDynamicPlatformResolution ma wartość true, ale projekt "{0}", do którego się odnosi, nie ma ustawionych metadanych "Platformy". Zostanie on skompilowany bez określonej platformy.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">Element ProjectReference i bieżący projekt mają tę samą platformę.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution é verdadeiro, mas o projeto referenciado '{0}' não tem nenhum conjunto de metadados de 'Plataformas'. Ele será criado sem uma plataforma especificada.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">O ProjectReference e o projeto atual têm a mesma plataforma.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution é verdadeiro, mas o projeto referenciado '{0}' não tem nenhum conjunto de metadados de 'Plataformas'. Ele será criado sem uma plataforma especificada.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution é verdadeiro, mas o projeto referenciado '{0}' não tem nenhum conjunto de metadados de 'Plataformas'. Ele será criado sem uma plataforma especificada.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution имеет значение true, но у указанного проекта "{0}" нет заданных метаданных "Platforms". Сборка будет выполнена без указанной платформы.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference и текущий проект используют одну платформу.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution имеет значение true, но у указанного проекта "{0}" нет заданных метаданных "Platforms". Сборка будет выполнена без указанной платформы.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution имеет значение true, но у указанного проекта "{0}" нет заданных метаданных "Platforms". Сборка будет выполнена без указанной платформы.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution doğru ancak başvurulan proje '{0}', 'Platforms' meta veri kümesine sahip değil. Belirli bir platform olmadan oluşturulacak.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference ve geçerli proje aynı platforma sahip.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution doğru ancak başvurulan proje '{0}', 'Platforms' meta veri kümesine sahip değil. Belirli bir platform olmadan oluşturulacak.</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution doğru ancak başvurulan proje '{0}', 'Platforms' meta veri kümesine sahip değil. Belirli bir platform olmadan oluşturulacak.</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution 为 true，但引用的项目 "{0}" 没有设置 "Platforms" 元数据。它将在没有指定平台的情况下生成。</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference 和当前项目具有相同的平台。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution 为 true，但引用的项目 "{0}" 没有设置 "Platforms" 元数据。它将在没有指定平台的情况下生成。</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution 为 true，但引用的项目 "{0}" 没有设置 "Platforms" 元数据。它将在没有指定平台的情况下生成。</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1362,8 +1362,8 @@
         <note>{StrBegin="MSB3981: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.NoPlatformsListed">
-        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' metadata set. It will be built without a specified platform.</source>
-        <target state="translated">MSB3982: EnableDynamicPlatformResolution 為 true，但參考的專案 '{0}' 未設定 'Platforms' 中繼資料。它將在沒有指定平台的情況下建置。</target>
+        <source>MSB3982: EnableDynamicPlatformResolution is true but referenced project '{0}' has no 'Platforms' or 'Platform' metadata set. It will be built without a specified platform.</source>
+        <target state="needs-review-translation">MSB3982: EnableDynamicPlatformResolution 為 true，但參考的專案 '{0}' 未設定 'Platforms' 中繼資料。它將在沒有指定平台的情況下建置。</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
       <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1366,6 +1366,11 @@
         <target state="translated">MSB3982: EnableDynamicPlatformResolution 為 true，但參考的專案 '{0}' 未設定 'Platforms' 中繼資料。它將在沒有指定平台的情況下建置。</target>
         <note>{StrBegin="MSB3982: "}</note>
       </trans-unit>
+      <trans-unit id="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
+        <source>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</source>
+        <target state="new">Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GetCompatiblePlatform.SamePlatform">
         <source>ProjectReference and current project have the same platform.</source>
         <target state="translated">ProjectReference 和目前的專案有相同的平台。</target>


### PR DESCRIPTION
Reduces the number of evaluations in platform-negotiated builds.

### Context
A (Platform=x86) -> B (Platforms=x64;x86, Platform=x86) (A, a project built as x86 references B, a project that _can_ build as x86 or x64, but will default to x86 if built in isolation)

Prior to this change, platform negotiation would build B with `SetPlatform=Platform=x86`, causing a new evaluation. This can be avoided because it would have built as `x86` with or without that global property being passed.

### Changes Made
`GetTargetFrameworks` target now also returns the `Platform` property from the target. During platform negotiation, if the referenced project's platform matches the current project's platform, we now decide to build that project **without** passing a global `Platform` property. This prevents a new evaluation and will maximize the number of re-used evaluations during platform negotiation.

### Testing
Created new UT for this.

### Notes
Commit by commit review may make it easier.