### PR TITLE
Parallelize Node Spawning

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2617,7 +2617,6 @@ namespace Microsoft.Build.Execution
                             _noNodesActiveEvent.Reset();
                             _activeNodes.Add(node.NodeId);
                         }
-                        ErrorUtilities.VerifyThrow(_activeNodes.Count != 0, "Still 0 nodes after asking for a new node.  Build cannot proceed.");
 
                         IEnumerable<ScheduleResponse> newResponses = _scheduler.ReportNodesCreated(newNodes);
                         PerformSchedulingActions(newResponses);

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2602,11 +2602,7 @@ namespace Microsoft.Build.Execution
                         break;
 
                     case ScheduleActionType.CreateNode:
-                        var nodeConfig = GetNodeConfiguration();
-
-                        IList<NodeInfo> newNodes;
-
-                        newNodes = _nodeManager.CreateNodes(nodeConfig, response.RequiredNodeType, response.NumberOfNodesToCreate);
+                        IList<NodeInfo> newNodes = _nodeManager.CreateNodes(GetNodeConfiguration(), response.RequiredNodeType, response.NumberOfNodesToCreate);
 
                         if (newNodes?.Count != response.NumberOfNodesToCreate || newNodes.Any(n => n == null))
                         {
@@ -2620,8 +2616,8 @@ namespace Microsoft.Build.Execution
                         {
                             _noNodesActiveEvent.Reset();
                             _activeNodes.Add(node.NodeId);
-                            ErrorUtilities.VerifyThrow(_activeNodes.Count != 0, "Still 0 nodes after asking for a new node.  Build cannot proceed.");
                         }
+                        ErrorUtilities.VerifyThrow(_activeNodes.Count != 0, "Still 0 nodes after asking for a new node.  Build cannot proceed.");
 
                         IEnumerable<ScheduleResponse> newResponses = _scheduler.ReportNodesCreated(newNodes);
                         PerformSchedulingActions(newResponses);

--- a/src/Build/BackEnd/Components/Communications/INodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/INodeManager.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Microsoft.Build.Execution;
-
-#nullable disable
 
 namespace Microsoft.Build.BackEnd
 {
@@ -21,11 +20,12 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="configuration">The configuration to use to create the node.</param>
         /// <param name="affinity">The <see cref="NodeAffinity"/> to use.</param>
+        /// <param name="numberOfNodesToCreate">Number of nodes to be reused or created.</param>
         /// <returns>Information about the node created</returns>
         /// <remarks>
         /// Throws an exception if the node could not be created.
         /// </remarks>
-        NodeInfo CreateNode(NodeConfiguration configuration, NodeAffinity affinity);
+        IList<NodeInfo> CreateNodes(NodeConfiguration configuration, NodeAffinity affinity, int numberOfNodesToCreate);
 
         /// <summary>
         /// Sends a data packet to a specific node

--- a/src/Build/BackEnd/Components/Communications/INodeProvider.cs
+++ b/src/Build/BackEnd/Components/Communications/INodeProvider.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
+using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -57,14 +58,15 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Requests that a new node be created on the specified machine.
         /// </summary>
-        /// <param name="nodeId">The id to assign to the node.</param>
+        /// <param name="nextNodeId">The id to assign to the first created node. Following nodes ids will be increasing by 1.</param>
         /// <param name="packetFactory">
         /// The packet factory used to create packets when data is
         /// received on this node.
         /// </param>
-        /// <param name="configuration">The configuration to use to create the remote node.</param>
-        /// <returns>True if the node was created, false otherwise.</returns>
-        bool CreateNode(int nodeId, INodePacketFactory packetFactory, NodeConfiguration configuration);
+        /// <param name="configurationFactory">NodeConfiguration factory of particular node</param>
+        /// <param name="numberOfNodesToCreate">Required number of nodes to create</param>
+        /// <returns>Array of NodeInfo which size is equal of successfully created nodes</returns>
+        IList<NodeInfo> CreateNodes(int nextNodeId, INodePacketFactory packetFactory, Func<NodeInfo, NodeConfiguration> configurationFactory, int numberOfNodesToCreate);
 
         /// <summary>
         /// Sends data to a specific node.

--- a/src/Build/BackEnd/Components/Communications/INodeProvider.cs
+++ b/src/Build/BackEnd/Components/Communications/INodeProvider.cs
@@ -58,14 +58,14 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Requests that a new node be created on the specified machine.
         /// </summary>
-        /// <param name="nextNodeId">The id to assign to the first created node. Following nodes ids will be increasing by 1.</param>
+        /// <param name="nextNodeId">The id to assign to the first created node. Resulting nodes ids will be in range [nextNodeId, nextNodeId + numberOfNodesToCreate - 1]</param>
         /// <param name="packetFactory">
         /// The packet factory used to create packets when data is
         /// received on this node.
         /// </param>
         /// <param name="configurationFactory">NodeConfiguration factory of particular node</param>
         /// <param name="numberOfNodesToCreate">Required number of nodes to create</param>
-        /// <returns>Array of NodeInfo which size is equal of successfully created nodes</returns>
+        /// <returns>Array of NodeInfo of successfully created nodes</returns>
         IList<NodeInfo> CreateNodes(int nextNodeId, INodePacketFactory packetFactory, Func<NodeInfo, NodeConfiguration> configurationFactory, int numberOfNodesToCreate);
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Communications/INodeProvider.cs
+++ b/src/Build/BackEnd/Components/Communications/INodeProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Build.BackEnd
 
         public IEnumerable<Process> GetProcesses()
         {
-            return _outOfProcNodeProvider?.GetProcesses() ?? new List<Process>(0);
+            return _outOfProcNodeProvider?.GetProcesses() ?? IEnumerable.Empty();
         }
     }
 }

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Build.BackEnd
             // We will prefer to make nodes on the "closest" providers first; in-proc, then
             // out-of-proc, then remote.
             // When we support distributed build, we will also consider the remote provider.
-            List<NodeInfo> nodes = new();
+            List<NodeInfo> nodes = new(numberOfNodesToCreate);
             if ((nodeAffinity == NodeAffinity.Any || nodeAffinity == NodeAffinity.InProc) && !_componentHost!.BuildParameters.DisableInProcNode)
             {
                 nodes.AddRange(AttemptCreateNode(_inProcNodeProvider!, configuration, numberOfNodesToCreate));

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Diagnostics;
 using System.Linq;
 
+#nullable disable
+
 namespace Microsoft.Build.BackEnd
 {
     /// <summary>

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Build.BackEnd
 
         public IEnumerable<Process> GetProcesses()
         {
-            return _outOfProcNodeProvider?.GetProcesses() ?? IEnumerable.Empty();
+            return _outOfProcNodeProvider?.GetProcesses()!;
         }
     }
 }

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Execution;
+using System.Threading;
 
 #nullable disable
 
@@ -329,8 +330,7 @@ namespace Microsoft.Build.BackEnd
             }
             else
             {
-                nodeId = _nextNodeId;
-                _nextNodeId++;
+                nodeId = Interlocked.Increment(ref _nextNodeId) - 1;
             }
 
             NodeConfiguration configToSend = nodeConfiguration.Clone();

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -7,9 +7,6 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Execution;
 using System.Threading;
 using System.Diagnostics;
-using System.Linq;
-
-#nullable disable
 
 namespace Microsoft.Build.BackEnd
 {
@@ -352,7 +349,7 @@ namespace Microsoft.Build.BackEnd
 
         public IEnumerable<Process> GetProcesses()
         {
-            return _outOfProcNodeProvider.GetProcesses();
+            return _outOfProcNodeProvider?.GetProcesses() ?? new List<Process>(0);
         }
     }
 }

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Execution;
 using System.Threading;
-
-#nullable disable
 
 namespace Microsoft.Build.BackEnd
 {
@@ -18,29 +16,24 @@ namespace Microsoft.Build.BackEnd
     internal class NodeManager : INodeManager
     {
         /// <summary>
-        /// The invalid node id
-        /// </summary>
-        private const int InvalidNodeId = 0;
-
-        /// <summary>
         /// The node provider for the in-proc node.
         /// </summary>
-        private INodeProvider _inProcNodeProvider;
+        private INodeProvider? _inProcNodeProvider;
 
         /// <summary>
         /// The node provider for out-of-proc nodes.
         /// </summary> 
-        private INodeProvider _outOfProcNodeProvider;
+        private INodeProvider? _outOfProcNodeProvider;
 
         /// <summary>
         /// The build component host.
         /// </summary>
-        private IBuildComponentHost _componentHost;
+        private IBuildComponentHost? _componentHost;
 
         /// <summary>
         /// Mapping of manager-produced node IDs to the provider hosting the node.
         /// </summary>
-        private ConcurrentDictionary<int, INodeProvider> _nodeIdToProvider;
+        private readonly Dictionary<int, INodeProvider> _nodeIdToProvider;
 
         /// <summary>
         /// The packet factory used to translate and route packets
@@ -81,7 +74,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private NodeManager()
         {
-            _nodeIdToProvider = new ConcurrentDictionary<int, INodeProvider>();
+            _nodeIdToProvider = new Dictionary<int, INodeProvider>();
             _packetFactory = new NodePacketFactory();
             _nextNodeId = _inprocNodeId + 1;
         }
@@ -93,32 +86,31 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="configuration">The configuration to use for the remote node.</param>
         /// <param name="nodeAffinity">The <see cref="NodeAffinity"/> to use.</param>
+        /// <param name="numberOfNodesToCreate">Number of nodes to be reused ot created.</param>
         /// <returns>A NodeInfo describing the node created, or null if none could be created.</returns>
-        public NodeInfo CreateNode(NodeConfiguration configuration, NodeAffinity nodeAffinity)
+        public IList<NodeInfo> CreateNodes(NodeConfiguration configuration, NodeAffinity nodeAffinity, int numberOfNodesToCreate)
         {
             // We will prefer to make nodes on the "closest" providers first; in-proc, then
             // out-of-proc, then remote.
             // When we support distributed build, we will also consider the remote provider.
-            int nodeId = InvalidNodeId;
-            if ((nodeAffinity == NodeAffinity.Any || nodeAffinity == NodeAffinity.InProc) && !_componentHost.BuildParameters.DisableInProcNode)
+            List<NodeInfo> nodes = new();
+            if ((nodeAffinity == NodeAffinity.Any || nodeAffinity == NodeAffinity.InProc) && !_componentHost!.BuildParameters.DisableInProcNode)
             {
-                nodeId = AttemptCreateNode(_inProcNodeProvider, configuration);
+                nodes.AddRange(AttemptCreateNode(_inProcNodeProvider!, configuration, numberOfNodesToCreate));
             }
 
-            if (nodeId == InvalidNodeId && (nodeAffinity == NodeAffinity.Any || nodeAffinity == NodeAffinity.OutOfProc))
+            if (nodes.Count < numberOfNodesToCreate && (nodeAffinity == NodeAffinity.Any || nodeAffinity == NodeAffinity.OutOfProc))
             {
-                nodeId = AttemptCreateNode(_outOfProcNodeProvider, configuration);
-            }
-
-            if (nodeId == InvalidNodeId)
-            {
-                return null;
+                nodes.AddRange(AttemptCreateNode(_outOfProcNodeProvider!, configuration, numberOfNodesToCreate - nodes.Count));
             }
 
             // If we created a node, they should no longer be considered shut down.
-            _nodesShutdown = false;
+            if (nodes.Count > 0)
+            {
+                _nodesShutdown = false;
+            }
 
-            return new NodeInfo(nodeId, _nodeIdToProvider[nodeId].ProviderType);
+            return nodes;
         }
 
         /// <summary>
@@ -128,14 +120,14 @@ namespace Microsoft.Build.BackEnd
         /// <param name="packet">The packet to send.</param>
         public void SendData(int node, INodePacket packet)
         {
-            // Look up the node provider for this node in the mapping.
-            if (!_nodeIdToProvider.TryGetValue(node, out INodeProvider provider))
+            if (!_nodeIdToProvider.TryGetValue(node, out INodeProvider? provider))
             {
                 ErrorUtilities.ThrowInternalError("Node {0} does not have a provider.", node);
             }
-
-            // Send the data.
-            provider.SendData(node, packet);
+            else
+            {
+                provider.SendData(node, packet);
+            }
         }
 
         /// <summary>
@@ -177,7 +169,7 @@ namespace Microsoft.Build.BackEnd
         {
             ErrorUtilities.VerifyThrow(_componentHost == null, "NodeManager already initialized.");
             ErrorUtilities.VerifyThrow(host != null, "We can't create a NodeManager with a null componentHost");
-            _componentHost = host;
+            _componentHost = host!;
 
             _inProcNodeProvider = _componentHost.GetComponent(BuildComponentType.InProcNodeProvider) as INodeProvider;
             _outOfProcNodeProvider = _componentHost.GetComponent(BuildComponentType.OutOfProcNodeProvider) as INodeProvider;
@@ -293,8 +285,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void RemoveNodeFromMapping(int nodeId)
         {
-            _nodeIdToProvider.TryRemove(nodeId, out _);
-            if (_nodeIdToProvider.IsEmpty)
+            _nodeIdToProvider.Remove(nodeId);
+            if (_nodeIdToProvider.Count == 0)
             {
                 // The inproc node is always 1 therefore when new nodes are requested we need to start at 2
                 _nextNodeId = _inprocNodeId + 1;
@@ -306,46 +298,52 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="nodeProvider">The provider used to create the node.</param>
         /// <param name="nodeConfiguration">The <see cref="NodeConfiguration"/> to use.</param>
-        /// <returns>The id of the node created.</returns>
-        private int AttemptCreateNode(INodeProvider nodeProvider, NodeConfiguration nodeConfiguration)
+        /// <param name="numberOfNodesToCreate">Number of nodes to be reused ot created.</param>
+        /// <returns>List of created nodes.</returns>
+        private IList<NodeInfo> AttemptCreateNode(INodeProvider nodeProvider, NodeConfiguration nodeConfiguration, int numberOfNodesToCreate)
         {
             // If no provider was passed in, we obviously can't create a node.
             if (nodeProvider == null)
             {
                 ErrorUtilities.ThrowInternalError("No node provider provided.");
-                return InvalidNodeId;
+                return new List<NodeInfo>();
             }
 
             // Are there any free slots on this provider?
             if (nodeProvider.AvailableNodes == 0)
             {
-                return InvalidNodeId;
+                return new List<NodeInfo>();
             }
 
             // Assign a global ID to the node we are about to create.
-            int nodeId;
+            int fromNodeId;
             if (nodeProvider is NodeProviderInProc)
             {
-                nodeId = _inprocNodeId;
+                fromNodeId = _inprocNodeId;
             }
             else
             {
-                nodeId = Interlocked.Increment(ref _nextNodeId) - 1;
+                // Reserve node numbers for all needed nodes.
+                fromNodeId = Interlocked.Add(ref _nextNodeId, numberOfNodesToCreate) - numberOfNodesToCreate;
             }
 
-            NodeConfiguration configToSend = nodeConfiguration.Clone();
-            configToSend.NodeId = nodeId;
 
             // Create the node and add it to our mapping.
-            bool createdNode = nodeProvider.CreateNode(nodeId, this, configToSend);
+            IList<NodeInfo> nodes = nodeProvider.CreateNodes(fromNodeId, this, AcquiredNodeConfigurationFactory, numberOfNodesToCreate);
 
-            if (!createdNode)
+            foreach (NodeInfo node in nodes)
             {
-                return InvalidNodeId;
+                _nodeIdToProvider.Add(node.NodeId, nodeProvider);
             }
 
-            _nodeIdToProvider.TryAdd(nodeId, nodeProvider);
-            return nodeId;
+            return nodes;
+
+            NodeConfiguration AcquiredNodeConfigurationFactory(NodeInfo nodeInfo)
+            {
+                var config = nodeConfiguration.Clone();
+                config.NodeId = nodeInfo.NodeId;
+                return config;
+            }
         }
     }
 }

--- a/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Build.BackEnd
                 NodeInfo nodeInfo = new(nodeId, ProviderType);
                 if (!CreateNode(nodeId, factory, configurationFactory(nodeInfo)))
                 {
-                    // If it fails let it return what we have crated so far to so caller can somehow acquire missing nodes.
+                    // If it fails let it return what we have created so far so caller can somehow acquire missing nodes.
                     break;
                 }
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
@@ -193,10 +193,12 @@ namespace Microsoft.Build.BackEnd
             {
                 int nodeId = nextNodeId + i;
 
-                NodeInfo nodeInfo = CreateNode(nodeId, factory, configurationFactory);
-                // If it fails let it return what we have crated so far to so caller can somehow acquire missing nodes.
-                if (nodeInfo == null)
+                NodeInfo nodeInfo = new(nodeId, ProviderType);
+                if (!CreateNode(nodeId, factory, configurationFactory(nodeInfo)))
+                {
+                    // If it fails let it return what we have crated so far to so caller can somehow acquire missing nodes.
                     break;
+                }
 
                 nodes.Add(nodeInfo);
             }
@@ -209,8 +211,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="nodeId">The id of the node to create.</param>
         /// <param name="factory">The factory to use to create packets from this node.</param>
-        /// <param name="configurationFactory">The configuration factory for the node.</param>
-        private NodeInfo CreateNode(int nodeId, INodePacketFactory factory, Func<NodeInfo, NodeConfiguration> configurationFactory)
+        /// <param name="configuration">The configuration for the node.</param>
+        private bool CreateNode(int nodeId, INodePacketFactory factory, NodeConfiguration configuration)
         {
             ErrorUtilities.VerifyThrow(nodeId != InvalidInProcNodeId, "Cannot create in-proc node.");
 
@@ -235,7 +237,7 @@ namespace Microsoft.Build.BackEnd
                     if (!InProcNodeOwningOperatingEnvironment.WaitOne(0))
                     {
                         // Can't take the operating environment.
-                        return null;
+                        return false;
                     }
                 }
             }
@@ -245,16 +247,14 @@ namespace Microsoft.Build.BackEnd
             {
                 if (!InstantiateNode(factory))
                 {
-                    return null;
+                    return false;
                 }
             }
 
-            NodeInfo nodeInfo = new(nodeId, ProviderType);
-
-            _inProcNodeEndpoint.SendData(configurationFactory(nodeInfo));
+            _inProcNodeEndpoint.SendData(configuration);
             _inProcNodeId = nodeId;
 
-            return nodeInfo;
+            return true;
         }
 
         #endregion

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -96,10 +96,9 @@ namespace Microsoft.Build.BackEnd
             // (next to msbuild.exe) is ignored.
             string commandLineArgs = $"/nologo /nodemode:1 /nodeReuse:{ComponentHost.BuildParameters.EnableNodeReuse.ToString().ToLower()} /low:{ComponentHost.BuildParameters.LowPriority.ToString().ToLower()}";
 
-            // Make it here.
-            CommunicationsUtilities.Trace("Starting to acquire a new or existing {1} node(s) to establish nodes starting from ID {0}...", nextNodeId, numberOfNodesToCreate);
+            CommunicationsUtilities.Trace("Starting to acquire {1} new or existing node(s) to establish nodes from ID {0} to {2}...", nextNodeId, numberOfNodesToCreate, nextNodeId + numberOfNodesToCreate - 1);
 
-            Handshake hostHandshake = new Handshake(CommunicationsUtilities.GetHandshakeOptions(taskHost: false, nodeReuse: ComponentHost.BuildParameters.EnableNodeReuse, lowPriority: ComponentHost.BuildParameters.LowPriority, is64Bit: EnvironmentUtilities.Is64BitProcess));
+            Handshake hostHandshake = new(CommunicationsUtilities.GetHandshakeOptions(taskHost: false, nodeReuse: ComponentHost.BuildParameters.EnableNodeReuse, lowPriority: ComponentHost.BuildParameters.LowPriority, is64Bit: EnvironmentUtilities.Is64BitProcess));
 
             IList<NodeContext> nodeContexts = GetNodes(null, commandLineArgs, nextNodeId, factory, hostHandshake, NodeContextCreated, NodeContextTerminated, numberOfNodesToCreate);
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Framework;

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Build.BackEnd
             //   we add into _nodeContexts premise of future node and verify that it will not cross limits.
             if (_nodeContexts.Count + numberOfNodesToCreate > ComponentHost.BuildParameters.MaxNodeCount)
             {
-                ErrorUtilities.ThrowInternalError("Exceeded max node count of '{0}'; current count '{_nodeContexts.Count}' ", _nodeContexts.Count);
+                ErrorUtilities.ThrowInternalError("Exceeded max node count of '{0}', current count is '{1}' ", ComponentHost.BuildParameters.MaxNodeCount, _nodeContexts.Count);
                 return new List<NodeInfo>();
             }
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Build.BackEnd
             {
                 while (possibleRunningNodes != null && possibleRunningNodes.TryDequeue(out var nodeToReuse))
                 {
-                    CommunicationsUtilities.Trace("Trying to connect to existing process with id {1} '{2} {3}' to establish node {0}...", nodeId, nodeToReuse.Id, nodeToReuse.ProcessName, nodeToReuse.StartInfo.Arguments);
+                    CommunicationsUtilities.Trace("Trying to connect to existing process {2} with id {1} to establish node {0}...", nodeId, nodeToReuse.Id, nodeToReuse.ProcessName);
                     if (nodeToReuse.Id == Process.GetCurrentProcess().Id)
                     {
                         continue;

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
@@ -23,8 +24,6 @@ using Microsoft.Build.Exceptions;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
-using Microsoft.Build.Utilities;
-
 using BackendNativeMethods = Microsoft.Build.BackEnd.NativeMethods;
 using Task = System.Threading.Tasks.Task;
 using Microsoft.Build.Framework;
@@ -70,6 +69,12 @@ namespace Microsoft.Build.BackEnd
         /// We decided to use ConcurrentDictionary of(string, byte) as common implementation of ConcurrentHashSet.
         /// </summary>
         private readonly ConcurrentDictionary<string, byte /*void*/> _processesToIgnore = new();
+
+        /// <summary>
+        /// Delegate used to tell the node provider that a context has been created.
+        /// </summary>
+        /// <param name="context">The created node context.</param>
+        internal delegate void NodeContextCreatedDelegate(NodeContext context);
 
         /// <summary>
         /// Delegate used to tell the node provider that a context has terminated.
@@ -144,7 +149,7 @@ namespace Microsoft.Build.BackEnd
             // INodePacketFactory
             INodePacketFactory factory = new NodePacketFactory();
 
-            List<Process> nodeProcesses = GetPossibleRunningNodes().nodeProcesses;
+            List<Process> nodeProcesses = GetPossibleRunningNodes().nodeProcesses.ToList();
 
             // Find proper MSBuildTaskHost executable name
             string msbuildtaskhostExeName = NodeProviderOutOfProcTaskHost.TaskHostNameForClr2TaskHost;
@@ -179,10 +184,16 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Finds or creates a child process which can act as a node.
+        /// Finds or creates a child processes which can act as a node.
         /// </summary>
-        /// <returns>The pipe stream representing the node.</returns>
-        protected NodeContext GetNode(string msbuildLocation, string commandLineArgs, int nodeId, INodePacketFactory factory, Handshake hostHandshake, NodeContextTerminateDelegate terminateNode)
+        protected IList<NodeContext> GetNodes(string msbuildLocation,
+            string commandLineArgs,
+            int nextNodeId,
+            INodePacketFactory factory,
+            Handshake hostHandshake,
+            NodeContextCreatedDelegate createNode,
+            NodeContextTerminateDelegate terminateNode,
+            int numberOfNodesToCreate)
         {
 #if DEBUG
             if (Execution.BuildManager.WaitForDebugger)
@@ -207,22 +218,56 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
+            // Get all process of possible running node processes for reuse and put them into ConcurrentQueue.
+            // Processes from this queue will be concurrently consumed by TryReusePossibleRunningNodes while
+            //    trying to connect to them and reuse them. When queue is empty, no process to reuse left
+            //    new node process will be started.
+            string expectedProcessName = null;
+            ConcurrentQueue<Process> possibleRunningNodes = null;
 #if FEATURE_NODE_REUSE
             // Try to connect to idle nodes if node reuse is enabled.
             if (_componentHost.BuildParameters.EnableNodeReuse)
             {
-                (string expectedProcessName, List<Process> processes) runningNodesTuple = GetPossibleRunningNodes(msbuildLocation);
-
-                CommunicationsUtilities.Trace("Attempting to connect to each existing {1} process in turn to establish node {0}...", nodeId, runningNodesTuple.expectedProcessName);
-                foreach (Process nodeProcess in runningNodesTuple.processes)
+                (expectedProcessName, possibleRunningNodes) = GetPossibleRunningNodes(msbuildLocation);
+            }
+#endif
+            ConcurrentQueue<NodeContext> nodeContexts = new();
+            ConcurrentQueue<Exception> exceptions = new();
+            Parallel.For(nextNodeId, nextNodeId + numberOfNodesToCreate, (nodeId) =>
+            {
+                try
                 {
-                    if (nodeProcess.Id == Process.GetCurrentProcess().Id)
+                    if (!TryReuseAnyFromPossibleRunningNodes(nodeId) && !StartNewNode(nodeId))
+                    {
+                        // We were unable to reuse or launch a node.
+                        CommunicationsUtilities.Trace("FAILED TO CONNECT TO A CHILD NODE");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // It will be rethrown as aggregate exception
+                    exceptions.Enqueue(ex);
+                }
+            });
+            if (!exceptions.IsEmpty)
+            {
+                ErrorUtilities.ThrowInternalError("Cannot acquire required number of nodes.", new AggregateException(exceptions.ToArray()));
+            }
+
+            return nodeContexts.ToList();
+
+            bool TryReuseAnyFromPossibleRunningNodes(int nodeId)
+            {
+                while (possibleRunningNodes != null && possibleRunningNodes.TryDequeue(out var nodeToReuse))
+                {
+                    CommunicationsUtilities.Trace("Try to connect to each existing {0} process candidate to establish node {1}...", expectedProcessName, nodeId);
+                    if (nodeToReuse.Id == Process.GetCurrentProcess().Id)
                     {
                         continue;
                     }
 
                     // Get the full context of this inspection so that we can always skip this process when we have the same taskhost context
-                    string nodeLookupKey = GetProcessesToIgnoreKey(hostHandshake, nodeProcess.Id);
+                    string nodeLookupKey = GetProcessesToIgnoreKey(hostHandshake, nodeToReuse.Id);
                     if (_processesToIgnore.ContainsKey(nodeLookupKey))
                     {
                         continue;
@@ -232,90 +277,107 @@ namespace Microsoft.Build.BackEnd
                     _processesToIgnore.TryAdd(nodeLookupKey, default);
 
                     // Attempt to connect to each process in turn.
-                    Stream nodeStream = TryConnectToProcess(nodeProcess.Id, 0 /* poll, don't wait for connections */, hostHandshake);
+                    Stream nodeStream = TryConnectToProcess(nodeToReuse.Id, 0 /* poll, don't wait for connections */, hostHandshake);
                     if (nodeStream != null)
                     {
                         // Connection successful, use this node.
-                        CommunicationsUtilities.Trace("Successfully connected to existed node {0} which is PID {1}", nodeId, nodeProcess.Id);
-                        return new NodeContext(nodeId, nodeProcess, nodeStream, factory, terminateNode);
+                        CommunicationsUtilities.Trace("Successfully connected to existed node {0} which is PID {1}", nodeId, nodeToReuse.Id);
+
+                        CreateNodeContext(nodeId, nodeToReuse, nodeStream);
+                        return true;
                     }
                 }
-            }
-#endif
 
-            // None of the processes we tried to connect to allowed a connection, so create a new one.
-            // We try this in a loop because it is possible that there is another MSBuild multiproc
-            // host process running somewhere which is also trying to create nodes right now.  It might
-            // find our newly created node and connect to it before we get a chance.
-            CommunicationsUtilities.Trace("Could not connect to existing process, now creating a process...");
-            int retries = NodeCreationRetries;
-            while (retries-- > 0)
+                return false;
+            }
+
+            // Create a new node process.
+            bool StartNewNode(int nodeId)
             {
-#if FEATURE_NET35_TASKHOST
-                // We will also check to see if .NET 3.5 is installed in the case where we need to launch a CLR2 OOP TaskHost.
-                // Failure to detect this has been known to stall builds when Windows pops up a related dialog.
-                // It's also a waste of time when we attempt several times to launch multiple MSBuildTaskHost.exe (CLR2 TaskHost)
-                // nodes because we should never be able to connect in this case.
-                string taskHostNameForClr2TaskHost = Path.GetFileNameWithoutExtension(NodeProviderOutOfProcTaskHost.TaskHostNameForClr2TaskHost);
-                if (Path.GetFileNameWithoutExtension(msbuildLocation).Equals(taskHostNameForClr2TaskHost, StringComparison.OrdinalIgnoreCase))
+                CommunicationsUtilities.Trace("Could not connect to existing process, now creating a process...");
+
+                // We try this in a loop because it is possible that there is another MSBuild multiproc
+                // host process running somewhere which is also trying to create nodes right now.  It might
+                // find our newly created node and connect to it before we get a chance.
+                int retries = NodeCreationRetries;
+                while (retries-- > 0)
                 {
-                    if (FrameworkLocationHelper.GetPathToDotNetFrameworkV35(DotNetFrameworkArchitecture.Current) == null)
+#if FEATURE_NET35_TASKHOST
+                    // We will also check to see if .NET 3.5 is installed in the case where we need to launch a CLR2 OOP TaskHost.
+                    // Failure to detect this has been known to stall builds when Windows pops up a related dialog.
+                    // It's also a waste of time when we attempt several times to launch multiple MSBuildTaskHost.exe (CLR2 TaskHost)
+                    // nodes because we should never be able to connect in this case.
+                    string taskHostNameForClr2TaskHost = Path.GetFileNameWithoutExtension(NodeProviderOutOfProcTaskHost.TaskHostNameForClr2TaskHost);
+                    if (Path.GetFileNameWithoutExtension(msbuildLocation).Equals(taskHostNameForClr2TaskHost, StringComparison.OrdinalIgnoreCase))
                     {
-                        CommunicationsUtilities.Trace
+                        if (FrameworkLocationHelper.GetPathToDotNetFrameworkV35(DotNetFrameworkArchitecture.Current) == null)
+                        {
+                            CommunicationsUtilities.Trace
                             (
                                 "Failed to launch node from {0}. The required .NET Framework v3.5 is not installed or enabled. CommandLine: {1}",
                                 msbuildLocation,
                                 commandLineArgs
                             );
 
-                        string nodeFailedToLaunchError = ResourceUtilities.GetResourceString("TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled");
-                        throw new NodeFailedToLaunchException(null, nodeFailedToLaunchError);
+                            string nodeFailedToLaunchError = ResourceUtilities.GetResourceString("TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled");
+                            throw new NodeFailedToLaunchException(null, nodeFailedToLaunchError);
+                        }
                     }
-                }
 #endif
+                    // Create the node process
+                    Process msbuildProcess = LaunchNode(msbuildLocation, commandLineArgs);
+                    _processesToIgnore.TryAdd(GetProcessesToIgnoreKey(hostHandshake, msbuildProcess.Id), default);
 
-                // Create the node process
-                Process msbuildProcess = LaunchNode(msbuildLocation, commandLineArgs);
-                _processesToIgnore.TryAdd(GetProcessesToIgnoreKey(hostHandshake, msbuildProcess.Id), default);
+                    // Note, when running under IMAGEFILEEXECUTIONOPTIONS registry key to debug, the process ID
+                    // gotten back from CreateProcess is that of the debugger, which causes this to try to connect
+                    // to the debugger process. Instead, use MSBUILDDEBUGONSTART=1
 
-                // Note, when running under IMAGEFILEEXECUTIONOPTIONS registry key to debug, the process ID
-                // gotten back from CreateProcess is that of the debugger, which causes this to try to connect
-                // to the debugger process. Instead, use MSBUILDDEBUGONSTART=1
-
-                // Now try to connect to it.
-                Stream nodeStream = TryConnectToProcess(msbuildProcess.Id, TimeoutForNewNodeCreation, hostHandshake);
-                if (nodeStream != null)
-                {
-                    // Connection successful, use this node.
-                    CommunicationsUtilities.Trace("Successfully connected to created node {0} which is PID {1}", nodeId, msbuildProcess.Id);
-                    return new NodeContext(nodeId, msbuildProcess, nodeStream, factory, terminateNode);
-                }
-
-                if (msbuildProcess.HasExited)
-                {
-                    if (Traits.Instance.DebugNodeCommunication)
+                    // Now try to connect to it.
+                    Stream nodeStream = TryConnectToProcess(msbuildProcess.Id, TimeoutForNewNodeCreation, hostHandshake);
+                    if (nodeStream != null)
                     {
-                        try
+                        // Connection successful, use this node.
+                        CommunicationsUtilities.Trace("Successfully connected to created node {0} which is PID {1}", nodeId, msbuildProcess.Id);
+
+                        CreateNodeContext(nodeId, msbuildProcess, nodeStream);
+                        return true;
+                    }
+
+                    if (msbuildProcess.HasExited)
+                    {
+                        if (Traits.Instance.DebugNodeCommunication)
                         {
-                            CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with exit code {1}. This can indicate a crash at startup", msbuildProcess.Id, msbuildProcess.ExitCode);
-                        }
-                        catch (InvalidOperationException)
-                        {
-                            // This case is common on Windows where we called CreateProcess and the Process object
-                            // can't get the exit code.
-                            CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with unknown exit code. This can indicate a crash at startup", msbuildProcess.Id);
+                            try
+                            {
+                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with exit code {1}. This can indicate a crash at startup",
+                                    msbuildProcess.Id, msbuildProcess.ExitCode);
+                            }
+                            catch (InvalidOperationException)
+                            {
+                                // This case is common on Windows where we called CreateProcess and the Process object
+                                // can't get the exit code.
+                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with unknown exit code. This can indicate a crash at startup",
+                                    msbuildProcess.Id);
+                            }
                         }
                     }
+                    else
+                    {
+                        CommunicationsUtilities.Trace(
+                            "Could not connect to node with PID {0}; it is still running. This can occur when two multiprocess builds run in parallel and the other one 'stole' this node",
+                            msbuildProcess.Id);
+                    }
                 }
-                else
-                {
-                    CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it is still running. This can occur when two multiprocess builds run in parallel and the other one 'stole' this node", msbuildProcess.Id);
-                }
+
+                return false;
             }
 
-            // We were unable to launch a node.
-            CommunicationsUtilities.Trace("FAILED TO CONNECT TO A CHILD NODE");
-            return null;
+            void CreateNodeContext(int nodeId, Process nodeToReuse, Stream nodeStream)
+            {
+                NodeContext nodeContext = new(nodeId, nodeToReuse, nodeStream, factory, terminateNode);
+                nodeContexts.Enqueue(nodeContext);
+                createNode(nodeContext);
+            }
         }
 
         /// <summary>
@@ -324,9 +386,9 @@ namespace Microsoft.Build.BackEnd
         /// <param name="msbuildLocation"></param>
         /// <returns>
         /// Item 1 is the name of the process being searched for.
-        /// Item 2 is the list of processes themselves.
+        /// Item 2 is the queue of ordered processes themselves.
         /// </returns>
-        private (string expectedProcessName, List<Process> nodeProcesses) GetPossibleRunningNodes(string msbuildLocation = null)
+        private (string expectedProcessName, ConcurrentQueue<Process> nodeProcesses) GetPossibleRunningNodes(string msbuildLocation = null)
         {
             if (String.IsNullOrEmpty(msbuildLocation))
             {
@@ -335,12 +397,11 @@ namespace Microsoft.Build.BackEnd
 
             var expectedProcessName = Path.GetFileNameWithoutExtension(GetCurrentHost() ?? msbuildLocation);
 
-            List<Process> nodeProcesses = new List<Process>(Process.GetProcessesByName(expectedProcessName));
+            var processes = Process.GetProcessesByName(expectedProcessName);
+            Array.Sort(processes, (left, right) => left.Id.CompareTo(right.Id));
+            ConcurrentQueue<Process> orderedProcesses = new(processes);
 
-            // Trivial sort to try to prefer most recently used nodes
-            nodeProcesses.Sort((left, right) => left.Id - right.Id);
-
-            return (expectedProcessName, nodeProcesses);
+            return (expectedProcessName, orderedProcesses);
         }
 
         /// <summary>
@@ -728,6 +789,11 @@ namespace Microsoft.Build.BackEnd
                 _terminateDelegate = terminateDelegate;
                 _sharedReadBuffer = InterningBinaryReader.CreateSharedBuffer();
             }
+
+            /// <summary>
+            /// Id of node.
+            /// </summary>
+            public int NodeId => _nodeId;
 
             /// <summary>
             /// Starts a new asynchronous read operation for this node.

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -275,7 +275,10 @@ namespace Microsoft.Build.BackEnd
 
                 // Create the node process
                 Process msbuildProcess = LaunchNode(msbuildLocation, commandLineArgs);
-                _processesToIgnore.Add(GetProcessesToIgnoreKey(hostHandshake, msbuildProcess.Id));
+                if (_componentHost.BuildParameters.EnableNodeReuse)
+                {
+                    _processesToIgnore.Add(GetProcessesToIgnoreKey(hostHandshake, msbuildProcess.Id));
+                }
 
                 // Note, when running under IMAGEFILEEXECUTIONOPTIONS registry key to debug, the process ID
                 // gotten back from CreateProcess is that of the debugger, which causes this to try to connect

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -349,23 +349,19 @@ namespace Microsoft.Build.BackEnd
                         {
                             try
                             {
-                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with exit code {1}. This can indicate a crash at startup",
-                                    msbuildProcess.Id, msbuildProcess.ExitCode);
+                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with exit code {1}. This can indicate a crash at startup", msbuildProcess.Id, msbuildProcess.ExitCode);
                             }
                             catch (InvalidOperationException)
                             {
                                 // This case is common on Windows where we called CreateProcess and the Process object
                                 // can't get the exit code.
-                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with unknown exit code. This can indicate a crash at startup",
-                                    msbuildProcess.Id);
+                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with unknown exit code. This can indicate a crash at startup", msbuildProcess.Id);
                             }
                         }
                     }
                     else
                     {
-                        CommunicationsUtilities.Trace(
-                            "Could not connect to node with PID {0}; it is still running. This can occur when two multiprocess builds run in parallel and the other one 'stole' this node",
-                            msbuildProcess.Id);
+                        CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it is still running. This can occur when two multiprocess builds run in parallel and the other one 'stole' this node", msbuildProcess.Id);
                     }
                 }
 
@@ -386,7 +382,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="msbuildLocation"></param>
         /// <returns>
         /// Item 1 is the name of the process being searched for.
-        /// Item 2 is the queue of ordered processes themselves.
+        /// Item 2 is the ConcurrentQueue of ordered processes themselves.
         /// </returns>
         private (string expectedProcessName, ConcurrentQueue<Process> nodeProcesses) GetPossibleRunningNodes(string msbuildLocation = null)
         {

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -521,7 +521,7 @@ namespace Microsoft.Build.BackEnd
 
             CommunicationsUtilities.Trace("For a host context of {0}, spawning executable from {1}.", hostContext.ToString(), msbuildLocation ?? "MSBuild.exe");
 
-            // Make it here.
+            // There is always one task host per host context so we always create just 1 one task host node here.
             int nodeId = (int)hostContext;
             IList<NodeContext> nodeContexts = GetNodes(
                 msbuildLocation,

--- a/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Execution;
 
@@ -42,14 +43,10 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// Creates a node on an available NodeProvider, if any..
+        /// Not used - base class <see cref="NodeProviderOutOfProcBase"/> implementation is reused instead.
         /// </summary>
-        /// <param name="configuration">The configuration to use for the remote node.</param>
-        /// <param name="nodeAffinity">The <see cref="NodeAffinity"/> to use.</param>
-        /// <returns>A NodeInfo describing the node created, or null if none could be created.</returns>
-        public NodeInfo CreateNode(NodeConfiguration configuration, NodeAffinity nodeAffinity)
-        {
-            throw new NotSupportedException("not used");
-        }
+        public IList<NodeInfo> CreateNodes(NodeConfiguration configuration, NodeAffinity affinity, int numberOfNodesToCreate)
+            => throw new NotSupportedException("not used");
 
         /// <summary>
         /// Sends data to the specified node.

--- a/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Execution;
 using System.Collections.Generic;

--- a/src/Build/BackEnd/Components/IBuildComponent.cs
+++ b/src/Build/BackEnd/Components/IBuildComponent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
 namespace Microsoft.Build.BackEnd
 {
     /// <summary>

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -145,6 +145,11 @@ namespace Microsoft.Build.Internal
         private static bool s_trace = Traits.Instance.DebugNodeCommunication;
 
         /// <summary>
+        /// Lock trace to ensure we are logging in serial fashion.
+        /// </summary>
+        private static readonly object s_traceLock = new();
+
+        /// <summary>
         /// Place to dump trace
         /// </summary>
         private static string s_debugDumpPath;
@@ -600,49 +605,55 @@ namespace Microsoft.Build.Internal
         {
             if (s_trace)
             {
-                if (s_debugDumpPath == null)
+                lock (s_traceLock)
                 {
-                    s_debugDumpPath =
+                    if (s_debugDumpPath == null)
+                    {
+                        s_debugDumpPath =
 #if CLR2COMPATIBILITY
                         Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #else
-                        ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
-                            ? DebugUtils.DebugPath
-                            : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+                            ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
+                                ? DebugUtils.DebugPath
+                                : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #endif
 
-                    if (String.IsNullOrEmpty(s_debugDumpPath))
-                    {
-                        s_debugDumpPath = Path.GetTempPath();
-                    }
-                    else
-                    {
-                        Directory.CreateDirectory(s_debugDumpPath);
-                    }
-                }
-
-                try
-                {
-                    string fileName = @"MSBuild_CommTrace_PID_{0}";
-                    if (nodeId != -1)
-                    {
-                        fileName += "_node_" + nodeId;
+                        if (String.IsNullOrEmpty(s_debugDumpPath))
+                        {
+                            s_debugDumpPath = Path.GetTempPath();
+                        }
+                        else
+                        {
+                            Directory.CreateDirectory(s_debugDumpPath);
+                        }
                     }
 
-                    fileName += ".txt";
-
-                    using (StreamWriter file = FileUtilities.OpenWrite(String.Format(CultureInfo.CurrentCulture, Path.Combine(s_debugDumpPath, fileName), Process.GetCurrentProcess().Id, nodeId), append: true))
+                    try
                     {
-                        string message = String.Format(CultureInfo.CurrentCulture, format, args);
-                        long now = DateTime.UtcNow.Ticks;
-                        float millisecondsSinceLastLog = (float)(now - s_lastLoggedTicks) / 10000L;
-                        s_lastLoggedTicks = now;
-                        file.WriteLine("{0} (TID {1}) {2,15} +{3,10}ms: {4}", Thread.CurrentThread.Name, Thread.CurrentThread.ManagedThreadId, now, millisecondsSinceLastLog, message);
+                        string fileName = @"MSBuild_CommTrace_PID_{0}";
+                        if (nodeId != -1)
+                        {
+                            fileName += "_node_" + nodeId;
+                        }
+
+                        fileName += ".txt";
+
+                        using (StreamWriter file =
+                               FileUtilities.OpenWrite(String.Format(CultureInfo.CurrentCulture, Path.Combine(s_debugDumpPath, fileName), Process.GetCurrentProcess().Id, nodeId),
+                                   append: true))
+                        {
+                            string message = String.Format(CultureInfo.CurrentCulture, format, args);
+                            long now = DateTime.UtcNow.Ticks;
+                            float millisecondsSinceLastLog = (float)(now - s_lastLoggedTicks) / 10000L;
+                            s_lastLoggedTicks = now;
+                            file.WriteLine("{0} (TID {1}) {2,15} +{3,10}ms: {4}", Thread.CurrentThread.Name, Thread.CurrentThread.ManagedThreadId, now, millisecondsSinceLastLog,
+                                message);
+                        }
                     }
-                }
-                catch (IOException)
-                {
-                    // Ignore
+                    catch (IOException)
+                    {
+                        // Ignore
+                    }
                 }
             }
         }

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -613,9 +613,9 @@ namespace Microsoft.Build.Internal
 #if CLR2COMPATIBILITY
                         Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #else
-                            ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
-                                ? DebugUtils.DebugPath
-                                : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+                        ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
+                            ? DebugUtils.DebugPath
+                            : Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 #endif
 
                         if (String.IsNullOrEmpty(s_debugDumpPath))

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
@@ -114,6 +114,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ImplicitlyExpandDesignTimeFacades Condition="'$(ImplicitlyExpandDesignTimeFacades)' == '' and ('$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(TargetingClr2Framework)' != 'true' and '$(TargetFrameworkVersion)' != 'v4.0')">true</ImplicitlyExpandDesignTimeFacades>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AvailablePlatforms Condition="!$(AvailablePlatforms.Contains('ARM64')) and '$(TargetFrameworkIdentifier)' == '.NETFramework' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '4.0'))">$(AvailablePlatforms),ARM64</AvailablePlatforms>
+  </PropertyGroup>
+
   <!--Import props that are common for both full framework and core.
     And before the ImportAfter\* , so users can override it-->
   <Import Project="$(MSBuildToolsPath)\Microsoft.NET.props" />


### PR DESCRIPTION
Fixes #7379

### Context
MSBuild builds with Out Of Proc nodes which requires spawning processes.  Each node takes time to spawn and is serial.  This can lead to a slow start on machine with many cores.  

### Changes Made
Parallelize Node spawn.
Changed interface in `INodeProvider` to specify number of nodes to be created and let particular implementation of `INodeProvider` decide if it does it concurrently. This way the scope of thread safety is limited and manageable.

I tried to keep current logic as much in tact as possible. For example old logic allowed to call `INodeManager` to spawn multiple in-proc nodes but then it fails anyway. That does not make much sense to me, and if we want to address it please let me know.

### Testing
Various manual testing including scenarios with TaskHost.

### Notes
When nodereuse and nodes are still running the difference is not significant about 20ms per node as connecting to existing processes is quite fast.
In cold scenarios, either /nr=false or nodes have had terminated after 15 minutes of idling, the difference is 150ms per node.
So on my 24 cores machine, incremental building of orchard code in cold scenario were about 20% faster, in hot scenarios (reusing still running nodes) about 4% faster.

