### PR TITLE
Fix dotnet/msbuild#7504 DateTimeOffset property function

### DIFF
--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -341,6 +341,7 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.Char", new Tuple<string, Type>(null, typeof(Char)));
                         availableStaticMethods.TryAdd("System.Convert", new Tuple<string, Type>(null, typeof(Convert)));
                         availableStaticMethods.TryAdd("System.DateTime", new Tuple<string, Type>(null, typeof(DateTime)));
+                        availableStaticMethods.TryAdd("System.DateTimeOffset", new Tuple<string, Type>(null, typeof(DateTimeOffset)));
                         availableStaticMethods.TryAdd("System.Decimal", new Tuple<string, Type>(null, typeof(Decimal)));
                         availableStaticMethods.TryAdd("System.Double", new Tuple<string, Type>(null, typeof(Double)));
                         availableStaticMethods.TryAdd("System.Enum", new Tuple<string, Type>(null, typeof(Enum)));


### PR DESCRIPTION
Fixes #7504

### Context
Add static properties and methods of DateTimeOffset.

### Changes Made
Added one line in Constants.cs to add `DateTimeOffset` to `availableStaticMethods`.

### Testing
Built the bootstrap and tested with the following 'DateTimeOffsetPropFunc.proj' project file:

```
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <Target Name="Test">
        <PropertyGroup>
            <Today>$([System.DateTime]::Now)</Today>
            <Today2>$([System.DateTimeOffset]::Now)</Today2>
        </PropertyGroup>
        <Message Text="DateTime:       $(Today)"/>
        <Message Text="DateTimeOffset: $(Today2)"/>
    </Target>
</Project>
```

When the project is run with /v:n, the values for DateTime and DateTimeOffset are displayed. The DateTimeOffset value will include the offset from UTC.