### PR TITLE
Remove 16.10 changewave

### DIFF
--- a/documentation/wiki/ChangeWaves-Dev.md
+++ b/documentation/wiki/ChangeWaves-Dev.md
@@ -32,7 +32,7 @@ public static readonly Version Wave17_4 = new Version(17, 4);
 3. You may need to delete the lowest wave as new waves get added.
 4. Update the AllWaves array appropriately.
 ```c#
-public static readonly Version[] AllWaves = { Wave16_10, Wave17_0, Wave17_4 };
+public static readonly Version[] AllWaves = { Wave17_0, Wave17_2, Wave17_4 };
 ```
 
 ## Condition Your Feature On A Change Wave

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -22,12 +22,10 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 # Change Waves & Associated Features
 
 ## Current Rotation of Change Waves
-### 16.10
-- [Error when a property expansion in a condition has whitespace](https://github.com/dotnet/msbuild/pull/5672)
-- [Allow Custom CopyToOutputDirectory Location With TargetPath](https://github.com/dotnet/msbuild/pull/6237)
-- [Allow users that have certain special characters in their username to build successfully when using exec](https://github.com/dotnet/msbuild/pull/6223)
-- [Fail restore operations when an SDK is unresolveable](https://github.com/dotnet/msbuild/pull/6430)
-- [Optimize glob evaluation](https://github.com/dotnet/msbuild/pull/6151)
+
+### 17.4
+- [Respect deps.json when loading assemblies](https://github.com/dotnet/msbuild/pull/7520)
+- [Remove opt in for new schema for CombineTargetFrameworkInfoProperties](https://github.com/dotnet/msbuild/pull/6928)
 
 ### 17.0
 - [Scheduler should honor BuildParameters.DisableInprocNode](https://github.com/dotnet/msbuild/pull/6400)
@@ -47,3 +45,10 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Enable NoWarn](https://github.com/dotnet/msbuild/pull/5671)
 - [Truncate Target/Task skipped log messages to 1024 chars](https://github.com/dotnet/msbuild/pull/5553)
 - [Don't expand full drive globs with false condition](https://github.com/dotnet/msbuild/pull/5669)
+
+### 16.10
+- [Error when a property expansion in a condition has whitespace](https://github.com/dotnet/msbuild/pull/5672)
+- [Allow Custom CopyToOutputDirectory Location With TargetPath](https://github.com/dotnet/msbuild/pull/6237)
+- [Allow users that have certain special characters in their username to build successfully when using exec](https://github.com/dotnet/msbuild/pull/6223)
+- [Fail restore operations when an SDK is unresolveable](https://github.com/dotnet/msbuild/pull/6430)
+- [Optimize glob evaluation](https://github.com/dotnet/msbuild/pull/6151)

--- a/src/Build.UnitTests/Scanner_Tests.cs
+++ b/src/Build.UnitTests/Scanner_Tests.cs
@@ -133,24 +133,6 @@ namespace Microsoft.Build.UnitTests
             lexer._errorState.ShouldBeFalse();
         }
 
-        [Fact]
-        public void SpacePropertyOptOutWave16_10()
-        {
-            using TestEnvironment env = TestEnvironment.Create();
-            ChangeWaves.ResetStateForTests();
-            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave16_10.ToString());
-            BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
-
-            Scanner lexer = new Scanner("$(x )", ParserOptions.AllowProperties);
-            AdvanceToScannerError(lexer);
-            Assert.Null(lexer.UnexpectedlyFound);
-
-            lexer = new Scanner("$( x)", ParserOptions.AllowProperties);
-            AdvanceToScannerError(lexer);
-            Assert.Null(lexer.UnexpectedlyFound);
-            ChangeWaves.ResetStateForTests();
-        }
-
         /// <summary>
         /// Tests the special errors for "@(" and "@x" and similar cases.
         /// </summary>

--- a/src/Build/Evaluation/Conditionals/Scanner.cs
+++ b/src/Build/Evaluation/Conditionals/Scanner.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Build.Evaluation
                         // If it is not then the calling code will determine that
                         if (nestLevel == 0)
                         {
-                            if (whitespaceFound && !nonIdentifierCharacterFound && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10))
+                            if (whitespaceFound && !nonIdentifierCharacterFound)
                             {
                                 return false;
                             }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1833,7 +1833,7 @@ namespace Microsoft.Build.Evaluation
 
                 if (!sdkResult.Success)
                 {
-                    if (_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) && (!ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10) || !_loadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk)))
+                    if (_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) && !_loadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk))
                     {
                         ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
                             importElement.Location.Line,

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -24,11 +24,10 @@ namespace Microsoft.Build.Framework
     /// For dev docs: https://github.com/dotnet/msbuild/blob/master/documentation/wiki/ChangeWaves-Dev.md
     internal class ChangeWaves
     {
-        internal static readonly Version Wave16_10 = new Version(16, 10);
         internal static readonly Version Wave17_0 = new Version(17, 0);
         internal static readonly Version Wave17_2 = new Version(17, 2);
         internal static readonly Version Wave17_4 = new Version(17, 4);
-        internal static readonly Version[] AllWaves = { Wave16_10, Wave17_0, Wave17_2, Wave17_4 };
+        internal static readonly Version[] AllWaves = { Wave17_0, Wave17_2, Wave17_4 };
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
+++ b/src/Tasks.UnitTests/AssignTargetPath_Tests.cs
@@ -107,40 +107,6 @@ namespace Microsoft.Build.UnitTests
             t.AssignedFiles.Length.ShouldBe(1);
             t.AssignedFiles[0].GetMetadata("TargetPath").ShouldBe(targetPath);
         }
-
-        [Theory]
-        [InlineData("c:/fully/qualified/path.txt")]
-        [InlineData("test/output/file.txt")]
-        [InlineData(@"some\dir\to\file.txt")]
-        [InlineData("file.txt")]
-        [InlineData("file")]
-        public void TargetPathAlreadySet_DisabledUnderChangeWave16_10(string targetPath)
-        {
-            using TestEnvironment env = TestEnvironment.Create();
-            string link = "c:/some/path";
-
-            ChangeWaves.ResetStateForTests();
-            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave16_10.ToString());
-            BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
-
-            AssignTargetPath t = new AssignTargetPath();
-            t.BuildEngine = new MockEngine();
-            Dictionary<string, string> metaData = new Dictionary<string, string>();
-            metaData.Add("TargetPath", targetPath);
-            metaData.Add("Link", link);
-            t.Files = new ITaskItem[]
-                          {
-                              new TaskItem(
-                                  itemSpec: NativeMethodsShared.IsWindows ? @"c:\f1\f2\file.txt" : "/f1/f2/file.txt",
-                                  itemMetadata: metaData)
-                          };
-            t.RootFolder = NativeMethodsShared.IsWindows ? @"c:\f1\f2" : "/f1/f2";
-
-            t.Execute().ShouldBeTrue();
-            t.AssignedFiles.Length.ShouldBe(1);
-            t.AssignedFiles[0].GetMetadata("TargetPath").ShouldBe(link);
-            ChangeWaves.ResetStateForTests();
-        }
     }
 }
 

--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -69,31 +69,6 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        [Fact]
-        [Trait("Category", "mono-osx-failing")]
-        [Trait("Category", "netcore-osx-failing")]
-        [Trait("Category", "netcore-linux-failing")]
-        public void EscapeSpecifiedCharactersInPathToGeneratedBatchFile_DisabledUnderChangeWave16_10()
-        {
-            using (var testEnvironment = TestEnvironment.Create())
-            {
-                ChangeWaves.ResetStateForTests();
-                testEnvironment.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave16_10.ToString());
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
-
-                var newTempPath = testEnvironment.CreateNewTempPathWithSubfolder("hello()w]o(rld)").TempPath;
-
-                string tempPath = Path.GetTempPath();
-                Assert.StartsWith(newTempPath, tempPath);
-
-                // Now run the Exec task on a simple command.
-                Exec exec = PrepareExec("echo Hello World!");
-                exec.Execute().ShouldBeFalse();
-
-                ChangeWaves.ResetStateForTests();
-            }
-        }
-
         /// <summary>
         /// Ensures that calling the Exec task does not leave any extra TEMP files
         /// lying around.
@@ -1015,64 +990,6 @@ echo line 3"" />
 
                     result.OverallResult.ShouldBe(BuildResultCode.Success);
                 }
-            }
-        }
-
-        [Fact]
-        [Trait("Category", "mono-osx-failing")]
-        [Trait("Category", "netcore-osx-failing")]
-        [Trait("Category", "netcore-linux-failing")]
-        public void EndToEndMultilineExec_EscapeSpecialCharacters_DisabledUnderChangeWave16_10()
-        {
-            using (var env = TestEnvironment.Create(_output))
-            {
-                ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave16_10.ToString());
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
-
-                var testProject = env.CreateTestProjectWithFiles(@"<Project>
-<Target Name=""ExecCommand"">
-  <Exec Command=""echo Hello, World!"" />
-   </Target>
-</Project>");
-
-                // Ensure path has subfolders
-                var newTempPath = env.CreateNewTempPathWithSubfolder("hello()wo(rld)").TempPath;
-                string tempPath = Path.GetTempPath();
-                Assert.StartsWith(newTempPath, tempPath);
-
-                using (var buildManager = new BuildManager())
-                {
-                    MockLogger logger = new MockLogger(_output, profileEvaluation: false, printEventsToStdout: false);
-
-                    var parameters = new BuildParameters()
-                    {
-                        Loggers = new[] { logger },
-                    };
-
-                    var collection = new ProjectCollection(
-                        new Dictionary<string, string>(),
-                        new[] { logger },
-                        remoteLoggers: null,
-                        ToolsetDefinitionLocations.Default,
-                        maxNodeCount: 1,
-                        onlyLogCriticalEvents: false,
-                        loadProjectsReadOnly: true);
-
-                    var project = collection.LoadProject(testProject.ProjectFile).CreateProjectInstance();
-
-                    var request = new BuildRequestData(
-                        project,
-                        targetsToBuild: new[] { "ExecCommand" },
-                        hostServices: null);
-
-                    var result = buildManager.Build(parameters, request);
-
-                    logger.AssertLogContains("Hello, World!");
-
-                    result.OverallResult.ShouldBe(BuildResultCode.Failure);
-                }
-                ChangeWaves.ResetStateForTests();
             }
         }
     }

--- a/src/Tasks/AssignTargetPath.cs
+++ b/src/Tasks/AssignTargetPath.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Build.Tasks
 
                     // If TargetPath is already set, it takes priority.
                     // https://github.com/dotnet/msbuild/issues/2795
-                    string targetPath =  ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave16_10) ? Files[i].GetMetadata(ItemMetadataNames.targetPath) : null;
+                    string targetPath = Files[i].GetMetadata(ItemMetadataNames.targetPath);
 
                     // If TargetPath not already set, fall back to default behavior.
                     if (string.IsNullOrEmpty(targetPath))


### PR DESCRIPTION
### Context
Removes the 16.10 change wave and associated tests and edits documentation.

This is based on the respect deps.json pr to avoid an imminent merge conflict.