### PR TITLE
Stopy copying Node.js into bootstrap

### DIFF
--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -79,7 +79,8 @@
       <ShimTargets Include="Workflow.Targets" />
       <ShimTargets Include="Workflow.VisualBasic.Targets" />
 
-      <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.*" />
+      <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.*"
+                                    Exclude="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\NodeJs\**" />
 
       <InstalledNuGetFiles Include="$(MSBuildExtensionsPath)\Microsoft\NuGet\*" />
 


### PR DESCRIPTION
With some workloads installed, Visual Studio has a copy of the
Node.js runtime, which is for reasons not known to me inside
the MSBuild folder. As such, it was getting globbed and copied
into our bootstrap folder. We don't need that and it was taking
time.
