### PR TITLE
Bump refs to System packages

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -14,7 +14,7 @@
     <PackageReference Update="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
     <PackageReference Update="Microsoft.IO.Redist" Version="6.0.0" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" />
-    <PackageReference Update="Microsoft.Win32.Registry" Version="4.3.0" />
+    <PackageReference Update="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Update="NuGet.Build.Tasks" Version="$(NuGetBuildTasksVersion)" />
     <PackageReference Update="NuGet.Frameworks" Version="$(NuGetBuildTasksVersion)" />
     <PackageReference Update="System.CodeDom" Version="4.4.0" />
@@ -28,7 +28,7 @@
     <PackageReference Update="System.Security.Cryptography.Pkcs" Version="4.7.0" />
     <PackageReference Update="System.Security.Cryptography.Xml" Version="4.7.0" />
     <PackageReference Update="System.Security.Permissions" Version="4.7.0" />
-    <PackageReference Update="System.Security.Principal.Windows" Version="4.7.0" />
+    <PackageReference Update="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
     <PackageReference Update="System.Text.Json" Version="6.0.0" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="6.0.0" />

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -15,6 +15,9 @@
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.1.2196" PrivateAssets="All" />
     <PackageReference Update="PdbGit" Version="3.0.41" />
     <PackageReference Update="Shouldly" Version="3.0.0" />
+    <PackageReference Update="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Update="System.Runtime" Version="4.3.1" />
+    <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true' AND $(ProjectIsDeprecated) != 'true'">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -55,6 +55,10 @@
     <PackageReference Include="xunit.core" />
     <PackageReference Include="xunit.assert" />
 
+    <!-- Force updated reference to this package because xunit and shouldly
+         are netstandard1.6 and transitively bring in an old reference -->
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" />
+
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
 
     <!-- Don't localize unit test projects -->

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -231,6 +231,9 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
     <PackageReference Include="Microsoft.Win32.Registry" />
+    <!-- Bump these to the latest version despite transitive references to older -->
+    <PackageReference Include="System.Private.Uri" />
+    <PackageReference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Build\Microsoft.Build.csproj" />

--- a/src/StringTools.Benchmark/StringTools.Benchmark.csproj
+++ b/src/StringTools.Benchmark/StringTools.Benchmark.csproj
@@ -4,7 +4,7 @@
     <UseAppHost>false</UseAppHost>
     <TargetFrameworks>$(RuntimeOutputTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>$(RuntimeOutputPlatformTarget)</PlatformTarget>
-    
+
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
@@ -14,6 +14,9 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <!-- Bump these to the latest version despite transitive references to older -->
+    <PackageReference Include="System.Private.Uri" />
+    <PackageReference Include="System.Runtime" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
An old version of these packages were getting pulled in transitively by
netstandard packages, and causing Component Governance alerts.
Fortunately, the packages aren't really used so we can just update them.
