### PR TITLE
Base64 converter Fixes #7442

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3652,10 +3652,34 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [InlineData("\"\n()\tsdfIR$%#*;==")]
         public void TestBase64Conversion(string testCase)
         {
-            PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            PropertyDictionary<ProjectPropertyInstance> pg = new();
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new(pg, FileSystems.Default);
             string intermediate = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertToBase64('{testCase}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
             intermediate.Trim('=').All(c => char.IsLetterOrDigit(c) || c == '+' || c == '/').ShouldBeTrue();
+            string original = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertFromBase64('{intermediate}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
+            original.ShouldBe(testCase);
+        }
+
+        [Theory]
+        [InlineData("easycase", "ZWFzeWNhc2U=")]
+        [InlineData("", "")]
+        [InlineData("\"\n()\tsdfIR$%#*;==", "IgooKQlzZGZJUiQlIyo7PT0=")]
+        public void TestExplicitToBase64Conversion(string testCase, string result)
+        {
+            PropertyDictionary<ProjectPropertyInstance> pg = new();
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new(pg, FileSystems.Default);
+            string intermediate = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertToBase64('{testCase}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
+            intermediate.ShouldBe(result);
+        }
+
+        [Theory]
+        [InlineData("easycase", "ZWFzeWNhc2U=")]
+        [InlineData("", "")]
+        [InlineData("\"\n()\tsdfIR$%#*;==", "IgooKQlzZGZJUiQlIyo7PT0=")]
+        public void TestExplicitFromBase64Conversion(string testCase, string intermediate)
+        {
+            PropertyDictionary<ProjectPropertyInstance> pg = new();
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new(pg, FileSystems.Default);
             string original = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertFromBase64('{intermediate}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
             original.ShouldBe(testCase);
         }

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3646,6 +3646,20 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
 
+        [Theory]
+        [InlineData("easycase")]
+        [InlineData("")]
+        [InlineData("\"\n()\tsdfIR$%#*;==")]
+        public void TestBase64Conversion(string testCase)
+        {
+            PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            string intermediate = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertToBase64('{testCase}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
+            intermediate.Trim('=').All(c => char.IsLetterOrDigit(c) || c == '+' || c == '/').ShouldBeTrue();
+            string original = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertFromBase64('{intermediate}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
+            original.ShouldBe(testCase);
+        }
+
         /// <summary>
         /// A whole bunch error check tests
         /// </summary>

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3668,8 +3668,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new();
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new(pg, FileSystems.Default);
-            string intermediate = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertToBase64('{testCase}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
-            intermediate.ShouldBe(result);
+            string intermediate = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertToBase64('{plaintext}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
+            intermediate.ShouldBe(base64);
         }
 
         [Theory]
@@ -3680,8 +3680,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new();
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new(pg, FileSystems.Default);
-            string original = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertFromBase64('{intermediate}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
-            original.ShouldBe(testCase);
+            string original = expander.ExpandPropertiesLeaveTypedAndEscaped($"$([MSBuild]::ConvertFromBase64('{base64}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance) as string;
+            original.ShouldBe(plaintext);
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3664,7 +3664,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [InlineData("easycase", "ZWFzeWNhc2U=")]
         [InlineData("", "")]
         [InlineData("\"\n()\tsdfIR$%#*;==", "IgooKQlzZGZJUiQlIyo7PT0=")]
-        public void TestExplicitToBase64Conversion(string testCase, string result)
+        public void TestExplicitToBase64Conversion(string plaintext, string base64)
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new();
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new(pg, FileSystems.Default);
@@ -3676,7 +3676,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [InlineData("easycase", "ZWFzeWNhc2U=")]
         [InlineData("", "")]
         [InlineData("\"\n()\tsdfIR$%#*;==", "IgooKQlzZGZJUiQlIyo7PT0=")]
-        public void TestExplicitFromBase64Conversion(string testCase, string intermediate)
+        public void TestExplicitFromBase64Conversion(string plaintext, string base64)
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new();
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new(pg, FileSystems.Default);

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3510,7 +3510,10 @@ namespace Microsoft.Build.Evaluation
                     // If the result of the function call is a string, then we need to escape the result
                     // so that we maintain the "engine contains escaped data" state.
                     // The exception is that the user is explicitly calling MSBuild::Unescape or MSBuild::Escape
-                    if (functionResult is string functionResultString && !String.Equals("Unescape", _methodMethodName, StringComparison.OrdinalIgnoreCase) && !String.Equals("Escape", _methodMethodName, StringComparison.OrdinalIgnoreCase))
+                    if (functionResult is string functionResultString &&
+                        !String.Equals("Unescape", _methodMethodName, StringComparison.OrdinalIgnoreCase) &&
+                        !String.Equals("Escape", _methodMethodName, StringComparison.OrdinalIgnoreCase) &&
+                        !String.Equals("ConvertFromBase64", _methodMethodName, StringComparison.OrdinalIgnoreCase))
                     {
                         functionResult = EscapingUtilities.Escape(functionResultString);
                     }
@@ -4071,6 +4074,22 @@ namespace Microsoft.Build.Evaluation
                             if (TryGetArgs(args, out string arg1, out int arg2))
                             {
                                 returnVal = IntrinsicFunctions.GetTargetPlatformVersion(arg1, arg2);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.ConvertToBase64), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArg(args, out string arg0))
+                            {
+                                returnVal = IntrinsicFunctions.ConvertToBase64(arg0);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.ConvertFromBase64), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArg(args, out string arg0))
+                            {
+                                returnVal = IntrinsicFunctions.ConvertFromBase64(arg0);
                                 return true;
                             }
                         }

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3509,7 +3509,7 @@ namespace Microsoft.Build.Evaluation
 
                     // If the result of the function call is a string, then we need to escape the result
                     // so that we maintain the "engine contains escaped data" state.
-                    // The exception is that the user is explicitly calling MSBuild::Unescape or MSBuild::Escape
+                    // The exception is that the user is explicitly calling MSBuild::Unescape, MSBuild::Escape, or ConvertFromBase64
                     if (functionResult is string functionResultString &&
                         !String.Equals("Unescape", _methodMethodName, StringComparison.OrdinalIgnoreCase) &&
                         !String.Equals("Escape", _methodMethodName, StringComparison.OrdinalIgnoreCase) &&

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Build.Evaluation
         /// Returns the string after converting all bytes to base 64 (alphanumeric characters plus '+' and '/'), ending in one or two '='.
         /// </summary>
         /// <param name="toEncode">String to encode in base 64.</param>
-        /// <returns></returns>
+        /// <returns>The encoded string.</returns>
         internal static string ConvertToBase64(string toEncode)
         {
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(toEncode));
@@ -365,7 +365,7 @@ namespace Microsoft.Build.Evaluation
         /// Returns the string after converting from base 64 (alphanumeric characters plus '+' and '/'), ending in one or two '='.
         /// </summary>
         /// <param name="toDecode">The string to decode.</param>
-        /// <returns></returns>
+        /// <returns>The decoded string.</returns>
         internal static string ConvertFromBase64(string toDecode)
         {
             return Encoding.UTF8.GetString(Convert.FromBase64String(toDecode));

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns></returns>
         internal static string ConvertToBase64(string toEncode)
         {
-            return Convert.ToBase64String(Encoding.Default.GetBytes(toEncode));
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(toEncode));
         }
 
         /// <summary>
@@ -368,7 +368,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns></returns>
         internal static string ConvertFromBase64(string toDecode)
         {
-            return Encoding.Default.GetString(Convert.FromBase64String(toDecode));
+            return Encoding.UTF8.GetString(Convert.FromBase64String(toDecode));
         }
 
         /// <summary>

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using Microsoft.Build.Framework;
@@ -348,6 +349,26 @@ namespace Microsoft.Build.Evaluation
             {
                 return conditionValue;
             }
+        }
+
+        /// <summary>
+        /// Returns the string after converting all bytes to base 64 (alphanumeric characters plus '+' and '/'), ending in one or two '='.
+        /// </summary>
+        /// <param name="toEncode">String to encode in base 64.</param>
+        /// <returns></returns>
+        internal static string ConvertToBase64(string toEncode)
+        {
+            return Convert.ToBase64String(Encoding.Default.GetBytes(toEncode));
+        }
+
+        /// <summary>
+        /// Returns the string after converting from base 64 (alphanumeric characters plus '+' and '/'), ending in one or two '='.
+        /// </summary>
+        /// <param name="toDecode">The string to decode.</param>
+        /// <returns></returns>
+        internal static string ConvertFromBase64(string toDecode)
+        {
+            return Encoding.Default.GetString(Convert.FromBase64String(toDecode));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #7442

### Context
Some odd parameters sometimes need to be passed through MSBuild. This provides a built-in way to avoid escaping nonsense.

### Changes Made
Added intrinsic functions encoding or decoding a string to or from base 64.

### Testing
Added unit test