### PR TITLE
Auto-detect that we need Core

### DIFF
--- a/scripts/Deploy-MSBuild.ps1
+++ b/scripts/Deploy-MSBuild.ps1
@@ -4,7 +4,7 @@ Param(
   [string] $destination,
   [ValidateSet('Debug','Release')]
   [string] $configuration = "Debug",
-  [ValidateSet('Core','Desktop')]
+  [ValidateSet('Core','Desktop', 'Detect', 'Full')]
   [string] $runtime = "Detect"
 )
 

--- a/scripts/Deploy-MSBuild.ps1
+++ b/scripts/Deploy-MSBuild.ps1
@@ -50,6 +50,10 @@ $BackupFolder = New-Item (Join-Path $destination -ChildPath "Backup-$(Get-Date -
 Write-Verbose "Copying $configuration MSBuild to $destination"
 Write-Host "Existing MSBuild assemblies backed up to $BackupFolder"
 
+if ($destination -like "*dotnet*sdk*") {
+    $runtime = "Core"
+}
+
 if ($runtime -eq "Desktop") {
     $targetFramework = "net472"
 } else {

--- a/scripts/Deploy-MSBuild.ps1
+++ b/scripts/Deploy-MSBuild.ps1
@@ -5,7 +5,7 @@ Param(
   [ValidateSet('Debug','Release')]
   [string] $configuration = "Debug",
   [ValidateSet('Core','Desktop')]
-  [string] $runtime = "Desktop"
+  [string] $runtime = "Detect"
 )
 
 Set-StrictMode -Version "Latest"
@@ -50,8 +50,18 @@ $BackupFolder = New-Item (Join-Path $destination -ChildPath "Backup-$(Get-Date -
 Write-Verbose "Copying $configuration MSBuild to $destination"
 Write-Host "Existing MSBuild assemblies backed up to $BackupFolder"
 
-if ($destination -like "*dotnet*sdk*") {
-    $runtime = "Core"
+if ($runtime -eq "Detect") {
+    if ($destination -like "*dotnet*sdk*") {
+        $runtime = "Core"
+        Write-Host "Detected path that looks like an sdk. Writing .NET Core assemblies."
+    }
+    else {
+        $runtime = "Desktop"
+        Write-Host "Detected path that does not look like an sdk. Writing .NET Framework assemblies."
+    }
+}
+else if ($runtime -eq "Full") {
+    $runtime = "Desktop"
 }
 
 if ($runtime -eq "Desktop") {


### PR DESCRIPTION
With Deploy-MSBuild.ps1

Only works if you're deploying to a folder that looks like `*dotnet*sdk*`

Note that this is a bit hacky, but I think that's fine for a script that is mostly used by us.

### Testing

I tried deploying to a folder that looked like ...\dotnet\sdk\folder, and it put the Core assemblies in rather than Framework as desired.