### PR TITLE
Put win32 back for .NET Standard

### DIFF
--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\FileSystemSources.proj" />
   <Import Project="..\Shared\DebuggingSources.proj" />
@@ -35,6 +35,11 @@
     <PackageReference Include="System.Text.Encoding.CodePages" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <!-- Need Win32 API on .NET Standard to ping registry for some methods in ToolLocationHelper -->
+    <PackageReference Include="Microsoft.Win32.Registry" />
+  </ItemGroup>
+  
   <ItemGroup Label="Shared Code">
     <Compile Include="..\Shared\AssemblyFolders\AssemblyFoldersEx.cs">
       <Link>Shared\AssemblyFolders\AssemblyFoldersEx.cs</Link>


### PR DESCRIPTION
Used for pinging the registry as part of some windows-specific methods in ToolLocationHelper

### Context
Win32 was removed as unnecessary in parallel with introducing a new usage for it in .NET Standard, since RegistryHive and RegistryView are available without the explicit reference in net472 and .NET 6 but not .NET Standard. This adds back the reference if necessary.

### Testing
Built