### PR TITLE
Only include manifest files as built output if they exist. Fixes #4584.

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6106,7 +6106,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- This item represents the native manifest, example: WindowsApplication1.exe.manifest or Native.ClassLibrary1.manifest -->
     <ItemGroup>
-      <_BuiltProjectOutputGroupOutputIntermediate Include="$(OutDir)$(_DeploymentTargetApplicationManifestFileName)" Condition="'@(NativeReference)'!='' or '@(_IsolatedComReference)'!=''">
+      <_BuiltProjectOutputGroupOutputIntermediate Include="$(OutDir)$(_DeploymentTargetApplicationManifestFileName)" Condition="('@(NativeReference)'!='' or '@(_IsolatedComReference)'!='') And Exists('$(OutDir)$(_DeploymentTargetApplicationManifestFileName)')">
         <TargetPath>$(_DeploymentTargetApplicationManifestFileName)</TargetPath>
         <!-- For compatibility with 2.0 -->
         <OriginalItemSpec>$(OutDir)$(_DeploymentTargetApplicationManifestFileName)</OriginalItemSpec>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/4584.

### Context

The existing code assumes that the presence of NativeReference items means
that there will be native manifests (such as WindowsApplication1.exe.manifest).
This is an invalid assumption, because NativeReference items are used for
other project types, in particular a certain type of Xamarin.iOS projects,
and in those cases there won't be any manifest files.

The end result is that the build (pack) fails because it tries to include a
manifest file that doesn't exist.

### Changes Made

Only include manifest files as built output if the manifest files exist.

### Testing

I modified my local installation and the build (pack) worked just fine.

### Notes