### PR TITLE
Enable Live Unit Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ artifacts/
 *.pdb
 *.pgc
 *.pgd
-*.rsp
 *.sbr
 *.tlb
 *.tli
@@ -136,12 +135,6 @@ csx/
 # Windows Store app package directory
 AppPackages/
 
-# Visual Studio cache files
-# files ending in .cache can be ignored
-*.[Cc]ache
-# but keep track of directories ending in .cache
-!*.[Cc]ache/
-
 # Others
 ClientBin/
 [Ss]tyle[Cc]op.*
@@ -220,5 +213,5 @@ Samples/MultiprocessBuild/PortableTask.dll
 stage1/
 .tools
 
-# ETL traces    
+# ETL traces
 *.etl.zip

--- a/MSBuild.lutconfig
+++ b/MSBuild.lutconfig
@@ -1,0 +1,7 @@
+<LUTConfig Version="1.0">
+  <Repository />
+  <ParallelBuilds>true</ParallelBuilds>
+  <ParallelTestRuns>false</ParallelTestRuns>
+  <EnablePdbs>true</EnablePdbs>
+  <TestCaseTimeout>180000</TestCaseTimeout>
+</LUTConfig>

--- a/MSBuild.lutconfig
+++ b/MSBuild.lutconfig
@@ -1,7 +1,7 @@
 <LUTConfig Version="1.0">
   <Repository />
   <ParallelBuilds>true</ParallelBuilds>
-  <ParallelTestRuns>false</ParallelTestRuns>
+  <ParallelTestRuns>true</ParallelTestRuns>
   <EnablePdbs>true</EnablePdbs>
   <TestCaseTimeout>180000</TestCaseTimeout>
 </LUTConfig>


### PR DESCRIPTION
Add a `.lutconfig` file to configure Live Unit Testing for the repo.

Changes to `.gitignore` enabled it to be used for LUT's shadow copy; a couple of test assets were failing to copy with the prior rules.
