### PR TITLE
Simplify AssemblyName creation

### DIFF
--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -230,15 +230,7 @@ namespace Microsoft.Build.Shared
                     }
                 }
 
-                var metadataReader = peFile.GetMetadataReader();
-                var entry = metadataReader.GetAssemblyDefinition();
-
-                assemblyName = new AssemblyName();
-                assemblyName.Name = metadataReader.GetString(entry.Name);
-                assemblyName.Version = entry.Version;
-                assemblyName.CultureName = metadataReader.GetString(entry.Culture);
-                assemblyName.SetPublicKey(metadataReader.GetBlobBytes(entry.PublicKey));
-                assemblyName.Flags = (AssemblyNameFlags)(int)entry.Flags;
+                assemblyName = AssemblyName.GetAssemblyName(path);
             }
 #endif
             return assemblyName == null ? null : new AssemblyNameExtension(assemblyName);


### PR DESCRIPTION
The S.R.M version didn't include PublicKeyToken, apparently because it isn't part of the metadata.

Fixes internally reported issue

### Context
PublicKey was being added to an AssemblyName but not PublicKeyToken. When cloning the AssemblyName, it tried to access the token and failed, throwing an error. The particular case was in trying to figure out an appropriate binding redirect. An assembly had version x and y with x > y. y was primary, and it decided to make x primary after deciding it should unify on x. That led it to clone the AssemblyName, but the PublicKeyToken was missing.

### Changes Made
Create full AssemblyName.

### Testing
Reran the repro with this version of MSBuild, and the issue no longer reproduces.