### PR TITLE
Handle value types explicitly in TaskParameter translation

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
     /// <summary>
     /// A task used for testing the TaskExecutionHost, which reports what the TaskExecutionHost does to it.
     /// </summary>
-    internal class TaskBuilderTestTask : IGeneratedTask
+    public class TaskBuilderTestTask : IGeneratedTask
     {
         /// <summary>
         /// The task host.
@@ -84,7 +84,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set
             {
                 _boolOutput = value;
-                _testTaskHost.ParameterSet("BoolParam", value);
+                _testTaskHost?.ParameterSet("BoolParam", value);
             }
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set
             {
                 _boolArrayOutput = value;
-                _testTaskHost.ParameterSet("BoolArrayParam", value);
+                _testTaskHost?.ParameterSet("BoolArrayParam", value);
             }
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set
             {
                 _intOutput = value;
-                _testTaskHost.ParameterSet("IntParam", value);
+                _testTaskHost?.ParameterSet("IntParam", value);
             }
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set
             {
                 _intArrayOutput = value;
-                _testTaskHost.ParameterSet("IntArrayParam", value);
+                _testTaskHost?.ParameterSet("IntArrayParam", value);
             }
         }
 
@@ -132,7 +132,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set
             {
                 _stringOutput = value;
-                _testTaskHost.ParameterSet("StringParam", value);
+                _testTaskHost?.ParameterSet("StringParam", value);
             }
         }
 
@@ -144,7 +144,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set
             {
                 _stringArrayOutput = value;
-                _testTaskHost.ParameterSet("StringArrayParam", value);
+                _testTaskHost?.ParameterSet("StringArrayParam", value);
             }
         }
 
@@ -156,7 +156,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set
             {
                 _itemOutput = value;
-                _testTaskHost.ParameterSet("ItemParam", value);
+                _testTaskHost?.ParameterSet("ItemParam", value);
             }
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set
             {
                 _itemArrayOutput = value;
-                _testTaskHost.ParameterSet("ItemArrayParam", value);
+                _testTaskHost?.ParameterSet("ItemArrayParam", value);
             }
         }
 
@@ -181,7 +181,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set
             {
                 _executeReturnValue = value;
-                _testTaskHost.ParameterSet("ExecuteReturnParam", value);
+                _testTaskHost?.ParameterSet("ExecuteReturnParam", value);
             }
         }
 
@@ -193,7 +193,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("BoolOutput", _boolOutput);
+                _testTaskHost?.OutputRead("BoolOutput", _boolOutput);
                 return _boolOutput;
             }
         }
@@ -206,7 +206,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("BoolArrayOutput", _boolArrayOutput);
+                _testTaskHost?.OutputRead("BoolArrayOutput", _boolArrayOutput);
                 return _boolArrayOutput;
             }
         }
@@ -219,7 +219,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("IntOutput", _intOutput);
+                _testTaskHost?.OutputRead("IntOutput", _intOutput);
                 return _intOutput;
             }
         }
@@ -232,7 +232,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("IntArrayOutput", _intArrayOutput);
+                _testTaskHost?.OutputRead("IntArrayOutput", _intArrayOutput);
                 return _intArrayOutput;
             }
         }
@@ -245,7 +245,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("StringOutput", _stringOutput);
+                _testTaskHost?.OutputRead("StringOutput", _stringOutput);
                 return _stringOutput;
             }
         }
@@ -258,7 +258,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("EmptyStringOutput", null);
+                _testTaskHost?.OutputRead("EmptyStringOutput", null);
                 return String.Empty;
             }
         }
@@ -271,7 +271,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("EmptyStringArrayOutput", null);
+                _testTaskHost?.OutputRead("EmptyStringArrayOutput", null);
                 return Array.Empty<string>();
             }
         }
@@ -284,7 +284,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("NullStringOutput", null);
+                _testTaskHost?.OutputRead("NullStringOutput", null);
                 return null;
             }
         }
@@ -297,7 +297,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("NullITaskItemOutput", null);
+                _testTaskHost?.OutputRead("NullITaskItemOutput", null);
                 return null;
             }
         }
@@ -310,7 +310,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("NullStringArrayOutput", null);
+                _testTaskHost?.OutputRead("NullStringArrayOutput", null);
                 return null;
             }
         }
@@ -323,7 +323,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("NullITaskItemArrayOutput", null);
+                _testTaskHost?.OutputRead("NullITaskItemArrayOutput", null);
                 return null;
             }
         }
@@ -336,7 +336,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("StringArrayOutput", _stringArrayOutput);
+                _testTaskHost?.OutputRead("StringArrayOutput", _stringArrayOutput);
                 return _stringArrayOutput;
             }
         }
@@ -349,7 +349,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("ItemOutput", _itemOutput);
+                _testTaskHost?.OutputRead("ItemOutput", _itemOutput);
                 return _itemOutput;
             }
         }
@@ -362,7 +362,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("ItemArrayOutput", _itemArrayOutput);
+                _testTaskHost?.OutputRead("ItemArrayOutput", _itemArrayOutput);
                 return _itemArrayOutput;
             }
         }
@@ -375,52 +375,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             get
             {
-                _testTaskHost.OutputRead("ItemArrayNullOutput", _itemArrayOutput);
+                _testTaskHost?.OutputRead("ItemArrayNullOutput", _itemArrayOutput);
                 return null;
             }
         }
 
-        /// <summary>
-        /// An object output
-        /// </summary>
         [Output]
-        public object ObjectOutput
-        {
-            get
-            {
-                object output = new object();
-                _testTaskHost.OutputRead("ObjectOutput", output);
-                return output;
-            }
-        }
-
-        /// <summary>
-        /// An object array output
-        /// </summary>
-        [Output]
-        public object[] ObjectArrayOutput
-        {
-            get
-            {
-                object[] output = new object[] { new object(), new object() };
-                _testTaskHost.OutputRead("ObjectArrayOutput", output);
-                return output;
-            }
-        }
-
-        /// <summary>
-        /// An arraylist output
-        /// </summary>
-        [Output]
-        public ArrayList ArrayListOutput
-        {
-            get
-            {
-                ArrayList output = new ArrayList();
-                _testTaskHost.OutputRead("ArrayListOutput", output);
-                return output;
-            }
-        }
+        public TargetBuiltReason EnumOutput => TargetBuiltReason.BeforeTargets;
 
         #region ITask Members
 

--- a/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
@@ -1,11 +1,14 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Diagnostics;
 using Microsoft.Build.Execution;
 using Microsoft.Build.UnitTests;
+using Microsoft.Build.UnitTests.BackEnd;
+
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 #nullable disable
 
@@ -13,6 +16,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
     public sealed class TaskHostFactory_Tests
     {
+        ITestOutputHelper _output;
+
+        public TaskHostFactory_Tests(ITestOutputHelper testOutputHelper)
+        {
+            _output = testOutputHelper;
+        }
+
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         public void TaskNodesDieAfterBuild()
@@ -47,5 +57,38 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 }
             }
         }
+
+        [Fact]
+        public void VariousParameterTypesCanBeTransmittedToAndRecievedFromTaskHost()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+
+            string projectContents = $@"
+<Project>
+    <UsingTask TaskName=""{nameof(TaskBuilderTestTask)}"" AssemblyFile=""{typeof(TaskBuilderTestTask).Assembly.Location}"" TaskFactory=""TaskHostFactory"" />
+    <Target Name='{nameof(VariousParameterTypesCanBeTransmittedToAndRecievedFromTaskHost)}'>
+        <{nameof(TaskBuilderTestTask)}
+            ExecuteReturnParam=""true""
+            BoolParam=""true""
+            BoolArrayParam=""false;true;false""
+            IntParam=""314""
+            IntArrayParam=""42;67;98""
+            StringParam=""stringParamInput""
+            StringArrayParam=""stringArrayParamInput1;stringArrayParamInput2;stringArrayParamInput3"">
+
+            <Output PropertyName=""BoolOutput"" TaskParameter=""BoolOutput"" />
+            <Output PropertyName=""BoolArrayOutput"" TaskParameter=""BoolArrayOutput"" />
+            <Output PropertyName=""IntOutput"" TaskParameter=""IntOutput"" />
+            <Output PropertyName=""IntArrayOutput"" TaskParameter=""IntArrayOutput"" />
+            <Output PropertyName=""EnumOutput"" TaskParameter=""EnumOutput"" />
+            <Output PropertyName=""StringOutput"" TaskParameter=""StringOutput"" />
+            <Output PropertyName=""StringArrayOutput"" TaskParameter=""StringArrayOutput"" />
+        </{nameof(TaskBuilderTestTask)}>
+    </Target>
+</Project>";
+            TransientTestProjectWithFiles project = env.CreateTestProjectWithFiles(projectContents);
+            ProjectInstance projectInstance = new(project.ProjectFile);
+            projectInstance.Build(new[] { new MockLogger(env.Output) }).ShouldBeTrue();
+            }
     }
 }

--- a/src/Shared/BinaryTranslator.cs
+++ b/src/Shared/BinaryTranslator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -147,6 +147,26 @@ namespace Microsoft.Build.BackEnd
             public void Translate(ref int value)
             {
                 value = _reader.ReadInt32();
+            }
+
+            /// <summary>
+            /// Translates an <see langword="int"/> array.
+            /// </summary>
+            /// <param name="array">The array to be translated.</param>
+            public void Translate(ref int[] array)
+            {
+                if (!TranslateNullable(array))
+                {
+                    return;
+                }
+
+                int count = _reader.ReadInt32();
+                array = new int[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    array[i] = _reader.ReadInt32();
+                }
             }
 
             /// <summary>
@@ -809,6 +829,26 @@ namespace Microsoft.Build.BackEnd
             public void Translate(ref int value)
             {
                 _writer.Write(value);
+            }
+
+            /// <summary>
+            /// Translates an <see langword="int"/> array.
+            /// </summary>
+            /// <param name="array">The array to be translated.</param>
+            public void Translate(ref int[] array)
+            {
+                if (!TranslateNullable(array))
+                {
+                    return;
+                }
+
+                int count = array.Length;
+                _writer.Write(count);
+
+                for (int i = 0; i < count; i++)
+                {
+                    _writer.Write(array[i]);
+                }
             }
 
             /// <summary>

--- a/src/Shared/ITranslator.cs
+++ b/src/Shared/ITranslator.cs
@@ -129,6 +129,12 @@ namespace Microsoft.Build.BackEnd
         void Translate(ref int value);
 
         /// <summary>
+        /// Translates an <see langword="int"/> array.
+        /// </summary>
+        /// <param name="array">The array to be translated.</param>
+        void Translate(ref int[] array);
+
+        /// <summary>
         /// Translates a long.
         /// </summary>
         /// <param name="value">The value to be translated.</param>

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -107,7 +107,8 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrow
                 (
                     TaskParameterTypeVerifier.IsValidInputParameter(wrappedParameterType) || TaskParameterTypeVerifier.IsValidOutputParameter(wrappedParameterType),
-                    "How did we manage to get a task parameter that isn't a valid parameter type?"
+                    "How did we manage to get a task parameter of type {0} that isn't a valid parameter type?",
+                    wrappedParameterType
                 );
 
             if (wrappedParameterType.IsArray)

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Security;
@@ -16,7 +17,7 @@ using Microsoft.Build.Shared;
 namespace Microsoft.Build.BackEnd
 {
     /// <summary>
-    /// Type of parameter, used to figure out how to serialize it. 
+    /// Type of parameter, used to figure out how to serialize it.
     /// </summary>
     internal enum TaskParameterType
     {
@@ -36,17 +37,27 @@ namespace Microsoft.Build.BackEnd
         StringArray,
 
         /// <summary>
+        /// Parameter is <c>true</c> or <c>false</c>.
+        /// </summary>
+        Bool,
+
+        /// <summary>
+        /// Parameter is an <see langword="int"/>.
+        /// </summary>
+        Int,
+
+        /// <summary>
         /// Parameter is a value type.  Note:  Must be serializable
         /// </summary>
         ValueType,
 
         /// <summary>
-        /// Parameter is an array of value types.  Note:  Must be serializable. 
+        /// Parameter is an array of value types.  Note:  Must be serializable.
         /// </summary>
         ValueTypeArray,
 
         /// <summary>
-        /// Parameter is an ITaskItem 
+        /// Parameter is an ITaskItem
         /// </summary>
         ITaskItem,
 
@@ -56,15 +67,15 @@ namespace Microsoft.Build.BackEnd
         ITaskItemArray,
 
         /// <summary>
-        /// An invalid parameter -- the value of this parameter contains the exception 
-        /// that is thrown when trying to access it. 
+        /// An invalid parameter -- the value of this parameter contains the exception
+        /// that is thrown when trying to access it.
         /// </summary>
         Invalid
     }
 
     /// <summary>
-    /// Wrapper for task parameters, to allow proper serialization even 
-    /// in cases where the parameter is not .NET serializable. 
+    /// Wrapper for task parameters, to allow proper serialization even
+    /// in cases where the parameter is not .NET serializable.
     /// </summary>
     internal class TaskParameter :
 #if FEATURE_APPDOMAIN
@@ -103,7 +114,7 @@ namespace Microsoft.Build.BackEnd
                 return;
             }
 
-            // It's not null or invalid, so it should be a valid parameter type. 
+            // It's not null or invalid, so it should be a valid parameter type.
             ErrorUtilities.VerifyThrow
                 (
                     TaskParameterTypeVerifier.IsValidInputParameter(wrappedParameterType) || TaskParameterTypeVerifier.IsValidOutputParameter(wrappedParameterType),
@@ -157,6 +168,28 @@ namespace Microsoft.Build.BackEnd
                     _parameterType = TaskParameterType.ITaskItem;
                     _wrappedParameter = CreateNewTaskItemFrom((ITaskItem)wrappedParameter);
                 }
+                // Preserve enums as strings: the enum type itself may not
+                // be loaded on the other side of the serialization, but
+                // we would convert to string anyway after pulling the
+                // task output into a property or item.
+                else if (wrappedParameterType.IsEnum)
+                {
+                    _parameterType = TaskParameterType.String;
+                    _wrappedParameter = (string)Convert.ChangeType(wrappedParameter, typeof(string), CultureInfo.InvariantCulture);
+                }
+                    // Also stringify known common value types, to avoid calling
+                    // TranslateDotNet when they'll just be stringified on the
+                    // output side
+                else if (wrappedParameterType == typeof(bool))
+                {
+                    _parameterType = TaskParameterType.Bool;
+                    _wrappedParameter = wrappedParameter;
+                }
+                else if (wrappedParameterType == typeof(int))
+                {
+                    _parameterType = TaskParameterType.Int;
+                    _wrappedParameter = wrappedParameter;
+                }
                 else if (wrappedParameterType.GetTypeInfo().IsValueType)
                 {
                     _parameterType = TaskParameterType.ValueType;
@@ -197,7 +230,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// TaskParameter's ToString should just pass through to whatever it's wrapping. 
+        /// TaskParameter's ToString should just pass through to whatever it's wrapping.
         /// </summary>
         public override string ToString()
         {
@@ -205,7 +238,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Serialize / deserialize this item. 
+        /// Serialize / deserialize this item.
         /// </summary>
         public void Translate(ITranslator translator)
         {
@@ -225,6 +258,24 @@ namespace Microsoft.Build.BackEnd
                     string[] stringArrayParam = (string[])_wrappedParameter;
                     translator.Translate(ref stringArrayParam);
                     _wrappedParameter = stringArrayParam;
+                    break;
+                case TaskParameterType.Bool:
+                    bool boolParam = _wrappedParameter switch
+                    {
+                        bool hadValue => hadValue,
+                        _ => default,
+                    };
+                    translator.Translate(ref boolParam);
+                    _wrappedParameter = boolParam;
+                    break;
+                case TaskParameterType.Int:
+                    int intParam = _wrappedParameter switch
+                    {
+                        int hadValue => hadValue,
+                        _ => default,
+                    };
+                    translator.Translate(ref intParam);
+                    _wrappedParameter = intParam;
                     break;
                 case TaskParameterType.ValueType:
                 case TaskParameterType.ValueTypeArray:
@@ -271,7 +322,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Creates a new ITaskItem with the contents of the old one. 
+        /// Creates a new ITaskItem with the contents of the old one.
         /// </summary>
         private ITaskItem CreateNewTaskItemFrom(ITaskItem copyFrom)
         {
@@ -297,10 +348,10 @@ namespace Microsoft.Build.BackEnd
             }
             else
             {
-                // If we don't have ITaskItem2 to fall back on, we have to make do with the fact that 
-                // CloneCustomMetadata, GetMetadata, & ItemSpec returns unescaped values, and 
-                // TaskParameterTaskItem's constructor expects escaped values, so escaping them all 
-                // is the closest approximation to correct we can get.  
+                // If we don't have ITaskItem2 to fall back on, we have to make do with the fact that
+                // CloneCustomMetadata, GetMetadata, & ItemSpec returns unescaped values, and
+                // TaskParameterTaskItem's constructor expects escaped values, so escaping them all
+                // is the closest approximation to correct we can get.
                 escapedItemSpec = EscapingUtilities.Escape(copyFrom.ItemSpec);
 
                 escapedDefiningProject = EscapingUtilities.EscapeWithCaching(copyFrom.GetMetadata(FileUtilities.ItemSpecModifiers.DefiningProjectFullPath));
@@ -322,7 +373,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Serialize / deserialize this item. 
+        /// Serialize / deserialize this item.
         /// </summary>
         private void TranslateITaskItemArray(ITranslator translator)
         {
@@ -359,7 +410,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Serialize / deserialize this item. 
+        /// Serialize / deserialize this item.
         /// </summary>
         private void TranslateITaskItem(ITranslator translator)
         {
@@ -403,8 +454,8 @@ namespace Microsoft.Build.BackEnd
             }
             else
             {
-                // We know that the ITaskItem constructor expects an escaped string, and that ITaskItem.ItemSpec 
-                // is expected to be unescaped, so make sure we give the constructor what it wants. 
+                // We know that the ITaskItem constructor expects an escaped string, and that ITaskItem.ItemSpec
+                // is expected to be unescaped, so make sure we give the constructor what it wants.
                 escapedItemSpec = EscapingUtilities.Escape(wrappedItem.ItemSpec);
                 escapedDefiningProject = EscapingUtilities.EscapeWithCaching(wrappedItem.GetMetadata(FileUtilities.ItemSpecModifiers.DefiningProjectFullPath));
                 wrappedMetadata = wrappedItem.CloneCustomMetadata();
@@ -487,7 +538,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Super simple ITaskItem derivative that we can use as a container for read items.  
+        /// Super simple ITaskItem derivative that we can use as a container for read items.
         /// </summary>
         private class TaskParameterTaskItem :
 #if FEATURE_APPDOMAIN
@@ -500,7 +551,7 @@ namespace Microsoft.Build.BackEnd
 #endif
         {
             /// <summary>
-            /// The item spec 
+            /// The item spec
             /// </summary>
             private string _escapedItemSpec = null;
 
@@ -741,7 +792,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             /// <summary>
-            /// Sets the exact metadata value given to the metadata name requested. 
+            /// Sets the exact metadata value given to the metadata name requested.
             /// </summary>
             void ITaskItem2.SetMetadataValueLiteral(string metadataName, string metadataValue)
             {
@@ -749,7 +800,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             /// <summary>
-            /// Returns a dictionary containing all metadata and their escaped forms.  
+            /// Returns a dictionary containing all metadata and their escaped forms.
             /// </summary>
             IDictionary ITaskItem2.CloneCustomMetadataEscaped()
             {

--- a/src/Shared/UnitTests/TaskParameter_Tests.cs
+++ b/src/Shared/UnitTests/TaskParameter_Tests.cs
@@ -89,25 +89,25 @@ namespace Microsoft.Build.UnitTests
         /// Verifies that construction and serialization with a value type (integer) parameter is OK.
         /// </summary>
         [Fact]
-        public void ValueTypeParameter()
+        public void IntParameter()
         {
             TaskParameter t = new TaskParameter(1);
 
             Assert.Equal(1, t.WrappedParameter);
-            Assert.Equal(TaskParameterType.ValueType, t.ParameterType);
+            Assert.Equal(TaskParameterType.Int, t.ParameterType);
 
             ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
             TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
 
             Assert.Equal(1, t2.WrappedParameter);
-            Assert.Equal(TaskParameterType.ValueType, t2.ParameterType);
+            Assert.Equal(TaskParameterType.Int, t2.ParameterType);
         }
 
         /// <summary>
         /// Verifies that construction and serialization with a parameter that is an array of value types (ints) is OK.
         /// </summary>
         [Fact]
-        public void ValueTypeArrayParameter()
+        public void IntArrayParameter()
         {
             TaskParameter t = new TaskParameter(new int[] { 2, 15 });
 
@@ -129,6 +129,69 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(2, wrappedParameter2.Length);
             Assert.Equal(2, wrappedParameter2[0]);
             Assert.Equal(15, wrappedParameter2[1]);
+        }
+
+        enum TestEnumForParameter
+        {
+            Something,
+            SomethingElse
+        }
+
+        [Fact]
+        public void EnumParameter()
+        {
+            TaskParameter t = new TaskParameter(TestEnumForParameter.SomethingElse);
+
+            Assert.Equal("SomethingElse", t.WrappedParameter);
+            Assert.Equal(TaskParameterType.String, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            Assert.Equal("SomethingElse", t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.String, t2.ParameterType);
+        }
+
+        [Fact]
+        public void BoolParameter()
+        {
+            TaskParameter t = new TaskParameter(true);
+
+            Assert.Equal(true, t.WrappedParameter);
+            Assert.Equal(TaskParameterType.Bool, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            Assert.Equal(true, t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.Bool, t2.ParameterType);
+        }
+
+        /// <summary>
+        /// Verifies that construction and serialization with a parameter that is an array of value types (ints) is OK.
+        /// </summary>
+        [Fact]
+        public void BoolArrayParameter()
+        {
+            TaskParameter t = new TaskParameter(new bool[] { false, true });
+
+            Assert.Equal(TaskParameterType.ValueTypeArray, t.ParameterType);
+
+            bool[] wrappedParameter = t.WrappedParameter as bool[];
+            Assert.NotNull(wrappedParameter);
+            Assert.Equal(2, wrappedParameter.Length);
+            Assert.False(wrappedParameter[0]);
+            Assert.True(wrappedParameter[1]);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            Assert.Equal(TaskParameterType.ValueTypeArray, t2.ParameterType);
+
+            bool[] wrappedParameter2 = Assert.IsType<bool[]>(t2.WrappedParameter);
+            Assert.Equal(2, wrappedParameter2.Length);
+            Assert.False(wrappedParameter2[0]);
+            Assert.True(wrappedParameter2[1]);
         }
 
         /// <summary>


### PR DESCRIPTION
Remove uses of TranslateDotNet for types that make sense to pass to/from tasks.