### PR TITLE
Workaround mismatch type resolving

### DIFF
--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1666,34 +1666,42 @@ namespace Microsoft.Build.Execution
                         // Cannot have a null or empty name for the type after expansion.
                         ProjectErrorUtilities.VerifyThrowInvalidProject
                         (
-                        !String.IsNullOrEmpty(expandedType),
-                        parameter.ParameterTypeLocation,
-                        "InvalidEvaluatedAttributeValue",
-                        expandedType,
-                        parameter.ParameterType,
-                        XMakeAttributes.parameterType,
-                        XMakeElements.usingTaskParameter
+                            !String.IsNullOrEmpty(expandedType),
+                            parameter.ParameterTypeLocation,
+                            "InvalidEvaluatedAttributeValue",
+                            expandedType,
+                            parameter.ParameterType,
+                            XMakeAttributes.parameterType,
+                            XMakeElements.usingTaskParameter
                         );
 
-                        // Try and get the type directly 
-                        Type paramType = Type.GetType(expandedType);
+                        Type paramType;
+                        if (expandedType.StartsWith("Microsoft.Build.Framework.", StringComparison.OrdinalIgnoreCase) && !expandedType.Contains(","))
+                        {
+                            // This is workaround for internal bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1448821
+                            // Visual Studio can load different version of Microsoft.Build.Framework.dll and non fully classified type could be resolved from it 
+                            // which cause InvalidProjectFileException with "UnsupportedTaskParameterTypeError" message.
+                            // Another way to address this is to load types from compiled assembly - that would be more robust solution but also much more complex and risky code changes.
+                            paramType = Type.GetType(expandedType + "," + typeof(ITaskItem).GetTypeInfo().Assembly.FullName, false /* don't throw on error */, true /* case-insensitive */) ??
+                                        Type.GetType(expandedType);
+                        }
+                        else
+                        {
+                            paramType = Type.GetType(expandedType) ??
+                                        Type.GetType(expandedType + "," + typeof(ITaskItem).GetTypeInfo().Assembly.FullName, false /* don't throw on error */, true /* case-insensitive */);
+                        }
 
                         // The type could not be got directly try and see if the type can be found by appending the FrameworkAssemblyName to it.
-                        if (paramType == null)
-                        {
-                            paramType = Type.GetType(expandedType + "," + typeof(ITaskItem).GetTypeInfo().Assembly.FullName, false /* don't throw on error */, true /* case-insensitive */);
-
-                            ProjectErrorUtilities.VerifyThrowInvalidProject
-                            (
-                             paramType != null,
-                             parameter.ParameterTypeLocation,
-                             "InvalidEvaluatedAttributeValue",
-                             expandedType,
-                             parameter.ParameterType,
-                             XMakeAttributes.parameterType,
+                        ProjectErrorUtilities.VerifyThrowInvalidProject
+                        (
+                            paramType != null,
+                            parameter.ParameterTypeLocation,
+                            "InvalidEvaluatedAttributeValue",
+                            expandedType,
+                            parameter.ParameterType,
+                            XMakeAttributes.parameterType,
                             XMakeElements.usingTaskParameter
-                            );
-                        }
+                        );
 
                         bool output;
                         string expandedOutput = expander.ExpandIntoStringLeaveEscaped(parameter.Output, expanderOptions, parameter.OutputLocation);
@@ -1702,19 +1710,19 @@ namespace Microsoft.Build.Execution
                         {
                             ProjectErrorUtilities.ThrowInvalidProject
                             (
-                             parameter.OutputLocation,
-                             "InvalidEvaluatedAttributeValue",
-                             expandedOutput,
-                             parameter.Output,
-                             XMakeAttributes.output,
-                             XMakeElements.usingTaskParameter
+                                parameter.OutputLocation,
+                                "InvalidEvaluatedAttributeValue",
+                                expandedOutput,
+                                parameter.Output,
+                                XMakeAttributes.output,
+                                XMakeElements.usingTaskParameter
                             );
                         }
 
                         if (
                             (!output && (!TaskParameterTypeVerifier.IsValidInputParameter(paramType))) ||
                             (output && !TaskParameterTypeVerifier.IsValidOutputParameter(paramType))
-                           )
+                        )
                         {
                             ProjectErrorUtilities.ThrowInvalidProject
                             (
@@ -1723,7 +1731,7 @@ namespace Microsoft.Build.Execution
                                 paramType.FullName,
                                 parameter.ParameterType,
                                 parameter.Name
-                             );
+                            );
                         }
 
                         bool required;
@@ -1733,12 +1741,12 @@ namespace Microsoft.Build.Execution
                         {
                             ProjectErrorUtilities.ThrowInvalidProject
                             (
-                             parameter.RequiredLocation,
-                             "InvalidEvaluatedAttributeValue",
-                             expandedRequired,
-                             parameter.Required,
-                             XMakeAttributes.required,
-                             XMakeElements.usingTaskParameter
+                                parameter.RequiredLocation,
+                                "InvalidEvaluatedAttributeValue",
+                                expandedRequired,
+                                parameter.Required,
+                                XMakeAttributes.required,
+                                XMakeElements.usingTaskParameter
                             );
                         }
 

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1691,7 +1691,6 @@ namespace Microsoft.Build.Execution
                                         Type.GetType(expandedType + "," + typeof(ITaskItem).GetTypeInfo().Assembly.FullName, false /* don't throw on error */, true /* case-insensitive */);
                         }
 
-                        // The type could not be got directly try and see if the type can be found by appending the FrameworkAssemblyName to it.
                         ProjectErrorUtilities.VerifyThrowInvalidProject
                         (
                             paramType != null,


### PR DESCRIPTION
Fixes #
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1448821

### Context
Root cause:
- csproj requires lots of project properties, for this reason evaluation of project is started because project is considered dirty
- however this evaluation throws which causes this project to stay dirty
- above exception is somehow ignored by csproj and it proceeds with requesting more project properties each of those starting new evaluation in UI thread causing huge degradation in VS responsiveness
 
Why it throws?
- when MSBuild interprets \src\ConfigData\BuildTargets\Microsoft.DevDiv.BuildDiagCommon.targets line #119 the type "Microsoft.Build.Framework.ITaskItem[]" is resolved from another already loaded version of Microsoft.Build.Framework assembly.
this causes type check mismatch and that ParameterType is rejected and throws  InvalidProjectFileException with "UnsupportedTaskParameterTypeError" message.

### Changes Made
If resolving type prefixes with known namespace used for Framework assembly, we load it from it.

### Testing
After changes I was not able to reproduce this issue anymore. There is still, about 3s UI delay it this scenario but it is way batter than it used to be.

### Notes
