### PR TITLE
Compile AppDomainIsolatedTask for all targets

### DIFF
--- a/src/Utilities/AppDomainIsolatedTask.cs
+++ b/src/Utilities/AppDomainIsolatedTask.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if FEATURE_APPDOMAIN
 using System;
 using System.Resources;
 using System.Security;
@@ -17,6 +16,9 @@ namespace Microsoft.Build.Utilities
     /// instantiated in its own app domain.
     /// </summary>
     [LoadInSeparateAppDomain]
+#if !FEATURE_APPDOMAIN
+    [Obsolete("AppDomains are no longer supported in .NET Core or .NET 5.0 or higher.")]
+#endif
     public abstract class AppDomainIsolatedTask : MarshalByRefObject, ITask
     {
         #region Constructors
@@ -114,9 +116,15 @@ namespace Microsoft.Build.Utilities
         /// lease (5 minutes I think) and task instances can expire if they take long time processing.
         /// </summary>
         [SecurityCritical]
+#pragma warning disable CS0809 // InitializeLifetimeService is not marked as obsolete in netstandard2.0
+#if !FEATURE_APPDOMAIN
+        // This Obsolete is redundant since the whole class is obsoleted, but required to guard the reference
+        // to the obsolete MarshalByRefObject.InitializeLifetimeService.
+        [Obsolete("AppDomains are no longer supported in .NET Core or .NET 5.0 or higher.")]
+#endif
         public override object InitializeLifetimeService() => null; // null means infinite lease time
+#pragma warning restore
 
         #endregion
     }
 }
-#endif

--- a/src/Utilities/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Utilities/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,17 @@
+abstract Microsoft.Build.Utilities.AppDomainIsolatedTask.Execute() -> bool
+Microsoft.Build.Utilities.AppDomainIsolatedTask
+Microsoft.Build.Utilities.AppDomainIsolatedTask.AppDomainIsolatedTask() -> void
+Microsoft.Build.Utilities.AppDomainIsolatedTask.AppDomainIsolatedTask(System.Resources.ResourceManager taskResources) -> void
+Microsoft.Build.Utilities.AppDomainIsolatedTask.AppDomainIsolatedTask(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) -> void
+Microsoft.Build.Utilities.AppDomainIsolatedTask.BuildEngine.get -> Microsoft.Build.Framework.IBuildEngine
+Microsoft.Build.Utilities.AppDomainIsolatedTask.BuildEngine.set -> void
+Microsoft.Build.Utilities.AppDomainIsolatedTask.HelpKeywordPrefix.get -> string
+Microsoft.Build.Utilities.AppDomainIsolatedTask.HelpKeywordPrefix.set -> void
+Microsoft.Build.Utilities.AppDomainIsolatedTask.HostObject.get -> Microsoft.Build.Framework.ITaskHost
+Microsoft.Build.Utilities.AppDomainIsolatedTask.HostObject.set -> void
+Microsoft.Build.Utilities.AppDomainIsolatedTask.Log.get -> Microsoft.Build.Utilities.TaskLoggingHelper
+Microsoft.Build.Utilities.AppDomainIsolatedTask.TaskResources.get -> System.Resources.ResourceManager
+Microsoft.Build.Utilities.AppDomainIsolatedTask.TaskResources.set -> void
 Microsoft.Build.Utilities.AssemblyFoldersExInfo
 Microsoft.Build.Utilities.AssemblyFoldersExInfo.AssemblyFoldersExInfo(Microsoft.Win32.RegistryHive hive, Microsoft.Win32.RegistryView view, string registryKey, string directoryPath, System.Version targetFrameworkVersion) -> void
 Microsoft.Build.Utilities.AssemblyFoldersExInfo.DirectoryPath.get -> string
@@ -5,4 +19,5 @@ Microsoft.Build.Utilities.AssemblyFoldersExInfo.Hive.get -> Microsoft.Win32.Regi
 Microsoft.Build.Utilities.AssemblyFoldersExInfo.Key.get -> string
 Microsoft.Build.Utilities.AssemblyFoldersExInfo.TargetFrameworkVersion.get -> System.Version
 Microsoft.Build.Utilities.AssemblyFoldersExInfo.View.get -> Microsoft.Win32.RegistryView
+override Microsoft.Build.Utilities.AppDomainIsolatedTask.InitializeLifetimeService() -> object
 static Microsoft.Build.Utilities.ToolLocationHelper.GetAssemblyFoldersExInfo(string registryRoot, string targetFrameworkVersion, string registryKeySuffix, string osVersion, string platform, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) -> System.Collections.Generic.IList<Microsoft.Build.Utilities.AssemblyFoldersExInfo>


### PR DESCRIPTION
Today, if you want to run an `AppDomainIsolatedTask` in `dotnet build`, it fails
because `AppDomainIsolatedTask` can't be identified. With this change, a user
can make the attempt to run the task, for instance with TaskHost isolation
instead.

This was extra silly, because the main thing `AppDomainIsolatedTask` does is
apply the `[LoadInSeparateAppDomain]` attribute, which _was_ already working in
.NET Core MSBuild.

This came up internally when someone was trying to run an old task that didn't
appear to really need the AppDomain. Fixes [AB#1532369](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1532369).