### PR TITLE
No else if in powershell

### DIFF
--- a/scripts/Deploy-MSBuild.ps1
+++ b/scripts/Deploy-MSBuild.ps1
@@ -60,8 +60,10 @@ if ($runtime -eq "Detect") {
         Write-Host "Detected path that does not look like an sdk. Writing .NET Framework assemblies."
     }
 }
-else if ($runtime -eq "Full") {
-    $runtime = "Desktop"
+else {
+    if ($runtime -eq "Full") {
+        $runtime = "Desktop"
+    }
 }
 
 if ($runtime -eq "Desktop") {


### PR DESCRIPTION
### Context
`else if` is a thing in powershell but only since about 3 months ago...which means that if you just updated powershell, the PR is unnecessary. This just means you don't have to be on the very latest version for it to work.

### Changes Made


### Testing
I used it

### Notes
