### PR TITLE
RemoveDir: Ignore Empty Directories

### DIFF
--- a/src/Tasks.UnitTests/RemoveDir_Tests.cs
+++ b/src/Tasks.UnitTests/RemoveDir_Tests.cs
@@ -72,5 +72,32 @@ namespace Microsoft.Build.UnitTests
                 }
             }
         }
+
+        /// <summary>
+        /// Regression test: https://github.com/dotnet/msbuild/issues/7563
+        /// </summary>
+        [Fact]
+        public void DeleteEmptyDirectory_WarnsAndContinues()
+        {
+
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+               List<TaskItem> list = new List<TaskItem>();
+
+                for (int i = 0; i < 20; i++)
+               {
+                    list.Add(new TaskItem(""));
+               }
+
+               RemoveDir t = new RemoveDir();
+               t.Directories = list.ToArray();
+               t.BuildEngine = new MockEngine(_output);
+               t.Execute().ShouldBeTrue();
+
+                t.RemovedDirectories.Length.ShouldBe(0);
+                ((MockEngine)t.BuildEngine).Warnings.ShouldBe(20);
+               ((MockEngine)t.BuildEngine).AssertLogContains("MSB3232");
+            }
+        }
     }
 }

--- a/src/Tasks/RemoveDir.cs
+++ b/src/Tasks/RemoveDir.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Tasks
                 {
                     // Skip any empty ItemSpecs, otherwise RemoveDir will wipe the root of the current drive (!).
                     // https://github.com/dotnet/msbuild/issues/7563
-                    Log.LogWarning("RemoveDir.EmptyPath");
+                    Log.LogWarningWithCodeFromResources("RemoveDir.EmptyPath");
                     continue;
                 }
 

--- a/src/Tasks/RemoveDir.cs
+++ b/src/Tasks/RemoveDir.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Build.Tasks
             {
                 if (string.IsNullOrEmpty(directory.ItemSpec))
                 {
+                    // Skip any empty ItemSpecs, otherwise RemoveDir will wipe the root of the current drive (!).
+                    // https://github.com/dotnet/msbuild/issues/7563
                     Log.LogWarning("RemoveDir.EmptyPath");
                     continue;
                 }

--- a/src/Tasks/RemoveDir.cs
+++ b/src/Tasks/RemoveDir.cs
@@ -51,6 +51,12 @@ namespace Microsoft.Build.Tasks
 
             foreach (ITaskItem directory in Directories)
             {
+                if (string.IsNullOrEmpty(directory.ItemSpec))
+                {
+                    Log.LogWarning("RemoveDir.EmptyPath");
+                    continue;
+                }
+
                 if (FileSystems.Default.DirectoryExists(directory.ItemSpec))
                 {
                     // Do not log a fake command line as well, as it's superfluous, and also potentially expensive

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1338,6 +1338,10 @@
   <data name="RemoveDir.SkippingNonexistentDirectory">
     <value>Directory "{0}" doesn't exist. Skipping.</value>
   </data>
+  <data name="RemoveDir.EmptyPath">
+    <value>MSB3232: Detected an empty directory. Skipping.</value>
+    <comment>{StrBegin="MSB3232: "}</comment>
+  </data>
   <!--
         The ResGen message bucket is: MSB3451 - MSB3460
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1339,7 +1339,7 @@
     <value>Directory "{0}" doesn't exist. Skipping.</value>
   </data>
   <data name="RemoveDir.EmptyPath">
-    <value>MSB3232: Detected an empty directory. Skipping.</value>
+    <value>MSB3232: An empty directory was passed to RemoveDir and was ignored.</value>
     <comment>{StrBegin="MSB3232: "}</comment>
   </data>
   <!--

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: Nelze zaregistrovat sestavení {0}. Byl odepřen přístup. Zkontrolujte, zda spouštíte aplikaci jako správce. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: Nelze odebrat adresář {0}. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: Die "{0}"-Assembly kann nicht registriert werden – Zugriff verweigert. Stellen Sie sicher, dass Sie die Anwendung als Administrator ausführen. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: Das Verzeichnis "{0}" kann nicht entfernt werden. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: No se puede registrar el ensamblado "{0}": acceso denegado. Asegúrese de que está ejecutando la aplicación como administrador. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: No se puede quitar el directorio "{0}". {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: Impossible d'inscrire l'assembly "{0}", car l'accès est refusé. Assurez-vous d'exécuter l'application comme administrateur. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: Impossible de supprimer le répertoire "{0}". {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: non è possibile registrare l'assembly "{0}". Accesso negato. Assicurarsi di eseguire l'applicazione come amministratore. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: non è possibile rimuovere la directory "{0}". {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: アセンブリ "{0}" を登録できません - アクセスが拒否されました。管理者としてアプリケーションを実行しているか確認してください。{1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: ディレクトリ "{0}" を削除できません。{1}</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: "{0}" 어셈블리를 등록할 수 없습니다. 액세스가 거부되었습니다. 관리자로 애플리케이션을 실행하고 있는지 확인하세요. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: "{0}" 디렉터리를 제거할 수 없습니다. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: Nie można zarejestrować zestawu „{0}” — odmowa dostępu. Upewnij się, że aplikacja została uruchomiona z uprawnieniami administratora. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: Nie można usunąć katalogu „{0}”. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: Não é possível registrar o assembly "{0}"; acesso negado. Verifique se você está executando o aplicativo como administrador. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: Não é possível remover o diretório "{0}". {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: невозможно зарегистрировать сборку "{0}" — отказано в доступе. Убедитесь, что приложение запущено с правами администратора. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: Не удалось удалить каталог "{0}". {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: "{0}" bütünleştirilmiş kodu kaydedilemiyor - erişim reddedildi. Lütfen uygulamayı yönetici olarak çalıştırdığınızdan emin olun. {1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: "{0}" dizini kaldırılamıyor. {1}</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: 无法注册程序集“{0}”- 拒绝访问。请确保您正在以管理员身份运行应用程序。{1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: 无法移除目录“{0}”。{1}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1547,6 +1547,11 @@
         <target state="translated">MSB3216: 無法註冊組件 "{0}" - 存取遭拒。請確認您以系統管理員身分執行此應用程式。{1}</target>
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
+      <trans-unit id="RemoveDir.EmptyPath">
+        <source>MSB3232: Detected an empty directory. Skipping.</source>
+        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <note>{StrBegin="MSB3232: "}</note>
+      </trans-unit>
       <trans-unit id="RemoveDir.Error">
         <source>MSB3231: Unable to remove directory "{0}". {1}</source>
         <target state="translated">MSB3231: 無法移除目錄 "{0}"。{1}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1548,8 +1548,8 @@
         <note>{StrBegin="MSB3216: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.EmptyPath">
-        <source>MSB3232: Detected an empty directory. Skipping.</source>
-        <target state="new">MSB3232: Detected an empty directory. Skipping.</target>
+        <source>MSB3232: An empty directory was passed to RemoveDir and was ignored.</source>
+        <target state="new">MSB3232: An empty directory was passed to RemoveDir and was ignored.</target>
         <note>{StrBegin="MSB3232: "}</note>
       </trans-unit>
       <trans-unit id="RemoveDir.Error">


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/7563

### Context
Passing in an empty directory to the `RemoveDir` task causes the C drive to be wiped (!).

### Changes Made
Log a warning and continue on empty itemspecs.

### Testing
👀

### Notes
