### PR TITLE
Fix control sequence emission

### DIFF
--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -230,26 +230,13 @@ namespace Microsoft.Build.Execution
 
         private void SupportVT100()
         {
-            const int STD_OUTPUT_HANDLE = -11;
-            const uint DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
-            const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
-
-            var stdOut = GetStdHandle(STD_OUTPUT_HANDLE);
-            if (GetConsoleMode(stdOut, out uint consoleMode))
+            IntPtr stdOut = NativeMethodsShared.GetStdHandle(NativeMethodsShared.STD_OUTPUT_HANDLE);
+            if (NativeMethodsShared.GetConsoleMode(stdOut, out uint consoleMode))
             {
-                consoleMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN;
-                SetConsoleMode(stdOut, consoleMode);
+                consoleMode |= NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING | NativeMethodsShared.DISABLE_NEWLINE_AUTO_RETURN;
+                NativeMethodsShared.SetConsoleMode(stdOut, consoleMode);
             }
         }
-
-        [DllImport("kernel32.dll")]
-        private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
-
-        [DllImport("kernel32.dll")]
-        private static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern IntPtr GetStdHandle(int nStdHandle);
 
         private void SendCancelCommand(NamedPipeClientStream nodeStream) => throw new NotImplementedException();
 

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using System.Text;
 using System.Threading;
 
 using Microsoft.Build.Shared;
@@ -37,6 +36,8 @@ internal static class NativeMethods
     internal const uint RUNTIME_INFO_DONT_SHOW_ERROR_DIALOG = 0x40;
     internal const uint FILE_TYPE_CHAR = 0x0002;
     internal const Int32 STD_OUTPUT_HANDLE = -11;
+    internal const uint DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
+    internal const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
     internal const uint RPC_S_CALLPENDING = 0x80010115;
     internal const uint E_ABORT = (uint)0x80004004;
 
@@ -1487,6 +1488,12 @@ internal static class NativeMethods
 
     [DllImport("kernel32.dll")]
     internal static extern IntPtr GetStdHandle(int nStdHandle);
+
+    [DllImport("kernel32.dll")]
+    internal static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+    [DllImport("kernel32.dll")]
+    internal static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
 
     [DllImport("kernel32.dll")]
     internal static extern uint GetFileType(IntPtr hFile);


### PR DESCRIPTION
### Context
When building with the MSBuild server, you could sometimes see VT100 control character sequences rather than interpreting them as desired. This fixes that.

### Changes Made
Tell the console to expect VT100.

### Testing
Built before and after; it displayed properly with this change.