### PR TITLE
Removed now obsolete featureflag regarding envvars in ToolTask

### DIFF
--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -87,7 +87,6 @@
   <PropertyGroup Condition="'$(NetCoreBuild)'=='true'">
     <CompilerToolsDir>$([System.IO.Path]::Combine($(ToolPackagesDir)Microsoft.Net.Compilers, $(CompilerToolsVersion), "tools"))$([System.IO.Path]::DirectorySeparatorChar)</CompilerToolsDir>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYLOADCONTEXT</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_PROCESSSTARTINFO_ENVIRONMENT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEINFORMATION</DefineConstants>
     <DefineConstants>$(DefineConstants);USE_MSBUILD_DLL_EXTN</DefineConstants>
     <DefineConstants>$(DefineConstants);WORKAROUND_COREFX_19110</DefineConstants>

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Build.UnitTests
 
                 // We just tried to run "cmd.exe /C garbagegarbagegarbagegarbage.exe".  This should fail,
                 // but since "cmd.exe" doesn't log its errors in canonical format, no errors got
-                // logged by the tool itself.  Therefore, ToolTask's default implementation of 
+                // logged by the tool itself.  Therefore, ToolTask's default implementation of
                 // HandleTaskExecutionErrors should have logged error MSB6006.
                 engine.AssertLogContains("MSB6006");
             }
@@ -227,7 +227,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// ToolTask should never run String.Format on strings that are 
+        /// ToolTask should never run String.Format on strings that are
         /// not meant to be formatted.
         /// </summary>
         [Fact]
@@ -524,27 +524,16 @@ namespace Microsoft.Build.UnitTests
 
             ProcessStartInfo startInfo = task.StartInfo;
 
-#if FEATURE_PROCESSSTARTINFO_ENVIRONMENT
             startInfo.Environment["a"].ShouldBe("b");
             startInfo.Environment["c"].ShouldBe("d");
             startInfo.Environment[userVarName].ShouldBe("x");
             startInfo.Environment["path"].ShouldBe(String.Empty);
-#else
-            startInfo.EnvironmentVariables["a"].ShouldBe("b");
-            startInfo.EnvironmentVariables["c"].ShouldBe("d");
-            startInfo.EnvironmentVariables[userVarName].ShouldBe("x");
-            startInfo.EnvironmentVariables["path"].ShouldBe(string.Empty);
-#endif
 
             if (NativeMethodsShared.IsWindows)
             {
                 Assert.Equal(
                         Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
-#if FEATURE_PROCESSSTARTINFO_ENVIRONMENT
                         startInfo.Environment["programfiles"],
-#else
-                        startInfo.EnvironmentVariables["programfiles"],
-#endif
                         true);
             }
         }
@@ -562,11 +551,7 @@ namespace Microsoft.Build.UnitTests
             bool result = task.Execute();
 
             result.ShouldBe(true);
-#if FEATURE_PROCESSSTARTINFO_ENVIRONMENT
             task.StartInfo.Environment["a"].ShouldBe("b=c");
-#else
-            task.StartInfo.EnvironmentVariables["a"].ShouldBe("b=c");
-#endif
         }
 
         /// <summary>
@@ -628,12 +613,7 @@ namespace Microsoft.Build.UnitTests
 
             result.ShouldBe(true);
             task.ExecuteCalled.ShouldBe(true);
-            Assert.True(
-#if FEATURE_PROCESSSTARTINFO_ENVIRONMENT
-                task.StartInfo.Environment["PATH"].Length > 0);
-#else
-                task.StartInfo.EnvironmentVariables["PATH"].Length > 0);
-#endif
+            Assert.True(task.StartInfo.Environment["PATH"].Length > 0);
         }
 
         /// <summary>
@@ -707,22 +687,14 @@ namespace Microsoft.Build.UnitTests
         public void GetProcessStartInfoCanOverrideEnvironmentVariables()
         {
             MyTool task = new MyTool();
-#if FEATURE_PROCESSSTARTINFO_ENVIRONMENT
             task.DoProcessStartInfoMutation = (p) => p.Environment.Remove("a");
-#else
-            task.DoProcessStartInfoMutation = (p) => p.EnvironmentVariables.Remove("a");
-#endif
-            
+
             task.BuildEngine = new MockEngine();
             task.EnvironmentVariables = new[] { "a=b" };
             bool result = task.Execute();
 
             result.ShouldBe(true);
-#if FEATURE_PROCESSSTARTINFO_ENVIRONMENT
             task.StartInfo.Environment.ContainsKey("a").ShouldBe(false);
-#else
-            task.StartInfo.EnvironmentVariables.ContainsKey("a").ShouldBe(false);
-#endif
         }
 
         [Fact]

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Utilities
         UseHostObjectToExecute,
 
         /// <summary>
-        /// This means that either there is no host object available, or that the host object is 
+        /// This means that either there is no host object available, or that the host object is
         /// not capable of supporting all of the features required for this build.  Therefore,
         /// ToolTask should fallback to an alternate means of doing the build, such as invoking
         /// the command-line tool.
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Utilities
     /// Base class used for tasks that spawn an executable. This class implements the ToolPath property which can be used to
     /// override the default path.
     /// </summary>
-    // INTERNAL WARNING: DO NOT USE the Log property in this class! Log points to resources in the task assembly itself, and 
+    // INTERNAL WARNING: DO NOT USE the Log property in this class! Log points to resources in the task assembly itself, and
     // we want to use resources from Utilities. Use LogPrivate (for private Utilities resources) and LogShared (for shared MSBuild resources)
     public abstract class ToolTask : Task, ICancelableTask
     {
@@ -65,7 +65,7 @@ namespace Microsoft.Build.Utilities
         #region Constructors
 
         /// <summary>
-        /// Protected constructor 
+        /// Protected constructor
         /// </summary>
         protected ToolTask()
         {
@@ -87,7 +87,7 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Protected constructor 
+        /// Protected constructor
         /// </summary>
         /// <param name="taskResources">The resource manager for task resources</param>
         protected ToolTask(ResourceManager taskResources)
@@ -97,7 +97,7 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Protected constructor 
+        /// Protected constructor
         /// </summary>
         /// <param name="taskResources">The resource manager for task resources</param>
         /// <param name="helpKeywordPrefix">The help keyword prefix for task's messages</param>
@@ -112,7 +112,7 @@ namespace Microsoft.Build.Utilities
         #region Properties
 
         /// <summary>
-        /// The return code of the spawned process. If the task logged any errors, but the process 
+        /// The return code of the spawned process. If the task logged any errors, but the process
         /// had an exit code of 0 (success), this will be set to -1.
         /// </summary>
         [Output]
@@ -187,7 +187,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Whether or not to use UTF8 encoding for the cmd file and console window.
         /// Values: Always, Never, Detect
-        /// If set to Detect, the current code page will be used unless it cannot represent 
+        /// If set to Detect, the current code page will be used unless it cannot represent
         /// the Command string. In that case, UTF-8 is used.
         /// </summary>
         public string UseUtf8Encoding { get; set; } = EncodingUtilities.UseUtf8Detect;
@@ -205,7 +205,7 @@ namespace Microsoft.Build.Utilities
 
         /// <summary>
         /// Project visible property that allows the user to specify an amount of time after which the task executable
-        /// is terminated. 
+        /// is terminated.
         /// </summary>
         /// <value>Time-out in milliseconds. Default is <see cref="System.Threading.Timeout.Infinite"/> (no time-out).</value>
         public virtual int Timeout { set; get; } = System.Threading.Timeout.Infinite;
@@ -326,7 +326,7 @@ namespace Microsoft.Build.Utilities
         protected virtual void ProcessStarted() { }
 
         /// <summary>
-        /// Gets the fully qualified tool name. Should return ToolExe if ToolTask should search for the tool 
+        /// Gets the fully qualified tool name. Should return ToolExe if ToolTask should search for the tool
         /// in the system path. If ToolPath is set, this is ignored.
         /// </summary>
         /// <returns>Path string.</returns>
@@ -334,7 +334,7 @@ namespace Microsoft.Build.Utilities
 
         /// <summary>
         /// Gets the working directory to use for the process. Should return null if ToolTask should use the
-        /// current directory. 
+        /// current directory.
         /// </summary>
         /// <remarks>This is a method rather than a property so that derived classes (like Exec) can choose to
         /// expose a public WorkingDirectory property, and it would be confusing to have two properties.</remarks>
@@ -413,7 +413,7 @@ namespace Microsoft.Build.Utilities
 
         /// <summary>
         /// We expect tasks to override this method if they support host objects.  The implementation should
-        /// make sure that the host object is ready to perform the real work of the task.  
+        /// make sure that the host object is ready to perform the real work of the task.
         /// </summary>
         /// <returns>The return value indicates what steps to take next.  The default is to assume that there
         /// is no host object provided, and therefore we should fallback to calling the command-line tool.</returns>
@@ -480,7 +480,7 @@ namespace Microsoft.Build.Utilities
                 }
             }
 
-            // only look for the file if we have a path to it. If we have just the file name, we'll 
+            // only look for the file if we have a path to it. If we have just the file name, we'll
             // look for it in the path
             if (pathToTool != null)
             {
@@ -627,12 +627,7 @@ namespace Microsoft.Build.Utilities
             {
                 foreach (KeyValuePair<string, string> entry in envOverrides)
                 {
-#if FEATURE_PROCESSSTARTINFO_ENVIRONMENT
                     startInfo.Environment[entry.Key] = entry.Value;
-#else
-                    startInfo.EnvironmentVariables[entry.Key] = entry.Value;
-#endif
-
                 }
 #pragma warning restore 0618
             }
@@ -642,11 +637,7 @@ namespace Microsoft.Build.Utilities
             {
                 foreach (KeyValuePair<string, string> variable in _environmentVariablePairs)
                 {
-#if FEATURE_PROCESSSTARTINFO_ENVIRONMENT
                     startInfo.Environment[variable.Key] = variable.Value;
-#else
-                    startInfo.EnvironmentVariables[variable.Key] = variable.Value;
-#endif
                 }
             }
 
@@ -807,7 +798,7 @@ namespace Microsoft.Build.Utilities
             }
             catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
             {
-                // Warn only -- occasionally temp files fail to delete because of virus checkers; we 
+                // Warn only -- occasionally temp files fail to delete because of virus checkers; we
                 // don't want the build to fail in such cases
                 LogShared.LogWarningWithCodeFromResources("Shared.FailedDeletingTempFile", fileName, e.Message);
             }
@@ -1225,7 +1216,7 @@ namespace Microsoft.Build.Utilities
             {
                 try
                 {
-                    // Parse the raw importance string into a strongly typed enumeration.  
+                    // Parse the raw importance string into a strongly typed enumeration.
                     _standardErrorImportanceToUse = (MessageImportance)Enum.Parse(typeof(MessageImportance), StandardErrorImportance, true /* case-insensitive */);
                 }
                 catch (ArgumentException)
@@ -1245,7 +1236,7 @@ namespace Microsoft.Build.Utilities
             {
                 try
                 {
-                    // Parse the raw importance string into a strongly typed enumeration.  
+                    // Parse the raw importance string into a strongly typed enumeration.
                     _standardOutputImportanceToUse = (MessageImportance)Enum.Parse(typeof(MessageImportance), StandardOutputImportance, true /* case-insensitive */);
                 }
                 catch (ArgumentException)
@@ -1386,7 +1377,7 @@ namespace Microsoft.Build.Utilities
 
                             if (encoding.CodePage != EncodingUtilities.CurrentSystemOemEncoding.CodePage)
                             {
-                                // cmd.exe reads the first line in the console CP, 
+                                // cmd.exe reads the first line in the console CP,
                                 // which for a new console (as here) is OEMCP
                                 // this string should ideally always be ASCII
                                 // and the same in any OEMCP.
@@ -1433,7 +1424,7 @@ namespace Microsoft.Build.Utilities
 
                 // Initialize the host object.  At this point, the task may elect
                 // to not proceed.  Compiler tasks do this for purposes of up-to-date
-                // checking in the IDE.  
+                // checking in the IDE.
                 HostObjectInitializationStatus nextAction = InitializeHostObject();
                 if (nextAction == HostObjectInitializationStatus.NoActionReturnSuccess)
                 {
@@ -1483,13 +1474,13 @@ namespace Microsoft.Build.Utilities
 
                 if (UseCommandProcessor)
                 {
-                    // Log that we are about to invoke the specified command.  
+                    // Log that we are about to invoke the specified command.
                     LogToolCommand(pathToTool + commandLineCommands);
                     LogToolCommand(batchFileContents);
                 }
                 else
                 {
-                    // Log that we are about to invoke the specified command.  
+                    // Log that we are about to invoke the specified command.
                     LogToolCommand(pathToTool + commandLineCommands + " " + responseFileCommands);
                 }
                 ExitCode = 0;
@@ -1497,7 +1488,7 @@ namespace Microsoft.Build.Utilities
                 if (nextAction == HostObjectInitializationStatus.UseHostObjectToExecute)
                 {
                     // The hosting IDE passed in a host object to this task.  Give the task
-                    // a chance to call this host object to do the actual work.  
+                    // a chance to call this host object to do the actual work.
                     try
                     {
                         if (!CallHostObjectToExecute())
@@ -1632,12 +1623,12 @@ namespace Microsoft.Build.Utilities
         private static readonly char[] s_equalsSplitter = MSBuildConstants.EqualsChar;
 
         /// <summary>
-        /// The actual importance at which standard out messages will be logged 
+        /// The actual importance at which standard out messages will be logged
         /// </summary>
         private MessageImportance _standardOutputImportanceToUse = MessageImportance.Low;
 
         /// <summary>
-        /// The actual importance at which standard error messages will be logged 
+        /// The actual importance at which standard error messages will be logged
         /// </summary>
         private MessageImportance _standardErrorImportanceToUse = MessageImportance.Normal;
 
@@ -1669,7 +1660,7 @@ namespace Microsoft.Build.Utilities
         private ManualResetEvent _toolExited;
 
         /// <summary>
-        /// Set to true if the tool process was terminated, 
+        /// Set to true if the tool process was terminated,
         /// either because the timeout was reached or it was canceled.
         /// </summary>
         private bool _terminatedTool;


### PR DESCRIPTION
Since `ProcessStartInfo.Environment` is now available in all supported TFMs,
the feature flag is now just obsolete and even more so an unnecessary
difference between core and framework versions of MSBuild.


### Context

Found this old feature flag to be obsolete while researching `ToolTask` behavior.
This was added during the original OSS porting work of MSBuild, when `ProcessStartInfo.Environment` was only available
in .NET Core.

### Changes Made

Use `ProcessStartInfo.Environment` for all flavors of MSBuild.

### Testing

I don't think any additional testing code is needed - preexisting test suites cover this all pretty well and the change between `Environment` and `EnvironmentVariable` is only a change in type not an underlying change in behavior.

### Notes

1. EditorConfig enforced a couple of whitespace changes with `trim_trailing_whitespace`. I didn't remove these since that's supposed to happen at some point anyways. I hope that's ok.
2. I didn't create an issue first since this is primarily a cosmetic change to reduce clutter and the change is relatively small - unified behavior between core and framework flavors only comes in second. Again, i hope that's cool with everyone 😅
