### PR TITLE
Also offer Key as an option Fixes #7336

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -6153,6 +6153,13 @@ elementFormDefault="qualified">
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="Key" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="InternalsVisibleTo_PublicKey" _locComment="" -->Optional public key associated with the strong name signature of the friend assembly.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>


### PR DESCRIPTION
Fixes #7336

### Context
Key is a supported metadatum on the InternalsVisibleTo item, but the xsd claims PublicKey is the supported metadatum. https://github.com/dotnet/sdk/pulls/25000 ensures both are supported; this provides intellisense for both.

### Changes Made
Added Key to M.B.CommonTypes.xsd