### PR TITLE
Update System.Resources.Extensions pkgdef version

### DIFF
--- a/src/Tasks/System.Resources.Extensions.pkgdef
+++ b/src/Tasks/System.Resources.Extensions.pkgdef
@@ -4,4 +4,4 @@
 "publicKeyToken"="cc7b13ffcd2ddd51"
 "culture"="neutral"
 "oldVersion"="0.0.0.0-99.9.9.9"
-"newVersion"="4.0.0.0"
+"newVersion"="6.0.0.0"


### PR DESCRIPTION
To match the version we're shipping as of b362620217.

Fixes the perf DDRIT regression observed in VS insertion PR https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/365606.