### PR TITLE
Restore CombineTargetFrameworkInfoProperties opt-in

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -25,7 +25,6 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 
 ### 17.4
 - [Respect deps.json when loading assemblies](https://github.com/dotnet/msbuild/pull/7520)
-- [Remove opt in for new schema for CombineTargetFrameworkInfoProperties](https://github.com/dotnet/msbuild/pull/6928)
 - [Consider `Platform` as default during Platform Negotiation](https://github.com/dotnet/msbuild/pull/7511)
 
 ### 17.0

--- a/src/Tasks/CombineTargetFrameworkInfoProperties.cs
+++ b/src/Tasks/CombineTargetFrameworkInfoProperties.cs
@@ -39,8 +39,7 @@ namespace Microsoft.Build.Tasks
         {
             if (PropertiesAndValues != null)
             {
-                // When removing the change wave, also remove UseAttributeForTargetFrameworkInfoPropertyNames.
-                XElement root = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) || UseAttributeForTargetFrameworkInfoPropertyNames ?
+                XElement root = UseAttributeForTargetFrameworkInfoPropertyNames ?
                     new("TargetFramework", new XAttribute("Name", EscapingUtilities.Escape(RootElementName))) :
                     new(RootElementName);
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1907,9 +1907,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </_AdditionalTargetFrameworkInfoPropertyWithValue>
     </ItemGroup>
 
+    <PropertyGroup>
+      <_UseAttributeForTargetFrameworkInfoPropertyNames Condition="'$(_UseAttributeForTargetFrameworkInfoPropertyNames)' == ''">false</_UseAttributeForTargetFrameworkInfoPropertyNames>
+    </PropertyGroup>
+
     <CombineTargetFrameworkInfoProperties
         RootElementName="$(TargetFramework)"
-        PropertiesAndValues="@(_AdditionalTargetFrameworkInfoPropertyWithValue)">
+        PropertiesAndValues="@(_AdditionalTargetFrameworkInfoPropertyWithValue)"
+        UseAttributeForTargetFrameworkInfoPropertyNames="$(_UseAttributeForTargetFrameworkInfoPropertyNames)">
       <Output TaskParameter="Result"
               PropertyName="_AdditionalTargetFrameworkInfoProperties"/>
     </CombineTargetFrameworkInfoProperties>


### PR DESCRIPTION
This caused a regression in scenarios using Visual Studio 17.3 previews
with `global.json` files pointing to old .NET SDKs.

This reverts commit fe4fde95dee67b8925ff9b22a3d157d1c02e1d7b.

Conflicts:
	src/Framework/ChangeWaves.cs
	src/Tasks/CombineTargetFrameworkInfoProperties.cs

Fixes [AB#1534809](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1534809).