### PR TITLE
Properly recover from SDK resolver exception.

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
             SdkResult response = null;
 
-            // Create an SdkReference from the request, bellow SdkReference constructor shall never throw.
+            // Create an SdkReference from the request; the SdkReference constructor below never throws.
             SdkReference sdkReference = new SdkReference(request.Name, request.Version, request.MinimumVersion);
             try
             {

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -67,11 +67,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
             SdkResult response = null;
 
+            // Create an SdkReference from the request, bellow SdkReference constructor shall never throw.
+            SdkReference sdkReference = new SdkReference(request.Name, request.Version, request.MinimumVersion);
             try
             {
-                // Create an SdkReference from the request
-                SdkReference sdkReference = new SdkReference(request.Name, request.Version, request.MinimumVersion);
-
                 ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
 
                 // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
@@ -90,7 +89,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 // Get the node manager and send the response back to the node that requested the SDK
                 INodeManager nodeManager = Host.GetComponent(BuildComponentType.NodeManager) as INodeManager;
 
-                nodeManager.SendData(request.NodeId, response);
+                nodeManager.SendData(request.NodeId, response ?? new SdkResult(sdkReference, null, null));
             }
         }
 


### PR DESCRIPTION
Fixes [AB#1540178](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1540178)

### Context
When SDK resolver throw, like described here https://github.com/dotnet/msbuild/pull/2964, we need to make sure we gracefully recover from it as oppose to throw nullrefex.

### Changes Made
Ensure not null `SdkResult` is passed into `SendData`

### Testing
Manual

### Notes
Since this is old bug, introduced in 2018 by https://github.com/dotnet/msbuild/commit/b57bd10b51245b980f5e5ad16773ccc40cc9d1a5#diff-b37b42cd03a0c209c8297ced3d7e23c8afa0b6f8ff900b115e424c1506a761dbR168 
there is huge chance it is not root cause as SDK resolver is not supposed to be throwing. However, this fix allows proper Build failure which hopefully will be reported by dogfooding channels if it is indeed a real bug.
