### PR TITLE
Solving memory leak by reusing BuildManager and ProjectRoolElementCache

### DIFF
--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Build.Evaluation
                 // we do not need to auto reload.
                 bool autoReloadFromDisk = reuseProjectRootElementCache;
                 ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk, loadProjectsReadOnly);
-                if (reuseProjectRootElementCache && s_projectRootElementCache == null)
+                if (reuseProjectRootElementCache)
                 {
                     s_projectRootElementCache = ProjectRootElementCache;
                 }

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -145,6 +145,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private static string s_assemblyDisplayVersion;
 
+        private static ProjectRootElementCacheBase s_projectRootElementCache = null;
+
         /// <summary>
         /// The projects loaded into this collection.
         /// </summary>
@@ -302,6 +304,26 @@ namespace Microsoft.Build.Evaluation
         /// <param name="onlyLogCriticalEvents">If set to true, only critical events will be logged.</param>
         /// <param name="loadProjectsReadOnly">If set to true, load all projects as read-only.</param>
         public ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly)
+            : this(globalProperties, loggers, remoteLoggers, toolsetDefinitionLocations, maxNodeCount, onlyLogCriticalEvents, loadProjectsReadOnly, reuseProjectRootElementCache: false)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a project collection with specified global properties and loggers and using the
+        /// specified toolset locations, node count, and setting of onlyLogCriticalEvents.
+        /// Global properties and loggers may be null.
+        /// Throws InvalidProjectFileException if any of the global properties are reserved.
+        /// May throw InvalidToolsetDefinitionException.
+        /// </summary>
+        /// <param name="globalProperties">The default global properties to use. May be null.</param>
+        /// <param name="loggers">The loggers to register. May be null and specified to any build instead.</param>
+        /// <param name="remoteLoggers">Any remote loggers to register. May be null and specified to any build instead.</param>
+        /// <param name="toolsetDefinitionLocations">The locations from which to load toolsets.</param>
+        /// <param name="maxNodeCount">The maximum number of nodes to use for building.</param>
+        /// <param name="onlyLogCriticalEvents">If set to true, only critical events will be logged.</param>
+        /// <param name="loadProjectsReadOnly">If set to true, load all projects as read-only.</param>
+        /// <param name="reuseProjectRootElementCache">If set to true, it will try to reuse <see cref="ProjectRootElementCacheBase"/> singleton.</param>
+        public ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool reuseProjectRootElementCache)
         {
             _loadedProjects = new LoadedProjectCollection();
             ToolsetLocations = toolsetDefinitionLocations;
@@ -311,10 +333,23 @@ namespace Microsoft.Build.Evaluation
             {
                 ProjectRootElementCache = new SimpleProjectRootElementCache();
             }
+            else if (reuseProjectRootElementCache && s_projectRootElementCache != null)
+            {
+                ProjectRootElementCache = s_projectRootElementCache;
+            }
             else
             {
-                ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk: false, loadProjectsReadOnly);
+                // When we are reusing ProjectRootElementCache we need to reload XMLs if it has changed between MSBuild Server sessions/builds.
+                // If we are not reusing, cache will be released at end of build and as we do not support project files will changes during build
+                // we do not need to auto reload.
+                bool autoReloadFromDisk = reuseProjectRootElementCache;
+                ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk, loadProjectsReadOnly);
+                if (reuseProjectRootElementCache && s_projectRootElementCache == null)
+                {
+                    s_projectRootElementCache = ProjectRootElementCache;
+                }
             }
+
             OnlyLogCriticalEvents = onlyLogCriticalEvents;
 
             try
@@ -1603,6 +1638,12 @@ namespace Microsoft.Build.Evaluation
             if (disposing)
             {
                 ShutDownLoggingService();
+                if (ProjectRootElementCache != null)
+                {
+                    ProjectRootElementCache.ProjectRootElementAddedHandler -= ProjectRootElementCache_ProjectRootElementAddedHandler;
+                    ProjectRootElementCache.ProjectRootElementDirtied -= ProjectRootElementCache_ProjectRootElementDirtiedHandler;
+                    ProjectRootElementCache.ProjectDirtied -= ProjectRootElementCache_ProjectDirtiedHandler;
+                }
                 Tracing.Dump();
             }
         }

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -415,6 +415,12 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal override void DiscardImplicitReferences()
         {
+            if (_autoReloadFromDisk)
+            {
+                // no need to clear it, as auto reload properly invalidates caches if changed.
+                return;
+            }
+
             lock (_locker)
             {
                 // Make a new Weak cache only with items that have been explicitly loaded, this will be a small number, there will most likely

--- a/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.Build.Evaluation.ProjectCollection.ProjectCollection(System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool reuseProjectRootElementCache) -> void
 Microsoft.Build.Execution.MSBuildClient
 Microsoft.Build.Execution.MSBuildClient.Execute(string commandLine, System.Threading.CancellationToken cancellationToken) -> Microsoft.Build.Execution.MSBuildClientExitResult
 Microsoft.Build.Execution.MSBuildClient.MSBuildClient(string exeLocation, string dllLocation) -> void

--- a/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.Build.Evaluation.ProjectCollection.ProjectCollection(System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool reuseProjectRootElementCache) -> void
 Microsoft.Build.Execution.MSBuildClient
 Microsoft.Build.Execution.MSBuildClient.Execute(string commandLine, System.Threading.CancellationToken cancellationToken) -> Microsoft.Build.Execution.MSBuildClientExitResult
 Microsoft.Build.Execution.MSBuildClient.MSBuildClient(string exeLocation, string dllLocation) -> void

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1082,7 +1082,8 @@ namespace Microsoft.Build.CommandLine
                     toolsetDefinitionLocations,
                     cpuCount,
                     onlyLogCriticalEvents,
-                    loadProjectsReadOnly: !preprocessOnly
+                    loadProjectsReadOnly: !preprocessOnly,
+                    reuseProjectRootElementCache: s_isServerNode
                 );
 
                 if (toolsVersion != null && !projectCollection.ContainsToolset(toolsVersion))
@@ -1315,7 +1316,14 @@ namespace Microsoft.Build.CommandLine
                 FileUtilities.ClearCacheDirectory();
                 projectCollection?.Dispose();
 
-                BuildManager.DefaultBuildManager.Dispose();
+                // Build manager shall be reused for all build sessions.
+                // If, for one reason or another, this behavior needs to change in future
+                // please be aware that current code creates and keep running  InProcNode even
+                // when its owning default build manager is disposed resulting in leek of memory and threads.
+                if (!s_isServerNode)
+                {
+                    BuildManager.DefaultBuildManager.Dispose();
+                }
             }
 
             return success;


### PR DESCRIPTION
Fixes #7639

### Context
Memory leak has been detected when MSBuild server runs many sessions.

### Changes Made
- Reusing `BuildManager.DefaultBuildManager` by not disposing it.
- Reusing `ProjectRootElementCache` between MSBuild server sessions.
- Do not clear `ProjectRootElementCache` before build.

### Testing
Manual tests. Manual memory consumption analyze.

When I run simple console.csproj build in loop this is how used memory looked like:

Before:
![image](https://user-images.githubusercontent.com/25249058/170666608-3ac0a687-4099-49bd-b7bf-39112e798eaf.png)

After:
![image](https://user-images.githubusercontent.com/25249058/170666071-6117d9a3-1975-4473-a7d3-da451d5a029d.png)

### Notes
Changes are isolated to Server mode only.
`XmlDocumentWithLocation.s_globalStringCache` roots unbounded `ProjectStringCache._documents` which is not cleared at the end of build but at the start of build indirectly through `ProjectRootElementCache` callbacks, so if `ProjectRootElementCache` is not reused, it is never cleared.

