### PR TITLE
Avoid AssemblyName.KeyPair on .NET

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -147,7 +147,7 @@ jobs:
 - job: CoreBootstrappedOnLinux
   displayName: "Linux Core"
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build
@@ -179,7 +179,7 @@ jobs:
 - job: CoreOnMac
   displayName: "macOS Core"
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build
@@ -211,7 +211,7 @@ jobs:
 - job: MonoOnMac
   displayName: "macOS Mono"
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   steps:
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#mono
   - bash: |

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -147,7 +147,7 @@ jobs:
 - job: CoreBootstrappedOnLinux
   displayName: "Linux Core"
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-18.04'
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -156,12 +156,12 @@ stages:
 
     # Publishes setup VSIXes to a drop.
     # Note: The insertion tool looks for the display name of this task in the logs.
-    - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
-      displayName: Upload VSTS Drop
-      inputs:
-        DropName: $(VisualStudio.DropName)
-        DropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-      condition: succeeded()
+    # - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
+    #   displayName: Upload VSTS Drop
+    #   inputs:
+    #     DropName: $(VisualStudio.DropName)
+    #     DropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+    #   condition: succeeded()
 
     # Publish an artifact that the RoslynInsertionTool is able to find by its name.
     - task: PublishBuildArtifacts@1

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -28,7 +28,7 @@ stages:
   jobs:
   - job: Windows_NT
     pool:
-      name: VSEng-MicroBuildVS2019
+      name: VSEngSS-MicroBuild2019-1ES
       demands:
       - agent.os -equals Windows_NT
 

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -99,46 +99,46 @@ stages:
       condition: succeeded()
 
     # Publish OptProf configuration files
-    - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
-      inputs:
-        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
-        sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
-        toLowerCase: false
-        usePat: false
-      displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
-      condition: succeeded()
+    # - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+    #   inputs:
+    #     dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+    #     buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+    #     sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
+    #     toLowerCase: false
+    #     usePat: false
+    #   displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
+    #   condition: succeeded()
 
     # Build VS bootstrapper
     # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-    - task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
-      inputs:
-        vsMajorVersion: $(VisualStudio.MajorVersion)
-        channelName: $(VisualStudio.ChannelName)
-        manifests: $(VisualStudio.SetupManifestList)
-        outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-      displayName: 'OptProf - Build VS bootstrapper'
-      condition: succeeded()
+    # - task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
+    #   inputs:
+    #     vsMajorVersion: $(VisualStudio.MajorVersion)
+    #     channelName: $(VisualStudio.ChannelName)
+    #     manifests: $(VisualStudio.SetupManifestList)
+    #     outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+    #   displayName: 'OptProf - Build VS bootstrapper'
+    #   condition: succeeded()
 
     # Publish run settings
-    - task: PowerShell@2
-      inputs:
-        filePath: eng\common\sdk-task.ps1
-        arguments: -configuration $(BuildConfiguration)
-                  -task VisualStudio.BuildIbcTrainingSettings
-                  /p:VisualStudioDropName=$(VisualStudio.DropName)
-                  /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-      displayName: 'OptProf - Build IBC training settings'
-      condition: succeeded()
+    # - task: PowerShell@2
+    #   inputs:
+    #     filePath: eng\common\sdk-task.ps1
+    #     arguments: -configuration $(BuildConfiguration)
+    #               -task VisualStudio.BuildIbcTrainingSettings
+    #               /p:VisualStudioDropName=$(VisualStudio.DropName)
+    #               /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+    #   displayName: 'OptProf - Build IBC training settings'
+    #   condition: succeeded()
 
     # Publish bootstrapper info
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-        ArtifactName: MicroBuildOutputs
-        ArtifactType: Container
-      displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-      condition: succeeded()
+    # - task: PublishBuildArtifacts@1
+    #   inputs:
+    #     PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+    #     ArtifactName: MicroBuildOutputs
+    #     ArtifactType: Container
+    #   displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
+    #   condition: succeeded()
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: logs'
@@ -199,11 +199,11 @@ stages:
       condition: succeeded()
 
     # Tag the build at the very end when we know it's been successful.
-    - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-      displayName: Tag build as ready for optimization training
-      inputs:
-        tags: 'ready-for-training'
-      condition: succeeded()
+    # - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+    #   displayName: Tag build as ready for optimization training
+    #   inputs:
+    #     tags: 'ready-for-training'
+    #   condition: succeeded()
 
     - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
       displayName: Execute cleanup tasks

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <!-- Toolset Dependencies -->
   <PropertyGroup>
-    <DotNetCliVersion>3.1.100</DotNetCliVersion>
+    <DotNetCliVersion>3.1.120</DotNetCliVersion>
     <MicrosoftNetCompilersToolsetVersion>3.3.1-beta3-final</MicrosoftNetCompilersToolsetVersion>
     <NuGetBuildTasksVersion>5.9.0-preview.3.7016</NuGetBuildTasksVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.9.2</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>16.9.3</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.1.100",
+    "dotnet": "3.1.120",
     "runtimes": {
       "dotnet/x64": [
         "2.1.7"

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -147,7 +147,9 @@ namespace Microsoft.Build.Shared
                 var hashAlgorithm = (System.Configuration.Assemblies.AssemblyHashAlgorithm) info.GetInt32("hashAlg");
                 var versionCompatibility = (AssemblyVersionCompatibility) info.GetInt32("verCompat");
                 var codeBase = info.GetString("codebase");
+#if NETFRAMEWORK
                 var keyPair = (StrongNameKeyPair) info.GetValue("keypair", typeof(StrongNameKeyPair));
+#endif
 
                 asAssemblyName = new AssemblyName
                 {
@@ -159,7 +161,9 @@ namespace Microsoft.Build.Shared
                     HashAlgorithm = hashAlgorithm,
                     VersionCompatibility = versionCompatibility,
                     CodeBase = codeBase,
+#if NETFRAMEWORK
                     KeyPair = keyPair
+#endif
                 };
 
                 asAssemblyName.SetPublicKey(publicKey);
@@ -984,7 +988,9 @@ namespace Microsoft.Build.Shared
                 info.AddValue("hashAlg", asAssemblyName.HashAlgorithm);
                 info.AddValue("verCompat", asAssemblyName.VersionCompatibility);
                 info.AddValue("codebase", asAssemblyName.CodeBase);
+#if NETFRAMEWORK
                 info.AddValue("keypair", asAssemblyName.KeyPair);
+#endif
             }
 
             info.AddValue("asStr", asString);


### PR DESCRIPTION
It throws on .NET 6 and wasn't helpful before anyway:

(from https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assemblyname.keypair?view=net-5.0#remarks):

> When the runtime loads an assembly, it does not set the KeyPair property. The getter for the property is only useful if the user set the property before using the AssemblyName object to create a dynamic assembly, and subsequently wants to retrieve the key pair.

Fixes https://github.com/dotnet/msbuild/issues/7662

Work item (Internal use): 

### Summary


### Customer Impact


### Regression?


### Testing


### Risk
