### PR TITLE
backport keypair elision 16.11

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -223,7 +223,7 @@ jobs:
   condition: eq(1,2)
   displayName: "macOS Mono"
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   steps:
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#mono
   - bash: |

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -74,14 +74,14 @@ stages:
         signType: $(SignType)
         zipSources: false
       condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
-      
+
     - task: MicroBuildOptProfPlugin@6
       inputs:
         ProfilingInputsDropName: '$(VisualStudio.DropName)'
         ShouldSkipOptimize: true
         AccessToken: '$(System.AccessToken)'
         feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-      displayName: 'Install OptProf Plugin'      
+      displayName: 'Install OptProf Plugin'
 
     # Required by MicroBuildBuildVSBootstrapper
     - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.22159.5">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.22276.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ee744068a4fcccc5b8b56e0025f9c95aa19ff318</Sha>
+      <Sha>9c6a04ea1e79e9fcd4e60abd5d2c577075787f93</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.9.1-rc.8">
       <Uri>https://github.com/nuget/nuget.client</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.22123.4">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.22159.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>295d305a5520815cbf4ccb3f209f6ee8ba11b45d</Sha>
+      <Sha>ee744068a4fcccc5b8b56e0025f9c95aa19ff318</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.9.1-rc.8">
       <Uri>https://github.com/nuget/nuget.client</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
          Otherwise, this version of dotnet will not be installed and the build will error out. -->
     <DotNetCliVersion>5.0.408</DotNetCliVersion>
     <MicrosoftNetCompilersToolsetVersion>3.9.0-2.20574.26</MicrosoftNetCompilersToolsetVersion>
-    <NuGetBuildTasksVersion>5.11.0-rc.10</NuGetBuildTasksVersion>
+    <NuGetBuildTasksVersion>5.11.1-rc.5</NuGetBuildTasksVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,7 +28,7 @@
   <PropertyGroup>
     <!-- DotNetCliVersion MUST match the dotnet version in global.json.
          Otherwise, this version of dotnet will not be installed and the build will error out. -->
-    <DotNetCliVersion>5.0.401</DotNetCliVersion>
+    <DotNetCliVersion>5.0.408</DotNetCliVersion>
     <MicrosoftNetCompilersToolsetVersion>3.9.0-2.20574.26</MicrosoftNetCompilersToolsetVersion>
     <NuGetBuildTasksVersion>5.11.0-rc.10</NuGetBuildTasksVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,8 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.11.2</VersionPrefix>
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>16.11.3</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -184,6 +184,7 @@ stages:
             arguments: -task SigningValidation -restore -msbuildEngine vs
               /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
               /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt'
+              /p:CheckEolTargetFramework=false
               ${{ parameters.signingValidationAdditionalParameters }}
 
         - template: ../steps/publish-logs.yml

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.401",
+    "dotnet": "5.0.408",
     "runtimes": {
       "dotnet/x64": [
         "2.1.7"
@@ -12,6 +12,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.22159.5"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.22276.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -12,6 +12,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.22123.4"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.22159.5"
   }
 }

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -148,7 +148,9 @@ namespace Microsoft.Build.Shared
                 var hashAlgorithm = (System.Configuration.Assemblies.AssemblyHashAlgorithm) info.GetInt32("hashAlg");
                 var versionCompatibility = (AssemblyVersionCompatibility) info.GetInt32("verCompat");
                 var codeBase = info.GetString("codebase");
+#if NETFRAMEWORK
                 var keyPair = (StrongNameKeyPair) info.GetValue("keypair", typeof(StrongNameKeyPair));
+#endif
 
                 asAssemblyName = new AssemblyName
                 {
@@ -160,7 +162,9 @@ namespace Microsoft.Build.Shared
                     HashAlgorithm = hashAlgorithm,
                     VersionCompatibility = versionCompatibility,
                     CodeBase = codeBase,
+#if NETFRAMEWORK
                     KeyPair = keyPair
+#endif
                 };
 
                 asAssemblyName.SetPublicKey(publicKey);
@@ -1001,7 +1005,9 @@ namespace Microsoft.Build.Shared
                 info.AddValue("hashAlg", asAssemblyName.HashAlgorithm);
                 info.AddValue("verCompat", asAssemblyName.VersionCompatibility);
                 info.AddValue("codebase", asAssemblyName.CodeBase);
+#if NETFRAMEWORK
                 info.AddValue("keypair", asAssemblyName.KeyPair);
+#endif
             }
 
             info.AddValue("asStr", asString);


### PR DESCRIPTION
- Update dependencies from https://github.com/dotnet/arcade build 20220309.5
- Update dependencies from https://github.com/dotnet/arcade build 20220526.2
- Bump CLI version to match global.json
- Bump NuGet version to match
- Avoid AssemblyName.KeyPair on .NET (#7660)

Fixes #

Work item (Internal use): 

### Summary


### Customer Impact


### Regression?


### Testing


### Risk
