### PR TITLE
Prevent symlink cycle

### DIFF
--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -90,6 +90,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEINFORMATION</DefineConstants>
     <DefineConstants>$(DefineConstants);USE_MSBUILD_DLL_EXTN</DefineConstants>
     <DefineConstants>$(DefineConstants);WORKAROUND_COREFX_19110</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SYMLINK_TARGET</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'net6.0'">

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -979,7 +979,8 @@ namespace Microsoft.Build.Shared
                     if (searchesToExcludeInSubdirs.TryGetValue(subdir, out List<RecursionState> searchesForSubdir))
                     {
                         // We've found the base directory that these exclusions apply to.  So now add them as normal searches
-                        newSearchesToExclude ??= new(searchesForSubdir);
+                        newSearchesToExclude ??= new();
+                        newSearchesToExclude.AddRange(searchesForSubdir);
                     }
                 }
 

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -2,17 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
-using System.IO;
-using System.Text;
-using System.Diagnostics;
-using System.Linq;
-using System.Text.RegularExpressions;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared.FileSystem;
-using System.Buffers;
 
 #nullable disable
 

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -855,7 +855,8 @@ namespace Microsoft.Build.Shared
                 }
             }
             // This fails in tests with the MockFileSystem when they don't have real paths.
-            catch (Exception) { }
+            catch (IOException) { }
+            catch (ArgumentException) { }
 #endif
 
             ErrorUtilities.VerifyThrow((recursionState.SearchData.Filespec == null) || (recursionState.SearchData.RegexFileMatch == null),

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -857,6 +857,7 @@ namespace Microsoft.Build.Shared
             // This fails in tests with the MockFileSystem when they don't have real paths.
             catch (IOException) { }
             catch (ArgumentException) { }
+            catch (UnauthorizedAccessException) { }
 #endif
 
             ErrorUtilities.VerifyThrow((recursionState.SearchData.Filespec == null) || (recursionState.SearchData.RegexFileMatch == null),

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared.FileSystem;
+using System.Buffers;
 
 #nullable disable
 
@@ -836,6 +837,20 @@ namespace Microsoft.Build.Shared
             Dictionary<string, List<RecursionState>> searchesToExcludeInSubdirs,
             TaskOptions taskOptions)
         {
+#if NET6_0
+            // This is a pretty quick, simple check, but it misses some cases:
+            // symlink in folder A pointing to folder B and symlink in folder B pointing to folder A
+            // GetFiles in folder C that contains a symlink that points folder D, which contains C as well as other files
+            // and most obviously, frameworks other than net6.0
+            // The solution I'd propose for the first two, if necessary, would be maintaining a set of symlinks and verifying, before following it,
+            // that we had not followed it previously. The third would require a more involved P/invoke-style fix.
+            DirectoryInfo baseDirectoryInfo = new(recursionState.BaseDirectory);
+            if (baseDirectoryInfo.LinkTarget is not null && baseDirectoryInfo.FullName.Contains(baseDirectoryInfo.LinkTarget))
+            {
+                return;
+            }
+#endif
+
             ErrorUtilities.VerifyThrow((recursionState.SearchData.Filespec == null) || (recursionState.SearchData.RegexFileMatch == null),
                 "File-spec overrides the regular expression -- pass null for file-spec if you want to use the regular expression.");
 

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -846,12 +846,16 @@ namespace Microsoft.Build.Shared
             // The solution I'd propose for the first two, if necessary, would be maintaining a set of symlinks and verifying, before following it,
             // that we had not followed it previously. The third would require a more involved P/invoke-style fix.
             // These issues should ideally be resolved as part of #703
-            DirectoryInfo info = new(recursionState.BaseDirectory);
-            FileSystemInfo linkTarget = Directory.ResolveLinkTarget(recursionState.BaseDirectory, returnFinalTarget: true);
-            if (linkTarget is not null && recursionState.BaseDirectory.Contains(linkTarget.FullName))
+            try
             {
-                return;
+                FileSystemInfo linkTarget = Directory.ResolveLinkTarget(recursionState.BaseDirectory, returnFinalTarget: true);
+                if (linkTarget is not null && recursionState.BaseDirectory.Contains(linkTarget.FullName))
+                {
+                    return;
+                }
             }
+            // This fails in tests with the MockFileSystem when they don't have real paths.
+            catch (Exception) { }
 #endif
 
             ErrorUtilities.VerifyThrow((recursionState.SearchData.Filespec == null) || (recursionState.SearchData.RegexFileMatch == null),

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -67,17 +67,18 @@ namespace Microsoft.Build.UnitTests
             fileMatches.Length.ShouldBe(expectedMatchCount, $"Matches: '{String.Join("', '", fileMatches)}'");
         }
 
-#if NET6_0_OR_GREATER
+#if FEATURE_SYMLINK_TARGET
         [Fact]
         // Please provide a better name for this test.
         public void DoNotFollowRecursiveSymlinks()
         {
             TransientTestFolder testFolder = _env.CreateFolder();
             TransientTestFile file = _env.CreateFile(testFolder, "Foo.cs");
-            string symlinkPath = Path.Combine(testFolder.Path, "mySymlink");
+            TransientTestFolder tf2 = _env.CreateFolder(Path.Combine(testFolder.Path, "subfolder"));
+            string symlinkPath = Path.Combine(tf2.Path, "mySymlink");
             try
             {
-                File.CreateSymbolicLink(symlinkPath, testFolder.Path);
+                Directory.CreateSymbolicLink(symlinkPath, testFolder.Path);
                 string[] fileMatches = FileMatcher.Default.GetFiles(testFolder.Path, "**").FileList;
                 fileMatches.Length.ShouldBe(1);
             }

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -84,9 +84,9 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                if (File.Exists(symlinkPath))
+                if (Directory.Exists(symlinkPath))
                 {
-                    File.Delete(symlinkPath);
+                    Directory.Delete(symlinkPath);
                 }
             }
         }

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -69,7 +69,6 @@ namespace Microsoft.Build.UnitTests
 
 #if FEATURE_SYMLINK_TARGET
         [Fact]
-        // Please provide a better name for this test.
         public void DoNotFollowRecursiveSymlinks()
         {
             TransientTestFolder testFolder = _env.CreateFolder();

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -67,6 +67,30 @@ namespace Microsoft.Build.UnitTests
             fileMatches.Length.ShouldBe(expectedMatchCount, $"Matches: '{String.Join("', '", fileMatches)}'");
         }
 
+#if NET6_0_OR_GREATER
+        [Fact]
+        // Please provide a better name for this test.
+        public void DoNotFollowRecursiveSymlinks()
+        {
+            TransientTestFolder testFolder = _env.CreateFolder();
+            TransientTestFile file = _env.CreateFile(testFolder, "Foo.cs");
+            string symlinkPath = Path.Combine(testFolder.Path, "mySymlink");
+            try
+            {
+                File.CreateSymbolicLink(symlinkPath, testFolder.Path);
+                string[] fileMatches = FileMatcher.Default.GetFiles(testFolder.Path, "**").FileList;
+                fileMatches.Length.ShouldBe(1);
+            }
+            finally
+            {
+                if (File.Exists(symlinkPath))
+                {
+                    File.Delete(symlinkPath);
+                }
+            }
+        }
+#endif
+
         [Theory]
         [MemberData(nameof(GetFilesComplexGlobbingMatchingInfo.GetTestData), MemberType = typeof(GetFilesComplexGlobbingMatchingInfo))]
         public void GetFilesComplexGlobbingMatching(GetFilesComplexGlobbingMatchingInfo info)
@@ -2077,7 +2101,7 @@ namespace Microsoft.Build.UnitTests
             isLegalFileSpec.ShouldBe(expectedIsLegalFileSpec);
         }
 
-        #region Support functions.
+#region Support functions.
 
         /// <summary>
         /// This support class simulates a file system.
@@ -2758,7 +2782,7 @@ namespace Microsoft.Build.UnitTests
             return match.isMatch;
         }
 
-        #endregion
+#endregion
 
         private class FileSystemAdapter : IFileSystem
         {

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -44,7 +44,6 @@
     <Compile Include="..\Shared\UnitTests\EscapingUtilities_Tests.cs" />
     <Compile Include="..\Shared\UnitTests\ErrorUtilities_Tests.cs" />
     <Compile Include="..\Shared\UnitTests\PrintLineDebugger_Tests.cs" />
-    <Compile Include="..\Shared\UnitTests\FileMatcher_Tests.cs" />
     <Compile Include="..\Shared\UnitTests\MockEngine.cs" />
     <Compile Include="..\Shared\UnitTests\MockLogger.cs" />
     <Compile Include="..\Shared\UnitTests\NativeMethodsShared_Tests.cs">


### PR DESCRIPTION
Fixes-ish [AB#1513887](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1513887)

### Context
A symlink in folder A pointing to A will recurse eternally (hang). This fixes that problem in a fairly simple way.

### Changes Made
Check if a symlink would take us to a folder above the one we're in before following it.

### Testing
I'd rather not introduce something that, if broken, just hangs.