### PR TITLE
Annotate windows-specific methods as windows-only Fixes #7612

### DIFF
--- a/src/Build.UnitTests/BackEnd/TargetUpToDateChecker_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetUpToDateChecker_Tests.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using System.Runtime.Versioning;
 
 #nullable disable
 
@@ -919,6 +920,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private static readonly DateTime New = new DateTime(2002, 1, 1);
 
         [Fact(Skip = "Creating a symlink on Windows requires elevation.")]
+        [SkipOnPlatform(TestPlatforms.AnyUnix, "Windows-specific test")]
+        [SupportedOSPlatform("windows")]
         public void NewSymlinkOldDestinationIsUpToDate()
         {
             SimpleSymlinkInputCheck(symlinkWriteTime: New,
@@ -928,6 +931,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact(Skip = "Creating a symlink on Windows requires elevation.")]
+        [SkipOnPlatform(TestPlatforms.AnyUnix, "Windows-specific test")]
+        [SupportedOSPlatform("windows")]
         public void OldSymlinkOldDestinationIsUpToDate()
         {
             SimpleSymlinkInputCheck(symlinkWriteTime: Old,
@@ -937,6 +942,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact(Skip = "Creating a symlink on Windows requires elevation.")]
+        [SkipOnPlatform(TestPlatforms.AnyUnix, "Windows-specific test")]
+        [SupportedOSPlatform("windows")]
         public void OldSymlinkNewDestinationIsNotUpToDate()
         {
             SimpleSymlinkInputCheck(symlinkWriteTime: Old,
@@ -946,6 +953,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact(Skip = "Creating a symlink on Windows requires elevation.")]
+        [SkipOnPlatform(TestPlatforms.AnyUnix, "Windows-specific test")]
+        [SupportedOSPlatform("windows")]
         public void NewSymlinkNewDestinationIsNotUpToDate()
         {
             SimpleSymlinkInputCheck(symlinkWriteTime: Middle,
@@ -956,12 +965,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         [DllImport("kernel32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
+        [SupportedOSPlatform("windows")]
         static extern bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, UInt32 dwFlags);
 
         [DllImport("kernel32.dll", SetLastError = true)]
+        [SupportedOSPlatform("windows")]
         private static extern bool SetFileTime(SafeFileHandle hFile, ref long creationTime,
             ref long lastAccessTime, ref long lastWriteTime);
 
+        [SupportedOSPlatform("windows")]
         private void SimpleSymlinkInputCheck(DateTime symlinkWriteTime, DateTime targetWriteTime,
             DateTime outputWriteTime, bool expectedOutOfDate)
         {

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -20,6 +20,7 @@ using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 using Microsoft.Build.Execution;
+using System.Runtime.Versioning;
 
 #nullable disable
 
@@ -2461,6 +2462,7 @@ namespace Microsoft.Build.UnitTests
         /// Check to see what kind of device we are outputting the log to, is it a character device, a file, or something else
         /// this can be used by loggers to modify their outputs based on the device they are writing to
         /// </summary>
+        [SupportedOSPlatform("windows")]
         internal bool IsRunningWithCharacterFileType()
         {
             // Get the std out handle

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -237,6 +237,8 @@ internal static class NativeMethods
         private SafeProcessHandle() : base(true)
         {
         }
+
+        [SupportedOSPlatform("windows")]
         protected override bool ReleaseHandle()
         {
             return CloseHandle(handle);
@@ -254,7 +256,7 @@ internal static class NativeMethods
         /// </summary>
         public MemoryStatus()
         {
-#if (CLR2COMPATIBILITY)
+#if CLR2COMPATIBILITY
             _length = (uint)Marshal.SizeOf(typeof(MemoryStatus));
 #else
             _length = (uint)Marshal.SizeOf<MemoryStatus>();
@@ -516,7 +518,7 @@ internal static class NativeMethods
             var result = GetLogicalCoreCountOnWindows();
             if (result != -1)
             {
-                numberOfCpus = result;
+                return result;
             }
         }
 #endif
@@ -530,6 +532,7 @@ internal static class NativeMethods
     /// as Environment.ProcessorCount has a 32-core limit in that case.
     /// https://github.com/dotnet/runtime/blob/221ad5b728f93489655df290c1ea52956ad8f51c/src/libraries/System.Runtime.Extensions/src/System/Environment.Windows.cs#L171-L210
     /// </summary>
+    [SupportedOSPlatform("windows")]
     private unsafe static int GetLogicalCoreCountOnWindows()
     {
         uint len = 0;
@@ -718,10 +721,7 @@ internal static class NativeMethods
 #else
         get
         {
-            if (_isWindows == null)
-            {
-                _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            }
+            _isWindows ??= RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             return _isWindows.Value;
         }
 #endif
@@ -741,10 +741,7 @@ internal static class NativeMethods
 #else
         get
         {
-            if (_isOSX == null)
-            {
-                _isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-            }
+            _isOSX ??= RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
             return _isOSX.Value;
         }
 #endif
@@ -869,21 +866,17 @@ internal static class NativeMethods
 
 #region Wrapper methods
 
-    /// <summary>
-    /// Really truly non pumping wait.
-    /// Raw IntPtrs have to be used, because the marshaller does not support arrays of SafeHandle, only
-    /// single SafeHandles.
-    /// </summary>
-    [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
-    public static extern Int32 WaitForMultipleObjects(uint handle, IntPtr[] handles, bool waitAll, uint milliseconds);
 
     [DllImport("kernel32.dll", SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
 
     [DllImport("kernel32.dll", SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern void GetNativeSystemInfo(ref SYSTEM_INFO lpSystemInfo);
 
     [DllImport("kernel32.dll", SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern bool GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP RelationshipType, IntPtr Buffer, ref uint ReturnedLength);
 
     /// <summary>
@@ -973,6 +966,7 @@ internal static class NativeMethods
     /// </summary>
     /// <param name="path"></param>
     /// <returns></returns>
+    [SupportedOSPlatform("windows")]
     internal static string GetLongFilePath(string path)
     {
         if (IsUnixLike)
@@ -1112,6 +1106,7 @@ internal static class NativeMethods
     /// This is the most accurate timestamp-extraction mechanism, but it is too slow to use all the time.
     /// See https://github.com/dotnet/msbuild/issues/2052.
     /// </remarks>
+    [SupportedOSPlatform("windows")]
     private static DateTime GetContentLastWriteFileUtcTime(string fullPath)
     {
         DateTime fileModifiedTime = DateTime.MinValue;
@@ -1179,6 +1174,7 @@ internal static class NativeMethods
     /// <summary>
     /// Kills the specified process by id and all of its children recursively.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     internal static void KillTree(int processIdToKill)
     {
         // Note that GetProcessById does *NOT* internally hold on to the process handle.
@@ -1257,6 +1253,7 @@ internal static class NativeMethods
     /// Returns the parent process id for the specified process.
     /// Returns zero if it cannot be gotten for some reason.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     internal static int GetParentProcessId(int processId)
     {
         int ParentID = 0;
@@ -1327,6 +1324,7 @@ internal static class NativeMethods
     /// Returns an array of all the immediate child processes by id.
     /// NOTE: The IntPtr in the tuple is the handle of the child process.  CloseHandle MUST be called on this.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     internal static List<KeyValuePair<int, SafeProcessHandle>> GetChildProcessIds(int parentProcessId, DateTime parentStartTime)
     {
         List<KeyValuePair<int, SafeProcessHandle>> myChildren = new List<KeyValuePair<int, SafeProcessHandle>>();
@@ -1391,6 +1389,7 @@ internal static class NativeMethods
         return Directory.GetCurrentDirectory();
     }
 
+    [SupportedOSPlatform("windows")]
     private unsafe static int GetCurrentDirectoryWin32(int nBufferLength, char* lpBuffer)
     {
         int pathLength = GetCurrentDirectory(nBufferLength, lpBuffer);
@@ -1398,6 +1397,7 @@ internal static class NativeMethods
         return pathLength;
     }
 
+    [SupportedOSPlatform("windows")]
     internal unsafe static string GetFullPath(string path)
     {
         int bufferSize = GetFullPathWin32(path, 0, null, IntPtr.Zero);
@@ -1407,6 +1407,7 @@ internal static class NativeMethods
         return AreStringsEqual(buffer, fullPathLength, path) ? path : new string(buffer, startIndex: 0, length: fullPathLength);
     }
 
+    [SupportedOSPlatform("windows")]
     private unsafe static int GetFullPathWin32(string target, int bufferLength, char* buffer, IntPtr mustBeZero)
     {
         int pathLength = GetFullPathName(target, bufferLength, buffer, mustBeZero);
@@ -1460,20 +1461,25 @@ internal static class NativeMethods
     /// that needs to be used for instance when writing to batch files
     /// </summary>
     [DllImport(kernel32Dll)]
+    [SupportedOSPlatform("windows")]
     internal static extern int GetOEMCP();
 
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     [return: MarshalAs(UnmanagedType.Bool)]
+    [SupportedOSPlatform("windows")]
     internal static extern bool GetFileAttributesEx(String name, int fileInfoLevel, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
 
     [DllImport("kernel32.dll", PreserveSig = true, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
+    [SupportedOSPlatform("windows")]
     internal static extern bool FreeLibrary([In] IntPtr module);
 
     [DllImport("kernel32.dll", PreserveSig = true, BestFitMapping = false, ThrowOnUnmappableChar = true, CharSet = CharSet.Ansi, SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern IntPtr GetProcAddress(IntPtr module, string procName);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, PreserveSig = true, SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern IntPtr LoadLibrary(string fileName);
 
     /// <summary>
@@ -1483,21 +1489,26 @@ internal static class NativeMethods
     /// <param name="buffer">The character buffer used to return the file name.</param>
     /// <param name="length">The length of the buffer.</param>
     [DllImport(kernel32Dll, SetLastError = true, CharSet = CharSet.Unicode)]
+    [SupportedOSPlatform("windows")]
     internal static extern int GetModuleFileName(HandleRef hModule, [Out] char[] buffer, int length);
 
     [DllImport("kernel32.dll")]
+    [SupportedOSPlatform("windows")]
     internal static extern IntPtr GetStdHandle(int nStdHandle);
 
     [DllImport("kernel32.dll")]
+    [SupportedOSPlatform("windows")]
     internal static extern uint GetFileType(IntPtr hFile);
 
     [SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api", Justification = "Using unmanaged equivalent for performance reasons")]
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [SupportedOSPlatform("windows")]
     internal unsafe static extern int GetCurrentDirectory(int nBufferLength, char* lpBuffer);
 
     [SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api", Justification = "Using unmanaged equivalent for performance reasons")]
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "SetCurrentDirectory")]
     [return: MarshalAs(UnmanagedType.Bool)]
+    [SupportedOSPlatform("windows")]
     internal static extern bool SetCurrentDirectoryWindows(string path);
 
     internal static bool SetCurrentDirectory(string path)
@@ -1519,28 +1530,36 @@ internal static class NativeMethods
     }
 
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [SupportedOSPlatform("windows")]
     internal static unsafe extern int GetFullPathName(string target, int bufferLength, char* buffer, IntPtr mustBeZero);
 
     [DllImport("KERNEL32.DLL")]
+    [SupportedOSPlatform("windows")]
     private static extern SafeProcessHandle OpenProcess(eDesiredAccess dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, int dwProcessId);
 
     [DllImport("NTDLL.DLL")]
+    [SupportedOSPlatform("windows")]
     private static extern int NtQueryInformationProcess(SafeProcessHandle hProcess, PROCESSINFOCLASS pic, ref PROCESS_BASIC_INFORMATION pbi, uint cb, ref int pSize);
 
     [return: MarshalAs(UnmanagedType.Bool)]
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     private static extern bool GlobalMemoryStatusEx([In, Out] MemoryStatus lpBuffer);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, BestFitMapping = false)]
+    [SupportedOSPlatform("windows")]
     internal static extern int GetShortPathName(string path, [Out] char[] fullpath, [In] int length);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, BestFitMapping = false)]
+    [SupportedOSPlatform("windows")]
     internal static extern int GetLongPathName([In] string path, [Out] char[] fullpath, [In] int length);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern bool CreatePipe(out SafeFileHandle hReadPipe, out SafeFileHandle hWritePipe, SecurityAttributes lpPipeAttributes, int nSize);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern bool ReadFile(SafeFileHandle hFile, byte[] lpBuffer, uint nNumberOfBytesToRead, out uint lpNumberOfBytesRead, IntPtr lpOverlapped);
 
     /// <summary>
@@ -1549,6 +1568,7 @@ internal static class NativeMethods
     /// build thread which the main thread (blocked on BuildSubmission.Execute) must service.
     /// </summary>
     [DllImport("ole32.dll")]
+    [SupportedOSPlatform("windows")]
     public static extern int CoWaitForMultipleHandles(COWAIT_FLAGS dwFlags, int dwTimeout, int cHandles, [MarshalAs(UnmanagedType.LPArray)] IntPtr[] pHandles, out int pdwIndex);
 
     internal const uint GENERIC_READ = 0x80000000;
@@ -1559,6 +1579,7 @@ internal static class NativeMethods
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall,
         SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern SafeFileHandle CreateFile(
         string lpFileName,
         uint dwDesiredAccess,
@@ -1570,6 +1591,7 @@ internal static class NativeMethods
         );
 
     [DllImport("kernel32.dll", SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern bool GetFileTime(
         SafeFileHandle hFile,
         out FILETIME lpCreationTime,
@@ -1579,55 +1601,12 @@ internal static class NativeMethods
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
+    [SupportedOSPlatform("windows")]
     internal static extern bool CloseHandle(IntPtr hObject);
 
     [DllImport("kernel32.dll", SetLastError = true)]
+    [SupportedOSPlatform("windows")]
     internal static extern bool SetThreadErrorMode(int newMode, out int oldMode);
-
-#endregion
-
-#region Extensions
-
-    /// <summary>
-    /// Waits while pumping APC messages.  This is important if the waiting thread is an STA thread which is potentially
-    /// servicing COM calls from other threads.
-    /// </summary>
-    [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle", Scope = "member", Target = "Microsoft.Build.Shared.NativeMethodsShared.#MsgWaitOne(System.Threading.WaitHandle,System.Int32)", Justification = "This is necessary and it has been used for a long time. No need to change it now.")]
-    internal static bool MsgWaitOne(this WaitHandle handle)
-    {
-        return handle.MsgWaitOne(Timeout.Infinite);
-    }
-
-    /// <summary>
-    /// Waits while pumping APC messages.  This is important if the waiting thread is an STA thread which is potentially
-    /// servicing COM calls from other threads.
-    /// </summary>
-    internal static bool MsgWaitOne(this WaitHandle handle, TimeSpan timeout)
-    {
-        return MsgWaitOne(handle, (int)timeout.TotalMilliseconds);
-    }
-
-    /// <summary>
-    /// Waits while pumping APC messages.  This is important if the waiting thread is an STA thread which is potentially
-    /// servicing COM calls from other threads.
-    /// </summary>
-    [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle", Justification = "Necessary to avoid pumping")]
-    internal static bool MsgWaitOne(this WaitHandle handle, int timeout)
-    {
-        // CoWaitForMultipleHandles allows us to wait in an STA apartment and still service RPC requests from other threads.
-        // VS needs this in order to allow the in-proc compilers to properly initialize, since they will make calls from the
-        // build thread which the main thread (blocked on BuildSubmission.Execute) must service.
-        int waitIndex;
-        IntPtr handlePtr = handle.SafeWaitHandle.DangerousGetHandle();
-        int returnValue = CoWaitForMultipleHandles(COWAIT_FLAGS.COWAIT_NONE, timeout, 1, new IntPtr[] { handlePtr }, out waitIndex);
-
-        if (!(returnValue == 0 || ((uint)returnValue == RPC_S_CALLPENDING && timeout != Timeout.Infinite)))
-        {
-            throw new InternalErrorException($"Received {returnValue} from CoWaitForMultipleHandles, but expected 0 (S_OK)");
-        }
-
-        return returnValue == 0;
-    }
 
 #endregion
 
@@ -1640,6 +1619,7 @@ internal static class NativeMethods
             : Directory.Exists(fullPath);
     }
 
+    [SupportedOSPlatform("windows")]
     internal static bool DirectoryExistsWindows(string fullPath)
     {
         WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
@@ -1654,6 +1634,7 @@ internal static class NativeMethods
             : File.Exists(fullPath);
     }
 
+    [SupportedOSPlatform("windows")]
     internal static bool FileExistsWindows(string fullPath)
     {
         WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
@@ -1668,6 +1649,7 @@ internal static class NativeMethods
             : File.Exists(path) || Directory.Exists(path);
     }
 
+    [SupportedOSPlatform("windows")]
     internal static bool FileOrDirectoryExistsWindows(string path)
     {
         WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();

--- a/src/Shared/FileSystem/MSBuildOnWindowsFileSystem.cs
+++ b/src/Shared/FileSystem/MSBuildOnWindowsFileSystem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Versioning;
 
 #nullable disable
 
@@ -13,6 +14,7 @@ namespace Microsoft.Build.Shared.FileSystem
     /// Implementation of file system operations on windows. Combination of native and managed implementations.
     /// TODO Remove this class and replace with WindowsFileSystem. Test perf to ensure no regressions.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     internal class MSBuildOnWindowsFileSystem : IFileSystem
     {
         private static readonly MSBuildOnWindowsFileSystem Instance = new MSBuildOnWindowsFileSystem();

--- a/src/Shared/FileSystem/WindowsFileSystem.cs
+++ b/src/Shared/FileSystem/WindowsFileSystem.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 #nullable disable
 
@@ -28,9 +29,10 @@ namespace Microsoft.Build.Shared.FileSystem
     /// Windows-specific implementation of file system operations using Windows native invocations.
     /// TODO For potential extra perf gains, provide native implementations for all IFileSystem methods and stop inheriting from ManagedFileSystem
     /// </summary>
+    [SupportedOSPlatform("windows")]
     internal class WindowsFileSystem : ManagedFileSystem
     {
-        private static readonly WindowsFileSystem Instance = new WindowsFileSystem();
+        private static readonly WindowsFileSystem Instance = new();
 
         public new static WindowsFileSystem Singleton() => WindowsFileSystem.Instance;
 


### PR DESCRIPTION
Also deleted a few unused methods

Fixes #7612

### Context
NativeMethods.KillTree uses a windows-specific native call. The same is true for a lot of other methods in that class. I annotated them to make that clear and prevent accidental usage in the future.

### Changes Made
Added annotations

### Testing
Built