### PR TITLE
CopyParallel - break from loop if cancellation was requested

### DIFF
--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -586,11 +586,18 @@ namespace Microsoft.Build.Tasks
 
             foreach (List<int> partition in partitionsByDestination.Values)
             {
-                bool partitionAccepted = partitionCopyActionBlock.Post(partition);
-                if (!partitionAccepted)
+                if (_cancellationTokenSource.IsCancellationRequested)
                 {
-                    // Retail assert...
-                    ErrorUtilities.ThrowInternalError("Failed posting a file copy to an ActionBlock. Should not happen with block at max int capacity.");
+                    break;
+                }
+                else
+                {
+                    bool partitionAccepted = partitionCopyActionBlock.Post(partition);
+                    if (!partitionAccepted)
+                    {
+                        // Retail assert...
+                        ErrorUtilities.ThrowInternalError("Failed posting a file copy to an ActionBlock. Should not happen with block at max int capacity.");
+                    }
                 }
             }
 

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -596,7 +596,6 @@ namespace Microsoft.Build.Tasks
                     // Retail assert...
                     ErrorUtilities.ThrowInternalError("Failed posting a file copy to an ActionBlock. Should not happen with block at max int capacity.");
                 }
-
             }
 
             partitionCopyActionBlock.Complete();

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -304,7 +304,7 @@ namespace Microsoft.Build.Tasks
 
                 File.Copy(sourceFileState.Name, destinationFileState.Name, true);
             }
-            
+
             // Files were successfully copied or linked. Those are equivalent here.
             WroteAtLeastOneFile = true;
 
@@ -586,19 +586,17 @@ namespace Microsoft.Build.Tasks
 
             foreach (List<int> partition in partitionsByDestination.Values)
             {
+                bool partitionAccepted = partitionCopyActionBlock.Post(partition);
                 if (_cancellationTokenSource.IsCancellationRequested)
                 {
                     break;
                 }
-                else
+                else if (!partitionAccepted)
                 {
-                    bool partitionAccepted = partitionCopyActionBlock.Post(partition);
-                    if (!partitionAccepted)
-                    {
-                        // Retail assert...
-                        ErrorUtilities.ThrowInternalError("Failed posting a file copy to an ActionBlock. Should not happen with block at max int capacity.");
-                    }
+                    // Retail assert...
+                    ErrorUtilities.ThrowInternalError("Failed posting a file copy to an ActionBlock. Should not happen with block at max int capacity.");
                 }
+
             }
 
             partitionCopyActionBlock.Complete();
@@ -948,17 +946,17 @@ namespace Microsoft.Build.Tasks
             return String.Equals(fullSourcePath, fullDestinationPath, filenameComparison);
         }
 
-    	private static int GetParallelismFromEnvironment()
-	    {
-	        int parallelism = Traits.Instance.CopyTaskParallelism;
-	        if (parallelism < 0)
-	        {
-	            parallelism = DefaultCopyParallelism;
-	        }
+        private static int GetParallelismFromEnvironment()
+        {
+            int parallelism = Traits.Instance.CopyTaskParallelism;
+            if (parallelism < 0)
+            {
+                parallelism = DefaultCopyParallelism;
+            }
             else if (parallelism == 0)
-	        {
-	            parallelism = int.MaxValue;
-	        }
+            {
+                parallelism = int.MaxValue;
+            }
             return parallelism;
         }
     }


### PR DESCRIPTION
Fixes #7088

### Context
MSBuild Error: Failed posting a file copy to an ActionBlock. Should not happen with block at max int capacity

### Changes Made
Added break from loop if cancellation was requested.

### Testing
Unit