### PR TITLE
Cleaning up msbuild static graph setplatform negotiation logic

### DIFF
--- a/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Build.Graph.UnitTests
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
                 GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties["Platform"].ShouldBe("AnyCPU");
                 GetFirstNodeWithProjectNumber(graph, 3).ProjectInstance.GlobalProperties["Platform"].ShouldBe("AnyCPU");
+                graph.ProjectNodes.Count.ShouldBe(3);
             }
         }
 

--- a/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
@@ -76,6 +76,47 @@ namespace Microsoft.Build.Graph.UnitTests
         }
 
         [Fact]
+        public void ResolvesMultibleReferencesToSameProject()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+
+                TransientTestFile entryProject = CreateProjectFile(env, 1, extraContent: @"<PropertyGroup>
+                                                                                                <EnableDynamicPlatformResolution>true</EnableDynamicPlatformResolution>
+                                                                                                <Platform>x64</Platform>
+                                                                                                <PlatformLookupTable>win32=x64</PlatformLookupTable>
+                                                                                            </PropertyGroup>
+                                                                                            <ItemGroup>
+                                                                                                <ProjectReference Include=""$(MSBuildThisFileDirectory)2.proj"" />
+                                                                                                <ProjectReference Include=""$(MSBuildThisFileDirectory)3.proj"" />
+                                                                                            </ItemGroup>");
+                var proj2 = env.CreateFile("2.proj", @"
+                                                    <Project>
+                                                        <PropertyGroup>
+                                                            <EnableDynamicPlatformResolution>true</EnableDynamicPlatformResolution>
+                                                            <Platforms>AnyCPU</Platforms>
+                                                        </PropertyGroup>
+                                                        <ItemGroup>
+                                                            <ProjectReference Include=""$(MSBuildThisFileDirectory)3.proj"" />
+                                                        </ItemGroup>
+                                                    </Project>");
+
+                var proj3 = env.CreateFile("3.proj", @"
+                                                    <Project>
+                                                        <PropertyGroup>
+                                                            <Platforms>AnyCPU</Platforms>
+                                                        </PropertyGroup>
+                                                    </Project>");
+
+
+                ProjectGraph graph = new ProjectGraph(entryProject.Path);
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties["Platform"].ShouldBe("AnyCPU");
+                GetFirstNodeWithProjectNumber(graph, 3).ProjectInstance.GlobalProperties["Platform"].ShouldBe("AnyCPU");
+
+            }
+        }
+
+        [Fact]
         public void ResolvesViaPlatformLookupTable()
         {
             using (var env = TestEnvironment.Create())

--- a/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
@@ -112,7 +112,6 @@ namespace Microsoft.Build.Graph.UnitTests
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
                 GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties["Platform"].ShouldBe("AnyCPU");
                 GetFirstNodeWithProjectNumber(graph, 3).ProjectInstance.GlobalProperties["Platform"].ShouldBe("AnyCPU");
-
             }
         }
 

--- a/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Graph.UnitTests
         }
 
         [Fact]
-        public void ResolvesMultibleReferencesToSameProject()
+        public void ResolvesMultipleReferencesToSameProject()
         {
             using (var env = TestEnvironment.Create())
             {

--- a/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
+++ b/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
@@ -58,12 +58,6 @@ namespace Microsoft.Build.BackEnd
             _toolsVersion = MSBuildConstants.CurrentToolsVersion;
             _globalProperties = globalProperties;
         }
-        public ConfigurationMetadata(string projectFullPath, PropertyDictionary<ProjectPropertyInstance> globalProperties, string previousPlatform, string previousPlatformLookupTable, bool isSetPlatformHardCoded) : this(projectFullPath, globalProperties)
-        {
-            PreviousPlatform = previousPlatform;
-            PreviousPlatformLookupTable = previousPlatformLookupTable;
-            IsSetPlatformHardCoded = isSetPlatformHardCoded;
-        }
 
         public ConfigurationMetadata(ITranslator translator)
         {
@@ -86,11 +80,6 @@ namespace Microsoft.Build.BackEnd
         /// or a Project tag, or the default.
         /// </summary>
         public string ToolsVersion => _toolsVersion;
-
-        public string PreviousPlatform { get; } = "";
-
-        public string PreviousPlatformLookupTable { get; } = "";
-        public bool IsSetPlatformHardCoded { get; } = false;
 
         private PropertyDictionary<ProjectPropertyInstance> _globalProperties;
 
@@ -175,12 +164,9 @@ namespace Microsoft.Build.BackEnd
             {
                 return true;
             }
-
             return ProjectFullPath.Equals(other.ProjectFullPath, StringComparison.OrdinalIgnoreCase) &&
-                   ToolsVersion.Equals(other.ToolsVersion, StringComparison.OrdinalIgnoreCase) &&
-                   GlobalProperties.Equals(other.GlobalProperties) &&
-                   PreviousPlatform.Equals(other.PreviousPlatform, StringComparison.OrdinalIgnoreCase) &&
-                   PreviousPlatformLookupTable.Equals(other.PreviousPlatformLookupTable, StringComparison.OrdinalIgnoreCase);
+                ToolsVersion.Equals(other.ToolsVersion, StringComparison.OrdinalIgnoreCase) &&
+                GlobalProperties.Equals(other.GlobalProperties);
         }
 
         private string DebugString()

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -22,10 +22,6 @@ namespace Microsoft.Build.Graph
 {
     internal class GraphBuilder
     {
-        private const string PlatformLookupTableMetadataName = "PlatformLookupTable";
-        private const string PlatformMetadataName = "Platform";
-        private const string PlatformsMetadataName = "Platforms";
-        private const string EnableDynamicPlatformResolutionMetadataName = "EnableDynamicPlatformResolution";
         internal const string SolutionItemReference = "_SolutionReference";
         
         /// <summary>
@@ -505,44 +501,18 @@ namespace Microsoft.Build.Graph
         {
             // TODO: ProjectInstance just converts the dictionary back to a PropertyDictionary, so find a way to directly provide it.
             var globalProperties = configurationMetadata.GlobalProperties.ToDictionary();
-            ProjectGraphNode graphNode;
-            ProjectInstance projectInstance;
-            var negotiatePlatform = PlatformNegotiationEnabled && !configurationMetadata.IsSetPlatformHardCoded;
 
-            projectInstance = _projectInstanceFactory(
-                                configurationMetadata.ProjectFullPath,
-                                negotiatePlatform ? null : globalProperties, // Platform negotiation requires an evaluation with no global properties first
-                                _projectCollection);
-
-            if (ConversionUtilities.ValidBooleanTrue(projectInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName)))
-            {
-                PlatformNegotiationEnabled = true;
-            }
+            var projectInstance = _projectInstanceFactory(
+                configurationMetadata.ProjectFullPath,
+                globalProperties,
+                _projectCollection);
 
             if (projectInstance == null)
             {
                 throw new InvalidOperationException(ResourceUtilities.GetResourceString("NullReferenceFromProjectInstanceFactory"));
             }
 
-            if (negotiatePlatform)
-            {
-                var selectedPlatform = PlatformNegotiation.GetNearestPlatform(projectInstance.GetPropertyValue(PlatformMetadataName), projectInstance.GetPropertyValue(PlatformsMetadataName), projectInstance.GetPropertyValue(PlatformLookupTableMetadataName), configurationMetadata.PreviousPlatformLookupTable, projectInstance.FullPath, configurationMetadata.PreviousPlatform);
-
-                if (selectedPlatform.Equals(String.Empty))
-                {
-                    globalProperties.Remove(PlatformMetadataName);
-                }
-                else
-                {
-                    globalProperties[PlatformMetadataName] = selectedPlatform;
-                }
-                projectInstance = _projectInstanceFactory(
-                                configurationMetadata.ProjectFullPath,
-                                globalProperties,
-                                _projectCollection);           
-            }
-
-            graphNode = new ProjectGraphNode(projectInstance);
+            var graphNode = new ProjectGraphNode(projectInstance);
 
             var referenceInfos = ParseReferences(graphNode);
 
@@ -578,8 +548,9 @@ namespace Microsoft.Build.Graph
         private List<ProjectInterpretation.ReferenceInfo> ParseReferences(ProjectGraphNode parsedProject)
         {
             var referenceInfos = new List<ProjectInterpretation.ReferenceInfo>();
+            
 
-            foreach (var referenceInfo in _projectInterpretation.GetReferences(parsedProject.ProjectInstance))
+            foreach (var referenceInfo in _projectInterpretation.GetReferences(parsedProject.ProjectInstance, _projectCollection, _projectInstanceFactory))
             {
                 if (FileUtilities.IsSolutionFilename(referenceInfo.ReferenceConfiguration.ProjectFullPath))
                 {

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -48,8 +48,6 @@ namespace Microsoft.Build.Graph
         private readonly ProjectGraph.ProjectInstanceFactoryFunc _projectInstanceFactory;
         private IReadOnlyDictionary<string, IReadOnlyCollection<string>> _solutionDependencies;
 
-        private bool PlatformNegotiationEnabled = false;
-
         public GraphBuilder(
             IEnumerable<ProjectGraphEntryPoint> entryPoints,
             ProjectCollection projectCollection,

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Build.Graph
                 var requesterPlatform = "";
                 var requesterPlatformLookupTable = "";
 
-                if (ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName)) && !projectReferenceItem.HasMetadata("setplatform"))
+                if (ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName)) && !projectReferenceItem.HasMetadata(SetPlatformMetadataName))
                 {
                     requesterPlatform = requesterInstance.GetPropertyValue("Platform");
                     requesterPlatformLookupTable = requesterInstance.GetPropertyValue("PlatformLookupTable");

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Build.Graph
         private const string InnerBuildReferenceItemName = "_ProjectSelfReference";
         internal static string TransitiveReferenceItemName = "_TransitiveProjectReference";
         internal const string AddTransitiveProjectReferencesInStaticGraphPropertyName = "AddTransitiveProjectReferencesInStaticGraph";
+        private const string PlatformLookupTableMetadataName = "PlatformLookupTable";
+        private const string PlatformMetadataName = "Platform";
+        private const string PlatformsMetadataName = "Platforms";
+        private const string EnableDynamicPlatformResolutionMetadataName = "EnableDynamicPlatformResolution";
 
         private static readonly char[] PropertySeparator = MSBuildConstants.SemicolonChar;
 
@@ -59,7 +63,7 @@ namespace Microsoft.Build.Graph
             }
         }
 
-        public IEnumerable<ReferenceInfo> GetReferences(ProjectInstance requesterInstance)
+        public IEnumerable<ReferenceInfo> GetReferences(ProjectInstance requesterInstance, ProjectCollection _projectCollection, ProjectGraph.ProjectInstanceFactoryFunc _projectInstanceFactory)
         {
             IEnumerable<ProjectItemInstance> projectReferenceItems;
             IEnumerable<GlobalPropertiesModifier> globalPropertiesModifiers = null;
@@ -101,13 +105,30 @@ namespace Microsoft.Build.Graph
                 var requesterPlatform = "";
                 var requesterPlatformLookupTable = "";
 
-                if (ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue("EnableDynamicPlatformResolution")))
+                if (ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName)) && !projectReferenceItem.HasMetadata("setplatform"))
                 {
                     requesterPlatform = requesterInstance.GetPropertyValue("Platform");
                     requesterPlatformLookupTable = requesterInstance.GetPropertyValue("PlatformLookupTable");
+
+                    var  projectInstance = _projectInstanceFactory(
+                        projectReferenceFullPath,
+                        null, // Platform negotiation requires an evaluation with no global properties first
+                        _projectCollection);
+
+                    var selectedPlatform = PlatformNegotiation.GetNearestPlatform(projectInstance.GetPropertyValue(PlatformMetadataName), projectInstance.GetPropertyValue(PlatformsMetadataName), projectInstance.GetPropertyValue(PlatformLookupTableMetadataName), requesterInstance.GetPropertyValue(PlatformLookupTableMetadataName), projectInstance.FullPath, requesterInstance.GetPropertyValue(PlatformMetadataName));
+
+                    if (selectedPlatform.Equals(String.Empty))
+                    {
+                        referenceGlobalProperties.Remove(PlatformMetadataName);
+                    }
+                    else
+                    {
+                        var platformPropertyInstance = ProjectPropertyInstance.Create(PlatformMetadataName, selectedPlatform);
+                        referenceGlobalProperties[PlatformMetadataName] = platformPropertyInstance;
+                    }
                 }
 
-                var referenceConfig = new ConfigurationMetadata(projectReferenceFullPath, referenceGlobalProperties, requesterPlatform, requesterPlatformLookupTable, projectReferenceItem.HasMetadata("SetPlatform"));
+                var referenceConfig = new ConfigurationMetadata(projectReferenceFullPath, referenceGlobalProperties);
 
                 yield return new ReferenceInfo(referenceConfig, projectReferenceItem);
             }

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Build.Graph
                 var requesterPlatform = "";
                 var requesterPlatformLookupTable = "";
 
-                if (ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName)) && !projectReferenceItem.HasMetadata(SetPlatformMetadataName))
+                if ( !projectReferenceItem.HasMetadata(SetPlatformMetadataName) && ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName)))
                 {
                     requesterPlatform = requesterInstance.GetPropertyValue("Platform");
                     requesterPlatformLookupTable = requesterInstance.GetPropertyValue("PlatformLookupTable");


### PR DESCRIPTION
Fixes #

This fixes an issue where if two projects each building a separate platform reference the same project and that project resolves to the same platform in both cases the project graph would have two separate nodes to that that references project.

Example
proj a (x86) -> projb (anycpu)
projc(x64) -> projb (anycpu)

This would output a projectgraph with the following nodes
proj a (x86)
projb (anycpu)
projb (anycpu)
projc(x64)

Correct behavior would be 

proj a (x86)
projb (anycpu)
projc(x64)

### Context


### Changes Made


### Testing

I added in a unit test to test for this scenario. 


### Notes

This way of doing the set platform negotiation is actually much closer to how it is done during build which is good as project graph is meant to mimic build as much as possible
