### PR TITLE
Avoid loading ConfigurationManager on .NET 6

### DIFF
--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -128,10 +128,21 @@ namespace Microsoft.Build.Evaluation
                     configurationReader = new ToolsetConfigurationReader(environmentProperties, globalProperties);
                 }
 
-                // Accumulation of properties is okay in the config file because it's deterministically ordered
-                defaultToolsVersionFromConfiguration = configurationReader.ReadToolsets(toolsets, globalProperties,
-                    initialProperties, true /* accumulate properties */, out overrideTasksPathFromConfiguration,
-                    out defaultOverrideToolsVersionFromConfiguration);
+                ReadConfigToolset();
+
+                // This is isolated into its own function in order to isolate loading of
+                // System.Configuration.ConfigurationManager.dll to codepaths that really
+                // need it as a way of mitigating the need to update references to that
+                // assembly in API consumers.
+                //
+                // https://github.com/microsoft/MSBuildLocator/issues/159
+                void ReadConfigToolset()
+                {
+                    // Accumulation of properties is okay in the config file because it's deterministically ordered
+                    defaultToolsVersionFromConfiguration = configurationReader.ReadToolsets(toolsets, globalProperties,
+                                    initialProperties, true /* accumulate properties */, out overrideTasksPathFromConfiguration,
+                                    out defaultOverrideToolsVersionFromConfiguration);
+                }
             }
 
             string defaultToolsVersionFromRegistry = null;


### PR DESCRIPTION
### Context

After we updated System.Configuration.ConfigurationManager to 6.0, it broke some API consumers that use MSBuildLocator because they deploy the old ConfigurationManager.dll, which prevents loading the new one even from the SDK directory.

### Changes Made

 This mitigates the problem by avoiding JITing a method that needs ConfigurationManager types on codepaths that won't use it (by moving the calls into a separate method).

### Testing

Validated that this makes the changes from dotnet/upgrade-assistant#1162 unnecessary (but harmless).
