### PR TITLE
Ignore dwproj

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -809,16 +809,28 @@ namespace Microsoft.Build.BackEnd
             }
             catch (InvalidProjectFileException ex)
             {
-                if (_projectLoggingContext != null)
+                if (_requestEntry.RequestConfiguration.ProjectFullPath.EndsWith("dwproj"))
+                {
+                    result = new BuildResult(_requestEntry.Request);
+                    if (_projectLoggingContext is null)
+                    {
+                        _nodeLoggingContext.LogWarning("SolutionParseUnknownProjectType", Path.GetFileName(_requestEntry.RequestConfiguration.ProjectFullPath));
+                    }
+                    else
+                    {
+                        _projectLoggingContext.LogWarning("SolutionParseUnknownProjectType", Path.GetFileName(_requestEntry.RequestConfiguration.ProjectFullPath));
+                    }
+                }
+                else if (_projectLoggingContext != null)
                 {
                     _projectLoggingContext.LogInvalidProjectFileError(ex);
+                    thrownException = ex;
                 }
                 else
                 {
                     _nodeLoggingContext.LogInvalidProjectFileError(ex);
+                    thrownException = ex;
                 }
-
-                thrownException = ex;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This should be extended to _not_ ignore known projects rather than just not erroring on dwproj.

Fixes #2064

### Context


### Changes Made


### Testing


### Notes
