### PR TITLE
Short circuit ValidBooleanTrue on empty strings

### DIFF
--- a/src/Shared/ConversionUtilities.cs
+++ b/src/Shared/ConversionUtilities.cs
@@ -96,12 +96,12 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static bool ValidBooleanTrue(string parameterValue)
         {
-            return String.Equals(parameterValue, "true", StringComparison.OrdinalIgnoreCase) ||
+            return !String.IsNullOrWhiteSpace(parameterValue) && (String.Equals(parameterValue, "true", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "on", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) ||
-                   String.Equals(parameterValue, "!no", StringComparison.OrdinalIgnoreCase);
+                   String.Equals(parameterValue, "!no", StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -110,12 +110,12 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private static bool ValidBooleanFalse(string parameterValue)
         {
-            return String.Equals(parameterValue, "false", StringComparison.OrdinalIgnoreCase) ||
+            return !String.IsNullOrWhiteSpace(parameterValue) && (String.Equals(parameterValue, "false", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "off", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "no", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) ||
-                   String.Equals(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase);
+                   String.Equals(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/src/Shared/ConversionUtilities.cs
+++ b/src/Shared/ConversionUtilities.cs
@@ -96,7 +96,8 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static bool ValidBooleanTrue(string parameterValue)
         {
-            return !String.IsNullOrWhiteSpace(parameterValue) && (String.Equals(parameterValue, "true", StringComparison.OrdinalIgnoreCase) ||
+            return !String.IsNullOrEmpty(parameterValue) &&
+                   (String.Equals(parameterValue, "true", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "on", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) ||
@@ -110,7 +111,8 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private static bool ValidBooleanFalse(string parameterValue)
         {
-            return !String.IsNullOrWhiteSpace(parameterValue) && (String.Equals(parameterValue, "false", StringComparison.OrdinalIgnoreCase) ||
+            return !String.IsNullOrEmpty(parameterValue) &&
+                   (String.Equals(parameterValue, "false", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "off", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "no", StringComparison.OrdinalIgnoreCase) ||
                    String.Equals(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) ||


### PR DESCRIPTION
### Context
ValidBooleanTrue & ValidBoolean false are called often and do lots of `String.Equals` checks. 

### Changes Made
Add a short-circuit for these string comparisons when the thing we're checking is null or empty.

### Testing


### Notes
