### PR TITLE
Always include BuildStartedEventArgs.BuildEnvironment

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -388,9 +388,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 message = ResourceUtilities.GetResourceString("BuildStarted");
             }
 
-            IDictionary<string, string> environmentProperties = _componentHost?.BuildParameters != null && Traits.Instance.LogAllEnvironmentVariables ?
-                _componentHost.BuildParameters.BuildProcessEnvironment
-                : null;
+            IDictionary<string, string> environmentProperties = _componentHost?.BuildParameters?.BuildProcessEnvironment;
 
             BuildStartedEventArgs buildEvent = new(message, helpKeyword: null, environmentProperties);
 


### PR DESCRIPTION
Tools like C++ depend on reading all environment variables from BuildStarted, so send it to all loggers like before.

BinaryLogger filters them out anyway unless LogAll trait is set.
