### PR TITLE
Enable tasks require for building WinUI projects in dotnet build

### DIFF
--- a/src/Tasks.UnitTests/GetInstalledSDKLocations_Tests.cs
+++ b/src/Tasks.UnitTests/GetInstalledSDKLocations_Tests.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Build.UnitTests.GetInstalledSDKLocation_Tests
     /// <summary>
     /// Test the GetInstalledSDKLocations task
     /// </summary>
+    [PlatformSpecific(TestPlatforms.Windows)]
     public class GetInstalledSDKLocationsTestFixture : IClassFixture<FakeSDKStructure>
     {
         private readonly string _fakeSDKStructureRoot;

--- a/src/Tasks.UnitTests/GetSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/GetSDKReference_Tests.cs
@@ -180,6 +180,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
     /// <summary>
     /// Test the expansion of sdk reference assemblies.
     /// </summary>
+    [PlatformSpecific(TestPlatforms.Windows)]
     public class GetSDKReferenceFilesTestFixture : IDisposable, IClassFixture<FakeSdkStructure>
     {
         private readonly ITestOutputHelper _output;

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -102,8 +102,6 @@
     <Compile Remove="ResourceHandling\GenerateResourceOutOfProc_Tests.cs" />
     <Compile Remove="ResourceHandling\ResGen_Tests.cs" />
     <Compile Remove="ResourceHandling\ResGenDependencies_Tests.cs" />
-    <Compile Remove="GetInstalledSDKLocations_Tests.cs" />
-    <Compile Remove="GetSDKReference_Tests.cs" />
     <Compile Remove="LC_Tests.cs" />
     <Compile Remove="MockTypeInfo.cs" />
     <Compile Remove="MockTypeLib.cs" />
@@ -124,7 +122,6 @@
     <Compile Remove="AssemblyDependency\VerifyTargetFrameworkHigherThanRedist.cs" />
     <Compile Remove="AssemblyDependency\WinMDTests.cs" />
     <Compile Remove="ResolveComReference_Tests.cs" />
-    <Compile Remove="ResolveSDKReference_Tests.cs" />
     <Compile Remove="SdkToolsPathUtility_Tests.cs" />
     <Compile Remove="TlbImp_Tests.cs" />
     <Compile Remove="VisualBasicParserUtilitites_Tests.cs" />

--- a/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
@@ -20,6 +20,7 @@ using Xunit;
 
 namespace Microsoft.Build.UnitTests.ResolveSDKReference_Tests
 {
+    [PlatformSpecific(TestPlatforms.Windows)]
     public class ResolveSDKReferenceTestFixture
     {
         private Microsoft.Build.UnitTests.MockEngine.GetStringDelegate _resourceDelegate = new Microsoft.Build.UnitTests.MockEngine.GetStringDelegate(AssemblyResources.GetString);

--- a/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
@@ -3701,6 +3701,7 @@ namespace Microsoft.Build.UnitTests.ResolveSDKReference_Tests
     /// <summary>
     /// Test the output groups which will be used to generate the recipe fileGatherSDKOutputGroups
     /// </summary>
+    [PlatformSpecific(TestPlatforms.Windows)]
     public class GatherSDKOutputGroupsTestFixture
     {
         [Fact]

--- a/src/Tasks/GetInstalledSDKLocations.cs
+++ b/src/Tasks/GetInstalledSDKLocations.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Build.Tasks
     ///  Gathers the list of installed SDKS in the registry and on disk and outputs them into the project
     ///  so they can be used during SDK reference resolution and RAR for single files.
     /// </summary>
+#pragma warning disable RS0022 // Constructor make noninheritable base class inheritable: Longstanding API design that we shouldn't change now
     public class GetInstalledSDKLocations : TaskExtension
+#pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
     {
         /// <summary>
         /// Metadata name for directory roots on installed SDK items

--- a/src/Tasks/GetInstalledSDKLocations.cs
+++ b/src/Tasks/GetInstalledSDKLocations.cs
@@ -124,6 +124,12 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public override bool Execute()
         {
+            if (!NativeMethodsShared.IsWindows)
+            {
+                Log.LogErrorWithCodeFromResources("General.TaskRequiresWindows", nameof(GetInstalledSDKLocations));
+                return false;
+            }
+
             // TargetPlatformVersion and TargetPlatformIdentifier are requried to correctly look for SDKs.
             if (String.IsNullOrEmpty(TargetPlatformVersion) || String.IsNullOrEmpty(TargetPlatformIdentifier))
             {

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Resolves an SDKReference to a full path on disk
     /// </summary>
+#pragma warning disable RS0022 // Constructor make noninheritable base class inheritable: Longstanding API design that we shouldn't change now
     public class GetSDKReferenceFiles : TaskExtension
+#pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
     {
         /// <summary>
         /// Set of resolvedSDK references which we will use to find the reference assemblies.
@@ -1084,7 +1086,7 @@ namespace Microsoft.Build.Tasks
                 string currentAssembly = String.Empty;
                 try
                 {
-                    currentAssembly = Assembly.GetExecutingAssembly().CodeBase;
+                    currentAssembly = Assembly.GetExecutingAssembly().Location;
                     var codeBase = new Uri(currentAssembly);
                     DateTime currentCodeLastWriteTime = File.GetLastWriteTimeUtc(codeBase.LocalPath);
                     if (FileSystems.Default.FileExists(referencesCacheFile) && currentCodeLastWriteTime < referencesCacheFileLastWriteTimeUtc)

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -227,6 +227,11 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public override bool Execute()
         {
+            if (!NativeMethodsShared.IsWindows)
+            {
+                Log.LogErrorWithCodeFromResources("General.TaskRequiresWindows", nameof(GetSDKReferenceFiles));
+                return false;
+            }
             return Execute(AssemblyNameExtension.GetAssemblyNameEx, AssemblyInformation.GetRuntimeVersion, p => FileUtilities.FileExistsNoThrow(p), synchronous: false);
         }
 

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -1091,7 +1091,11 @@ namespace Microsoft.Build.Tasks
                 string currentAssembly = String.Empty;
                 try
                 {
+#if NETCOREAPP
                     currentAssembly = Assembly.GetExecutingAssembly().Location;
+#else
+                    currentAssembly = Assembly.GetExecutingAssembly().CodeBase;
+#endif
                     var codeBase = new Uri(currentAssembly);
                     DateTime currentCodeLastWriteTime = File.GetLastWriteTimeUtc(codeBase.LocalPath);
                     if (FileSystems.Default.FileExists(referencesCacheFile) && currentCodeLastWriteTime < referencesCacheFileLastWriteTimeUtc)

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -417,6 +417,8 @@
     <Compile Include="GetAssemblyIdentity.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="GetInstalledSDKLocations.cs" />
+    <Compile Include="GetSDKReferenceFiles.cs" />
     <Compile Include="IAnalyzerHostObject.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -502,6 +504,7 @@
     <Compile Include="ResolveProjectBase.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="ResolveSDKReference.cs" />
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactory.cs" />
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryCodeType.cs" />
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryCompilers.cs" />
@@ -604,8 +607,6 @@
     <Compile Include="GetFrameworkSDKPath.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="GetInstalledSDKLocations.cs" />
-    <Compile Include="GetSDKReferenceFiles.cs" />
     <Compile Include="IComReferenceResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -626,7 +627,6 @@
     <Compile Include="ResolveNativeReference.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="ResolveSDKReference.cs" />
     <Compile Include="RequiresFramework35SP1Assembly.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Tasks/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Tasks/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,52 @@
+Microsoft.Build.Tasks.GetInstalledSDKLocations
+Microsoft.Build.Tasks.GetInstalledSDKLocations.GetInstalledSDKLocations() -> void
+Microsoft.Build.Tasks.GetInstalledSDKLocations.InstalledSDKs.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.GetInstalledSDKLocations.InstalledSDKs.set -> void
+Microsoft.Build.Tasks.GetInstalledSDKLocations.SDKDirectoryRoots.get -> string[]
+Microsoft.Build.Tasks.GetInstalledSDKLocations.SDKDirectoryRoots.set -> void
+Microsoft.Build.Tasks.GetInstalledSDKLocations.SDKExtensionDirectoryRoots.get -> string[]
+Microsoft.Build.Tasks.GetInstalledSDKLocations.SDKExtensionDirectoryRoots.set -> void
+Microsoft.Build.Tasks.GetInstalledSDKLocations.SDKRegistryRoot.get -> string
+Microsoft.Build.Tasks.GetInstalledSDKLocations.SDKRegistryRoot.set -> void
+Microsoft.Build.Tasks.GetInstalledSDKLocations.TargetPlatformIdentifier.get -> string
+Microsoft.Build.Tasks.GetInstalledSDKLocations.TargetPlatformIdentifier.set -> void
+Microsoft.Build.Tasks.GetInstalledSDKLocations.TargetPlatformVersion.get -> string
+Microsoft.Build.Tasks.GetInstalledSDKLocations.TargetPlatformVersion.set -> void
+Microsoft.Build.Tasks.GetInstalledSDKLocations.WarnWhenNoSDKsFound.get -> bool
+Microsoft.Build.Tasks.GetInstalledSDKLocations.WarnWhenNoSDKsFound.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles
+Microsoft.Build.Tasks.GetSDKReferenceFiles.CacheFileFolderPath.get -> string
+Microsoft.Build.Tasks.GetSDKReferenceFiles.CacheFileFolderPath.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.CopyLocalFiles.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.GetSDKReferenceFiles.GetSDKReferenceFiles() -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogCacheFileExceptions.get -> bool
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogCacheFileExceptions.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogRedistConflictBetweenSDKsAsWarning.get -> bool
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogRedistConflictBetweenSDKsAsWarning.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogRedistConflictWithinSDKAsWarning.get -> bool
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogRedistConflictWithinSDKAsWarning.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogRedistFilesList.get -> bool
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogRedistFilesList.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogReferenceConflictBetweenSDKsAsWarning.get -> bool
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogReferenceConflictBetweenSDKsAsWarning.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogReferenceConflictWithinSDKAsWarning.get -> bool
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogReferenceConflictWithinSDKAsWarning.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogReferencesList.get -> bool
+Microsoft.Build.Tasks.GetSDKReferenceFiles.LogReferencesList.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.RedistFiles.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.GetSDKReferenceFiles.ReferenceExtensions.get -> string[]
+Microsoft.Build.Tasks.GetSDKReferenceFiles.ReferenceExtensions.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.References.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.GetSDKReferenceFiles.ResolvedSDKReferences.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.GetSDKReferenceFiles.ResolvedSDKReferences.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.TargetPlatformIdentifier.get -> string
+Microsoft.Build.Tasks.GetSDKReferenceFiles.TargetPlatformIdentifier.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.TargetPlatformVersion.get -> string
+Microsoft.Build.Tasks.GetSDKReferenceFiles.TargetPlatformVersion.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.TargetSDKIdentifier.get -> string
+Microsoft.Build.Tasks.GetSDKReferenceFiles.TargetSDKIdentifier.set -> void
+Microsoft.Build.Tasks.GetSDKReferenceFiles.TargetSDKVersion.get -> string
+Microsoft.Build.Tasks.GetSDKReferenceFiles.TargetSDKVersion.set -> void
 Microsoft.Build.Tasks.IFixedTypeInfo
 Microsoft.Build.Tasks.IFixedTypeInfo.AddressOfMember(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, out System.IntPtr ppv) -> void
 Microsoft.Build.Tasks.IFixedTypeInfo.CreateInstance(object pUnkOuter, ref System.Guid riid, out object ppvObj) -> void
@@ -18,3 +67,35 @@ Microsoft.Build.Tasks.IFixedTypeInfo.Invoke(object pvInstance, int memid, short 
 Microsoft.Build.Tasks.IFixedTypeInfo.ReleaseFuncDesc(System.IntPtr pFuncDesc) -> void
 Microsoft.Build.Tasks.IFixedTypeInfo.ReleaseTypeAttr(System.IntPtr pTypeAttr) -> void
 Microsoft.Build.Tasks.IFixedTypeInfo.ReleaseVarDesc(System.IntPtr pVarDesc) -> void
+Microsoft.Build.Tasks.ResolveSDKReference
+Microsoft.Build.Tasks.ResolveSDKReference.DisallowedSDKDependencies.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.ResolveSDKReference.DisallowedSDKDependencies.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.InstalledSDKs.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.ResolveSDKReference.InstalledSDKs.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.LogResolutionErrorsAsWarnings.get -> bool
+Microsoft.Build.Tasks.ResolveSDKReference.LogResolutionErrorsAsWarnings.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.Prefer32Bit.get -> bool
+Microsoft.Build.Tasks.ResolveSDKReference.Prefer32Bit.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.ProjectName.get -> string
+Microsoft.Build.Tasks.ResolveSDKReference.ProjectName.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.References.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.ResolveSDKReference.References.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.ResolvedSDKReferences.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.ResolveSDKReference.ResolveSDKReference() -> void
+Microsoft.Build.Tasks.ResolveSDKReference.RuntimeReferenceOnlySDKDependencies.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.ResolveSDKReference.RuntimeReferenceOnlySDKDependencies.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.SDKReferences.get -> Microsoft.Build.Framework.ITaskItem[]
+Microsoft.Build.Tasks.ResolveSDKReference.SDKReferences.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.TargetedSDKArchitecture.get -> string
+Microsoft.Build.Tasks.ResolveSDKReference.TargetedSDKArchitecture.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.TargetedSDKConfiguration.get -> string
+Microsoft.Build.Tasks.ResolveSDKReference.TargetedSDKConfiguration.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.TargetPlatformIdentifier.get -> string
+Microsoft.Build.Tasks.ResolveSDKReference.TargetPlatformIdentifier.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.TargetPlatformVersion.get -> string
+Microsoft.Build.Tasks.ResolveSDKReference.TargetPlatformVersion.set -> void
+Microsoft.Build.Tasks.ResolveSDKReference.WarnOnMissingPlatformVersion.get -> bool
+Microsoft.Build.Tasks.ResolveSDKReference.WarnOnMissingPlatformVersion.set -> void
+override Microsoft.Build.Tasks.GetInstalledSDKLocations.Execute() -> bool
+override Microsoft.Build.Tasks.GetSDKReferenceFiles.Execute() -> bool
+override Microsoft.Build.Tasks.ResolveSDKReference.Execute() -> bool

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Resolves an SDKReference to a full path on disk
     /// </summary>
+#pragma warning disable RS0022 // Constructor make noninheritable base class inheritable: Longstanding API design that we shouldn't change now
     public class ResolveSDKReference : TaskExtension
+#pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
     {
         #region fields
 

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -259,6 +259,12 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public override bool Execute()
         {
+            if (!NativeMethodsShared.IsWindows)
+            {
+                Log.LogErrorWithCodeFromResources("General.TaskRequiresWindows", nameof(ResolveSDKReference));
+                return false;
+            }
+
             ResolvedSDKReferences = Array.Empty<ITaskItem>();
 
             if (InstalledSDKs.Length == 0)


### PR DESCRIPTION
Build some tasks for .NET 6 that were previously .NET Framework only (but are really Windows-only, and should work fine in `dotnet build`).

Fixes #7452