### PR TITLE
Maybe fix cpp

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -144,7 +144,6 @@ namespace Microsoft.Build.UnitTests
         {
             using (TestEnvironment env = TestEnvironment.Create())
             {
-                env.SetEnvironmentVariable("MSBUILDONLYLOGUSEDENVIRONMENTVARIABLES", "1");
                 env.SetEnvironmentVariable("EnvVar1", "itsValue");
                 env.SetEnvironmentVariable("EnvVar2", "value2");
                 env.SetEnvironmentVariable("EnvVar3", "value3");

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -29,31 +29,30 @@ namespace Microsoft.Build.UnitTests
         [InlineData(false)]
         public void RoundtripBuildStartedEventArgs(bool serializeAllEnvironmentVariables)
         {
-            using (TestEnvironment env = TestEnvironment.Create())
-            {
-                env.SetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES", serializeAllEnvironmentVariables ? "1" : null);
-                var args = new BuildStartedEventArgs(
-                    "Message",
-                    "HelpKeyword",
-                    DateTime.Parse("3/1/2017 11:11:56 AM"));
-                Roundtrip(args,
-                    e => e.Message,
-                    e => e.HelpKeyword,
-                    e => e.Timestamp.ToString());
+            Traits.Instance.LogAllEnvironmentVariables = serializeAllEnvironmentVariables;
+            var args = new BuildStartedEventArgs(
+                "Message",
+                "HelpKeyword",
+                DateTime.Parse("3/1/2017 11:11:56 AM"));
+            Roundtrip(args,
+                e => e.Message,
+                e => e.HelpKeyword,
+                e => e.Timestamp.ToString());
 
-                args = new BuildStartedEventArgs(
-                    "M",
-                    null,
-                    new Dictionary<string, string>
-                    {
-                    { "SampleName", "SampleValue" }
-                    });
-                Roundtrip(args,
-                    e => serializeAllEnvironmentVariables ? TranslationHelpers.ToString(e.BuildEnvironment) : null,
-                    e => e.HelpKeyword,
-                    e => e.ThreadId.ToString(),
-                    e => e.SenderName);
-            }
+            args = new BuildStartedEventArgs(
+                "M",
+                null,
+                new Dictionary<string, string>
+                {
+                { "SampleName", "SampleValue" }
+                });
+            Roundtrip(args,
+                e => serializeAllEnvironmentVariables ? TranslationHelpers.ToString(e.BuildEnvironment) : null,
+                e => e.HelpKeyword,
+                e => e.ThreadId.ToString(),
+                e => e.SenderName);
+
+            Traits.Instance.LogAllEnvironmentVariables = false;
         }
 
         [Fact]

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData(false)]
         public void RoundtripBuildStartedEventArgs(bool serializeAllEnvironmentVariables)
         {
-            Traits.Instance.LogAllEnvironmentVariables = serializeAllEnvironmentVariables;
+            Traits.LogAllEnvironmentVariables = serializeAllEnvironmentVariables;
             var args = new BuildStartedEventArgs(
                 "Message",
                 "HelpKeyword",
@@ -52,7 +52,7 @@ namespace Microsoft.Build.UnitTests
                 e => e.ThreadId.ToString(),
                 e => e.SenderName);
 
-            Traits.Instance.LogAllEnvironmentVariables = false;
+            Traits.LogAllEnvironmentVariables = false;
         }
 
         [Fact]

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -388,9 +388,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 message = ResourceUtilities.GetResourceString("BuildStarted");
             }
 
-            IDictionary<string, string> environmentProperties = _componentHost?.BuildParameters != null && Traits.Instance.LogAllEnvironmentVariables ?
-                _componentHost.BuildParameters.BuildProcessEnvironment
-                : null;
+            IDictionary<string, string> environmentProperties = _componentHost?.BuildParameters?.BuildProcessEnvironment;
 
             BuildStartedEventArgs buildEvent = new(message, helpKeyword: null, environmentProperties);
 

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 {
                     properties = Enumerable.Empty<DictionaryEntry>();
                 }
-                else if (Traits.Instance.LogAllEnvironmentVariables)
+                else if (Traits.LogAllEnvironmentVariables)
                 {
                     properties = projectProperties.GetCopyOnReadEnumerable(property => new DictionaryEntry(property.Name, property.EvaluatedValue));
                 }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -812,7 +812,7 @@ namespace Microsoft.Build.Evaluation
             if (this._evaluationLoggingContext.LoggingService.IncludeEvaluationPropertiesAndItems)
             {
                 globalProperties = _data.GlobalPropertiesDictionary;
-                properties = Traits.Instance.LogAllEnvironmentVariables ? _data.Properties : FilterOutEnvironmentDerivedProperties(_data.Properties);
+                properties = Traits.LogAllEnvironmentVariables ? _data.Properties : FilterOutEnvironmentDerivedProperties(_data.Properties);
                 items = _data.Items;
             }
 

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -1050,7 +1050,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     return true;
                 case "SHOWENVIRONMENT":
                     showEnvironment = true;
-                    Traits.Instance.LogAllEnvironmentVariables = true;
+                    Traits.LogAllEnvironmentVariables = true;
                     return true;
                 case "SHOWPROJECTFILE":
                     if (parameterValue == null)

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -1050,6 +1050,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     return true;
                 case "SHOWENVIRONMENT":
                     showEnvironment = true;
+                    Traits.Instance.LogAllEnvironmentVariables = true;
                     return true;
                 case "SHOWPROJECTFILE":
                     if (parameterValue == null)

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -940,7 +940,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
         public virtual void Shutdown()
         {
-            // do nothing
+            Traits.LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES")) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4);
         }
 
         internal abstract void ResetConsoleLoggerState();

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -247,7 +247,7 @@ Build
         {
             Write(BinaryLogRecordKind.BuildStarted);
             WriteBuildEventArgsFields(e);
-            if (Traits.Instance.LogAllEnvironmentVariables)
+            if (Traits.LogAllEnvironmentVariables)
             {
                 Write(e.BuildEnvironment);
             }

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 WriteLinePrettyFromResource("BuildStartedWithTime", e.Timestamp);
             }
 
-            if (Traits.Instance.LogAllEnvironmentVariables)
+            if (Traits.LogAllEnvironmentVariables)
             {
                 WriteEnvironment(e.BuildEnvironment);
             }

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -231,7 +231,10 @@ namespace Microsoft.Build.BackEnd.Logging
                 WriteLinePrettyFromResource("BuildStartedWithTime", e.Timestamp);
             }
 
-            WriteEnvironment(e.BuildEnvironment);
+            if (Traits.Instance.LogAllEnvironmentVariables)
+            {
+                WriteEnvironment(e.BuildEnvironment);
+            }
         }
 
         /// <summary>

--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 WriteLinePrettyFromResource("BuildStartedWithTime", e.Timestamp);
             }
 
-            if (Traits.Instance.LogAllEnvironmentVariables)
+            if (Traits.LogAllEnvironmentVariables)
             {
                 WriteEnvironment(e.BuildEnvironment);
             }

--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -108,7 +108,10 @@ namespace Microsoft.Build.BackEnd.Logging
                 WriteLinePrettyFromResource("BuildStartedWithTime", e.Timestamp);
             }
 
-            WriteEnvironment(e.BuildEnvironment);
+            if (Traits.Instance.LogAllEnvironmentVariables)
+            {
+                WriteEnvironment(e.BuildEnvironment);
+            }
         }
 
         /// <summary>

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Log all environment variables whether or not they are used in a build in the binary log.
         /// </summary>
-        public bool LogAllEnvironmentVariables = false;
+        public static bool LogAllEnvironmentVariables = false;
 
         /// <summary>
         /// Log property tracking information.

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Log all environment variables whether or not they are used in a build in the binary log.
         /// </summary>
-        public bool LogAllEnvironmentVariables => string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDONLYLOGUSEDENVIRONMENTVARIABLES"))
+        public readonly bool LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES"))
 #if !TASKHOST
             && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4)
 #endif

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -94,11 +94,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Log all environment variables whether or not they are used in a build in the binary log.
         /// </summary>
-        public readonly bool LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES"))
-#if !TASKHOST
-            && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4)
-#endif
-            ;
+        public bool LogAllEnvironmentVariables = false;
 
         /// <summary>
         /// Log property tracking information.

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -94,8 +94,11 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Log all environment variables whether or not they are used in a build in the binary log.
         /// </summary>
-        public static bool LogAllEnvironmentVariables = false;
-
+        public static bool LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES")) &&
+#if !TASKHOST
+            ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4)
+#endif
+            ;
         /// <summary>
         /// Log property tracking information.
         /// </summary>

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Log all environment variables whether or not they are used in a build in the binary log.
         /// </summary>
-        public static bool LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES")) &&
+        public static bool LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES"))
 #if !TASKHOST
-            ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4)
+            && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4)
 #endif
             ;
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -566,8 +566,10 @@ namespace Microsoft.Build.CommandLine
                 string outputResultsCache = null;
                 CommandLineSwitches.SwitchesFromResponseFiles ??= new();
 
-                GatherAllSwitches(commandLine, out var switchesFromAutoResponseFile, out var switchesNotFromAutoResponseFile);
+                // Reset the value of LogAllEnvironmentVariables. It may have been changed via ShowEnvironment in a previous build.
+                Traits.Instance.LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES")) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4);
 
+                GatherAllSwitches(commandLine, out var switchesFromAutoResponseFile, out var switchesNotFromAutoResponseFile);
                 bool buildCanBeInvoked = ProcessCommandLineSwitches(
                                             switchesFromAutoResponseFile,
                                             switchesNotFromAutoResponseFile,

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -566,9 +566,6 @@ namespace Microsoft.Build.CommandLine
                 string outputResultsCache = null;
                 CommandLineSwitches.SwitchesFromResponseFiles ??= new();
 
-                // Reset the value of LogAllEnvironmentVariables. It may have been changed via ShowEnvironment in a previous build.
-                Traits.LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES")) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4);
-
                 GatherAllSwitches(commandLine, out var switchesFromAutoResponseFile, out var switchesNotFromAutoResponseFile);
                 bool buildCanBeInvoked = ProcessCommandLineSwitches(
                                             switchesFromAutoResponseFile,

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Build.CommandLine
                 CommandLineSwitches.SwitchesFromResponseFiles ??= new();
 
                 // Reset the value of LogAllEnvironmentVariables. It may have been changed via ShowEnvironment in a previous build.
-                Traits.Instance.LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES")) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4);
+                Traits.LogAllEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLENVIRONMENTVARIABLES")) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4);
 
                 GatherAllSwitches(commandLine, out var switchesFromAutoResponseFile, out var switchesNotFromAutoResponseFile);
                 bool buildCanBeInvoked = ProcessCommandLineSwitches(

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -862,7 +862,7 @@ namespace Microsoft.Build.Utilities
                         _firstProjectStartedEventContext = buildEvent.BuildEventContext;
 
                         // We've never seen a project started event, so raise the build started event and save this project started event.
-                        BuildStartedEventArgs startedEvent = new BuildStartedEventArgs(_buildStartedEvent.Message, _buildStartedEvent.HelpKeyword, Traits.Instance.LogAllEnvironmentVariables ? _buildStartedEvent.BuildEnvironment : null);
+                        BuildStartedEventArgs startedEvent = new BuildStartedEventArgs(_buildStartedEvent.Message, _buildStartedEvent.HelpKeyword, Traits.LogAllEnvironmentVariables ? _buildStartedEvent.BuildEnvironment : null);
                         RaiseBuildStartedEvent(sender, startedEvent);
                     }
 


### PR DESCRIPTION
### Context
MSBuild has a command-line switch that tells it to output all environment variables. C++ used that fairly regularly. This PR automatically opts out of the environment variable logging change in #7484 for the duration of the one build.

### Changes Made
Made the Trait settable via environment variable or with the file logger parameter. Since the parameter needs to be applied first, this means the Trait has to be set after the start of the build, so it is no longer read-only. In tests, Traits.Instance is reset every time a variable is read, so setting it at the start of the test does not work. For that reason, I had to make it a static variable on Traits instead of Traits.Instance.

Of importance, the Trait is reset (to the environment variable's value) at logger shutdown for any BaseConsoleLogger. There is theoretically a race condition here, since the Trait is set at logger initialization (if the parameter is set) and used for the BuildStarted event. If there are two builds executing concurrently in the entrypoint node, and loggers are initialized for both, then one finishes before the other has gotten to BuildStarted, the latter will not log the environment. On the other hand, that doesn't affect whether your build succeeds, and the resolution is to just run the build again, and it will likely succeed.

### Testing
It passed unit tests. I also created an experimental insertion, and it passed the C++ test.
