### PR TITLE
Fix promotion bug

### DIFF
--- a/src/Build.UnitTests/BackEnd/LoggingService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingService_Tests.cs
@@ -801,6 +801,18 @@ namespace Microsoft.Build.UnitTests.Logging
             logger.Errors.ShouldHaveSingleItem();
         }
 
+        [Fact]
+        public void VerifyWarningsPromotedToErrorsAreCounted()
+        {
+            ILoggingService ls = LoggingService.CreateLoggingService(LoggerMode.Synchronous, 1);
+            ls.WarningsAsErrors = new HashSet<string>();
+            ls.WarningsAsErrors.Add("FOR123");
+            BuildWarningEventArgs warningArgs = new("abc", "FOR123", "", 0, 0, 0, 0, "warning message", "keyword", "sender");
+            warningArgs.BuildEventContext = new BuildEventContext(1, 2, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidProjectContextId, 5, 6);
+            ls.LogBuildEvent(warningArgs);
+            ls.HasBuildSubmissionLoggedErrors(1).ShouldBeTrue();
+        }
+
         /// <summary>
         /// Verifies that a warning is logged as a low importance message when it's warning code is specified.
         /// </summary>

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using InternalLoggerException = Microsoft.Build.Exceptions.InternalLoggerException;
@@ -1477,12 +1476,14 @@ namespace Microsoft.Build.BackEnd.Logging
                     };
                 }
             }
-            else if (loggingEvent is BuildErrorEventArgs errorEvent)
+
+            if (loggingEvent is BuildErrorEventArgs errorEvent)
             {
                 // Keep track of build submissions that have logged errors.  If there is no build context, add BuildEventContext.InvalidSubmissionId.
                 _buildSubmissionIdsThatHaveLoggedErrors.Add(errorEvent.BuildEventContext?.SubmissionId ?? BuildEventContext.InvalidSubmissionId);
             }
-            else if (loggingEvent is ProjectFinishedEventArgs projectFinishedEvent && projectFinishedEvent.BuildEventContext != null)
+
+            if (loggingEvent is ProjectFinishedEventArgs projectFinishedEvent && projectFinishedEvent.BuildEventContext != null)
             {
                 int key = GetWarningsAsErrorOrMessageKey(projectFinishedEvent);
                 _warningsAsErrorsByProject?.Remove(key);
@@ -1708,10 +1709,8 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         private string GetAndVerifyProjectFileFromContext(BuildEventContext context)
         {
-            _projectFileMap.TryGetValue(context.ProjectContextId, out string projectFile);
-
             // PERF: Not using VerifyThrow to avoid boxing an int in the non-error case.
-            if (projectFile == null)
+            if (!_projectFileMap.TryGetValue(context.ProjectContextId, out string projectFile))
             {
                 ErrorUtilities.ThrowInternalError("ContextID {0} should have been in the ID-to-project file mapping but wasn't!", context.ProjectContextId);
             }


### PR DESCRIPTION
Fixes SDK issue

### Context
Warnings promoted to errors were not being counted properly

### Changes Made
Reverted change that introduced the issue

### Testing
Added unit test. Verified that it failed without the change.

### Notes
