### PR TITLE
Fallback to 32/64 bitness logic for unknown architectures

### DIFF
--- a/src/Shared/XMakeAttributes.cs
+++ b/src/Shared/XMakeAttributes.cs
@@ -447,7 +447,10 @@ namespace Microsoft.Build.Shared
                     currentArchitecture = MSBuildArchitectureValues.arm64;
                     break;
                 default:
-                    throw new PlatformNotSupportedException(string.Format("{0} is not a supported architecture.", RuntimeInformation.ProcessArchitecture));
+                    // We're not sure what the architecture is, default to original 32/64bit logic.
+                    // This allows architectures like s390x to continue working.
+                    // https://github.com/dotnet/msbuild/issues/7729
+                    currentArchitecture = (IntPtr.Size == sizeof(Int64)) ? MSBuildArchitectureValues.x64 : MSBuildArchitectureValues.x86;
             }
 #else
             string currentArchitecture = (IntPtr.Size == sizeof(Int64)) ? MSBuildArchitectureValues.x64 : MSBuildArchitectureValues.x86;


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/7729

### Context
Previously, MSBuild checked the architecture by looking at the size of an IntPtr. With the necessary changes needed for arm64, we threw an exception for any not-well-known architectures. This breaks scenarios that previously worked (arch: s390x).

### Changes Made
Stop throwing an exception for unknown architectures. Instead, fall back to the logic that previously worked as a "best effort"

### Testing


### Notes
