### PR TITLE
Hide new internal dependencies

### DIFF
--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -230,8 +230,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Bump these to the latest version despite transitive references to older -->
-    <PackageReference Include="System.Private.Uri" />
-    <PackageReference Include="System.Runtime" />
+    <PackageReference Include="System.Private.Uri" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Build\Microsoft.Build.csproj" />


### PR DESCRIPTION
Do not expose dependencies that we took only to avoid component-governance alerts caused by restoring (but not using) stale packages.

These were added in #7538, but as pointed out in comments on https://github.com/dotnet/msbuild/commit/20cdf6ff1f617fc6d486c170dff95df0300676e3, that had visible effects on our package consumers, even though it shouldn't have.

I have not yet been able to apply all of the changes desired there (each has knock-on effects), but we can easily avoid the impact on our packages via `PrivateAssets`.

Fixes #7651.