### PR TITLE
Update Newtonsoft.Json in test projects

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -14,6 +14,7 @@
     <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.36" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" PrivateAssets="All" />
     <PackageReference Update="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Update="PdbGit" Version="3.0.41" />
     <PackageReference Update="Shouldly" Version="3.0.0" />
     <PackageReference Update="System.CodeDom" Version="6.0.0" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -59,6 +59,10 @@
          are netstandard1.6 and transitively bring in an old reference -->
     <PackageReference Include="System.Security.Cryptography.X509Certificates" />
 
+    <!-- As of 17.3, one TF of Microsoft.NET.Test.Sdk depends on Newtonsoft.Json
+         9.0.1, causing it to be downloaded and flagged by component governance -->
+    <PackageReference Include="Newtonsoft.Json" />
+
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
 
     <!-- Don't localize unit test projects -->


### PR DESCRIPTION
We don't depend on Newtonsoft.Json, but a version of is transitively required by Microsoft.NET.Test.Sdk, which references an old version that is flagged by compponent governance alerts as vulnerable to https://github.com/advisories/GHSA-5crp-9r3c-p9vr.

Fixes https://dev.azure.com/devdiv/DevDiv/_componentGovernance/DotNet-msbuild-Trusted/alert/7087180?typeId=6797870.