### PR TITLE
Unset bootstrapperCoreVersion in BuildVSBootstrapper

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -147,6 +147,7 @@ stages:
         channelName: $(VisualStudio.ChannelName)
         manifests: $(VisualStudio.SetupManifestList)
         outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+        bootstrapperCoreVersion: 
       displayName: 'OptProf - Build VS bootstrapper'
       condition: succeeded()
 


### PR DESCRIPTION
This task had a specific old default version that had a reference to Newtonsoft.Json 9.0.1, but accepts "no version" as "use latest", so if we explicitly specify . . . nothing . . . it should resolve a component governance alert.