### PR TITLE
Stop ngen for resource assemblies

### DIFF
--- a/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
+++ b/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
@@ -47,28 +47,28 @@ folder InstallDir:\MSBuild\Current\Bin\arm64\MSBuild
   file source=$(Arm64BinPath)\MSBuild\Microsoft.Build.CommonTypes.xsd
 
 folder InstallDir:\MSBuild\Current\Bin\arm64\cs
-  file source=$(Arm64BinPath)cs\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)cs\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\de
-  file source=$(Arm64BinPath)de\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)de\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\es
-  file source=$(Arm64BinPath)es\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)es\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\fr
-  file source=$(Arm64BinPath)fr\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)fr\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\it
-  file source=$(Arm64BinPath)it\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)it\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ja
-  file source=$(Arm64BinPath)ja\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)ja\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ko
-  file source=$(Arm64BinPath)ko\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)ko\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\pl
-  file source=$(Arm64BinPath)pl\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)pl\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\pt-BR
-  file source=$(Arm64BinPath)pt-BR\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)pt-BR\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ru
-  file source=$(Arm64BinPath)ru\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)ru\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\tr
-  file source=$(Arm64BinPath)tr\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)tr\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\zh-Hans
-  file source=$(Arm64BinPath)zh-Hans\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)zh-Hans\MSBuild.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\zh-Hant
-  file source=$(Arm64BinPath)zh-Hant\MSBuild.resources.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)zh-Hant\MSBuild.resources.dll

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -92,83 +92,83 @@ folder InstallDir:\MSBuild\Current\Bin\SdkResolvers\Microsoft.Build.NuGetSdkReso
   file source=$(SourceDir)MSBuild\SdkResolvers\VS\Microsoft.Build.NuGetSdkResolver.xml
 
 folder InstallDir:\MSBuild\Current\Bin\cs
-  file source=$(X86BinPath)cs\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)cs\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)cs\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)cs\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)cs\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)cs\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\de
-  file source=$(X86BinPath)de\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)de\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)de\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)de\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)de\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)de\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)de\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)de\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)de\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)de\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\es
-  file source=$(X86BinPath)es\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)es\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)es\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)es\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)es\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)es\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)es\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)es\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)es\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)es\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\fr
-  file source=$(X86BinPath)fr\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)fr\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)fr\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)fr\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)fr\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)fr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\it
-  file source=$(X86BinPath)it\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)it\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)it\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)it\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)it\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)it\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)it\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)it\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)it\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)it\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\ja
-  file source=$(X86BinPath)ja\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ja\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)ja\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)ja\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)ja\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)ja\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\ko
-  file source=$(X86BinPath)ko\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ko\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)ko\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)ko\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)ko\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)ko\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\pl
-  file source=$(X86BinPath)pl\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pl\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)pl\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)pl\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)pl\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)pl\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\pt-BR
-  file source=$(X86BinPath)pt-BR\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pt-BR\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)pt-BR\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)pt-BR\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)pt-BR\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)pt-BR\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\ru
-  file source=$(X86BinPath)ru\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ru\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)ru\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)ru\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)ru\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)ru\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\tr
-  file source=$(X86BinPath)tr\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)tr\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)tr\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)tr\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)tr\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)tr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\zh-Hans
-  file source=$(X86BinPath)zh-Hans\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hans\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)zh-Hans\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)zh-Hans\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)zh-Hans\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)zh-Hans\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\zh-Hant
-  file source=$(X86BinPath)zh-Hant\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hant\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)zh-Hant\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)zh-Hant\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)zh-Hant\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)zh-Hant\MSBuildTaskHost.resources.dll
 
 folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64
@@ -231,83 +231,83 @@ folder InstallDir:\MSBuild\Current\Bin\amd64\MSBuild
   file source=$(X86BinPath)\MSBuild\Microsoft.Build.CommonTypes.xsd
 
 folder InstallDir:\MSBuild\Current\Bin\amd64\cs
-  file source=$(X64BinPath)cs\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)cs\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)cs\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)cs\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)cs\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)cs\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\de
-  file source=$(X64BinPath)de\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)de\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)de\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)de\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)de\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)de\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)de\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)de\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)de\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)de\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\es
-  file source=$(X64BinPath)es\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)es\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)es\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)es\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)es\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)es\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)es\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)es\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)es\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)es\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\fr
-  file source=$(X64BinPath)fr\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)fr\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)fr\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)fr\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)fr\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)fr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\it
-  file source=$(X64BinPath)it\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)it\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)it\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)it\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)it\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)it\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)it\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)it\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)it\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)it\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\ja
-  file source=$(X64BinPath)ja\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ja\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)ja\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)ja\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)ja\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)ja\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\ko
-  file source=$(X64BinPath)ko\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ko\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)ko\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)ko\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)ko\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)ko\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\pl
-  file source=$(X64BinPath)pl\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pl\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)pl\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)pl\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)pl\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)pl\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\pt-BR
-  file source=$(X64BinPath)pt-BR\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pt-BR\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)pt-BR\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)pt-BR\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)pt-BR\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)pt-BR\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\ru
-  file source=$(X64BinPath)ru\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ru\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)ru\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)ru\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)ru\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)ru\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\tr
-  file source=$(X64BinPath)tr\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)tr\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)tr\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)tr\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)tr\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)tr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\zh-Hans
-  file source=$(X64BinPath)zh-Hans\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hans\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)zh-Hans\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)zh-Hans\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)zh-Hans\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)zh-Hans\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\amd64\zh-Hant
-  file source=$(X64BinPath)zh-Hant\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hant\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)zh-Hant\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)zh-Hant\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)zh-Hant\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)zh-Hant\MSBuildTaskHost.resources.dll
 
 folder InstallDir:\Common7\IDE\CommonExtensions\MSBuild
   file source=$(SourceDir)Package\MSBuild.VSSetup\MSBuild.clientenabledpkg


### PR DESCRIPTION
Since there is no code to JIT in these assemblies, specifying that
they should be ngened was just a waste of install time.

Fixes [AB#1541728](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1541728).