### PR TITLE
Revert "Update to .NET SDK 6.0.301"

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "6.0.301",
+    "dotnet": "6.0.200",
     "vs": {
       "version": "17.0"
     }


### PR DESCRIPTION
Reverts dotnet/msbuild#7724, which caused an internal official build break.