### PR TITLE
Version StringTools package with MSBuild

### DIFF
--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -10,8 +10,7 @@
     <PackageId>Microsoft.NET.StringTools</PackageId>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <AssemblyVersion></AssemblyVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <SemanticVersioningV1>true</SemanticVersioningV1>
 
     <AssemblyName>Microsoft.NET.StringTools</AssemblyName>


### PR DESCRIPTION
The StringTools assembly is new and was initially configured with a hardcoded
version that didn't increase over time, but this caused confusing publish-time
errors because final GA MSBuild builds produce 1.0.0 StringTools packages,
even though some prior GA build did that and published it for the first time.

Fixes #7562.
