### PR TITLE
Reduce allocations in routing build events

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1433,7 +1433,10 @@ namespace Microsoft.Build.BackEnd.Logging
         private void RouteBuildEvent(object loggingEvent)
         {
             BuildEventArgs buildEventArgs = loggingEvent as BuildEventArgs ?? (loggingEvent as KeyValuePair<int, BuildEventArgs>?)?.Value;
-            ErrorUtilities.VerifyThrow(buildEventArgs is not null, "Unknown logging item in queue:" + loggingEvent.GetType().FullName);
+            if (buildEventArgs is null)
+            {
+                ErrorUtilities.ThrowInternalError("Unknown logging item in queue:" + loggingEvent.GetType().FullName);
+            }
 
             if (buildEventArgs is BuildWarningEventArgs warningEvent)
             {


### PR DESCRIPTION
The change to logging environment variables (#7484) included essentially switching an if (condition) throw; to a VerifyThrow call. The VerifyThrow call creates the string that would be used in the throw eagerly, which is bad for a hot path like this.