### PR TITLE
Fix installation error for ClickOnce SF apps that have an application icon set

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4355,7 +4355,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_ClickOnceFiles Include="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce);@(_ClickOnceRuntimeCopyLocalItems)"/>
     </ItemGroup>
 
-    <!-- For single file publish, we need to include the SF bundle EXE and files excluded from the bundle EXE in the clickonce manifest -->
+    <!-- For single file publish, we need to include the SF bundle EXE, application icon file and files excluded from the bundle EXE in the clickonce manifest -->
     <ItemGroup Condition="'$(PublishSingleFile)' == 'true'">
       <_ClickOnceFiles Include="$(PublishedSingleFilePath);@(_DeploymentManifestIconFile)"/>
       <_ClickOnceFiles Include="@(_FilesExcludedFromBundle)"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4357,7 +4357,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- For single file publish, we need to include the SF bundle EXE and files excluded from the bundle EXE in the clickonce manifest -->
     <ItemGroup Condition="'$(PublishSingleFile)' == 'true'">
-      <_ClickOnceFiles Include="$(PublishedSingleFilePath)"/>
+      <_ClickOnceFiles Include="$(PublishedSingleFilePath);@(_DeploymentManifestIconFile)"/>
       <_ClickOnceFiles Include="@(_FilesExcludedFromBundle)"/>
 
       <!-- Include file association icons from Content as loose files -->


### PR DESCRIPTION
Fixes [AB#1555818](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1555818)

### Context
Installation of ClickOnce app as a Single-File with an Application Icon project property set fails to install.

### Changes Made
Include _DeploymentManifestIconFile itemgroup to _ClickOnceFiles itemgroup in Single-File mode.

### Testing
Verified publish and installation of all ClickOnce configurations (FDD and SC) with WPF and Forms app.

### Notes
