### PR TITLE
Add PublishAot to CommonTypes and fix a couple comments

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -2356,9 +2356,14 @@ elementFormDefault="qualified">
         <xs:documentation><!-- _locID_text="PublishReadyToRun" _locComment="" -->Indicates whether the project should produce ReadyToRun images during publish.</xs:documentation>
       </xs:annotation>
     </xs:element>
+    <xs:element name="PublishAot" type="msb:boolean" substitutionGroup="msb:Property">
+      <xs:annotation>
+        <xs:documentation><!-- _locID_text="PublishAot" _locComment="" -->Indicates whether the project should produce native ahead-of-time compiled images during publish.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="PublishSingleFile" type="msb:boolean" substitutionGroup="msb:Property">
       <xs:annotation>
-        <xs:documentation><!-- _locID_text="PublishSingleFile" _locComment="" -->Indicates whether the project should produce a self-extracting executable during publish.</xs:documentation>
+        <xs:documentation><!-- _locID_text="PublishSingleFile" _locComment="" -->Indicates whether the project should bundle all application-dependent files into a single binary during publish.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="PublishTrimmed" type="msb:boolean" substitutionGroup="msb:Property">
@@ -2368,12 +2373,12 @@ elementFormDefault="qualified">
     </xs:element>
     <xs:element name="TrimmerRootAssembly" type="msb:StringPropertyType" substitutionGroup="msb:Property">
       <xs:annotation>
-        <xs:documentation><!-- _locID_text="TrimmerRootAssembly" _locComment="" -->Indicates to the linker to explicitly keep an assembly by adding it to your csproj (use the assembly name without extension).</xs:documentation>
+        <xs:documentation><!-- _locID_text="TrimmerRootAssembly" _locComment="" -->Assemblies that should not be trimmed (specify the assembly name without extension).</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="TrimmerRootDescriptor" type="msb:StringPropertyType" substitutionGroup="msb:Property">
       <xs:annotation>
-        <xs:documentation><!-- _locID_text="TrimmerRootDescriptor" _locComment="" -->Gives the linker a more specific list of types/methods, etc. to include. Path to an xml file.</xs:documentation>
+        <xs:documentation><!-- _locID_text="TrimmerRootDescriptor" _locComment="" -->XML files that specify assemblies, types, and their members that should not be trimmed.</xs:documentation>
       </xs:annotation>
     </xs:element>
 


### PR DESCRIPTION
### Context
* PublishAot is new in .NET 7.
* PublishSingleFile no longer extracts things by default since ~.NET 6?
* We don't want "link"/"linker" in public facing docs because "linker" is an established term in computer engineering, and "IL Linker" (the internal tool that does IL Level trimming) is not a linker.

### Changes Made


### Testing


### Notes

Cc @dotnet/ilc-contrib 