### PR TITLE
Make folder if needed for MSBUILDDEBUGPATH Fixes #7552

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -174,6 +174,8 @@ namespace Microsoft.Build.Shared
             try
             {
                 string testFilePath = Path.Combine(directory, $"MSBuild_{Guid.NewGuid().ToString("N")}_testFile.txt");
+                FileInfo file = new(testFilePath);
+                file.Directory.Create(); // If the directory already exists, this method does nothing.
                 File.WriteAllText(testFilePath, $"MSBuild process {Process.GetCurrentProcess().Id} successfully wrote to file.");
                 File.Delete(testFilePath);
                 return true;


### PR DESCRIPTION
Fixes #7752

### Context
When using MSBuildDebugEngine, we recommend specifying MSBUILDDEBUGPATH. If you specify somewhere we can't write to, we have fallbacks. However, if you specify somewhere we can write to but doesn't yet exist, we can't write to it yet, so that part returns false, and we go on to the fallbacks. This makes the folder explicitly if we can, making it return true if we can write to a directory, but it doesn't yet exist.

### Changes Made
Create folder if needed.

### Testing
Tested before and after the change, and it worked.