### PR TITLE
Make BuildEventContext.Invalid a singleton

### DIFF
--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Returns a default invalid BuildEventContext
         /// </summary>
-        public static BuildEventContext Invalid => new BuildEventContext(InvalidNodeId, InvalidTargetId, InvalidProjectContextId, InvalidTaskId);
+        public static BuildEventContext Invalid { get; } = new BuildEventContext(InvalidNodeId, InvalidTargetId, InvalidProjectContextId, InvalidTaskId);
 
         /// <summary>
         /// Retrieves the Evaluation id.


### PR DESCRIPTION
This is a minor perf improvement to ensure usages of `BuildEventContext.Invalid` get the same instance instead of creating a new one each time. Since `BuildEventContext` is immutable, this should be safe.