### PR TITLE
Use package version properties for dependabot project during source build

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -1,12 +1,14 @@
 <Project>
 
   <!-- Packages in this file have versions updated periodically by Dependabot.
-       Versions managed by Darc/Maestro should be in ..\Packages.props. -->
+  Versions managed by Darc/Maestro should be in ..\Packages.props.
 
-  <!--
-    Make sure to update the binding redirects (in src\MSBuild\app.config and src\MSBuild\app.amd64.config) for any changes to
-    the list of assemblies redistributed by MSBuild (non-MSBuild assemblies in the .vsix package).
-     -->
+  Make sure to update the binding redirects (in src\MSBuild\app.config and src\MSBuild\app.amd64.config) for any changes to
+  the list of assemblies redistributed by MSBuild (non-MSBuild assemblies in the .vsix package).
+
+  Packages must be set to their package version property if it exists (ex. BenchmarkDotNetVersion) since source-build uses
+  these properties to override package versions if necessary. -->
+
   <ItemGroup>
     <PackageReference Update="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Update="BenchmarkDotNet" Condition="'$(BenchmarkDotNetVersion)' != ''" Version="$(BenchmarkDotNetVersion)" />

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -1,23 +1,5 @@
 <Project>
 
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
-    <PackageReference Update="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
-    <PackageReference Update="LargeAddressAware" Version="$(LargeAddressAwareVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
-    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="$(MicrosoftVisualStudioSDKEmbedInteropTypesVersion)" />
-    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(MicrosoftVisualStudioSetupConfigurationInteropVersion)" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
-    <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Update="PdbGit" Version="$(PdbGitVersion)" />
-    <PackageReference Update="Shouldly" Version="$(ShouldlyVersion)" />
-    <PackageReference Update="System.CodeDom" Version="$(SystemCodeDomVersion)" />
-    <PackageReference Update="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
-    <PackageReference Update="System.Runtime" Version="$(SystemRuntimeVersion)" />
-    <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
-    <PackageReference Update="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
-    <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)" />
-  </ItemGroup>
-
   <!-- Packages in this file have versions updated periodically by Dependabot.
        Versions managed by Darc/Maestro should be in ..\Packages.props. -->
 
@@ -26,21 +8,50 @@
     the list of assemblies redistributed by MSBuild (non-MSBuild assemblies in the .vsix package).
      -->
   <ItemGroup>
-    <PackageReference Update="BenchmarkDotNet" Condition="'$(BenchmarkDotNetVersion)' == ''" Version="0.13.1" />
-    <PackageReference Update="LargeAddressAware" Condition="'$(LargeAddressAwareVersion)' == ''" Version="1.0.5" />
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' == ''" Version="3.3.3" />
-    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Condition="'$(MicrosoftVisualStudioSDKEmbedInteropTypesVersion)' == ''" Version="15.0.36" />
-    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Condition="'$(MicrosoftVisualStudioSetupConfigurationInteropVersion)' == ''" Version="3.2.2146" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.Win32.Registry" Condition="'$(MicrosoftWin32RegistryVersion)' == ''" Version="5.0.0" />
-    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' == ''" Version="13.0.1" />
-    <PackageReference Update="PdbGit" Condition="'$(PdbGitVersion)' == ''" Version="3.0.41" />
-    <PackageReference Update="Shouldly" Condition="'$(ShouldlyVersion)' == ''" Version="3.0.0" />
-    <PackageReference Update="System.CodeDom" Condition="'$(SystemCodeDomVersion)' == ''" Version="6.0.0" />
-    <PackageReference Update="System.Private.Uri" Condition="'$(SystemPrivateUriVersion)' == ''" Version="4.3.2" />
-    <PackageReference Update="System.Runtime" Condition="'$(SystemRuntimeVersion)' == ''" Version="4.3.1" />
-    <PackageReference Update="System.Security.Cryptography.Pkcs" Condition="'$(SystemSecurityCryptographyPkcsVersion)' == ''" Version="6.0.1" />
-    <PackageReference Update="System.Security.Cryptography.Xml" Condition="'$(SystemSecurityCryptographyXmlVersion)' == ''" Version="6.0.0" />
-    <PackageReference Update="System.Security.Cryptography.X509Certificates" Condition="'$(SystemSecurityCryptographyX509CertificatesVersion)' == ''" Version="4.3.2" />
+    <PackageReference Update="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Update="BenchmarkDotNet" Condition="'$(BenchmarkDotNetVersion)' != ''" Version="$(BenchmarkDotNetVersion)" />
+
+    <PackageReference Update="LargeAddressAware" Version="1.0.5" />
+    <PackageReference Update="LargeAddressAware" Condition="'$(LargeAddressAwareVersion)' != ''" Version="$(LargeAddressAwareVersion)" />
+
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3" />
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
+
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.36" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Condition="'$(MicrosoftVisualStudioSDKEmbedInteropTypesVersion)' != ''" Version="$(MicrosoftVisualStudioSDKEmbedInteropTypesVersion)" />
+
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Condition="'$(MicrosoftVisualStudioSetupConfigurationInteropVersion)' != ''" Version="$(MicrosoftVisualStudioSetupConfigurationInteropVersion)" PrivateAssets="All" />
+
+    <PackageReference Update="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Win32.Registry" Condition="'$(MicrosoftWin32RegistryVersion)' != ''" Version="$(MicrosoftWin32RegistryVersion)" />
+
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' != ''" Version="$(NewtonsoftJsonVersion)" />
+
+    <PackageReference Update="PdbGit" Version="3.0.41" />
+    <PackageReference Update="PdbGit" Condition="'$(PdbGitVersion)' != ''" Version="$(PdbGitVersion)" />
+
+    <PackageReference Update="Shouldly" Version="3.0.0" />
+    <PackageReference Update="Shouldly" Condition="'$(ShouldlyVersion)' != ''" Version="$(ShouldlyVersion)" />
+
+    <PackageReference Update="System.CodeDom" Version="6.0.0" />
+    <PackageReference Update="System.CodeDom" Condition="'$(SystemCodeDomVersion)' != ''" Version="$(SystemCodeDomVersion)" />
+
+    <PackageReference Update="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Update="System.Private.Uri" Condition="'$(SystemPrivateUriVersion)' != ''" Version="$(SystemPrivateUriVersion)" />
+
+    <PackageReference Update="System.Runtime" Version="4.3.1" />
+    <PackageReference Update="System.Runtime" Condition="'$(SystemRuntimeVersion)' != ''" Version="$(SystemRuntimeVersion)" />
+
+    <PackageReference Update="System.Security.Cryptography.Pkcs" Version="6.0.1" />
+    <PackageReference Update="System.Security.Cryptography.Pkcs" Condition="'$(SystemSecurityCryptographyPkcsVersion)' != ''" Version="$(SystemSecurityCryptographyPkcsVersion)" />
+
+    <PackageReference Update="System.Security.Cryptography.Xml" Version="6.0.0" />
+    <PackageReference Update="System.Security.Cryptography.Xml" Condition="'$(SystemSecurityCryptographyXmlVersion)' != ''" Version="$(SystemSecurityCryptographyXmlVersion)" />
+
+    <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+    <PackageReference Update="System.Security.Cryptography.X509Certificates" Condition="'$(SystemSecurityCryptographyX509CertificatesVersion)' != ''" Version="$(SystemSecurityCryptographyX509CertificatesVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true' AND $(ProjectIsDeprecated) != 'true'">

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -1,5 +1,23 @@
 <Project>
 
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <PackageReference Update="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Update="LargeAddressAware" Version="$(LargeAddressAwareVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="$(MicrosoftVisualStudioSDKEmbedInteropTypesVersion)" />
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(MicrosoftVisualStudioSetupConfigurationInteropVersion)" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Update="PdbGit" Version="$(PdbGitVersion)" />
+    <PackageReference Update="Shouldly" Version="$(ShouldlyVersion)" />
+    <PackageReference Update="System.CodeDom" Version="$(SystemCodeDomVersion)" />
+    <PackageReference Update="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
+    <PackageReference Update="System.Runtime" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
+    <PackageReference Update="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)" />
+  </ItemGroup>
+
   <!-- Packages in this file have versions updated periodically by Dependabot.
        Versions managed by Darc/Maestro should be in ..\Packages.props. -->
 
@@ -8,29 +26,26 @@
     the list of assemblies redistributed by MSBuild (non-MSBuild assemblies in the .vsix package).
      -->
   <ItemGroup>
-    <PackageReference Update="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Update="LargeAddressAware" Version="1.0.5" />
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3" />
-    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.36" />
-    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Update="PdbGit" Version="3.0.41" />
-    <PackageReference Update="Shouldly" Version="3.0.0" />
-    <PackageReference Update="System.CodeDom" Version="6.0.0" />
-    <PackageReference Update="System.Private.Uri" Version="4.3.2" />
-    <PackageReference Update="System.Runtime" Version="4.3.1" />
-    <PackageReference Update="System.Security.Cryptography.Pkcs" Version="6.0.1" />
-    <PackageReference Update="System.Security.Cryptography.Xml" Version="6.0.0" />
-    <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+    <PackageReference Update="BenchmarkDotNet" Condition="'$(BenchmarkDotNetVersion)' == ''" Version="0.13.1" />
+    <PackageReference Update="LargeAddressAware" Condition="'$(LargeAddressAwareVersion)' == ''" Version="1.0.5" />
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' == ''" Version="3.3.3" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Condition="'$(MicrosoftVisualStudioSDKEmbedInteropTypesVersion)' == ''" Version="15.0.36" />
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Condition="'$(MicrosoftVisualStudioSetupConfigurationInteropVersion)' == ''" Version="3.2.2146" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.Win32.Registry" Condition="'$(MicrosoftWin32RegistryVersion)' == ''" Version="5.0.0" />
+    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' == ''" Version="13.0.1" />
+    <PackageReference Update="PdbGit" Condition="'$(PdbGitVersion)' == ''" Version="3.0.41" />
+    <PackageReference Update="Shouldly" Condition="'$(ShouldlyVersion)' == ''" Version="3.0.0" />
+    <PackageReference Update="System.CodeDom" Condition="'$(SystemCodeDomVersion)' == ''" Version="6.0.0" />
+    <PackageReference Update="System.Private.Uri" Condition="'$(SystemPrivateUriVersion)' == ''" Version="4.3.2" />
+    <PackageReference Update="System.Runtime" Condition="'$(SystemRuntimeVersion)' == ''" Version="4.3.1" />
+    <PackageReference Update="System.Security.Cryptography.Pkcs" Condition="'$(SystemSecurityCryptographyPkcsVersion)' == ''" Version="6.0.1" />
+    <PackageReference Update="System.Security.Cryptography.Xml" Condition="'$(SystemSecurityCryptographyXmlVersion)' == ''" Version="6.0.0" />
+    <PackageReference Update="System.Security.Cryptography.X509Certificates" Condition="'$(SystemSecurityCryptographyX509CertificatesVersion)' == ''" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true' AND $(ProjectIsDeprecated) != 'true'">
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all"/>
-  </ItemGroup>
-
-  <ItemGroup>
     <GlobalPackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.36" PrivateAssets="All" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 


### PR DESCRIPTION
### Context
See https://github.com/dotnet/source-build/issues/2933

### Changes Made

- During source-build, set PackageReferences to versions specified by their respective `*Version` properties (like `SystemCodeDomVersion` for example). Source-build will define and import properties for packages that are available during source-build.
- Then, if any of the packages didn't have *Version properties set, set them to the dependabot-managed versions.
- During a non-source-build build, these dependencies should all be set to their dependabot-managed versions, since none of these dependencies have versions properties defined in `eng/Versions.props`.

### Testing
I tested the msbuild build locally by running `./build.sh` on Linux. I also tested this commit in source-build locally and confirmed that packages in this file no longer report as prebuilts. Here is the prebuilt report from my local build.

[msbuild-annotated-prebuilt-usage.txt](https://github.com/dotnet/msbuild/files/9067964/msbuild-annotated-prebuilt-usage.txt)

### Notes

There is still the open question of if dependabot can read and update these dependencies with conditions in their PackageReferences. I spent too long trying to get dependabot to run locally with no luck. I dug into the source code at it appears they use a proper XML parsing library.

Here is where it looks for PackageReferences: 
https://github.com/dependabot/dependabot-core/blob/8315e7b213870959158c1c2bcfb482728a7e801a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb#L17-L21

Here is where it looks for the Version of each PackageReference: https://github.com/dependabot/dependabot-core/blob/8315e7b213870959158c1c2bcfb482728a7e801a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb#L195

Of course if dependabot fails to work with this pattern we can revert and revisit this. I'm opening as draft to check for feedback.