### PR TITLE
Check derivable from ITaskItem directly

### DIFF
--- a/src/Build.UnitTests/BackEnd/AssemblyTaskFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/AssemblyTaskFactory_Tests.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void VerifyGetTaskParameters()
         {
             TaskPropertyInfo[] propertyInfos = _taskFactory.GetTaskParameters();
-            LoadedType comparisonType = new LoadedType(typeof(TaskToTestFactories), _loadInfo, typeof(TaskToTestFactories).GetTypeInfo().Assembly);
+            LoadedType comparisonType = new LoadedType(typeof(TaskToTestFactories), _loadInfo, typeof(TaskToTestFactories).GetTypeInfo().Assembly, typeof(ITaskItem));
             PropertyInfo[] comparisonInfo = comparisonType.Type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
             Assert.Equal(comparisonInfo.Length, propertyInfos.Length);
 

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -1161,7 +1161,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #else
             AssemblyLoadInfo loadInfo = AssemblyLoadInfo.Create(typeof(TaskBuilderTestTask.TaskBuilderTestTaskFactory).GetTypeInfo().FullName, null);
 #endif
-            LoadedType loadedType = new LoadedType(typeof(TaskBuilderTestTask.TaskBuilderTestTaskFactory), loadInfo, typeof(TaskBuilderTestTask.TaskBuilderTestTaskFactory).GetTypeInfo().Assembly);
+            LoadedType loadedType = new LoadedType(typeof(TaskBuilderTestTask.TaskBuilderTestTaskFactory), loadInfo, typeof(TaskBuilderTestTask.TaskBuilderTestTaskFactory).GetTypeInfo().Assembly, typeof(ITaskItem));
 
             TaskBuilderTestTask.TaskBuilderTestTaskFactory taskFactory = new TaskBuilderTestTask.TaskBuilderTestTaskFactory();
             taskFactory.ThrowOnExecute = throwOnExecute;

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -904,13 +904,13 @@ namespace Microsoft.Build.BackEnd
                 if (String.Equals(returnClass.TaskFactory.TaskType.FullName, "Microsoft.Build.Tasks.MSBuild", StringComparison.OrdinalIgnoreCase))
                 {
                     Assembly taskExecutionHostAssembly = typeof(TaskExecutionHost).GetTypeInfo().Assembly;
-                    returnClass = new TaskFactoryWrapper(new IntrinsicTaskFactory(typeof(MSBuild)), new LoadedType(typeof(MSBuild), AssemblyLoadInfo.Create(taskExecutionHostAssembly.FullName, null), taskExecutionHostAssembly), _taskName, null);
+                    returnClass = new TaskFactoryWrapper(new IntrinsicTaskFactory(typeof(MSBuild)), new LoadedType(typeof(MSBuild), AssemblyLoadInfo.Create(taskExecutionHostAssembly.FullName, null), taskExecutionHostAssembly, typeof(ITaskItem)), _taskName, null);
                     _intrinsicTasks[_taskName] = returnClass;
                 }
                 else if (String.Equals(returnClass.TaskFactory.TaskType.FullName, "Microsoft.Build.Tasks.CallTarget", StringComparison.OrdinalIgnoreCase))
                 {
                     Assembly taskExecutionHostAssembly = typeof(TaskExecutionHost).GetTypeInfo().Assembly;
-                    returnClass = new TaskFactoryWrapper(new IntrinsicTaskFactory(typeof(CallTarget)), new LoadedType(typeof(CallTarget), AssemblyLoadInfo.Create(taskExecutionHostAssembly.FullName, null), taskExecutionHostAssembly), _taskName, null);
+                    returnClass = new TaskFactoryWrapper(new IntrinsicTaskFactory(typeof(CallTarget)), new LoadedType(typeof(CallTarget), AssemblyLoadInfo.Create(taskExecutionHostAssembly.FullName, null), taskExecutionHostAssembly, typeof(ITaskItem)), _taskName, null);
                     _intrinsicTasks[_taskName] = returnClass;
                 }
             }

--- a/src/MSBuildTaskHost/TypeLoader.cs
+++ b/src/MSBuildTaskHost/TypeLoader.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.Build.Framework;
 
 #nullable disable
 
@@ -286,7 +287,7 @@ namespace Microsoft.Build.Shared
                     return null;
                 });
 
-                return type != null ? new LoadedType(type, _assemblyLoadInfo, _loadedAssembly ?? type.Assembly) : null;
+                return type != null ? new LoadedType(type, _assemblyLoadInfo, _loadedAssembly ?? type.Assembly, typeof(ITaskItem)) : null;
             }
 
             /// <summary>

--- a/src/Shared/TypeLoader.cs
+++ b/src/Shared/TypeLoader.cs
@@ -54,16 +54,15 @@ namespace Microsoft.Build.Shared
         // We need to append Microsoft.Build.Framework from next to the executing assembly first to make sure it's loaded before the runtime variant.
         private static string[] findRuntimeAssembliesWithMicrosoftBuildFramework()
         {
+            string msbuildDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            microsoftBuildFrameworkPath = Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll");
+            string[] msbuildAssemblies = Directory.GetFiles(msbuildDirectory, "*.dll");
             string[] runtimeAssemblies = Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll");
-            string[] allAssemblies = new string[runtimeAssemblies.Length + 1];
-            microsoftBuildFrameworkPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Microsoft.Build.Framework.dll");
-            allAssemblies[0] = microsoftBuildFrameworkPath;
-            for (int i = 0; i < runtimeAssemblies.Length; i++)
-            {
-                allAssemblies[i + 1] = runtimeAssemblies[i];
-            }
 
-            return allAssemblies;
+            List<string> msbuildAssembliesList = new(msbuildAssemblies);
+            msbuildAssembliesList.AddRange(runtimeAssemblies);
+
+            return msbuildAssembliesList.ToArray();
         }
 
         /// <summary>

--- a/src/Shared/TypeLoader.cs
+++ b/src/Shared/TypeLoader.cs
@@ -13,6 +13,7 @@ using System.Runtime.Loader;
 #endif
 using System.Threading;
 using Microsoft.Build.Eventing;
+using Microsoft.Build.Framework;
 
 #nullable disable
 
@@ -354,7 +355,7 @@ namespace Microsoft.Build.Shared
                     return null;
                 });
 
-                return type != null ? new LoadedType(type, _assemblyLoadInfo, _loadedAssembly ?? type.Assembly, loadedViaMetadataLoadContext: false) : null;
+                return type != null ? new LoadedType(type, _assemblyLoadInfo, _loadedAssembly ?? type.Assembly, typeof(ITaskItem), loadedViaMetadataLoadContext: false) : null;
             }
 
             private LoadedType GetLoadedTypeFromTypeNameUsingMetadataLoadContext(string typeName)
@@ -370,7 +371,7 @@ namespace Microsoft.Build.Shared
                         if (_isDesiredType(publicType, null) && (typeName.Length == 0 || TypeLoader.IsPartialTypeNameMatch(publicType.FullName, typeName)))
                         {
                             MSBuildEventSource.Log.CreateLoadedTypeStart(loadedAssembly.FullName);
-                            LoadedType loadedType = new(publicType, _assemblyLoadInfo, loadedAssembly, loadedViaMetadataLoadContext: true);
+                            LoadedType loadedType = new(publicType, _assemblyLoadInfo, loadedAssembly, _context.LoadFromAssemblyName("Microsoft.Build.Framework").GetType(typeof(ITaskItem).FullName), loadedViaMetadataLoadContext: true);
                             _context?.Dispose();
                             _context = null;
                             MSBuildEventSource.Log.CreateLoadedTypeStop(loadedAssembly.FullName);

--- a/src/Shared/TypeLoader.cs
+++ b/src/Shared/TypeLoader.cs
@@ -48,7 +48,23 @@ namespace Microsoft.Build.Shared
 
         private static MetadataLoadContext _context;
 
-        private static string[] runtimeAssemblies = Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll");
+        private static string[] runtimeAssemblies = findRuntimeAssembliesWithMicrosoftBuildFramework();
+        private static string microsoftBuildFrameworkPath;
+
+        // We need to append Microsoft.Build.Framework from next to the executing assembly first to make sure it's loaded before the runtime variant.
+        private static string[] findRuntimeAssembliesWithMicrosoftBuildFramework()
+        {
+            string[] runtimeAssemblies = Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll");
+            string[] allAssemblies = new string[runtimeAssemblies.Length + 1];
+            microsoftBuildFrameworkPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Microsoft.Build.Framework.dll");
+            allAssemblies[0] = microsoftBuildFrameworkPath;
+            for (int i = 0; i < runtimeAssemblies.Length; i++)
+            {
+                allAssemblies[i + 1] = runtimeAssemblies[i];
+            }
+
+            return allAssemblies;
+        }
 
         /// <summary>
         /// Constructor.
@@ -371,7 +387,7 @@ namespace Microsoft.Build.Shared
                         if (_isDesiredType(publicType, null) && (typeName.Length == 0 || TypeLoader.IsPartialTypeNameMatch(publicType.FullName, typeName)))
                         {
                             MSBuildEventSource.Log.CreateLoadedTypeStart(loadedAssembly.FullName);
-                            LoadedType loadedType = new(publicType, _assemblyLoadInfo, loadedAssembly, _context.LoadFromAssemblyName("Microsoft.Build.Framework").GetType(typeof(ITaskItem).FullName), loadedViaMetadataLoadContext: true);
+                            LoadedType loadedType = new(publicType, _assemblyLoadInfo, loadedAssembly, _context.LoadFromAssemblyPath(microsoftBuildFrameworkPath).GetType(typeof(ITaskItem).FullName), loadedViaMetadataLoadContext: true);
                             _context?.Dispose();
                             _context = null;
                             MSBuildEventSource.Log.CreateLoadedTypeStop(loadedAssembly.FullName);


### PR DESCRIPTION
Previously checked if any base type was named ITaskItem

### Context
A type derived from a MetadataLoadContext does not inherit from any type not derived from the same MetadataLoadContext. To work around that, the previous code checked whether each input passed to a task type can be cast to an ITaskItem by comparing it and its base types to ITaskItem by full name. There may be multiple plausible base types, however. This corrects that by checking if ITaskItem IsAssignableFrom the type, ensuring that a separate "ITaskItem" is passed for MLC and non-MLC contexts.

### Customer Impact
Customers with custom tasks that take in or return types derived from ITaskItem (or ITaskItem[]) rather than ITaskItem (or ITaskItem[]) itself cannot build.

### Regression?
Yes, in 17.3p3.

### Risk
I believe it is reasonably low, but I would like @rainersigwald to comment.

### Changes Made
Use IsAssignableFrom instead of checking by name.

### Testing
Tried building a simple test project, and it worked as expected. Tried building a more complicated test project that used TaskFactory="TaskHostFactory" in a UsingTask with a custom Task assembly, and it worked. Tried building the sln that had failed leading to this issue, and it built successfully.