### PR TITLE
Don't allocate closure objects when enumerating properties

### DIFF
--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -559,7 +559,7 @@ namespace Microsoft.Build.BackEnd.Logging
             // Gather a sorted list of all the properties.
             var list = new List<DictionaryEntry>(properties.FastCountOrZero());
 
-            Internal.Utilities.EnumerateProperties(properties, kvp => list.Add(new DictionaryEntry(kvp.Key, kvp.Value)));
+            Internal.Utilities.EnumerateProperties(properties, list, static (list, kvp) => list.Add(new DictionaryEntry(kvp.Key, kvp.Value)));
 
             list.Sort(new DictionaryEntryKeyComparer());
             return list;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -941,7 +941,7 @@ Build
                 return;
             }
 
-            Internal.Utilities.EnumerateProperties(properties, kvp => nameValueListBuffer.Add(kvp));
+            Internal.Utilities.EnumerateProperties(properties, nameValueListBuffer, static (list, kvp) => list.Add(kvp));
 
             WriteNameValueList();
 

--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -618,7 +618,7 @@ namespace Microsoft.Build.Internal
             return enumerator.ToEnumerable().ToArray();
         }
 
-        public static void EnumerateProperties(IEnumerable properties, Action<KeyValuePair<string, string>> callback)
+        public static void EnumerateProperties<TArg>(IEnumerable properties, TArg arg, Action<TArg, KeyValuePair<string, string>> callback)
         {
             if (properties == null)
             {
@@ -629,14 +629,14 @@ namespace Microsoft.Build.Internal
             {
                 propertyInstanceDictionary.Enumerate((key, value) =>
                 {
-                    callback(new KeyValuePair<string, string>(key, value));
+                    callback(arg, new KeyValuePair<string, string>(key, value));
                 });
             }
             else if (properties is PropertyDictionary<ProjectProperty> propertyDictionary)
             {
                 propertyDictionary.Enumerate((key, value) =>
                 {
-                    callback(new KeyValuePair<string, string>(key, value));
+                    callback(arg, new KeyValuePair<string, string>(key, value));
                 });
             }
             else
@@ -645,15 +645,15 @@ namespace Microsoft.Build.Internal
                 {
                     if (item is IProperty property && !string.IsNullOrEmpty(property.Name))
                     {
-                        callback(new KeyValuePair<string, string>(property.Name, property.EvaluatedValue ?? string.Empty));
+                        callback(arg, new KeyValuePair<string, string>(property.Name, property.EvaluatedValue ?? string.Empty));
                     }
                     else if (item is DictionaryEntry dictionaryEntry && dictionaryEntry.Key is string key && !string.IsNullOrEmpty(key))
                     {
-                        callback(new KeyValuePair<string, string>(key, dictionaryEntry.Value as string ?? string.Empty));
+                        callback(arg, new KeyValuePair<string, string>(key, dictionaryEntry.Value as string ?? string.Empty));
                     }
                     else if (item is KeyValuePair<string, string> kvp)
                     {
-                        callback(kvp);
+                        callback(arg, kvp);
                     }
                     else
                     {

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -882,7 +882,7 @@ namespace Microsoft.Build.Shared
             // it is expensive to access a ThreadStatic field every time
             var list = reusablePropertyList;
 
-            Internal.Utilities.EnumerateProperties(properties, kvp => list.Add(kvp));
+            Internal.Utilities.EnumerateProperties(properties, list, static (list, kvp) => list.Add(kvp));
 
             BinaryWriterExtensions.Write7BitEncodedInt(writer, list.Count);
 


### PR DESCRIPTION
This requires passing an argument via the stack, rather than on a heap allocated closure.

This change was sitting in my workspace for a while, and I'm working through those changes now. It was motivated by allocations I saw in a trace, but I don't have any numbers available offhand.