### PR TITLE
Null annotate some build event args types

### DIFF
--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -7,8 +7,6 @@ using System.IO;
 using System.Text;
 using Microsoft.Build.Shared;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -27,17 +25,17 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Message. Volatile because it may be updated lock-free after construction.
         /// </summary>
-        private volatile string message;
+        private volatile string? message;
 
         /// <summary>
         /// Help keyword
         /// </summary>
-        private string helpKeyword;
+        private string? helpKeyword;
 
         /// <summary>
         /// Sender name
         /// </summary>
-        private string senderName;
+        private string? senderName;
 
         /// <summary>
         /// Timestamp
@@ -56,7 +54,7 @@ namespace Microsoft.Build.Framework
         /// Build event context
         /// </summary>
         [OptionalField(VersionAdded = 2)]
-        private BuildEventContext buildEventContext;
+        private BuildEventContext? buildEventContext;
 
         /// <summary>
         /// Default constructor
@@ -72,7 +70,7 @@ namespace Microsoft.Build.Framework
         /// <param name="message">text message</param>
         /// <param name="helpKeyword">help keyword </param>
         /// <param name="senderName">name of event sender</param>
-        protected BuildEventArgs(string message, string helpKeyword, string senderName)
+        protected BuildEventArgs(string? message, string? helpKeyword, string? senderName)
             : this(message, helpKeyword, senderName, DateTime.UtcNow)
         {
         }
@@ -84,7 +82,7 @@ namespace Microsoft.Build.Framework
         /// <param name="helpKeyword">help keyword </param>
         /// <param name="senderName">name of event sender</param>
         /// <param name="eventTimestamp">TimeStamp of when the event was created</param>
-        protected BuildEventArgs(string message, string helpKeyword, string senderName, DateTime eventTimestamp)
+        protected BuildEventArgs(string? message, string? helpKeyword, string? senderName, DateTime eventTimestamp)
         {
             this.message = message;
             this.helpKeyword = helpKeyword;
@@ -133,7 +131,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Text of event.
         /// </summary>
-        public virtual string Message
+        public virtual string? Message
         {
             get => message;
             protected set => message = value;
@@ -143,7 +141,7 @@ namespace Microsoft.Build.Framework
         /// Exposes the underlying message field without side-effects.
         /// Used for serialization.
         /// </summary>
-        protected internal string RawMessage
+        protected internal string? RawMessage
         {
             get => FormattedMessage;
             set => message = value;
@@ -153,7 +151,7 @@ namespace Microsoft.Build.Framework
         /// Like <see cref="RawMessage"/> but returns a formatted message string if available.
         /// Used for serialization.
         /// </summary>
-        private protected virtual string FormattedMessage
+        private protected virtual string? FormattedMessage
         {
             get => message;
         }
@@ -161,17 +159,17 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Custom help keyword associated with event.
         /// </summary>
-        public string HelpKeyword => helpKeyword;
+        public string? HelpKeyword => helpKeyword;
 
         /// <summary>
         /// Name of the object sending this event.
         /// </summary>
-        public string SenderName => senderName;
+        public string? SenderName => senderName;
 
         /// <summary>
         /// Event contextual information for the build event argument
         /// </summary>
-        public BuildEventContext BuildEventContext
+        public BuildEventContext? BuildEventContext
         {
             get => buildEventContext;
             set => buildEventContext = value;
@@ -183,7 +181,7 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="writer">Binary writer which is attached to the stream the event will be serialized into</param>
         /// <param name="messageToWrite">The message to write to the stream.</param>
-        private protected void WriteToStreamWithExplicitMessage(BinaryWriter writer, string messageToWrite)
+        private protected void WriteToStreamWithExplicitMessage(BinaryWriter writer, string? messageToWrite)
         {
             writer.WriteOptionalString(messageToWrite);
             writer.WriteOptionalString(helpKeyword);
@@ -286,7 +284,7 @@ namespace Microsoft.Build.Framework
         /// This is used by the Message property overrides to reconstruct the
         /// message lazily on demand.
         /// </summary>
-        internal static Func<string, string[], string> ResourceStringFormatter = (string resourceName, string[] arguments) =>
+        internal static Func<string, string?[], string> ResourceStringFormatter = (string resourceName, string?[] arguments) =>
         {
             var sb = new StringBuilder();
             sb.Append(resourceName);
@@ -317,7 +315,7 @@ namespace Microsoft.Build.Framework
         /// <param name="resourceName">Name of the resource string.</param>
         /// <param name="arguments">Optional list of arguments to pass to the formatted string.</param>
         /// <returns>The concatenated formatted string.</returns>
-        internal static string FormatResourceStringIgnoreCodeAndKeyword(string resourceName, params string[] arguments)
+        internal static string FormatResourceStringIgnoreCodeAndKeyword(string resourceName, params string?[] arguments)
         {
             return ResourceStringFormatter(resourceName, arguments);
         }

--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -237,7 +235,7 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="obj"></param>
         /// <returns></returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             // If the references are the same no need to do any more comparing
             if (ReferenceEquals(this, obj))
@@ -265,7 +263,7 @@ namespace Microsoft.Build.Framework
         /// <param name="left">Left hand side operand</param>
         /// <param name="right">Right hand side operand</param>
         /// <returns>True if the object values are identical, false if they are not identical</returns>
-        public static bool operator ==(BuildEventContext left, BuildEventContext right)
+        public static bool operator ==(BuildEventContext? left, BuildEventContext? right)
         {
             if (ReferenceEquals(left, right))
             {
@@ -287,7 +285,7 @@ namespace Microsoft.Build.Framework
         /// <param name="left">Left hand side operand</param>
         /// <param name="right">Right hand side operand</param>
         /// <returns>True if the object values are not identical, false if they are identical</returns>
-        public static bool operator !=(BuildEventContext left, BuildEventContext right)
+        public static bool operator !=(BuildEventContext? left, BuildEventContext? right)
         {
             return !(left == right);
         }

--- a/src/Framework/BuildFinishedEventArgs.cs
+++ b/src/Framework/BuildFinishedEventArgs.cs
@@ -4,8 +4,6 @@
 using System;
 using System.IO;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -43,8 +41,8 @@ namespace Microsoft.Build.Framework
         /// <param name="succeeded">True indicates a successful build</param>
         public BuildFinishedEventArgs
         (
-            string message,
-            string helpKeyword,
+            string? message,
+            string? helpKeyword,
             bool succeeded
         )
             : this(message, helpKeyword, succeeded, DateTime.UtcNow)
@@ -60,8 +58,8 @@ namespace Microsoft.Build.Framework
         /// <param name="eventTimestamp">Timestamp when the event was created</param>
         public BuildFinishedEventArgs
         (
-            string message,
-            string helpKeyword,
+            string? message,
+            string? helpKeyword,
             bool succeeded,
             DateTime eventTimestamp
         )
@@ -80,11 +78,11 @@ namespace Microsoft.Build.Framework
         /// <param name="messageArgs">message arguments</param>
         public BuildFinishedEventArgs
         (
-            string message,
-            string helpKeyword,
+            string? message,
+            string? helpKeyword,
             bool succeeded,
             DateTime eventTimestamp,
-            params object[] messageArgs
+            params object[]? messageArgs
         )
             : base(message, helpKeyword, "MSBuild", eventTimestamp, messageArgs)
         {

--- a/src/Framework/BuildStartedEventArgs.cs
+++ b/src/Framework/BuildStartedEventArgs.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -20,7 +18,7 @@ namespace Microsoft.Build.Framework
     [Serializable]
     public class BuildStartedEventArgs : BuildStatusEventArgs
     {
-        private IDictionary<string, string> environmentOnBuildStart;
+        private IDictionary<string, string>? environmentOnBuildStart;
 
         /// <summary>
         /// Default constructor
@@ -56,8 +54,8 @@ namespace Microsoft.Build.Framework
         /// <param name="environmentOfBuild">A dictionary which lists the environment of the build when the build is started.</param>
         public BuildStartedEventArgs
         (
-            string message,
-            string helpKeyword,
+            string? message,
+            string? helpKeyword,
             IDictionary<string, string> environmentOfBuild
         )
             : this(message, helpKeyword, DateTime.UtcNow)
@@ -73,8 +71,8 @@ namespace Microsoft.Build.Framework
         /// <param name="eventTimestamp">Timestamp when the event was created</param>
         public BuildStartedEventArgs
         (
-            string message,
-            string helpKeyword,
+            string? message,
+            string? helpKeyword,
             DateTime eventTimestamp
         )
             : this(message, helpKeyword, eventTimestamp, null)
@@ -91,10 +89,10 @@ namespace Microsoft.Build.Framework
         /// <param name="messageArgs">message args</param>
         public BuildStartedEventArgs
         (
-            string message,
-            string helpKeyword,
+            string? message,
+            string? helpKeyword,
             DateTime eventTimestamp,
-            params object[] messageArgs
+            params object[]? messageArgs
         )
             : base(message, helpKeyword, "MSBuild", eventTimestamp, messageArgs)
         {
@@ -104,7 +102,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// The environment which is used at the start of the build
         /// </summary>
-        public IDictionary<string, string> BuildEnvironment
+        public IDictionary<string, string>? BuildEnvironment
         {
             get { return environmentOnBuildStart; }
         }

--- a/src/Framework/BuildStatusEventArgs.cs
+++ b/src/Framework/BuildStatusEventArgs.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary> 
@@ -39,9 +37,9 @@ namespace Microsoft.Build.Framework
         /// <param name="senderName">name of event sender</param> 
         protected BuildStatusEventArgs
         (
-            string message,
-            string helpKeyword,
-            string senderName
+            string? message,
+            string? helpKeyword,
+            string? senderName
         )
             : this(message, helpKeyword, senderName, DateTime.UtcNow)
         {
@@ -58,9 +56,9 @@ namespace Microsoft.Build.Framework
         /// <param name="eventTimestamp">Timestamp when event was created</param>
         protected BuildStatusEventArgs
         (
-            string message,
-            string helpKeyword,
-            string senderName,
+            string? message,
+            string? helpKeyword,
+            string? senderName,
             DateTime eventTimestamp
         )
             : this(message, helpKeyword, senderName, eventTimestamp, messageArgs: null)
@@ -78,11 +76,11 @@ namespace Microsoft.Build.Framework
         /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
         protected BuildStatusEventArgs
         (
-            string message,
-            string helpKeyword,
-            string senderName,
+            string? message,
+            string? helpKeyword,
+            string? senderName,
             DateTime eventTimestamp,
-            params object[] messageArgs
+            params object[]? messageArgs
         )
             : base(message, helpKeyword, senderName, eventTimestamp, messageArgs)
         {

--- a/src/Framework/LazyFormattedBuildEventArgs.cs
+++ b/src/Framework/LazyFormattedBuildEventArgs.cs
@@ -5,8 +5,6 @@ using System;
 using System.Globalization;
 using System.IO;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -18,12 +16,12 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Stores the message arguments.
         /// </summary>
-        private volatile object argumentsOrFormattedMessage;
+        private volatile object? argumentsOrFormattedMessage;
 
         /// <summary>
         /// Exposes the underlying arguments field to serializers.
         /// </summary>
-        internal object[] RawArguments
+        internal object[]? RawArguments
         {
             get => (argumentsOrFormattedMessage is object[] arguments) ? arguments : null;
         }
@@ -31,7 +29,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Exposes the formatted message string to serializers.
         /// </summary>
-        private protected override string FormattedMessage
+        private protected override string? FormattedMessage
         {
             get => (argumentsOrFormattedMessage is string formattedMessage) ? formattedMessage : base.FormattedMessage;
         }
@@ -44,9 +42,9 @@ namespace Microsoft.Build.Framework
         /// <param name="senderName">name of event sender.</param>
         public LazyFormattedBuildEventArgs
         (
-            string message,
-            string helpKeyword,
-            string senderName
+            string? message,
+            string? helpKeyword,
+            string? senderName
         )
             : this(message, helpKeyword, senderName, DateTime.Now, null)
         {
@@ -62,11 +60,11 @@ namespace Microsoft.Build.Framework
         /// <param name="messageArgs">Message arguments.</param>
         public LazyFormattedBuildEventArgs
         (
-            string message,
-            string helpKeyword,
-            string senderName,
+            string? message,
+            string? helpKeyword,
+            string? senderName,
             DateTime eventTimestamp,
-            params object[] messageArgs
+            params object[]? messageArgs
         )
             : base(message, helpKeyword, senderName, eventTimestamp)
         {
@@ -84,17 +82,17 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Gets the formatted message.
         /// </summary>
-        public override string Message
+        public override string? Message
         {
             get
             {
-                object argsOrMessage = argumentsOrFormattedMessage;
+                object? argsOrMessage = argumentsOrFormattedMessage;
                 if (argsOrMessage is string formattedMessage)
                 {
                     return formattedMessage;
                 }
 
-                if (argsOrMessage is object[] arguments && arguments.Length > 0)
+                if (argsOrMessage is object[] arguments && arguments.Length > 0 && base.Message is not null)
                 {
                     formattedMessage = FormatString(base.Message, arguments);
                     argumentsOrFormattedMessage = formattedMessage;
@@ -111,7 +109,7 @@ namespace Microsoft.Build.Framework
         /// <param name="writer">Binary writer which is attached to the stream the event will be serialized into.</param>
         internal override void WriteToStream(BinaryWriter writer)
         {
-            object argsOrMessage = argumentsOrFormattedMessage;
+            object? argsOrMessage = argumentsOrFormattedMessage;
             if (argsOrMessage is object[] arguments && arguments.Length > 0)
             {
                 base.WriteToStreamWithExplicitMessage(writer, base.Message);
@@ -121,7 +119,7 @@ namespace Microsoft.Build.Framework
                 {
                     // Arguments may be ints, etc, so explicitly convert
                     // Convert.ToString returns String.Empty when it cannot convert, rather than throwing
-                    writer.Write(Convert.ToString(argument, CultureInfo.CurrentCulture));
+                    writer.Write(Convert.ToString(argument, CultureInfo.CurrentCulture) ?? "");
                 }
             }
             else
@@ -142,7 +140,7 @@ namespace Microsoft.Build.Framework
 
             if (version > 20)
             {
-                string[] messageArgs = null;
+                string[]? messageArgs = null;
                 int numArguments = reader.ReadInt32();
 
                 if (numArguments >= 0)

--- a/src/Framework/LazyFormattedBuildEventArgs.cs
+++ b/src/Framework/LazyFormattedBuildEventArgs.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Build.Framework
                 {
                     // Arguments may be ints, etc, so explicitly convert
                     // Convert.ToString returns String.Empty when it cannot convert, rather than throwing
+                    // It returns null if the input is null.
                     writer.Write(Convert.ToString(argument, CultureInfo.CurrentCulture) ?? "");
                 }
             }

--- a/src/Framework/ProjectEvaluationFinishedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationFinishedEventArgs.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections;
 using Microsoft.Build.Framework.Profiler;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -25,7 +23,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Initializes a new instance of the ProjectEvaluationFinishedEventArgs class.
         /// </summary>
-        public ProjectEvaluationFinishedEventArgs(string message, params object[] messageArgs)
+        public ProjectEvaluationFinishedEventArgs(string? message, params object[]? messageArgs)
             : base(message, helpKeyword: null, senderName: null, DateTime.UtcNow, messageArgs)
         {
         }
@@ -33,22 +31,22 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Gets or sets the full path of the project that started evaluation.
         /// </summary>
-        public string ProjectFile { get; set; }
+        public string? ProjectFile { get; set; }
 
         /// <summary>
         /// Global properties used during this evaluation.
         /// </summary>
-        public IEnumerable GlobalProperties { get; set; }
+        public IEnumerable? GlobalProperties { get; set; }
 
         /// <summary>
         /// Final set of properties produced by this evaluation.
         /// </summary>
-        public IEnumerable Properties { get; set; }
+        public IEnumerable? Properties { get; set; }
 
         /// <summary>
         /// Final set of items produced by this evaluation.
         /// </summary>
-        public IEnumerable Items { get; set; }
+        public IEnumerable? Items { get; set; }
 
         /// <summary>
         /// The result of profiling a project.

--- a/src/Framework/ProjectEvaluationStartedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationStartedEventArgs.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -23,7 +21,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Initializes a new instance of the ProjectEvaluationStartedEventArgs class.
         /// </summary>
-        public ProjectEvaluationStartedEventArgs(string message, params object[] messageArgs)
+        public ProjectEvaluationStartedEventArgs(string? message, params object[]? messageArgs)
             : base(message, helpKeyword: null, senderName: null, DateTime.UtcNow, messageArgs)
         {
         }
@@ -31,6 +29,6 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Gets or sets the full path of the project that started evaluation.
         /// </summary>
-        public string ProjectFile { get; set; }
+        public string? ProjectFile { get; set; }
     }
 }

--- a/src/Framework/ProjectFinishedEventArgs.cs
+++ b/src/Framework/ProjectFinishedEventArgs.cs
@@ -5,8 +5,6 @@ using System;
 using System.IO;
 using Microsoft.Build.Shared;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -40,9 +38,9 @@ namespace Microsoft.Build.Framework
         /// <param name="succeeded">true indicates project built successfully</param>
         public ProjectFinishedEventArgs
         (
-            string message,
-            string helpKeyword,
-            string projectFile,
+            string? message,
+            string? helpKeyword,
+            string? projectFile,
             bool succeeded
         )
             : this(message, helpKeyword, projectFile, succeeded, DateTime.UtcNow)
@@ -60,9 +58,9 @@ namespace Microsoft.Build.Framework
         /// <param name="eventTimestamp">Timestamp when the event was created</param>
         public ProjectFinishedEventArgs
         (
-            string message,
-            string helpKeyword,
-            string projectFile,
+            string? message,
+            string? helpKeyword,
+            string? projectFile,
             bool succeeded,
             DateTime eventTimestamp
         )
@@ -72,7 +70,7 @@ namespace Microsoft.Build.Framework
             this.succeeded = succeeded;
         }
 
-        private string projectFile;
+        private string? projectFile;
         private bool succeeded;
 
         #region CustomSerializationToStream
@@ -105,7 +103,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Project name
         /// </summary>
-        public string ProjectFile => projectFile;
+        public string? ProjectFile => projectFile;
 
         /// <summary>
         /// True if project built successfully, false otherwise

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -9,8 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Shared;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -203,12 +201,12 @@ namespace Microsoft.Build.Framework
         }
 
         [OptionalField(VersionAdded = 2)]
-        private BuildEventContext parentProjectBuildEventContext;
+        private BuildEventContext? parentProjectBuildEventContext;
 
         /// <summary>
         /// Event context information, where the event was fired from in terms of the build location
         /// </summary>
-        public BuildEventContext ParentProjectBuildEventContext
+        public BuildEventContext? ParentProjectBuildEventContext
         {
             get
             {
@@ -219,12 +217,12 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// The name of the project file
         /// </summary>
-        private string projectFile;
+        private string? projectFile;
 
         /// <summary>
         /// Project name
         /// </summary>
-        public string ProjectFile
+        public string? ProjectFile
         {
             get
             {
@@ -235,12 +233,12 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Targets that we will build in the project
         /// </summary>
-        private string targetNames;
+        private string? targetNames;
 
         /// <summary>
         /// Targets that we will build in the project
         /// </summary>
-        public string TargetNames
+        public string? TargetNames
         {
             get
             {
@@ -252,12 +250,12 @@ namespace Microsoft.Build.Framework
         /// Gets the set of global properties used to evaluate this project.
         /// </summary>
         [OptionalField(VersionAdded = 2)]
-        private IDictionary<string, string> globalProperties;
+        private IDictionary<string, string>? globalProperties;
 
         /// <summary>
         /// Gets the set of global properties used to evaluate this project.
         /// </summary>
-        public IDictionary<string, string> GlobalProperties
+        public IDictionary<string, string>? GlobalProperties
         {
             get
             {
@@ -271,12 +269,12 @@ namespace Microsoft.Build.Framework
         }
 
         [OptionalField(VersionAdded = 2)]
-        private string toolsVersion;
+        private string? toolsVersion;
 
         /// <summary>
         /// Gets the tools version used to evaluate this project.
         /// </summary>
-        public string ToolsVersion
+        public string? ToolsVersion
         {
             get
             {
@@ -293,12 +291,12 @@ namespace Microsoft.Build.Framework
         // (a) this event will not be thrown by tasks, so it should not generally cross AppDomain boundaries
         // (b) this event still makes sense when this field is "null"
         [NonSerialized]
-        private IEnumerable properties;
+        private IEnumerable? properties;
 
         /// <summary>
         /// List of properties in this project. This is a live, read-only list.
         /// </summary>
-        public IEnumerable Properties
+        public IEnumerable? Properties
         {
             get
             {
@@ -318,12 +316,12 @@ namespace Microsoft.Build.Framework
         // (a) this event will not be thrown by tasks, so it should not generally cross AppDomain boundaries
         // (b) this event still makes sense when this field is "null"
         [NonSerialized]
-        private IEnumerable items;
+        private IEnumerable? items;
 
         /// <summary>
         /// List of items in this project. This is a live, read-only list.
         /// </summary>
-        public IEnumerable Items
+        public IEnumerable? Items
         {
             get
             {
@@ -367,7 +365,7 @@ namespace Microsoft.Build.Framework
             writer.WriteOptionalString(projectFile);
 
             // TargetNames cannot be null as per the constructor
-            writer.Write(targetNames);
+            writer.Write(targetNames!);
 
             // If no properties were added to the property list 
             // then we have nothing to create when it is deserialized
@@ -391,7 +389,7 @@ namespace Microsoft.Build.Framework
                 foreach (var propertyPair in validProperties)
                 {
                     writer.Write((string)propertyPair.Key);
-                    writer.Write((string)propertyPair.Value);
+                    writer.Write((string?)propertyPair.Value ?? "");
                 }
             }
         }
@@ -491,14 +489,14 @@ namespace Microsoft.Build.Framework
             {
                 if (RawMessage == null)
                 {
-                    string projectFilePath = Path.GetFileName(ProjectFile);
+                    string? projectFilePath = Path.GetFileName(ProjectFile);
 
                     // Check to see if the there are any specific target names to be built.
                     // If targetNames is null or empty then we will be building with the
                     // default targets.
                     if (!string.IsNullOrEmpty(TargetNames))
                     {
-                        RawMessage = FormatResourceStringIgnoreCodeAndKeyword("ProjectStartedPrefixForTopLevelProjectWithTargetNames", projectFilePath, TargetNames);
+                        RawMessage = FormatResourceStringIgnoreCodeAndKeyword("ProjectStartedPrefixForTopLevelProjectWithTargetNames", projectFilePath, TargetNames!);
                     }
                     else
                     {

--- a/src/Shared/BinaryReaderExtensions.cs
+++ b/src/Shared/BinaryReaderExtensions.cs
@@ -6,14 +6,12 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
 
-#nullable disable
-
 namespace Microsoft.Build.Shared
 {
     internal static class BinaryReaderExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ReadOptionalString(this BinaryReader reader)
+        public static string? ReadOptionalString(this BinaryReader reader)
         {
             return reader.ReadByte() == 0 ? null : reader.ReadString();
         }
@@ -53,7 +51,7 @@ namespace Microsoft.Build.Shared
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static BuildEventContext ReadOptionalBuildEventContext(this BinaryReader reader)
+        public static BuildEventContext? ReadOptionalBuildEventContext(this BinaryReader reader)
         {
             if (reader.ReadByte() == 0)
             {

--- a/src/Shared/BinaryWriterExtensions.cs
+++ b/src/Shared/BinaryWriterExtensions.cs
@@ -6,14 +6,12 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
 
-#nullable disable
-
 namespace Microsoft.Build.Shared
 {
     internal static class BinaryWriterExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteOptionalString(this BinaryWriter writer, string value)
+        public static void WriteOptionalString(this BinaryWriter writer, string? value)
         {
             if (value == null)
             {
@@ -49,7 +47,7 @@ namespace Microsoft.Build.Shared
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteOptionalBuildEventContext(this BinaryWriter writer, BuildEventContext context)
+        public static void WriteOptionalBuildEventContext(this BinaryWriter writer, BuildEventContext? context)
         {
             if (context == null)
             {


### PR DESCRIPTION
While consuming some of these types last week I was tripped up by null values a few times. This commit adds annotations for the types I experienced issues with, to hopefully avoid such problems for others in future.

In general these annotations have no run-time impact. There were a few places I had to add behaviour changes to address warnings once this code was marked `#nullable enable`.