### PR TITLE
Link to new canonical-error doc

### DIFF
--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -1364,7 +1364,7 @@ namespace Microsoft.Build.Utilities
 
         /// <summary>
         /// Logs an error/warning/message from the given line of text. Errors/warnings are only logged for lines that fit a
-        /// particular (canonical) format -- all other lines are treated as messages.
+        /// <see href="https://docs.microsoft.com/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks">particular (canonical) format</see> -- all other lines are treated as messages.
         /// Thread safe.
         /// </summary>
         /// <param name="lineOfText">The line of text to log from.</param>


### PR DESCRIPTION
The XML docs for LogMessageFromText have long referenced the canonical error
format but left it as an exercise to figure out what that was. But we have docs
now!

Fixes MicrosoftDocs/visualstudio-docs#7626