### PR TITLE
Fix incorrect WarningsAsErrors elements

### DIFF
--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="'$(MSBuildRuntimeType)' != 'Core' and '$(MonoBuild)' != 'true'">$(LibraryTargetFrameworks);net35</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <WarningsAsErrors>true</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>true</IsPackable>
     <GenerateReferenceAssemblySource>true</GenerateReferenceAssemblySource>
     <LangVersion>8.0</LangVersion>


### PR DESCRIPTION
The project file element `<WarningsAsErrors>` is used to specify a list of warning codes that should be treated as errors. Passing _true_ here has no meaning.

If you're instead trying to say "treat all warnings as errors," the correct syntax is:

```xml
<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
```