### PR TITLE
Remove references to System.Private.Uri

### DIFF
--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -232,7 +232,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Bump these to the latest version despite transitive references to older -->
-    <PackageReference Include="System.Private.Uri" PrivateAssets="all" />
     <PackageReference Include="System.Runtime" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>

--- a/src/StringTools.Benchmark/StringTools.Benchmark.csproj
+++ b/src/StringTools.Benchmark/StringTools.Benchmark.csproj
@@ -15,7 +15,6 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
     <!-- Bump these to the latest version despite transitive references to older -->
-    <PackageReference Include="System.Private.Uri" />
     <PackageReference Include="System.Runtime" />
   </ItemGroup>
 


### PR DESCRIPTION
System.Private.Uri 6.0.0 is reported as a prebuilt in source-build due to these references. This fix is similar to https://github.com/dotnet/sdk/pull/26448.

I tested this change in a source-build tarball context and verified the prebuilt package is no longer getting pulled. I also made sure msbuild builds with `./build.sh`.

I noticed that these were introduced due to some CG concerns (https://github.com/dotnet/msbuild/commit/20cdf6ff1f617fc6d486c170dff95df0300676e3), so if this change causes issues for the MSBuild build, then these System.Private.Uri and System.Runtime references can be conditioned out for source-build instead.