### PR TITLE
Add MLC to deploy script

### DIFF
--- a/scripts/Deploy-MSBuild.ps1
+++ b/scripts/Deploy-MSBuild.ps1
@@ -121,6 +121,7 @@ if ($runtime -eq "Desktop") {
         FileToCopy "$bootstrapBinDirectory\System.Collections.Immutable.dll"
         FileToCopy "$bootstrapBinDirectory\System.Memory.dll"
         FileToCopy "$bootstrapBinDirectory\System.Numerics.Vectors.dll"
+        FileToCopy "$bootstrapBinDirectory\System.Reflection.MetadataLoadContext.dll"
         FileToCopy "$bootstrapBinDirectory\System.Resources.Extensions.dll"
         FileToCopy "$bootstrapBinDirectory\System.Runtime.CompilerServices.Unsafe.dll"
         FileToCopy "$bootstrapBinDirectory\System.Text.Encodings.Web.dll"


### PR DESCRIPTION
I noticed an error of failing to find S.R.MLC if we deploy to the SDK since it isn't currently there. I think this should be made unnecessary for newer SDKs soon, but it'd still be useful for older SDKs, and it doesn't hurt.
