### PR TITLE
Do not use msbuild server with escape hatch for VSTestTask enabled.

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -227,7 +227,10 @@ namespace Microsoft.Build.CommandLine
             }
 
             int exitCode;
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) && Environment.GetEnvironmentVariable(Traits.UseMSBuildServerEnvVarName) == "1")
+            if (
+                ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) &&
+                Environment.GetEnvironmentVariable(Traits.UseMSBuildServerEnvVarName) == "1" &&
+                !Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout)
             {
                 Console.CancelKeyPress += Console_CancelKeyPress;
 


### PR DESCRIPTION
When escape hatch `MSBUILDENSURESTDOUTFORTASKPROCESSES` for issue https://github.com/Microsoft/vstest/issues/1503 is enabled, we should not use msbuild server. 
Otherwise, the same reasons described in the issue apply and that break `dotnet test` command.