### PR TITLE
Account for FileTrackerA4 in LoadFileTrackerDll

### DIFF
--- a/src/Shared/InprocTrackingNativeMethods.cs
+++ b/src/Shared/InprocTrackingNativeMethods.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Build.Shared
 
         private static class FileTrackerDllStub
         {
-            private readonly static Lazy<string> fileTrackerDllName = new Lazy<string>(() => (IntPtr.Size == sizeof(Int32)) ? "FileTracker32.dll" : "FileTracker64.dll");
+            private readonly static Lazy<string> fileTrackerDllName = new Lazy<string>(() => RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "FileTrackerA4.dll" : (IntPtr.Size == sizeof(Int32)) ? "FileTracker32.dll" : "FileTracker64.dll");
 
             // Handle for FileTracker.dll itself
             [SecurityCritical]


### PR DESCRIPTION
### Context
Allows users of the filetracker API to successfully call tracker.exe without fail.

### Changes Made
Arm64 msbuild processes point to the arm64 filetracker dll now.

### Testing
Tested locally.

### Notes
cc @jgoshi 