### PR TITLE
Simplify exception handling for graph builds

### DIFF
--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -78,12 +78,10 @@ namespace Microsoft.Build.Graph.UnitTests
                 defaultTargets: null,
                 extraContent: referenceToSolution);
 
-            var exception = Should.Throw<InvalidOperationException>(
-                () =>
-                {
-                    new ProjectGraph(root.Path);
-                });
+            var aggException = Should.Throw<AggregateException>(() => new ProjectGraph(root.Path));
+            aggException.InnerExceptions.ShouldHaveSingleItem();
 
+            var exception = aggException.InnerExceptions[0].ShouldBeOfType<InvalidOperationException>();
             exception.Message.ShouldContain("MSB4263:");
         }
 

--- a/src/Build.UnitTests/Graph/ParallelWorkSet_Tests.cs
+++ b/src/Build.UnitTests/Graph/ParallelWorkSet_Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
-using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
 using Shouldly;
 using Xunit;
@@ -19,7 +18,7 @@ namespace Microsoft.Build.Graph.UnitTests
 
             internal Dictionary<string, string> ExpectedCompletedWork =
                 new Dictionary<string, string>(StringComparer.Ordinal);
-            internal bool ShouldExpectException { get; set; }
+            internal int NumExpectedExceptions { get; set; }
         }
 
         private struct WorkItem
@@ -55,7 +54,7 @@ namespace Microsoft.Build.Graph.UnitTests
                         WorkFunc = () => throw new Exception()
                     }
                 },
-                ShouldExpectException = true
+                NumExpectedExceptions = 3
             });
         }
 
@@ -83,7 +82,7 @@ namespace Microsoft.Build.Graph.UnitTests
                         WorkFunc = () => throw new Exception()
                     }
                 },
-                ShouldExpectException = true
+                NumExpectedExceptions = 3
             });
         }
 
@@ -236,15 +235,33 @@ namespace Microsoft.Build.Graph.UnitTests
         {
             _workSet = new ParallelWorkSet<string, string>(tt.DegreeOfParallelism, StringComparer.Ordinal, CancellationToken.None);
 
+            List<Exception> observedExceptions = new();
+
             foreach (WorkItem workItem in tt.WorkItemsToAdd)
             {
-                _workSet.AddWork(workItem.Key, workItem.WorkFunc);
+                _workSet.AddWork(
+                    workItem.Key,
+                    () =>
+                    {
+                        try
+                        {
+                            return workItem.WorkFunc();
+                        }
+                        catch (Exception ex)
+                        {
+                            lock (observedExceptions)
+                            {
+                                observedExceptions.Add(ex);
+                            }
+
+                            throw;
+                        }
+                    });
             }
 
-            if (tt.ShouldExpectException)
+            if (tt.NumExpectedExceptions > 0)
             {
-                Should.Throw<Exception>(() => _workSet.WaitForAllWorkAndComplete());
-
+                Should.Throw<AggregateException>(() => _workSet.WaitForAllWorkAndComplete()).InnerExceptions.ShouldBe(observedExceptions);
                 return;
             }
 

--- a/src/Build.UnitTests/Graph/ParallelWorkSet_Tests.cs
+++ b/src/Build.UnitTests/Graph/ParallelWorkSet_Tests.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Build.Graph.UnitTests
 
             if (tt.NumExpectedExceptions > 0)
             {
-                Should.Throw<AggregateException>(() => _workSet.WaitForAllWorkAndComplete()).InnerExceptions.ShouldBe(observedExceptions);
+                Should.Throw<AggregateException>(() => _workSet.WaitForAllWorkAndComplete()).InnerExceptions.ShouldBeSetEquivalentTo(observedExceptions);
                 return;
             }
 

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -201,10 +201,13 @@ namespace Microsoft.Build.Graph.UnitTests
             {
                 TransientTestFile entryProject = CreateProjectFile(env, 1);
 
-                Should.Throw<InvalidOperationException>(() => new ProjectGraph(
+                var aggException = Should.Throw<AggregateException>(() => new ProjectGraph(
                     entryProject.Path,
                     ProjectCollection.GlobalProjectCollection,
                     (projectPath, globalProperties, projectCollection) => null));
+                aggException.InnerExceptions.ShouldHaveSingleItem();
+
+                aggException.InnerExceptions[0].ShouldBeOfType<InvalidOperationException>();
             }
         }
 
@@ -554,7 +557,10 @@ namespace Microsoft.Build.Graph.UnitTests
 </Project>");
                 CreateProjectFile(env, 3);
 
-                Should.Throw<InvalidProjectFileException>(() => new ProjectGraph(entryProject.Path));
+                var aggException = Should.Throw<AggregateException>(() => new ProjectGraph(entryProject.Path));
+                aggException.InnerExceptions.ShouldHaveSingleItem();
+
+                aggException.InnerExceptions[0].ShouldBeOfType<InvalidProjectFileException>();
             }
         }
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1723,19 +1723,35 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void HandleSubmissionException(GraphBuildSubmission submission, Exception ex)
         {
-            if (ex is InvalidProjectFileException projectException)
+            if (ex is AggregateException ae)
             {
-                if (!projectException.HasBeenLogged)
+                // If there's exactly 1, just flatten it
+                if (ae.InnerExceptions.Count == 1)
                 {
-                    BuildEventContext buildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-                    ((IBuildComponentHost)this).LoggingService.LogInvalidProjectFileError(buildEventContext, projectException);
-                    projectException.HasBeenLogged = true;
+                    ex = ae.InnerExceptions[0];
+                }
+                else
+                {
+                    // Log each InvalidProjectFileException encountered during ProjectGraph creation
+                    foreach (Exception innerException in ae.InnerExceptions)
+                    {
+                        if (innerException is InvalidProjectFileException innerProjectException)
+                        {
+                            LogInvalidProjectFileError(innerProjectException);
+                        }
+                    }
                 }
             }
 
-            ex = ex is AggregateException ae && ae.InnerExceptions.Count == 1
-                ? ae.InnerExceptions.First()
-                : ex;
+            if (ex is InvalidProjectFileException projectException)
+            {
+                LogInvalidProjectFileError(projectException);
+            }
+
+            if (ex is CircularDependencyException)
+            {
+                LogInvalidProjectFileError(new InvalidProjectFileException(ex.Message, ex));
+            }
 
             lock (_syncLock)
             {
@@ -1746,6 +1762,16 @@ namespace Microsoft.Build.Execution
 
                 _overallBuildSuccess = false;
                 CheckSubmissionCompletenessAndRemove(submission);
+            }
+
+            void LogInvalidProjectFileError(InvalidProjectFileException projectException)
+            {
+                if (!projectException.HasBeenLogged)
+                {
+                    BuildEventContext buildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+                    ((IBuildComponentHost)this).LoggingService.LogInvalidProjectFileError(buildEventContext, projectException);
+                    projectException.HasBeenLogged = true;
+                }
             }
         }
 
@@ -1876,127 +1902,84 @@ namespace Microsoft.Build.Execution
 
         private void ExecuteGraphBuildScheduler(GraphBuildSubmission submission)
         {
-            try
+            if (_shuttingDown)
             {
-                if (_shuttingDown)
-                {
-                    throw new BuildAbortedException();
-                }
-
-                var projectGraph = submission.BuildRequestData.ProjectGraph;
-                if (projectGraph == null)
-                {
-                    projectGraph = new ProjectGraph(
-                        submission.BuildRequestData.ProjectGraphEntryPoints,
-                        ProjectCollection.GlobalProjectCollection,
-                        (path, properties, collection) =>
-                        {
-                            ProjectLoadSettings projectLoadSettings = _buildParameters.ProjectLoadSettings;
-                            if (submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports))
-                            {
-                                projectLoadSettings |= ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreEmptyImports;
-                            }
-
-                            if (submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.FailOnUnresolvedSdk))
-                            {
-                                projectLoadSettings |= ProjectLoadSettings.FailOnUnresolvedSdk;
-                            }
-
-                            return new ProjectInstance(
-                                path,
-                                properties,
-                                null,
-                                _buildParameters,
-                                ((IBuildComponentHost)this).LoggingService,
-                                new BuildEventContext(
-                                    submission.SubmissionId,
-                                    _buildParameters.NodeId,
-                                    BuildEventContext.InvalidEvaluationId,
-                                    BuildEventContext.InvalidProjectInstanceId,
-                                    BuildEventContext.InvalidProjectContextId,
-                                    BuildEventContext.InvalidTargetId,
-                                    BuildEventContext.InvalidTaskId),
-                                SdkResolverService,
-                                submission.SubmissionId,
-                                projectLoadSettings);
-                        });
-                }
-
-                LogMessage(
-                    ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
-                        "StaticGraphConstructionMetrics",
-                        Math.Round(projectGraph.ConstructionMetrics.ConstructionTime.TotalSeconds, 3),
-                        projectGraph.ConstructionMetrics.NodeCount,
-                        projectGraph.ConstructionMetrics.EdgeCount));
-
-                Dictionary<ProjectGraphNode, BuildResult> resultsPerNode = null;
-
-                if (submission.BuildRequestData.GraphBuildOptions.Build)
-                {
-                    var cacheServiceTask = Task.Run(() => SearchAndInitializeProjectCachePluginFromGraph(projectGraph));
-                    var targetListTask = projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames);
-
-                    DumpGraph(projectGraph, targetListTask);
-
-                    using DisposablePluginService cacheService = cacheServiceTask.Result;
-
-                    resultsPerNode = BuildGraph(projectGraph, targetListTask, submission.BuildRequestData);
-                }
-                else
-                {
-                    DumpGraph(projectGraph);
-                }
-
-                ErrorUtilities.VerifyThrow(
-                    submission.BuildResult?.Exception == null,
-                    "Exceptions only get set when the graph submission gets completed with an exception in OnThreadException. That should not happen during graph builds.");
-
-                // The overall submission is complete, so report it as complete
-                ReportResultsToSubmission(
-                    new GraphBuildResult(
-                        submission.SubmissionId,
-                        new ReadOnlyDictionary<ProjectGraphNode, BuildResult>(resultsPerNode ?? new Dictionary<ProjectGraphNode, BuildResult>())));
+                throw new BuildAbortedException();
             }
-            catch (CircularDependencyException ex)
-            {
-                BuildEventContext projectBuildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-                ((IBuildComponentHost)this).LoggingService.LogInvalidProjectFileError(projectBuildEventContext, new InvalidProjectFileException(ex.Message, ex));
 
-                ReportResultsToSubmission(new GraphBuildResult(submission.SubmissionId, circularDependency: true));
-            }
-            catch (Exception ex) when (IsInvalidProjectOrIORelatedException(ex))
+            var projectGraph = submission.BuildRequestData.ProjectGraph;
+            if (projectGraph == null)
             {
-                // ProjectGraph throws an aggregate exception with InvalidProjectFileException inside when evaluation fails
-                if (ex is AggregateException aggregateException && aggregateException.InnerExceptions.All(innerException => innerException is InvalidProjectFileException))
-                {
-                    // Log each InvalidProjectFileException encountered during ProjectGraph creation
-                    foreach (Exception innerException in aggregateException.InnerExceptions)
+                projectGraph = new ProjectGraph(
+                    submission.BuildRequestData.ProjectGraphEntryPoints,
+                    ProjectCollection.GlobalProjectCollection,
+                    (path, properties, collection) =>
                     {
-                        var projectException = (InvalidProjectFileException) innerException;
-                        if (!projectException.HasBeenLogged)
+                        ProjectLoadSettings projectLoadSettings = _buildParameters.ProjectLoadSettings;
+                        if (submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports))
                         {
-                            BuildEventContext projectBuildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-                            ((IBuildComponentHost)this).LoggingService.LogInvalidProjectFileError(projectBuildEventContext, projectException);
-                            projectException.HasBeenLogged = true;
+                            projectLoadSettings |= ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreEmptyImports;
                         }
-                    }
-                }
-                else
-                {
-                    // Arbitrarily just choose the first entry point project's path
-                    string projectFile = submission.BuildRequestData.ProjectGraph?.EntryPointNodes.First().ProjectInstance.FullPath
-                        ?? submission.BuildRequestData.ProjectGraphEntryPoints?.First().ProjectFile;
-                    BuildEventContext buildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-                    ((IBuildComponentHost)this).LoggingService.LogFatalBuildError(buildEventContext, ex, new BuildEventFileInfo(projectFile));
-                }
 
-                ReportResultsToSubmission(new GraphBuildResult(submission.SubmissionId, ex));
+                        if (submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.FailOnUnresolvedSdk))
+                        {
+                            projectLoadSettings |= ProjectLoadSettings.FailOnUnresolvedSdk;
+                        }
 
-                lock (_syncLock)
-                {
-                    _overallBuildSuccess = false;
-                }
+                        return new ProjectInstance(
+                            path,
+                            properties,
+                            null,
+                            _buildParameters,
+                            ((IBuildComponentHost)this).LoggingService,
+                            new BuildEventContext(
+                                submission.SubmissionId,
+                                _buildParameters.NodeId,
+                                BuildEventContext.InvalidEvaluationId,
+                                BuildEventContext.InvalidProjectInstanceId,
+                                BuildEventContext.InvalidProjectContextId,
+                                BuildEventContext.InvalidTargetId,
+                                BuildEventContext.InvalidTaskId),
+                            SdkResolverService,
+                            submission.SubmissionId,
+                            projectLoadSettings);
+                    });
             }
+
+            LogMessage(
+                ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
+                    "StaticGraphConstructionMetrics",
+                    Math.Round(projectGraph.ConstructionMetrics.ConstructionTime.TotalSeconds, 3),
+                    projectGraph.ConstructionMetrics.NodeCount,
+                    projectGraph.ConstructionMetrics.EdgeCount));
+
+            Dictionary<ProjectGraphNode, BuildResult> resultsPerNode = null;
+
+            if (submission.BuildRequestData.GraphBuildOptions.Build)
+            {
+                var cacheServiceTask = Task.Run(() => SearchAndInitializeProjectCachePluginFromGraph(projectGraph));
+                var targetListTask = projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames);
+
+                DumpGraph(projectGraph, targetListTask);
+
+                using DisposablePluginService cacheService = cacheServiceTask.Result;
+
+                resultsPerNode = BuildGraph(projectGraph, targetListTask, submission.BuildRequestData);
+            }
+            else
+            {
+                DumpGraph(projectGraph);
+            }
+
+            ErrorUtilities.VerifyThrow(
+                submission.BuildResult?.Exception == null,
+                "Exceptions only get set when the graph submission gets completed with an exception in OnThreadException. That should not happen during graph builds.");
+
+            // The overall submission is complete, so report it as complete
+            ReportResultsToSubmission(
+                new GraphBuildResult(
+                    submission.SubmissionId,
+                    new ReadOnlyDictionary<ProjectGraphNode, BuildResult>(resultsPerNode ?? new Dictionary<ProjectGraphNode, BuildResult>())));
 
             static void DumpGraph(ProjectGraph graph, IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetList = null)
             {

--- a/src/Build/Graph/GraphBuildResult.cs
+++ b/src/Build/Graph/GraphBuildResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 
 #nullable disable
@@ -20,17 +21,6 @@ namespace Microsoft.Build.Graph
         {
             SubmissionId = submissionId;
             ResultsByNode = resultsByNode;
-        }
-
-        /// <summary>
-        /// Constructor creates a build result indicating a circular dependency was created.
-        /// </summary>
-        /// <param name="submissionId">The id of the build submission.</param>
-        /// <param name="circularDependency">Set to true if a circular dependency was detected.</param>
-        internal GraphBuildResult(int submissionId, bool circularDependency)
-        {
-            SubmissionId = submissionId;
-            CircularDependency = circularDependency;
         }
 
         /// <summary>
@@ -52,7 +42,7 @@ namespace Microsoft.Build.Graph
         /// <summary>
         /// Returns a flag indicating if a circular dependency was detected.
         /// </summary>
-        public bool CircularDependency { get; }
+        public bool CircularDependency => Exception is CircularDependencyException;
 
         /// <summary>
         /// Returns the exception generated while this result was run, if any.
@@ -66,7 +56,7 @@ namespace Microsoft.Build.Graph
         {
             get
             {
-                if (Exception != null || CircularDependency)
+                if (Exception != null)
                 {
                     return BuildResultCode.Failure;
                 }

--- a/src/Build/Graph/ParallelWorkSet.cs
+++ b/src/Build/Graph/ParallelWorkSet.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Build.Graph
 
         private readonly List<Task> _tasks;
 
+        private readonly List<Exception> _exceptions = new List<Exception>(0);
+
         /// <summary>
         /// Retrieves all completed work items.
         /// </summary>
@@ -54,6 +56,11 @@ namespace Microsoft.Build.Graph
                     {
                         completedWork[kvp.Key] = workItem.Value;
                     }
+                }
+
+                if (_exceptions.Count > 0)
+                {
+                    throw new AggregateException(_exceptions);
                 }
 
                 return completedWork;
@@ -138,7 +145,12 @@ namespace Microsoft.Build.Graph
 
             // Release one thread that will release all the threads when all the elements are processed.
             _semaphore.Release();
-            Task.WhenAll(_tasks.ToArray()).GetAwaiter().GetResult();
+            Task.WaitAll(_tasks.ToArray());
+
+            if (_exceptions.Count > 0)
+            {
+                throw new AggregateException(_exceptions);
+            }
         }
 
         private Task CreateProcessorItemTask()
@@ -179,7 +191,14 @@ namespace Microsoft.Build.Graph
             {
                 try
                 {
-                    TResult _ = workItem.Value;
+                    _ = workItem.Value;
+                }
+                catch (Exception ex)
+                {
+                    lock (_exceptions)
+                    {
+                        _exceptions.Add(ex);
+                    }
                 }
                 finally
                 {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1296,7 +1296,8 @@ namespace Microsoft.Build.CommandLine
 
                         // InvalidProjectFileExceptions and its aggregates have already been logged.
                         if (exception is not InvalidProjectFileException
-                            && !(exception is AggregateException aggregateException && aggregateException.InnerExceptions.All(innerException => innerException is InvalidProjectFileException)))
+                            && !(exception is AggregateException aggregateException && aggregateException.InnerExceptions.All(innerException => innerException is InvalidProjectFileException))
+                            && exception is not CircularDependencyException)
                         {
                             if (exception is LoggerException or InternalLoggerException or ProjectCacheException)
                             {


### PR DESCRIPTION
Just some cleanup and simplification in the exception handling for graph builds.

Functionally here are the differences:
* `ParallelWorkSet` now throws an aggregate exception containing all exceptions instead of just the first exception that gets thrown.
* `ParallelWorkSet` tasks no longer go away when they throw. They're caught and added to a list used in the point above.
* `BuildManager` now properly logs invalid project errors for *each* invalid project (due to the help of the points above). Previously it was attempting to catch the agg exception which was never thrown and also the way it was in the catch effectively made it unreachable in the first place.
* `GraphBuildResult` now exposes the `CircularDependencyException` via the `Exception` field instead of `Exception` being null while `CircularDependency` was true.