### PR TITLE
[Graph] Fix target list when there are multiple ProjectReferences with different Targets metadata

### DIFF
--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -2361,7 +2361,7 @@ $@"
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>()
                 {
-                    {1, new[] {2}},
+                    { 1, new[] { 2 } },
                 },
                 extraContentPerProjectNumber: new Dictionary<int, string>()
                 {
@@ -2371,28 +2371,29 @@ $@"
 <ItemGroup>
     <ProjectReferenceTmp Include='@(ProjectReference)' />
     <ProjectReference Include='@(ProjectReferenceTmp)' />
-</ItemGroup>"
-                    },
-                },
-                extraContentForAllNodes: @$"
-<PropertyGroup>
-</PropertyGroup>
-
-<ItemGroup>
-    <ProjectReferenceTargets Include='Build' Targets='{MSBuildConstants.ProjectReferenceTargetsOrDefaultTargetsMarker}' />
 </ItemGroup>
 
-<Target Name='Build' />
-");
+<ItemGroup>
+    <ProjectReferenceTargets Include='SomeDefaultTarget1' Targets='{MSBuildConstants.ProjectReferenceTargetsOrDefaultTargetsMarker}' />
+</ItemGroup>
 
-            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = graph.GetTargetLists(new[] { "Build" });
+<Target Name='SomeDefaultTarget1' />
+"
+                    },
+                    {
+                        2,
+                        @"<Target Name='SomeDefaultTarget2' />"
+                    }
+                });
+
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = graph.GetTargetLists(Array.Empty<string>());
 
             ProjectGraphNode project1 = GetFirstNodeWithProjectNumber(graph, 1);
             ProjectGraphNode project2 = GetFirstNodeWithProjectNumber(graph, 2);
 
             project1.ProjectReferences.ShouldHaveSingleItem().ShouldBe(project2);
-            targetLists[project1].ShouldBe(new[] { "Build" });
-            targetLists[project2].ShouldBe(new[] { "Build" });
+            targetLists[project1].ShouldBe(new[] { "SomeDefaultTarget1" });
+            targetLists[project2].ShouldBe(new[] { "SomeDefaultTarget2" });
         }
 
         [Fact]
@@ -2412,28 +2413,29 @@ $@"
 <ItemGroup>
     <ProjectReferenceTmp Include='@(ProjectReference)' />
     <ProjectReference Include='@(ProjectReferenceTmp)' Targets='SomeOtherTarget' />
-</ItemGroup>"
-                    },
-                },
-                extraContentForAllNodes: @$"
-<PropertyGroup>
-</PropertyGroup>
-
-<ItemGroup>
-    <ProjectReferenceTargets Include='Build' Targets='{MSBuildConstants.ProjectReferenceTargetsOrDefaultTargetsMarker}' />
 </ItemGroup>
 
-<Target Name='Build' />
-");
+<ItemGroup>
+    <ProjectReferenceTargets Include='SomeDefaultTarget1' Targets='{MSBuildConstants.ProjectReferenceTargetsOrDefaultTargetsMarker}' />
+</ItemGroup>
 
-            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = graph.GetTargetLists(new[] { "Build" });
+<Target Name='SomeDefaultTarget1' />
+"
+                    },
+                    {
+                        2,
+                        @"<Target Name='SomeDefaultTarget2' />"
+                    }
+                });
+
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = graph.GetTargetLists(Array.Empty<string>());
 
             ProjectGraphNode project1 = GetFirstNodeWithProjectNumber(graph, 1);
             ProjectGraphNode project2 = GetFirstNodeWithProjectNumber(graph, 2);
 
             project1.ProjectReferences.ShouldHaveSingleItem().ShouldBe(project2);
-            targetLists[project1].ShouldBe(new[] { "Build" });
-            targetLists[project2].ShouldBe(new[] { "Build", "SomeOtherTarget" });
+            targetLists[project1].ShouldBe(new[] { "SomeDefaultTarget1" });
+            targetLists[project2].ShouldBe(new[] { "SomeDefaultTarget2", "SomeOtherTarget" });
         }
 
         public void Dispose()

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Security.Cryptography.Xml;
 using System.Text;
 using System.Threading;
 using Microsoft.Build.BackEnd;
@@ -639,18 +640,18 @@ namespace Microsoft.Build.Graph
                             return existingItem;
                         }
 
-                        existingTargetsMetadata = GetEffectiveTargets(existingItem, existingTargetsMetadata);
-                        newTargetsMetadata = GetEffectiveTargets(newItem, newTargetsMetadata);
+                        existingTargetsMetadata = GetEffectiveTargets(key.reference, existingTargetsMetadata);
+                        newTargetsMetadata = GetEffectiveTargets(key.reference, newTargetsMetadata);
 
                         ProjectItemInstance mergedItem = existingItem.DeepClone();
                         mergedItem.SetMetadata(ItemMetadataNames.ProjectReferenceTargetsMetadataName, $"{existingTargetsMetadata};{newTargetsMetadata}");
                         return mergedItem;
 
-                        static string GetEffectiveTargets(ProjectItemInstance item, string targetsMetadata)
+                        static string GetEffectiveTargets(ProjectGraphNode reference, string targetsMetadata)
                         {
                             if (string.IsNullOrWhiteSpace(targetsMetadata))
                             {
-                                return string.Join(";", item.Project.DefaultTargets);
+                                return string.Join(";", reference.ProjectInstance.DefaultTargets);
                             }
 
                             return targetsMetadata;

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Build.Graph
                         newTargetsMetadata = GetEffectiveTargets(newItem, newTargetsMetadata);
 
                         ProjectItemInstance mergedItem = existingItem.DeepClone();
-                        mergedItem.SetMetadata(ItemMetadataNames.ProjectReferenceTargetsMetadataName, existingTargetsMetadata + ";" + newTargetsMetadata);
+                        mergedItem.SetMetadata(ItemMetadataNames.ProjectReferenceTargetsMetadataName, $"{existingTargetsMetadata};{newTargetsMetadata});
                         return mergedItem;
 
                         static string GetEffectiveTargets(ProjectItemInstance item, string targetsMetadata)

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Build.Graph
                         newTargetsMetadata = GetEffectiveTargets(newItem, newTargetsMetadata);
 
                         ProjectItemInstance mergedItem = existingItem.DeepClone();
-                        mergedItem.SetMetadata(ItemMetadataNames.ProjectReferenceTargetsMetadataName, $"{existingTargetsMetadata};{newTargetsMetadata});
+                        mergedItem.SetMetadata(ItemMetadataNames.ProjectReferenceTargetsMetadataName, $"{existingTargetsMetadata};{newTargetsMetadata}");
                         return mergedItem;
 
                         static string GetEffectiveTargets(ProjectItemInstance item, string targetsMetadata)

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -607,7 +607,7 @@ namespace Microsoft.Build.Graph
             return propertyDictionary;
         }
 
-        internal class GraphEdges
+        internal sealed class GraphEdges
         {
             private ConcurrentDictionary<(ProjectGraphNode, ProjectGraphNode), ProjectItemInstance> ReferenceItems =
                 new ConcurrentDictionary<(ProjectGraphNode, ProjectGraphNode), ProjectItemInstance>();
@@ -621,9 +621,42 @@ namespace Microsoft.Build.Graph
                     ErrorUtilities.VerifyThrow(ReferenceItems.TryGetValue(key, out ProjectItemInstance referenceItem), "All requested keys should exist");
                     return referenceItem;
                 }
+            }
 
-                // First edge wins, in accordance with vanilla msbuild behaviour when multiple msbuild tasks call into the same logical project
-                set => ReferenceItems.TryAdd(key, value);
+            public void AddOrUpdateEdge((ProjectGraphNode node, ProjectGraphNode reference) key, ProjectItemInstance edge)
+            {
+                ReferenceItems.AddOrUpdate(
+                    key,
+                    addValueFactory: static ((ProjectGraphNode node, ProjectGraphNode reference) key, ProjectItemInstance referenceItem) => referenceItem,
+                    updateValueFactory: static ((ProjectGraphNode node, ProjectGraphNode reference) key, ProjectItemInstance existingItem, ProjectItemInstance newItem) =>
+                    {
+                        string existingTargetsMetadata = existingItem.GetMetadataValue(ItemMetadataNames.ProjectReferenceTargetsMetadataName);
+                        string newTargetsMetadata = newItem.GetMetadataValue(ItemMetadataNames.ProjectReferenceTargetsMetadataName);
+
+                        // Bail out of the targets are the same.
+                        if (existingTargetsMetadata.Equals(newTargetsMetadata, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return existingItem;
+                        }
+
+                        existingTargetsMetadata = GetEffectiveTargets(existingItem, existingTargetsMetadata);
+                        newTargetsMetadata = GetEffectiveTargets(newItem, newTargetsMetadata);
+
+                        ProjectItemInstance mergedItem = existingItem.DeepClone();
+                        mergedItem.SetMetadata(ItemMetadataNames.ProjectReferenceTargetsMetadataName, existingTargetsMetadata + ";" + newTargetsMetadata);
+                        return mergedItem;
+
+                        static string GetEffectiveTargets(ProjectItemInstance item, string targetsMetadata)
+                        {
+                            if (string.IsNullOrWhiteSpace(targetsMetadata))
+                            {
+                                return string.Join(";", item.Project.DefaultTargets);
+                            }
+
+                            return targetsMetadata;
+                        }
+                    },
+                    edge);
             }
 
             public void RemoveEdge((ProjectGraphNode node, ProjectGraphNode reference) key)
@@ -632,7 +665,6 @@ namespace Microsoft.Build.Graph
             }
 
             internal bool HasEdge((ProjectGraphNode node, ProjectGraphNode reference) key) => ReferenceItems.ContainsKey(key);
-            internal bool TryGetEdge((ProjectGraphNode node, ProjectGraphNode reference) key, out ProjectItemInstance edge) => ReferenceItems.TryGetValue(key, out edge);
 
             internal IReadOnlyDictionary<(ConfigurationMetadata, ConfigurationMetadata), ProjectItemInstance> TestOnly_AsConfigurationMetadata()
             {

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -633,7 +633,7 @@ namespace Microsoft.Build.Graph
                         string existingTargetsMetadata = existingItem.GetMetadataValue(ItemMetadataNames.ProjectReferenceTargetsMetadataName);
                         string newTargetsMetadata = newItem.GetMetadataValue(ItemMetadataNames.ProjectReferenceTargetsMetadataName);
 
-                        // Bail out of the targets are the same.
+                        // Bail out if the targets are the same.
                         if (existingTargetsMetadata.Equals(newTargetsMetadata, StringComparison.OrdinalIgnoreCase))
                         {
                             return existingItem;

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -15,8 +15,6 @@ using Microsoft.Build.Eventing;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
-using Microsoft.Build.Shared.Debugging;
-using Microsoft.Build.Utilities;
 
 #nullable disable
 

--- a/src/Build/Graph/ProjectGraphNode.cs
+++ b/src/Build/Graph/ProjectGraphNode.cs
@@ -56,8 +56,7 @@ namespace Microsoft.Build.Graph
             _projectReferences.Add(reference);
             reference._referencingProjects.Add(this);
 
-            // First edge wins, in accordance with vanilla msbuild behaviour when multiple msbuild tasks call into the same logical project
-            edges[(this, reference)] = projectReferenceItem;
+            edges.AddOrUpdateEdge((this, reference), projectReferenceItem);
         }
 
         internal void RemoveReference(ProjectGraphNode reference, GraphBuilder.GraphEdges edges)

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -191,8 +191,6 @@ namespace Microsoft.Build.Graph
 
                             if (outerBuildReferencingProject.ProjectReferences.Contains(innerBuild))
                             {
-                                graphBuilder.Edges.TryGetEdge((outerBuildReferencingProject, innerBuild), out var existingEdge);
-
                                 ErrorUtilities.VerifyThrow(
                                     graphBuilder.Edges[(outerBuildReferencingProject, innerBuild)]
                                         .ItemType.Equals(


### PR DESCRIPTION
Fixes #7694

Today the first project reference wins and the targets from additional project references are ignored. There is a comment saying that behavior is "in accordance with vanilla msbuild behaviour when multiple msbuild tasks call into the same logical project", but that doesn't seem to be the case.

This change changes the `TryAdd` to an `AddOrUpdate` so that multiple sets of targets are considered from multiple project references.

## Simple repro:

Referenced\Referenced.csproj:
```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netcoreapp3.1</TargetFramework>
    <UnusualOutput>Configuration\Unusual.txt</UnusualOutput>
  </PropertyGroup>
  <Target Name="UnusualThing" Returns="$(UnusualOutput)" />
</Project>
```

Referencing\Referencing.csproj:
```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netcoreapp3.1</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <ProjectReference Include="..\Referenced\Referenced.csproj" Targets="UnusualThing" ReferenceOutputAssembly="false" />
    <ProjectReference Include="..\Referenced\Referenced.csproj"  />
  </ItemGroup>
</Project>
```

Run: `msbuild Referencing\Referencing.csproj -graph -isolate`

Note that the repro uses `-isolate` to point out the issue more strongly, but the issue exists with any graph build.