### PR TITLE
Ensure trailing slash is present for clickonce publish's output locat…

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -488,6 +488,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PublishDir Condition="'$(PublishDir)'==''">$(OutputPath)app.publish\</PublishDir>
   </PropertyGroup>
 
+  <!-- 
+    ClickOncePublishDir property is the output location used by all ClickOnce publish targets. This should be same as PublishDir except 
+    for a trailing slash. PublishDir when specified as a global property on the command line cannot be changed to add a trailing slash.
+  -->
+  <PropertyGroup>
+    <ClickOncePublishDir>$(PublishDir)</ClickOncePublishDir>
+    <ClickOncePublishDir Condition="!HasTrailingSlash('$(ClickOncePublishDir)')">$(ClickOncePublishDir)\</ClickOncePublishDir>
+  </PropertyGroup>
+
   <!--
     ProcessorArchitecture is the target processor architecture.
     -->
@@ -4416,7 +4425,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     This is being done to avoid Windows Forms designer memory issues that can arise while operating directly on files located in Obj directory. -->
     <Copy
       SourceFiles="@(_DeploymentManifestEntryPoint)"
-      DestinationFolder="$(PublishDir)">
+      DestinationFolder="$(ClickOncePublishDir)">
 
       <Output TaskParameter="DestinationFiles" ItemName="_DeploymentClickOnceApplicationExecutable" />
     </Copy>
@@ -5679,8 +5688,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Name="CleanPublishFolder">
 
     <RemoveDir
-        Directories="$(PublishDir)"
-        Condition="'$(PublishDir)'=='$(OutputPath)app.publish\' and Exists('$(PublishDir)')"/>
+        Directories="$(ClickOncePublishDir)"
+        Condition="'$(ClickOncePublishDir)'=='$(OutputPath)app.publish\' and Exists('$(ClickOncePublishDir)')"/>
 
   </Target>
 
@@ -5872,7 +5881,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <PropertyGroup>
       <_DeploymentApplicationFolderName>Application Files\$(AssemblyName)_$(_DeploymentApplicationVersionFragment)</_DeploymentApplicationFolderName>
-      <_DeploymentApplicationDir>$(PublishDir)$(_DeploymentApplicationFolderName)\</_DeploymentApplicationDir>
+      <_DeploymentApplicationDir>$(ClickOncePublishDir)$(_DeploymentApplicationFolderName)\</_DeploymentApplicationDir>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -5978,7 +5987,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         ComponentsUrl="$(_DeploymentFormattedComponentsUrl)"
         Culture="$(TargetCulture)"
         FallbackCulture="$(FallbackCulture)"
-        OutputPath="$(PublishDir)"
+        OutputPath="$(ClickOncePublishDir)"
         SupportUrl="$(_DeploymentFormattedSupportUrl)"
         Path="$(GenerateBootstrapperSdkPath)"
         VisualStudioVersion="$(VisualStudioVersion)"
@@ -6010,7 +6019,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         TargetFrameworkVersion="$(_DeploymentManifestTargetFrameworkVersion)"
         ApplicationManifest="$(_DeploymentApplicationDir)$(_DeploymentTargetApplicationManifestFileName)"
         InputManifest="$(OutDir)$(TargetDeployManifestFileName)"
-        OutputManifest="$(PublishDir)$(TargetDeployManifestFileName)">
+        OutputManifest="$(ClickOncePublishDir)$(TargetDeployManifestFileName)">
 
       <Output TaskParameter="OutputManifest" ItemName="PublishedDeployManifest"/>
 
@@ -6019,7 +6028,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <SignFile
         CertificateThumbprint="$(_DeploymentResolvedManifestCertificateThumbprint)"
         TimestampUrl="$(ManifestTimestampUrl)"
-        SigningTarget="$(PublishDir)$(TargetDeployManifestFileName)"
+        SigningTarget="$(ClickOncePublishDir)$(TargetDeployManifestFileName)"
         TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         DisallowMansignTimestampFallback="$(DisallowMansignTimestampFallback)"
@@ -6028,7 +6037,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <SignFile
         CertificateThumbprint="$(_DeploymentResolvedManifestCertificateThumbprint)"
         TimestampUrl="$(ManifestTimestampUrl)"
-        SigningTarget="$(PublishDir)\setup.exe"
+        SigningTarget="$(ClickOncePublishDir)setup.exe"
         Condition="'$(BootstrapperEnabled)'=='true' and '$(_DeploymentSignClickOnceManifests)'=='true'" />
 
   </Target>


### PR DESCRIPTION
…ion in all scenarios

Fixes [AB#1577754](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1577754)

### Context
Customers trying to publish through ClickOnce provider in ADO override the publish directory location by passing in the PublishDir property on the msbuild CLI. If a trailing backslash is not present in the path, publish can fail.

### Changes Made
The msbuild targets file does try to add a trailing backslash to PublishDir if it is not present. However, when passed on the msbuild command line, it's value cannot be changed due to being a global property.
To work around this, a new property ClickOncePublishDir is being added which will add a trailing backslash if not present and all ClickOnce specific targets will use this property.

### Testing
Tested with ClickOnce publish through VS and CLI (with both with and without trailing backslash in property value) across all supported configuration

### Notes
