### PR TITLE
BuildManager.ShutdownAllNodes shall shut down server as well

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -24,6 +24,7 @@ using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Eventing;
 using Microsoft.Build.Exceptions;
+using Microsoft.Build.Experimental;
 using Microsoft.Build.Experimental.ProjectCache;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Telemetry;
@@ -1111,10 +1112,12 @@ namespace Microsoft.Build.Execution
         {
             if (_nodeManager == null)
             {
-                _nodeManager = ((IBuildComponentHost)this).GetComponent(BuildComponentType.NodeManager) as INodeManager;
+                _nodeManager = (INodeManager)((IBuildComponentHost)this).GetComponent(BuildComponentType.NodeManager);
             }
 
             _nodeManager.ShutdownAllNodes();
+
+            MSBuildClient.ShutdownServer(CancellationToken.None);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Build.Experimental
             bool serverIsAlreadyRunning = ServerNamedMutex.WasOpen(serverRunningMutexName);
             if (!serverIsAlreadyRunning)
             {
-                CommunicationsUtilities.Trace("No need to shutdown server node for it is n-ot running.");
+                CommunicationsUtilities.Trace("No need to shutdown server node for it is not running.");
                 return true;
             }
 
@@ -240,20 +240,20 @@ namespace Microsoft.Build.Experimental
             var serverWasBusy = ServerNamedMutex.WasOpen(serverBusyMutexName);
             if (serverWasBusy)
             {
-                CommunicationsUtilities.Trace("Server can not be shutdown for it is not idle.");
+                CommunicationsUtilities.Trace("Server cannot be shut down for it is not idle.");
                 return false;
             }
 
             // Connect to server.
             if (!TryConnectToServer(1_000))
             {
-                CommunicationsUtilities.Trace("Server connect to idle server to shutdown it.");
+                CommunicationsUtilities.Trace("Client cannot connect to idle server to shut it down.");
                 return false;
             }
 
             if (!TrySendShutdownCommand())
             {
-                CommunicationsUtilities.Trace("Failed sent shutdown command to the server.");
+                CommunicationsUtilities.Trace("Failed to send shutdown command to the server.");
                 return false;
             }
 

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -96,6 +96,11 @@ namespace Microsoft.Build.Experimental
         private TargetConsoleConfiguration? _consoleConfiguration;
 
         /// <summary>
+        /// Incoming packet pump and redirection.
+        /// </summary>
+        private MSBuildClientPacketPump _packetPump;
+
+        /// <summary>
         /// Public constructor with parameters.
         /// </summary>
         /// <param name="commandLine">The command line to process. The first argument
@@ -122,10 +127,10 @@ namespace Microsoft.Build.Experimental
             _pipeName = OutOfProcServerNode.GetPipeName(_handshake);
             _nodeStream = new NamedPipeClientStream(".", _pipeName, PipeDirection.InOut, PipeOptions.Asynchronous
 #if FEATURE_PIPEOPTIONS_CURRENTUSERONLY
-                                                                         | PipeOptions.CurrentUserOnly
+                | PipeOptions.CurrentUserOnly
 #endif
             );
-
+            _packetPump = new MSBuildClientPacketPump(_nodeStream);
             _packetMemoryStream = new MemoryStream();
             _binaryWriter = new BinaryWriter(_packetMemoryStream);
         }
@@ -195,10 +200,74 @@ namespace Microsoft.Build.Experimental
             _numConsoleWritePackets = 0;
             _sizeOfConsoleWritePackets = 0;
 
+            ReadPacketsLoop(cancellationToken);
+
+            MSBuildEventSource.Log.MSBuildServerBuildStop(descriptiveCommandLine, _numConsoleWritePackets, _sizeOfConsoleWritePackets, _exitResult.MSBuildClientExitType.ToString(), _exitResult.MSBuildAppExitTypeString);
+            CommunicationsUtilities.Trace("Build finished.");
+            return _exitResult;
+        }
+
+        /// <summary>
+        /// Attempt to shutdown MSBuild Server node.
+        /// </summary>
+        /// <remarks>
+        /// It shutdown only server created by current user with current admin elevation.
+        /// </remarks>
+        /// <param name="cancellationToken"></param>
+        /// <returns>True if server is not running anymore.</returns>
+        public static bool ShutdownServer(CancellationToken cancellationToken)
+        {
+            // Neither commandLine nor msbuildlocation is involved in node shutdown
+            var client = new MSBuildClient(commandLine: null!, msbuildLocation: null!);
+
+            return client.TryShutdownServer(cancellationToken);
+        }
+
+        private bool TryShutdownServer(CancellationToken cancellationToken)
+        {
+            CommunicationsUtilities.Trace("Trying shutdown server node.");
+            string serverRunningMutexName = OutOfProcServerNode.GetRunningServerMutexName(_handshake);
+            string serverBusyMutexName = OutOfProcServerNode.GetBusyServerMutexName(_handshake);
+
+            bool serverIsAlreadyRunning = ServerNamedMutex.WasOpen(serverRunningMutexName);
+            if (!serverIsAlreadyRunning)
+            {
+                CommunicationsUtilities.Trace("No need to shutdown server node for it is n-ot running.");
+                return true;
+            }
+
+            // Check that server is not busy.
+            var serverWasBusy = ServerNamedMutex.WasOpen(serverBusyMutexName);
+            if (serverWasBusy)
+            {
+                CommunicationsUtilities.Trace("Server can not be shutdown for it is not idle.");
+                return false;
+            }
+
+            // Connect to server.
+            if (!TryConnectToServer(1_000))
+            {
+                CommunicationsUtilities.Trace("Server connect to idle server to shutdown it.");
+                return false;
+            }
+
+            if (!TrySendShutdownCommand())
+            {
+                CommunicationsUtilities.Trace("Failed sent shutdown command to the server.");
+                return false;
+            }
+
+            ReadPacketsLoop(cancellationToken);
+
+            return _exitResult.MSBuildClientExitType == MSBuildClientExitType.Success;
+        }
+
+        private void ReadPacketsLoop(CancellationToken cancellationToken)
+        {
             try
             {
                 // Start packet pump
-                using MSBuildClientPacketPump packetPump = new(_nodeStream);
+                using MSBuildClientPacketPump packetPump = _packetPump;
 
                 packetPump.RegisterPacketHandler(NodePacketType.ServerNodeConsoleWrite, ServerNodeConsoleWrite.FactoryForDeserialization, packetPump);
                 packetPump.RegisterPacketHandler(NodePacketType.ServerNodeBuildResult, ServerNodeBuildResult.FactoryForDeserialization, packetPump);
@@ -207,7 +276,7 @@ namespace Microsoft.Build.Experimental
                 WaitHandle[] waitHandles =
                 {
                     cancellationToken.WaitHandle,
-                    packetPump.PacketPumpErrorEvent,
+                    packetPump.PacketPumpCompleted,
                     packetPump.PacketReceivedEvent
                 };
 
@@ -224,7 +293,7 @@ namespace Microsoft.Build.Experimental
                             break;
 
                         case 1:
-                            HandlePacketPumpError(packetPump);
+                            HandlePacketPumpCompleted(packetPump);
                             break;
 
                         case 2:
@@ -246,10 +315,6 @@ namespace Microsoft.Build.Experimental
                 CommunicationsUtilities.Trace("MSBuild client error: problem during packet handling occurred: {0}.", ex);
                 _exitResult.MSBuildClientExitType = MSBuildClientExitType.Unexpected;
             }
-
-            MSBuildEventSource.Log.MSBuildServerBuildStop(descriptiveCommandLine, _numConsoleWritePackets, _sizeOfConsoleWritePackets, _exitResult.MSBuildClientExitType.ToString(), _exitResult.MSBuildAppExitTypeString);
-            CommunicationsUtilities.Trace("Build finished.");
-            return _exitResult;
         }
 
         private void ConfigureAndQueryConsoleProperties()
@@ -409,6 +474,12 @@ namespace Microsoft.Build.Experimental
 
         private bool TrySendCancelCommand() => TrySendPacket(() => new ServerNodeBuildCancel());
 
+        private bool TrySendShutdownCommand()
+        {
+            _packetPump.ServerWillDisconnect();
+            return  TrySendPacket(() => new NodeBuildComplete(false /* no node reuse */));
+        }
+
         private ServerNodeBuildCommand GetServerNodeBuildCommand()
         {
             Dictionary<string, string> envVars = new();
@@ -457,16 +528,21 @@ namespace Microsoft.Build.Experimental
         {
             TrySendCancelCommand();
 
-            CommunicationsUtilities.Trace("MSBuild client sent cancelation command.");
+            CommunicationsUtilities.Trace("MSBuild client sent cancellation command.");
         }
 
         /// <summary>
-        /// Handle packet pump error.
+        /// Handle when packet pump is completed both successfully or with error.
         /// </summary>
-        private void HandlePacketPumpError(MSBuildClientPacketPump packetPump)
+        private void HandlePacketPumpCompleted(MSBuildClientPacketPump packetPump)
         {
-            CommunicationsUtilities.Trace("MSBuild client error: packet pump unexpectedly shut down: {0}", packetPump.PacketPumpException);
-            throw packetPump.PacketPumpException ?? new InternalErrorException("Packet pump unexpectedly shut down");
+            if (packetPump.PacketPumpException != null)
+            {
+                CommunicationsUtilities.Trace("MSBuild client error: packet pump unexpectedly shut down: {0}", packetPump.PacketPumpException);
+                throw packetPump.PacketPumpException ?? new InternalErrorException("Packet pump unexpectedly shut down");
+            }
+
+            _buildFinished = true;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
+++ b/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
@@ -27,12 +27,12 @@ namespace Microsoft.Build.BackEnd.Client
         public AutoResetEvent PacketReceivedEvent { get; }
 
         /// <summary>
-        /// Set when the packet pump unexpectedly terminates (due to connection problems or because of deserialization issues).
+        /// Set when the packet pump terminates.
         /// </summary>
-        public ManualResetEvent PacketPumpErrorEvent { get; }
+        public ManualResetEvent PacketPumpCompleted { get; }
 
         /// <summary>
-        /// Exception appeared when the packet pump unexpectedly terminates.
+        /// Exception appeared when the packet pump unexpectedly terminates (due to connection problems or because of deserialization issues).
         /// </summary>
         public Exception? PacketPumpException { get; set; }
 
@@ -66,16 +66,24 @@ namespace Microsoft.Build.BackEnd.Client
         /// </summary>
         readonly ITranslator _binaryReadTranslator;
 
+        /// <summary>
+        /// True if this side is gracefully disconnecting.
+        /// In such case we have sent last packet to server side and we expect
+        /// it will soon broke pipe connection - unless client do it first.
+        /// </summary>
+        private bool _isServerDisconnecting;
+
         public MSBuildClientPacketPump(Stream stream)
         {
             ErrorUtilities.VerifyThrowArgumentNull(stream, nameof(stream));
 
             _stream = stream;
+            _isServerDisconnecting = false;
             _packetFactory = new NodePacketFactory();
 
             ReceivedPacketsQueue = new ConcurrentQueue<INodePacket>();
             PacketReceivedEvent = new AutoResetEvent(false);
-            PacketPumpErrorEvent = new ManualResetEvent(false);
+            PacketPumpCompleted = new ManualResetEvent(false);
             _packetPumpShutdownEvent = new ManualResetEvent(false);
 
             _readBufferMemoryStream = new MemoryStream();
@@ -170,7 +178,7 @@ namespace Microsoft.Build.BackEnd.Client
         /// set.
         /// </summary>
         /// <remarks>
-        /// Instead of throwing an exception, puts it in <see cref="PacketPumpException"/> and raises event <see cref="PacketPumpErrorEvent"/>.
+        /// Instead of throwing an exception, puts it in <see cref="PacketPumpException"/> and raises event <see cref="PacketPumpCompleted"/>.
         /// </remarks>
         private void PacketPumpProc()
         {
@@ -229,6 +237,12 @@ namespace Microsoft.Build.BackEnd.Client
                                     // Incomplete read. Abort.
                                     if (headerBytesRead == 0)
                                     {
+                                        if (_isServerDisconnecting)
+                                        {
+                                            continueReading = false;
+                                            break;
+                                        }
+
                                         ErrorUtilities.ThrowInternalError("Server disconnected abruptly");
                                     }
                                     else
@@ -292,13 +306,21 @@ namespace Microsoft.Build.BackEnd.Client
             {
                 CommunicationsUtilities.Trace("Exception occurred in the packet pump: {0}", ex);
                 PacketPumpException = ex;
-                PacketPumpErrorEvent.Set();
             }
 
             CommunicationsUtilities.Trace("Ending read loop.");
+            PacketPumpCompleted.Set();
         }
         #endregion
 
         public void Dispose() => Stop();
+
+        /// <summary>
+        /// Signalize that from now on we expect server will break connected named pipe.
+        /// </summary>
+        public void ServerWillDisconnect()
+        {
+            _isServerDisconnecting = true;
+        }
     }
 }

--- a/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -18,3 +18,4 @@ Microsoft.Build.Experimental.OutOfProcServerNode
 Microsoft.Build.Experimental.OutOfProcServerNode.BuildCallback
 Microsoft.Build.Experimental.OutOfProcServerNode.OutOfProcServerNode(Microsoft.Build.Experimental.OutOfProcServerNode.BuildCallback buildFunction) -> void
 Microsoft.Build.Experimental.OutOfProcServerNode.Run(out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
+static Microsoft.Build.Experimental.MSBuildClient.ShutdownServer(System.Threading.CancellationToken cancellationToken) -> bool

--- a/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -18,4 +18,5 @@ Microsoft.Build.Experimental.OutOfProcServerNode
 Microsoft.Build.Experimental.OutOfProcServerNode.BuildCallback
 Microsoft.Build.Experimental.OutOfProcServerNode.OutOfProcServerNode(Microsoft.Build.Experimental.OutOfProcServerNode.BuildCallback buildFunction) -> void
 Microsoft.Build.Experimental.OutOfProcServerNode.Run(out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
+static Microsoft.Build.Experimental.MSBuildClient.ShutdownServer(System.Threading.CancellationToken cancellationToken) -> bool
 

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -240,7 +240,11 @@ namespace Microsoft.Build.Engine.UnitTests
                 serverIsDown.ShouldBeTrue();
             }
 
-            serverProcess.WaitForExit(1000);
+            if (serverProcess.WaitForExit(3000))
+            {
+                serverProcess.WaitForExit();
+            }
+
             serverProcess.HasExited.ShouldBeTrue();
         }
 

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Experimental;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
@@ -208,6 +210,45 @@ namespace Microsoft.Build.Engine.UnitTests
             _env.Dispose();
             // 2nd wait for sleep task which will ends as soon as the process is killed above.
             t.Wait();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanShutdownServerProcess(bool byBuildManager)
+        {
+            _env.SetEnvironmentVariable("MSBUILDUSESERVER", "1");
+            TransientTestFile project = _env.CreateFile("testProject.proj", printPidContents);
+
+            // Start a server node and find its PID.
+            string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path, out bool success, false, _output);
+            success.ShouldBeTrue();
+            int pidOfServerProcess = ParseNumber(output, "Server ID is ");
+            _env.WithTransientProcess(pidOfServerProcess);
+
+            var serverProcess = Process.GetProcessById(pidOfServerProcess);
+
+            serverProcess.HasExited.ShouldBeFalse();
+
+            if (byBuildManager)
+            {
+                BuildManager.DefaultBuildManager.ShutdownAllNodes();
+            }
+            else
+            {
+                bool serverIsDown = MSBuildClient.ShutdownServer(CancellationToken.None);
+                serverIsDown.ShouldBeTrue();
+            }
+
+            serverProcess.WaitForExit(1000);
+            serverProcess.HasExited.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void CanShutdownServerProcessWhenNotRunning()
+        {
+            bool serverIsDown = MSBuildClient.ShutdownServer(CancellationToken.None);
+            serverIsDown.ShouldBeTrue();
         }
 
         [Fact]

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -583,7 +583,14 @@ namespace Microsoft.Build.UnitTests
         {
             if (_processId > -1)
             {
-                Process.GetProcessById(_processId).KillTree(1000);
+                try
+                {
+                    Process.GetProcessById(_processId).KillTree(1000);
+                }
+                catch
+                {
+                    // ignore if process is already dead
+                }
             }
         }
     }


### PR DESCRIPTION
### Context
Existing CLI command "dotnet build-server shutdown" was not shutting down MSBuild server.

### Changes Made
BuildManager.ShutdownAllNodes calls MSBuildClient which connects to Server by namedpipe and send it NodeBuildComplete packet(false) =>shutdown.

### Testing
Unit testing
