### PR TITLE
Enables logging when building metaprojects

### DIFF
--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -1013,6 +1013,7 @@ namespace Microsoft.Build.Construction
                 traversalProject,
                 _globalProperties,
                 explicitToolsVersionSpecified ? wrapperProjectToolsVersion : null,
+                _loggingService,
                 _solutionFile.VisualStudioVersion,
                 new ProjectCollection(),
                 _sdkResolverService,

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -471,6 +471,21 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ProjectInstance"/> class directly.
+        /// No intermediate Project object is created.
+        /// This is ideal if the project is simply going to be built, and not displayed or edited.
+        /// Global properties may be null.
+        /// Tools version may be null.
+        /// Used by SolutionProjectGenerator so that it can explicitly pass the vsVersionFromSolution in for use in
+        /// determining the sub-toolset version.
+        /// </summary>
+        internal ProjectInstance(ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, ILoggingService loggingService, int visualStudioVersionFromSolution, ProjectCollection projectCollection, ISdkResolverService sdkResolverService, int submissionId)
+        {
+            BuildEventContext buildEventContext = new BuildEventContext(0, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
+            Initialize(xml, globalProperties, toolsVersion, null, visualStudioVersionFromSolution, new BuildParameters(projectCollection), loggingService, buildEventContext, sdkResolverService, submissionId);
+        }
+
+        /// <summary>
         /// Creates a mutable ProjectInstance directly, using the specified logging service.
         /// Assumes the project path is already normalized.
         /// Used by the RequestBuilder.


### PR DESCRIPTION
### Context
Solution metaprojects were not logged just because we created a new ProjectCollection (with no loggers included) just before evaluation them. This fixes that by using the previously created logging service.

### Changes Made
Pipes the logging service used for other evaluations through to evaluation for the metaproject.

### Testing
Without this change:
<img width="367" alt="image" src="https://user-images.githubusercontent.com/12969783/181651504-c07d7d0b-eeac-438f-b880-c84d07f6cc43.png">

With this change:
<img width="438" alt="image" src="https://user-images.githubusercontent.com/12969783/181651525-b95263be-3cfd-4f12-9397-9ac8e6feeff4.png">


### Notes
Needed to only log used environment variables, as we were missing cases without this.