### PR TITLE
Read packet data in loop

### DIFF
--- a/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
+++ b/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Build.BackEnd.Client
                                     }
                                     else
                                     {
-                                        ErrorUtilities.ThrowInternalError("Incomplete header read from server.  {0} of {1} bytes read", headerBytesRead, headerByte.Length);
+                                        ErrorUtilities.ThrowInternalError("Incomplete header read.  {0} of {1} bytes read", headerBytesRead, headerByte.Length);
                                     }
                                 }
 
@@ -246,14 +246,18 @@ namespace Microsoft.Build.BackEnd.Client
                                 _readBufferMemoryStream.SetLength(packetLength);
                                 byte[] packetData = _readBufferMemoryStream.GetBuffer();
 
-                                packetBytesRead = localStream.Read(packetData, 0, packetLength);
-                                
-                                if (packetBytesRead != packetLength)
+                                while (packetBytesRead < packetLength)
                                 {
-                                    // Incomplete read.  Abort.
-                                    ErrorUtilities.ThrowInternalError("Incomplete header read from server. {0} of {1} bytes read", headerBytesRead, headerByte.Length);
-                                }
+                                    int bytesRead = localStream.Read(packetData, packetBytesRead, packetLength-packetBytesRead);
+                                    if (bytesRead == 0)
+                                    {
+                                        // Incomplete read.  Abort.
+                                        ErrorUtilities.ThrowInternalError("Incomplete packet read. {0} of {1} bytes read", packetBytesRead, packetLength);
+                                    }
 
+                                    packetBytesRead += bytesRead;
+                                }
+                                
                                 try
                                 {
                                     _packetFactory.DeserializeAndRoutePacket(0, packetType, _binaryReadTranslator);


### PR DESCRIPTION
Fixes #
https://github.com/dotnet/sdk/issues/26965

### Context
named pipe implementation on Linux works slightly different, and can, on `pipestream.Read()`, read only fraction of bytes.

### Changes Made
looping until all bytes are read.

### Testing
Can't repro above issues, even though I could have repro it consistently before those changes.

### Notes
Shall be service patch rc1?
