### PR TITLE
Fix for Scheduler using build parameter from previous build

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -38,11 +38,6 @@ namespace Microsoft.Build.BackEnd
         IBuildEngine10
     {
         /// <summary>
-        /// True if the "secret" environment variable MSBUILDNOINPROCNODE is set.
-        /// </summary>
-        private static bool s_disableInprocNodeByEnvironmentVariable = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1";
-
-        /// <summary>
         /// Help diagnose tasks that log after they return.
         /// </summary>
         private static bool s_breakOnLogAfterTaskReturns = Environment.GetEnvironmentVariable("MSBUILDBREAKONLOGAFTERTASKRETURNS") == "1";
@@ -129,8 +124,8 @@ namespace Microsoft.Build.BackEnd
             _activeProxy = true;
             _callbackMonitor = new object();
             _disableInprocNode = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
-                ? s_disableInprocNodeByEnvironmentVariable || host.BuildParameters.DisableInProcNode
-                : s_disableInprocNodeByEnvironmentVariable;
+                ? Traits.Instance.InProcNodeDisabled || host.BuildParameters.DisableInProcNode
+                : Traits.Instance.InProcNodeDisabled;
             EngineServices = new EngineServicesImpl(this);
         }
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private const double DefaultCustomSchedulerForSQLConfigurationLimitMultiplier = 1.1;
 
+        private static bool InprocNodeDisabledViaEnvironmentVariable = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1";
+
         #region Scheduler Data
 
         /// <summary>
@@ -144,7 +146,9 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Flag used for debugging by forcing all scheduling to go out-of-proc.
         /// </summary>
-        internal bool ForceAffinityOutOfProc { get; private set; }
+        internal bool ForceAffinityOutOfProc => ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
+            ? InprocNodeDisabledViaEnvironmentVariable || _componentHost.BuildParameters.DisableInProcNode
+            : InprocNodeDisabledViaEnvironmentVariable;
 
         /// <summary>
         /// The path into which debug files will be written.
@@ -621,10 +625,6 @@ namespace Microsoft.Build.BackEnd
             _resultsCache = (IResultsCache)_componentHost.GetComponent(BuildComponentType.ResultsCache);
             _configCache = (IConfigCache)_componentHost.GetComponent(BuildComponentType.ConfigCache);
             _inprocNodeContext =  new NodeLoggingContext(_componentHost.LoggingService, InProcNodeId, true);
-            var inprocNodeDisabledViaEnvironmentVariable = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1";
-            ForceAffinityOutOfProc = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
-                ? inprocNodeDisabledViaEnvironmentVariable || _componentHost.BuildParameters.DisableInProcNode
-                : inprocNodeDisabledViaEnvironmentVariable;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -15,7 +15,6 @@ using Microsoft.Build.Experimental.ProjectCache;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.Debugging;
-using Microsoft.Build.Utilities;
 using BuildAbortedException = Microsoft.Build.Exceptions.BuildAbortedException;
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using NodeLoggingContext = Microsoft.Build.BackEnd.Logging.NodeLoggingContext;
@@ -57,8 +56,6 @@ namespace Microsoft.Build.BackEnd
         /// + 10%.
         /// </summary>
         private const double DefaultCustomSchedulerForSQLConfigurationLimitMultiplier = 1.1;
-
-        private static bool InprocNodeDisabledViaEnvironmentVariable = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1";
 
         #region Scheduler Data
 
@@ -146,9 +143,10 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Flag used for debugging by forcing all scheduling to go out-of-proc.
         /// </summary>
-        internal bool ForceAffinityOutOfProc => ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
-            ? InprocNodeDisabledViaEnvironmentVariable || _componentHost.BuildParameters.DisableInProcNode
-            : InprocNodeDisabledViaEnvironmentVariable;
+        internal bool ForceAffinityOutOfProc
+            => ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_0)
+                ? Traits.Instance.InProcNodeDisabled || _componentHost.BuildParameters.DisableInProcNode
+                : Traits.Instance.InProcNodeDisabled;
 
         /// <summary>
         /// The path into which debug files will be written.

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.Build.Framework;
 
 #nullable disable
 
@@ -120,6 +119,8 @@ namespace Microsoft.Build.Framework
         public readonly bool DebugEngine = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBuildDebugEngine"));
         public readonly bool DebugScheduler;
         public readonly bool DebugNodeCommunication;
+
+        public readonly bool InProcNodeDisabled = Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") == "1";
 
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3236,7 +3236,7 @@ namespace Microsoft.Build.CommandLine
 
                 // Check to see if there is a possibility we will be logging from an out-of-proc node.
                 // If so (we're multi-proc or the in-proc node is disabled), we register a distributed logger.
-                if (cpuCount == 1 && Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") != "1")
+                if (cpuCount == 1 && !Traits.Instance.InProcNodeDisabled)
                 {
                     // We've decided to use the MP logger even in single proc mode.
                     // Switch it on here, rather than in the logger, so that other hosts that use
@@ -3308,7 +3308,7 @@ namespace Microsoft.Build.CommandLine
 
                 // Check to see if there is a possibility we will be logging from an out-of-proc node.
                 // If so (we're multi-proc or the in-proc node is disabled), we register a distributed logger.
-                if (cpuCount == 1 && Environment.GetEnvironmentVariable("MSBUILDNOINPROCNODE") != "1")
+                if (cpuCount == 1 && !Traits.Instance.InProcNodeDisabled)
                 {
                     // We've decided to use the MP logger even in single proc mode.
                     // Switch it on here, rather than in the logger, so that other hosts that use


### PR DESCRIPTION
This is a minor bug fix which ensures the Scheduler always uses the latest value for `BuildParameters.DisableInProcNode` rather than the value provided in the first build.

Note that the Scheduler is an `IBuildComponent` which has the same lifetime as the `BuildManager`. However, `BuildParameters` is per build, so caching a value from `BuildParameters` would be incorrect.