### PR TITLE
Fix flaky CanShutdownServerProcess test

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1110,14 +1110,10 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public void ShutdownAllNodes()
         {
-            if (_nodeManager == null)
-            {
-                _nodeManager = (INodeManager)((IBuildComponentHost)this).GetComponent(BuildComponentType.NodeManager);
-            }
-
-            _nodeManager.ShutdownAllNodes();
-
             MSBuildClient.ShutdownServer(CancellationToken.None);
+
+            _nodeManager ??= (INodeManager)((IBuildComponentHost)this).GetComponent(BuildComponentType.NodeManager);
+            _nodeManager.ShutdownAllNodes();
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -614,15 +614,21 @@ namespace Microsoft.Build.Experimental
                 {
                     NodeProviderOutOfProcBase.ConnectToPipeStream(_nodeStream, _pipeName, _handshake, Math.Max(1, timeoutMilliseconds - (int)sw.ElapsedMilliseconds));
                 }
-                catch (AggregateException ex) when (ex.Flatten().InnerExceptions.OfType<IOException>().Any())
-                {
-                    tryAgain = true;
-                }
                 catch (Exception ex)
                 {
-                    CommunicationsUtilities.Trace("Failed to connect to server: {0}", ex);
-                    _exitResult.MSBuildClientExitType = MSBuildClientExitType.UnableToConnect;
-                    return false;
+                    if (ex is IOException || (ex is AggregateException exa && exa.Flatten().InnerExceptions.OfType<IOException>().Any()))
+                    {
+                        CommunicationsUtilities.Trace("Retrying to connect to server after {0} ms", sw.ElapsedMilliseconds);
+                        // This solves race condition for time in which server started but have not yet listen on pipe or
+                        // when it just finished build request and is recycling pipe.
+                        tryAgain = true;
+                    }
+                    else
+                    {
+                        CommunicationsUtilities.Trace("Failed to connect to server: {0}", ex);
+                        _exitResult.MSBuildClientExitType = MSBuildClientExitType.UnableToConnect;
+                        return false;
+                    }
                 }
             }
 

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Build.Experimental
         /// <summary>
         /// The named pipe stream for client-server communication.
         /// </summary>
-        private readonly NamedPipeClientStream _nodeStream;
+        private NamedPipeClientStream _nodeStream;
 
         /// <summary>
         /// A way to cache a byte array when writing out packets
@@ -126,14 +126,19 @@ namespace Microsoft.Build.Experimental
             // Client <-> Server communication stream
             _handshake = GetHandshake();
             _pipeName = OutOfProcServerNode.GetPipeName(_handshake);
+            CreateNodePipeStream();
+            _packetMemoryStream = new MemoryStream();
+            _binaryWriter = new BinaryWriter(_packetMemoryStream);
+        }
+
+        private void CreateNodePipeStream()
+        {
             _nodeStream = new NamedPipeClientStream(".", _pipeName, PipeDirection.InOut, PipeOptions.Asynchronous
 #if FEATURE_PIPEOPTIONS_CURRENTUSERONLY
                 | PipeOptions.CurrentUserOnly
 #endif
             );
             _packetPump = new MSBuildClientPacketPump(_nodeStream);
-            _packetMemoryStream = new MemoryStream();
-            _binaryWriter = new BinaryWriter(_packetMemoryStream);
         }
 
         /// <summary>
@@ -622,6 +627,7 @@ namespace Microsoft.Build.Experimental
                         // This solves race condition for time in which server started but have not yet listen on pipe or
                         // when it just finished build request and is recycling pipe.
                         tryAgain = true;
+                        CreateNodePipeStream();
                     }
                     else
                     {

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -259,8 +259,6 @@ namespace Microsoft.Build.Experimental
         internal bool ServerIsRunning()
         {
             string serverRunningMutexName = OutOfProcServerNode.GetRunningServerMutexName(_handshake);
-
-            // Start server it if is not running.
             bool serverIsAlreadyRunning = ServerNamedMutex.WasOpen(serverRunningMutexName);
             return serverIsAlreadyRunning;
         }

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -622,7 +622,7 @@ namespace Microsoft.Build.Experimental
                 }
                 catch (Exception ex)
                 {
-                    if (ex is IOException || (ex is AggregateException exa && exa.Flatten().InnerExceptions.OfType<IOException>().Any()))
+                    if (ex is not TimeoutException && sw.ElapsedMilliseconds < timeoutMilliseconds)
                     {
                         CommunicationsUtilities.Trace("Retrying to connect to server after {0} ms", sw.ElapsedMilliseconds);
                         // This solves race condition for time in which server started but have not yet listen on pipe or

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Build.Experimental
         /// <summary>
         /// The named pipe stream for client-server communication.
         /// </summary>
-        private NamedPipeClientStream _nodeStream;
+        private NamedPipeClientStream _nodeStream = null!;
 
         /// <summary>
         /// A way to cache a byte array when writing out packets
@@ -99,7 +99,7 @@ namespace Microsoft.Build.Experimental
         /// <summary>
         /// Incoming packet pump and redirection.
         /// </summary>
-        private MSBuildClientPacketPump _packetPump;
+        private MSBuildClientPacketPump _packetPump = null!;
 
         /// <summary>
         /// Public constructor with parameters.
@@ -126,9 +126,10 @@ namespace Microsoft.Build.Experimental
             // Client <-> Server communication stream
             _handshake = GetHandshake();
             _pipeName = OutOfProcServerNode.GetPipeName(_handshake);
-            CreateNodePipeStream();
             _packetMemoryStream = new MemoryStream();
             _binaryWriter = new BinaryWriter(_packetMemoryStream);
+
+            CreateNodePipeStream();
         }
 
         private void CreateNodePipeStream()

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
+using System.Linq;
 using System.Threading;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Client;
@@ -601,17 +602,28 @@ namespace Microsoft.Build.Experimental
         /// Connects to MSBuild server.
         /// </summary>
         /// <returns> Whether the client connected to MSBuild server successfully.</returns>
-        private bool TryConnectToServer(int timeout)
+        private bool TryConnectToServer(int timeoutMilliseconds)
         {
-            try
+            bool tryAgain = true;
+            Stopwatch sw = Stopwatch.StartNew();
+
+            while (tryAgain && sw.ElapsedMilliseconds < timeoutMilliseconds)
             {
-                NodeProviderOutOfProcBase.ConnectToPipeStream(_nodeStream, _pipeName, _handshake, timeout);
-            }
-            catch (Exception ex)
-            {
-                CommunicationsUtilities.Trace("Failed to connect to server: {0}", ex);
-                _exitResult.MSBuildClientExitType = MSBuildClientExitType.UnableToConnect;
-                return false;
+                tryAgain = false;
+                try
+                {
+                    NodeProviderOutOfProcBase.ConnectToPipeStream(_nodeStream, _pipeName, _handshake, Math.Max(1, timeoutMilliseconds - (int)sw.ElapsedMilliseconds));
+                }
+                catch (AggregateException ex) when (ex.Flatten().InnerExceptions.OfType<IOException>().Any())
+                {
+                    tryAgain = true;
+                }
+                catch (Exception ex)
+                {
+                    CommunicationsUtilities.Trace("Failed to connect to server: {0}", ex);
+                    _exitResult.MSBuildClientExitType = MSBuildClientExitType.UnableToConnect;
+                    return false;
+                }
             }
 
             return true;

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -84,9 +84,9 @@ namespace Microsoft.Build.Experimental
         }
 
         #region INode Members
-        
+
         /// <summary>
-        /// Starts up the node and processes messages until the node is requested to shut down.
+        /// Starts up the server node and processes all build requests until the server is requested to shut down.
         /// </summary>
         /// <param name="shutdownException">The exception which caused shutdown, if any.</param> 
         /// <returns>The reason for shutting down.</returns>
@@ -107,12 +107,32 @@ namespace Microsoft.Build.Experimental
                 return NodeEngineShutdownReason.Error;
             }
 
+            while(true)
+            {
+                NodeEngineShutdownReason shutdownReason = RunInternal(out shutdownException, handshake);
+                if (shutdownReason != NodeEngineShutdownReason.BuildCompleteReuse)
+                {
+                    return shutdownReason;
+                }
+
+                // We need to clear cache for two reasons:
+                // - cache file names can collide cross build requests, which would cause stale caching
+                // - we might need to avoid cache builds-up in files system during lifetime of server
+                FileUtilities.ClearCacheDirectory();
+                _shutdownEvent.Reset();
+            }
+
+            // UNREACHABLE
+        }
+
+        private NodeEngineShutdownReason RunInternal(out Exception? shutdownException, ServerNodeHandshake handshake)
+        {
             _nodeEndpoint = new ServerNodeEndpointOutOfProc(GetPipeName(handshake), handshake);
             _nodeEndpoint.OnLinkStatusChanged += OnLinkStatusChanged;
             _nodeEndpoint.Listen(this);
 
             var waitHandles = new WaitHandle[] { _shutdownEvent, _packetReceivedEvent };
-            
+
             // Get the current directory before doing any work. We need this so we can restore the directory when the node shutsdown.
             while (true)
             {

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -221,6 +221,11 @@ namespace Microsoft.Build.Engine.UnitTests
 
             TransientTestFile project = _env.CreateFile("testProject.proj", printPidContents);
 
+            // TODO: delete
+            var debugFolder = _env.CreateFolder();
+            _env.SetEnvironmentVariable("MSBUILDDEBUGENGINE", "1");
+            _env.SetEnvironmentVariable("MSBUILDDEBUGPATH", debugFolder.Path);
+
             // Just for sure close server, so previous server instances does not effect this run.
             BuildManager.DefaultBuildManager.ShutdownAllNodes();
 

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -222,11 +222,6 @@ namespace Microsoft.Build.Engine.UnitTests
 
             TransientTestFile project = _env.CreateFile("testProject.proj", printPidContents);
 
-            // TODO: delete
-            var debugFolder = _env.CreateFolder();
-            _env.SetEnvironmentVariable("MSBUILDDEBUGCOMM", "1");
-            _env.SetEnvironmentVariable("MSBUILDDEBUGPATH", Path.GetTempPath());
-
             // Start a server node and find its PID.
             string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path, out bool success, false, _output);
             success.ShouldBeTrue();

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -245,6 +245,14 @@ namespace Microsoft.Build.Engine.UnitTests
                 serverProcess.WaitForExit();
             }
 
+            if (!NativeMethodsShared.IsWindows)
+            {
+                // For one reason or another on non Windows OS, it looks like if process dies it still take some time until
+                // owned mutexes are released.
+                // This was causing flaky tests. Lets wait a bit.
+                Thread.Sleep(1000);
+            }
+
             serverProcess.HasExited.ShouldBeTrue();
         }
 

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -21,6 +21,7 @@ using System.IO;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+using Path = System.IO.Path;
 
 namespace Microsoft.Build.Engine.UnitTests
 {
@@ -224,7 +225,7 @@ namespace Microsoft.Build.Engine.UnitTests
             // TODO: delete
             var debugFolder = _env.CreateFolder();
             _env.SetEnvironmentVariable("MSBUILDDEBUGENGINE", "1");
-            _env.SetEnvironmentVariable("MSBUILDDEBUGPATH", debugFolder.Path);
+            _env.SetEnvironmentVariable("MSBUILDDEBUGPATH", Path.GetTempPath());
 
             // Just for sure close server, so previous server instances does not effect this run.
             BuildManager.DefaultBuildManager.ShutdownAllNodes();

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -227,9 +227,6 @@ namespace Microsoft.Build.Engine.UnitTests
             _env.SetEnvironmentVariable("MSBUILDDEBUGCOMM", "1");
             _env.SetEnvironmentVariable("MSBUILDDEBUGPATH", Path.GetTempPath());
 
-            // Just for sure close server, so previous server instances does not effect this run.
-            BuildManager.DefaultBuildManager.ShutdownAllNodes();
-
             // Start a server node and find its PID.
             string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path, out bool success, false, _output);
             success.ShouldBeTrue();

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Build.Engine.UnitTests
 
             // TODO: delete
             var debugFolder = _env.CreateFolder();
-            _env.SetEnvironmentVariable("MSBUILDDEBUGENGINE", "1");
+            _env.SetEnvironmentVariable("MSBUILDDEBUGCOMM", "1");
             _env.SetEnvironmentVariable("MSBUILDDEBUGPATH", Path.GetTempPath());
 
             // Just for sure close server, so previous server instances does not effect this run.

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -676,6 +676,9 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static void Trace(int nodeId, string format, params object[] args)
         {
+            // TODO: debug logging, delete before merge
+            Console.WriteLine(String.Format(CultureInfo.CurrentCulture, format, args));
+
             if (s_trace)
             {
                 lock (s_traceLock)

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -676,9 +676,6 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static void Trace(int nodeId, string format, params object[] args)
         {
-            // TODO: debug logging, delete before merge
-            Console.WriteLine(String.Format(CultureInfo.CurrentCulture, format, args));
-
             if (s_trace)
             {
                 lock (s_traceLock)

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -71,15 +71,12 @@ namespace Microsoft.Build.UnitTests.Shared
         /// </summary>
         public static string RunProcessAndGetOutput(string process, string parameters, out bool successfulExit, bool shellExecute = false, ITestOutputHelper outputHelper = null)
         {
-            outputHelper?.WriteLine($"{DateTime.Now.ToString("hh:mm:ss tt")}:RunProcessAndGetOutput:1");
-
             if (shellExecute)
             {
                 // we adjust the psi data manually because on net core using ProcessStartInfo.UseShellExecute throws NotImplementedException
                 AdjustForShellExecution(ref process, ref parameters);
             }
 
-            outputHelper?.WriteLine($"{DateTime.Now.ToString("hh:mm:ss tt")}:RunProcessAndGetOutput:2");
             var psi = new ProcessStartInfo(process)
             {
                 CreateNoWindow = true,
@@ -92,7 +89,6 @@ namespace Microsoft.Build.UnitTests.Shared
             string output = string.Empty;
             int pid = -1;
 
-            outputHelper?.WriteLine($"{DateTime.Now.ToString("hh:mm:ss tt")}:RunProcessAndGetOutput:3");
             using (var p = new Process { EnableRaisingEvents = true, StartInfo = psi })
             {
                 DataReceivedEventHandler handler = delegate (object sender, DataReceivedEventArgs args)


### PR DESCRIPTION
### Context
We detected flaky unit tests related to msbuild server shutdown.
Example of failing checks: https://github.com/dotnet/msbuild/pull/7835

Root cause:
When server finish its build it eventually drops namedpipe, open new one with same name and start listen on it. 
If clients is trying to connect to server during this brief time, all kinds of exceptions could happen.

### Changes Made

a) Previously named mutex server-is-running was by server dropped after project weas build and re-acquired shortly after. Changes was made so mutex is acquired constantly.
b) Client retries during connection to server, which address all weird race conditions when server recycling named-pipe.

### Testing
Several `/azp run` s
Can't repro  on Linux and MacOS even though I could before final changes.

### Notes
Same bug is also possible while connecting to working nodes. In such case though, the worst that could happen though is that we span one unnecessary node which is, considering low probability of this to happen, acceptable.