### PR TITLE
Help Standalone MSBuild Find Its Family

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.3.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.3.1</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -552,7 +552,7 @@ namespace Microsoft.Build.Shared
                 MSBuildToolsDirectoryRoot = CurrentMSBuildToolsDirectory;
             }
 
-            if (mode == BuildEnvironmentMode.VisualStudio && MSBuildToolsDirectoryRoot != null)
+            if (MSBuildToolsDirectoryRoot != null)
             {
                 // Calculate potential paths to other architecture MSBuild.exe
                 var potentialAmd64FromX86 = FileUtilities.CombinePaths(MSBuildToolsDirectoryRoot, "amd64", msBuildExeName);
@@ -563,8 +563,8 @@ namespace Microsoft.Build.Shared
                 var existsCheck = mode == BuildEnvironmentMode.VisualStudio ? new Func<string, bool>(_ => true) : File.Exists;
 
                 MSBuildToolsDirectory32 = MSBuildToolsDirectoryRoot;
-                MSBuildToolsDirectory64 = Path.Combine(MSBuildToolsDirectoryRoot, "amd64");
-                MSBuildToolsDirectoryArm64 = File.Exists(potentialARM64FromX86) ? Path.Combine(MSBuildToolsDirectoryRoot, "arm64") : null;
+                MSBuildToolsDirectory64 = existsCheck(potentialAmd64FromX86) ? Path.Combine(MSBuildToolsDirectoryRoot, "amd64") : null;
+                MSBuildToolsDirectoryArm64 = existsCheck(potentialARM64FromX86) ? Path.Combine(MSBuildToolsDirectoryRoot, "arm64") : null;
             }
 
             MSBuildExtensionsPath = mode == BuildEnvironmentMode.VisualStudio

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -552,7 +552,8 @@ namespace Microsoft.Build.Shared
                 MSBuildToolsDirectoryRoot = CurrentMSBuildToolsDirectory;
 
                 // If we're standalone, we might not be in the SDK. Rely on folder paths at this point.
-                if (currentToolsDirectory.Name == "amd64" || currentToolsDirectory.Name == "arm64")
+                if (string.Equals(currentToolsDirectory.Name, "amd64", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(currentToolsDirectory.Name, "arm64", StringComparison.OrdinalIgnoreCase))
                 {
                     MSBuildToolsDirectoryRoot = currentToolsDirectory.Parent?.FullName;
                 }

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -570,7 +570,7 @@ namespace Microsoft.Build.Shared
                 var existsCheck = mode == BuildEnvironmentMode.VisualStudio ? new Func<string, bool>(_ => true) : File.Exists;
 
                 MSBuildToolsDirectory32 = MSBuildToolsDirectoryRoot;
-                MSBuildToolsDirectory64 = existsCheck(potentialAmd64FromX86) ? Path.Combine(MSBuildToolsDirectoryRoot, "amd64") : null;
+                MSBuildToolsDirectory64 = existsCheck(potentialAmd64FromX86) ? Path.Combine(MSBuildToolsDirectoryRoot, "amd64") : CurrentMSBuildToolsDirectory;
                 MSBuildToolsDirectoryArm64 = existsCheck(potentialARM64FromX86) ? Path.Combine(MSBuildToolsDirectoryRoot, "arm64") : null;
             }
 

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -550,6 +550,12 @@ namespace Microsoft.Build.Shared
             {
                 // In the .NET SDK, there's one copy of MSBuild.dll and it's in the root folder.
                 MSBuildToolsDirectoryRoot = CurrentMSBuildToolsDirectory;
+
+                // If we're standalone, we might not be in the SDK. Rely on folder paths at this point.
+                if (currentToolsDirectory.Name == "amd64" || currentToolsDirectory.Name == "arm64")
+                {
+                    MSBuildToolsDirectoryRoot = currentToolsDirectory.Parent?.FullName;
+                }
             }
 
             if (MSBuildToolsDirectoryRoot != null)


### PR DESCRIPTION
### Customer Impact
CoreXT is blocked because MSBuild can no longer discover itself when in "standalone" mode and in a non-SDK scenario.

### Testing
- [x] Injecting into the SDK
- [x] Injecting into VS
	- Injected & ran build.cmd in this repo
- [x] Decide if this should merge into the SDK
	- Doesn't matter, it'll flow eventually (this change doesn't affect the SDK)
- [x] 17.3 version should increment
- [x] @dfederm test the CoreXT scenario

### Risk
Low, code change is for non-VS code path and only affects MSBuild's that exist in an `amd64/` or `arm64/` directory, which does not affect the SDK scenario.

### Code Reviewers
Forgind
dfederm

### Description of fix
In the non-VS scenario, MSBuild will properly set the "root" folder when it's in the `amd64/` or `arm64/` directory, _before_ trying to find the `amd64`/`arm64` exe's.