### PR TITLE
Fix regression in ClickOnce publish in project with MS.ReportingServices.ReportViewerControl.Winforms as a package reference

### DIFF
--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -396,7 +396,8 @@ namespace Microsoft.Build.Tasks
                         AssemblyIdentity identity = AssemblyIdentity.FromManagedAssembly(item.ItemSpec);
                         if (identity != null && !String.Equals(identity.Culture, "neutral", StringComparison.Ordinal))
                         {
-                            CultureInfo satelliteCulture = GetItemCulture(item);
+                            CultureInfo satelliteCulture = new CultureInfo(identity.Culture);
+                            item.SetMetadata("Culture", identity.Culture);
                             if (PublishFlags.IsSatelliteIncludedByDefault(satelliteCulture, _targetCulture, _includeAllSatellites))
                             {
                                 _satelliteAssembliesPassedAsReferences.Add(item);


### PR DESCRIPTION
VS#1452098

### Context
Customer reported this issue with WinForms project with a reference to MS.ReportingServices.ReportViewerControl.Winforms that is failing ClickOnce publish when being migrated from VS 2019 to VS 2022.

The changes made in ClickOnce to support ClickOnce for .NET 5/6 has caused this regression in the ResolveManifestFiles task.

Specifically the referenced package has a localized assembly that is coming in as a reference and the task trips over while trying to figure out the culture of the assembly because it is trying to detect the culture based on the presence of the culture in the path of the reference and in this case, the path does not conform to this format.

https://developercommunity.visualstudio.com/t/Unable-to-compile-Project-from-VS2019-in/1615824

### Changes Made
The fix is not to get the culture from the path of the reference but instead get the culture from the assembly identity which is readily available.

### Testing
Stepped through the code with a repro project to confirm the fix.
CTI has validated the fix with the failing package and tested with other top packages for regressiosn.

### Notes
