### PR TITLE
Improve SDK resolver error reporting if none of the SDK resolvers attached are able to resolve a particular SDK

### DIFF
--- a/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
+++ b/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
         }
 
-        public Build.BackEnd.SdkResolution.SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
+        public Build.BackEnd.SdkResolution.SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
         {
             return null;
         }

--- a/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
+++ b/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
         }
 
-        public Build.BackEnd.SdkResolution.SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
+        public Build.BackEnd.SdkResolution.SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk)
         {
             return null;
         }

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("notfound", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Success.ShouldBeFalse();
             result.ShouldNotBeNull();
@@ -85,7 +85,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                             ))
                 });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Path.ShouldBe("path");
 
@@ -101,7 +101,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("1sdkName", "version1", "minimumVersion");
 
             // When an SDK resolver throws, the expander will catch it and stop the build.
-            SdkResolverException e = Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true));
+            SdkResolverException e = Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true));
             e.Resolver.Name.ShouldBe("MockSdkResolverThrows");
             e.Sdk.Name.ShouldBe("1sdkName");
         }
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("2sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern2");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
@@ -133,7 +133,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Path.ShouldBe("resolverpath1");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -154,7 +154,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
                 SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
 
-                var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+                var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
                 result.Path.ShouldBe("resolverpath1");
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -172,7 +172,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("11sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern1");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern1 running");
@@ -188,7 +188,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             // be logged because MockSdkResolver2 will succeed.
             SdkReference sdk = new SdkReference("2sdkName", "version2", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Path.ShouldBe("resolverpath2");
 
@@ -211,10 +211,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
             // First call should not know state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true).Path.ShouldBe("resolverpath");
 
             // Second call should have received state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true).Path.ShouldBe(MockSdkResolverWithState.Expected);
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true).Path.ShouldBe(MockSdkResolverWithState.Expected);
         }
 
         [Fact]
@@ -227,10 +227,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
             // First call should not know state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true).Path.ShouldBe("resolverpath");
 
             // Second call should have received state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true).Path.ShouldBe("resolverpath");
         }
 
         [Theory]
@@ -271,13 +271,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     resolver
                 });
 
-            var result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
             resolver.ResolvedCalls.Count.ShouldBe(1);
             result.Path.ShouldBe("path");
             result.Version.ShouldBe("1.0.0");
             _logger.WarningCount.ShouldBe(0);
 
-            result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, new SdkReference("foo", "2.0.0", null), _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, new SdkReference("foo", "2.0.0", null), _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
             resolver.ResolvedCalls.Count.ShouldBe(1);
             result.Path.ShouldBe("path");
             result.Version.ShouldBe("1.0.0");
@@ -353,7 +353,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Success.ShouldBeTrue();
             result.Path.ShouldBeNull();
@@ -390,7 +390,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Success.ShouldBeTrue();
             result.Path.ShouldBe(expectedPath);
@@ -437,7 +437,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Success.ShouldBeTrue();
 
@@ -483,7 +483,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
 
             result.Success.ShouldBeTrue();
 
@@ -531,7 +531,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             Parallel.For(
                 0,
                 10,
-                _ => service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true));
+                _ => service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true));
 
             var result = resolver.ResolvedCalls.ShouldHaveSingleItem();
 
@@ -569,8 +569,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 "projectPath",
                 // Pass along interactive and expect it to be received in the SdkResolverContext
                 interactive: true,
-                false,
-                true);
+                isRunningInVisualStudio: false,
+                throwExceptions: true);
 
             interactive.ShouldBeTrue();
         }
@@ -601,7 +601,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 false,
                 // Pass along isRunningInVisualStudio and expect it to be received in the SdkResolverContext
                 isRunningInVisualStudio: true,
-                true);
+                throwExceptions: true);
 
             isRunningInVisualStudio.ShouldBeTrue();
         }

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -63,7 +63,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
 
             // First error is a generic "we failed" message.
-            _logger.Errors.Skip(1).Select(i => i.Message).ShouldBe(new[] { "ERROR4", "ERROR1", "ERROR2" });
+            _logger.Errors.Skip(1).Select(i => i.Message).ShouldBe(new[] {
+                "ERROR4",
+                ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverReturnedNull", "MockResolverReturnsNull"),
+                "ERROR1",
+                "ERROR2",
+                "notfound"
+            });
             _logger.Warnings.Select(i => i.Message).ShouldBe(new[] { "WARNING4", "WARNING2" });
         }
 
@@ -780,7 +786,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             {
                 if (sdkReference.Name.Equals("notfound"))
                 {
-                    return null;
+                    return factory.IndicateFailure(new string[] { "notfound" });
                 }
                 if (resolverContext.State != null)
                 {

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -61,7 +61,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver2 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
-            _logger.Errors.Select(i => i.Message).ShouldBe(new [] { "ERROR4", "ERROR1", "ERROR2" });
+            string[] loggerErrors = _logger.Errors.Select(i => i.Message).ToArray();
+            loggerErrors[1].ShouldBe("ERROR4");
+            loggerErrors[3].ShouldBe("ERROR1");
+            loggerErrors[4].ShouldBe("ERROR2");
             _logger.Warnings.Select(i => i.Message).ShouldBe(new[] { "WARNING4", "WARNING2" });
         }
 

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("notfound", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Success.ShouldBeFalse();
             result.ShouldNotBeNull();
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                             ))
                 });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("path");
 
@@ -107,7 +107,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("1sdkName", "version1", "minimumVersion");
 
             // When an SDK resolver throws, the expander will catch it and stop the build.
-            SdkResolverException e = Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true));
+            SdkResolverException e = Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true));
             e.Resolver.Name.ShouldBe("MockSdkResolverThrows");
             e.Sdk.Name.ShouldBe("1sdkName");
         }
@@ -122,7 +122,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("2sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern2");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
@@ -139,7 +139,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath1");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -160,7 +160,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
                 SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
 
-                var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+                var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
                 result.Path.ShouldBe("resolverpath1");
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -178,7 +178,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("11sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern1");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern1 running");
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             // be logged because MockSdkResolver2 will succeed.
             SdkReference sdk = new SdkReference("2sdkName", "version2", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath2");
 
@@ -217,10 +217,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
             // First call should not know state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true).Path.ShouldBe("resolverpath");
 
             // Second call should have received state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true).Path.ShouldBe(MockSdkResolverWithState.Expected);
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true).Path.ShouldBe(MockSdkResolverWithState.Expected);
         }
 
         [Fact]
@@ -233,10 +233,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
             // First call should not know state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true).Path.ShouldBe("resolverpath");
 
             // Second call should have received state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true).Path.ShouldBe("resolverpath");
         }
 
         [Theory]
@@ -277,13 +277,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     resolver
                 });
 
-            var result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
             resolver.ResolvedCalls.Count.ShouldBe(1);
             result.Path.ShouldBe("path");
             result.Version.ShouldBe("1.0.0");
             _logger.WarningCount.ShouldBe(0);
 
-            result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, new SdkReference("foo", "2.0.0", null), _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, new SdkReference("foo", "2.0.0", null), _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
             resolver.ResolvedCalls.Count.ShouldBe(1);
             result.Path.ShouldBe("path");
             result.Version.ShouldBe("1.0.0");
@@ -359,7 +359,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Success.ShouldBeTrue();
             result.Path.ShouldBeNull();
@@ -396,7 +396,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Success.ShouldBeTrue();
             result.Path.ShouldBe(expectedPath);
@@ -443,7 +443,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Success.ShouldBeTrue();
 
@@ -489,7 +489,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Success.ShouldBeTrue();
 
@@ -537,7 +537,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             Parallel.For(
                 0,
                 10,
-                _ => service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, throwExceptions: true));
+                _ => service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true));
 
             var result = resolver.ResolvedCalls.ShouldHaveSingleItem();
 
@@ -576,7 +576,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 // Pass along interactive and expect it to be received in the SdkResolverContext
                 interactive: true,
                 isRunningInVisualStudio: false,
-                throwExceptions: true);
+                failOnUnresolvedSdk: true);
 
             interactive.ShouldBeTrue();
         }
@@ -607,7 +607,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 false,
                 // Pass along isRunningInVisualStudio and expect it to be received in the SdkResolverContext
                 isRunningInVisualStudio: true,
-                throwExceptions: true);
+                failOnUnresolvedSdk: true);
 
             isRunningInVisualStudio.ShouldBeTrue();
         }

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("notfound", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Success.ShouldBeFalse();
             result.ShouldNotBeNull();
@@ -83,7 +83,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                             ))
                 });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Path.ShouldBe("path");
 
@@ -99,7 +99,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("1sdkName", "version1", "minimumVersion");
 
             // When an SDK resolver throws, the expander will catch it and stop the build.
-            SdkResolverException e = Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false));
+            SdkResolverException e = Should.Throw<SdkResolverException>(() => SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true));
             e.Resolver.Name.ShouldBe("MockSdkResolverThrows");
             e.Sdk.Name.ShouldBe("1sdkName");
         }
@@ -114,7 +114,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("2sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern2");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
@@ -131,7 +131,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Path.ShouldBe("resolverpath1");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -152,7 +152,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
                 SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
 
-                var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+                var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
                 result.Path.ShouldBe("resolverpath1");
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -170,7 +170,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("11sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern1");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern1 running");
@@ -186,7 +186,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             // be logged because MockSdkResolver2 will succeed.
             SdkReference sdk = new SdkReference("2sdkName", "version2", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Path.ShouldBe("resolverpath2");
 
@@ -209,10 +209,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
             // First call should not know state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true).Path.ShouldBe("resolverpath");
 
             // Second call should have received state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false).Path.ShouldBe(MockSdkResolverWithState.Expected);
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true).Path.ShouldBe(MockSdkResolverWithState.Expected);
         }
 
         [Fact]
@@ -225,10 +225,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
             // First call should not know state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true).Path.ShouldBe("resolverpath");
 
             // Second call should have received state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true).Path.ShouldBe("resolverpath");
         }
 
         [Theory]
@@ -269,13 +269,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     resolver
                 });
 
-            var result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
             resolver.ResolvedCalls.Count.ShouldBe(1);
             result.Path.ShouldBe("path");
             result.Version.ShouldBe("1.0.0");
             _logger.WarningCount.ShouldBe(0);
 
-            result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, new SdkReference("foo", "2.0.0", null), _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, new SdkReference("foo", "2.0.0", null), _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
             resolver.ResolvedCalls.Count.ShouldBe(1);
             result.Path.ShouldBe("path");
             result.Version.ShouldBe("1.0.0");
@@ -351,7 +351,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Success.ShouldBeTrue();
             result.Path.ShouldBeNull();
@@ -388,7 +388,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Success.ShouldBeTrue();
             result.Path.ShouldBe(expectedPath);
@@ -435,7 +435,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Success.ShouldBeTrue();
 
@@ -481,7 +481,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true);
 
             result.Success.ShouldBeTrue();
 
@@ -529,7 +529,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             Parallel.For(
                 0,
                 10,
-                _ => service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false));
+                _ => service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, true));
 
             var result = resolver.ResolvedCalls.ShouldHaveSingleItem();
 
@@ -567,7 +567,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 "projectPath",
                 // Pass along interactive and expect it to be received in the SdkResolverContext
                 interactive: true,
-                false);
+                false,
+                true);
 
             interactive.ShouldBeTrue();
         }
@@ -597,7 +598,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 "projectPath",
                 false,
                 // Pass along isRunningInVisualStudio and expect it to be received in the SdkResolverContext
-                isRunningInVisualStudio: true);
+                isRunningInVisualStudio: true,
+                true);
 
             isRunningInVisualStudio.ShouldBeTrue();
         }

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -61,10 +61,9 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver2 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
-            string[] loggerErrors = _logger.Errors.Select(i => i.Message).ToArray();
-            loggerErrors[1].ShouldBe("ERROR4");
-            loggerErrors[3].ShouldBe("ERROR1");
-            loggerErrors[4].ShouldBe("ERROR2");
+
+            // First error is a generic "we failed" message.
+            _logger.Errors.Skip(1).Select(i => i.Message).ShouldBe(new[] { "ERROR4", "ERROR1", "ERROR2" });
             _logger.Warnings.Select(i => i.Message).ShouldBe(new[] { "WARNING4", "WARNING2" });
         }
 

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -63,13 +63,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
 
             // First error is a generic "we failed" message.
-            _logger.Errors.Skip(1).Select(i => i.Message).ShouldBe(new[] {
+            _logger.Errors[0].Message.ShouldBe(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("FailedToResolveSDK", "notfound", string.Join($"{Environment.NewLine}  ", new[] {
                 "ERROR4",
                 ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverReturnedNull", "MockResolverReturnsNull"),
                 "ERROR1",
                 "ERROR2",
                 "notfound"
-            });
+            })));
             _logger.Warnings.Select(i => i.Message).ShouldBe(new[] { "WARNING4", "WARNING2" });
         }
 

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _cache.Clear();
         }
 
-        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
+        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
         {
             SdkResult result;
 
@@ -46,7 +46,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
             if (Traits.Instance.EscapeHatches.DisableSdkResolutionCache)
             {
-                result = base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
+                result = base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, throwExceptions);
             }
             else
             {
@@ -65,7 +65,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     {
                         wasResultCached = false;
 
-                        return base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
+                        return base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, throwExceptions);
                     }));
 
                 // Get the lazy value which will block all waiting threads until the SDK is resolved at least once while subsequent calls get cached results.

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _cache.Clear();
         }
 
-        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
+        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk)
         {
             SdkResult result;
 
@@ -46,7 +46,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
             if (Traits.Instance.EscapeHatches.DisableSdkResolutionCache)
             {
-                result = base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, throwExceptions);
+                result = base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, failOnUnresolvedSdk);
             }
             else
             {
@@ -65,7 +65,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     {
                         wasResultCached = false;
 
-                        return base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, throwExceptions);
+                        return base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, failOnUnresolvedSdk);
                     }));
 
                 // Get the lazy value which will block all waiting threads until the SDK is resolved at least once while subsequent calls get cached results.

--- a/src/Build/BackEnd/Components/SdkResolution/DefaultSdkResolver.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/DefaultSdkResolver.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using System.Collections.Generic;
 using System.IO;
 
 using SdkResolverBase = Microsoft.Build.Framework.SdkResolver;
@@ -36,7 +37,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             // Note: On failure MSBuild will log a generic message, no need to indicate a failure reason here.
             return FileUtilities.DirectoryExistsNoThrow(sdkPath)
                 ? factory.IndicateSuccess(sdkPath, string.Empty)
-                : factory.IndicateFailure(null);
+                : factory.IndicateFailure(null, new List<string>() { ResourceUtilities.FormatResourceStringStripCodeAndKeyword("DefaultSDKResolverError", sdk.Name, sdkPath) });
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/DefaultSdkResolver.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/DefaultSdkResolver.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-using System.Collections.Generic;
 using System.IO;
 
 using SdkResolverBase = Microsoft.Build.Framework.SdkResolver;
@@ -32,12 +31,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
         public override SdkResultBase Resolve(SdkReference sdk, SdkResolverContextBase context, SdkResultFactoryBase factory)
         {
-            var sdkPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSDKsPath, sdk.Name, "Sdk");
+            string sdkPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSDKsPath, sdk.Name, "Sdk");
 
-            // Note: On failure MSBuild will log a generic message, no need to indicate a failure reason here.
             return FileUtilities.DirectoryExistsNoThrow(sdkPath)
                 ? factory.IndicateSuccess(sdkPath, string.Empty)
-                : factory.IndicateFailure(null, new List<string>() { ResourceUtilities.FormatResourceStringStripCodeAndKeyword("DefaultSDKResolverError", sdk.Name, sdkPath) });
+                : factory.IndicateFailure(new string[] { ResourceUtilities.FormatResourceStringStripCodeAndKeyword("DefaultSDKResolverError", sdk.Name, sdkPath) }, null);
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/DefaultSdkResolver.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/DefaultSdkResolver.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
             return FileUtilities.DirectoryExistsNoThrow(sdkPath)
                 ? factory.IndicateSuccess(sdkPath, string.Empty)
-                : factory.IndicateFailure(new string[] { ResourceUtilities.FormatResourceStringStripCodeAndKeyword("DefaultSDKResolverError", sdk.Name, sdkPath) }, null);
+                : factory.IndicateFailure(new string[] { ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("DefaultSDKResolverError", sdk.Name, sdkPath) }, null);
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         public abstract void PacketReceived(int node, INodePacket packet);
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public abstract SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio);
+        public abstract SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions);
 
         /// <inheritdoc cref="IBuildComponent.ShutdownComponent"/>
         public virtual void ShutdownComponent()

--- a/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         public abstract void PacketReceived(int node, INodePacket packet);
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public abstract SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions);
+        public abstract SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk);
 
         /// <inheritdoc cref="IBuildComponent.ShutdownComponent"/>
         public virtual void ShutdownComponent()

--- a/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
@@ -42,7 +42,8 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <param name="projectPath">The full path to the project file that is resolving the SDK.</param>
         /// <param name="interactive">Indicates whether or not the resolver is allowed to be interactive.</param>
         /// <param name="isRunningInVisualStudio">Indicates whether or not the resolver is running in Visual Studio.</param>
+        /// <param name="throwExceptions">Whether to throw an exception should the SDK fail to be resolved.</param>
         /// <returns>An <see cref="SdkResult"/> containing information about the resolved SDK. If no resolver was able to resolve it, then <see cref="Framework.SdkResult.Success"/> == false. </returns>
-        SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio);
+        SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions);
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <param name="projectPath">The full path to the project file that is resolving the SDK.</param>
         /// <param name="interactive">Indicates whether or not the resolver is allowed to be interactive.</param>
         /// <param name="isRunningInVisualStudio">Indicates whether or not the resolver is running in Visual Studio.</param>
-        /// <param name="throwExceptions">Whether to throw an exception should the SDK fail to be resolved.</param>
+        /// <param name="failOnUnresolvedSdk">Whether to throw an exception should the SDK fail to be resolved.</param>
         /// <returns>An <see cref="SdkResult"/> containing information about the resolved SDK. If no resolver was able to resolve it, then <see cref="Framework.SdkResult.Success"/> == false. </returns>
-        SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions);
+        SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk);
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -4,6 +4,7 @@
 using Microsoft.Build.BackEnd.Components.Logging;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using System;
@@ -72,9 +73,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             try
             {
                 ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
+                bool throwExceptions = !Host.BuildParameters.ProjectLoadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) || Host.BuildParameters.ProjectLoadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk);
 
                 // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
-                response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive, request.IsRunningInVisualStudio);
+                response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive, request.IsRunningInVisualStudio, throwExceptions);
             }
             catch (Exception e)
             {
@@ -94,14 +96,14 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
+        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
         {
             ErrorUtilities.VerifyThrowInternalNull(sdk, nameof(sdk));
             ErrorUtilities.VerifyThrowInternalNull(loggingContext, nameof(loggingContext));
             ErrorUtilities.VerifyThrowInternalNull(sdkReferenceLocation, nameof(sdkReferenceLocation));
             ErrorUtilities.VerifyThrowInternalLength(projectPath, nameof(projectPath));
 
-            return _cachedSdkResolver.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
+            return _cachedSdkResolver.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, throwExceptions);
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -73,10 +73,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             try
             {
                 ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
-                bool throwExceptions = !Host.BuildParameters.ProjectLoadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) || Host.BuildParameters.ProjectLoadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk);
+                bool failOnUnresolvedSdk = !Host.BuildParameters.ProjectLoadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) || Host.BuildParameters.ProjectLoadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk);
 
                 // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
-                response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive, request.IsRunningInVisualStudio, throwExceptions);
+                response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive, request.IsRunningInVisualStudio, failOnUnresolvedSdk);
             }
             catch (Exception e)
             {
@@ -96,14 +96,14 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
+        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk)
         {
             ErrorUtilities.VerifyThrowInternalNull(sdk, nameof(sdk));
             ErrorUtilities.VerifyThrowInternalNull(loggingContext, nameof(loggingContext));
             ErrorUtilities.VerifyThrowInternalNull(sdkReferenceLocation, nameof(sdkReferenceLocation));
             ErrorUtilities.VerifyThrowInternalLength(projectPath, nameof(projectPath));
 
-            return _cachedSdkResolver.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, throwExceptions);
+            return _cachedSdkResolver.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, failOnUnresolvedSdk);
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
+        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
         {
             bool wasResultCached = true;
 

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
+        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk)
         {
             bool wasResultCached = true;
 

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -14,7 +14,7 @@ using System.Reflection;
 using Microsoft.Build.Eventing;
 using System.Linq;
 using System.Text.RegularExpressions;
-using static Microsoft.Build.Shared.FileMatcher;
+using System.Diagnostics;
 
 #nullable disable
 
@@ -126,12 +126,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 {
                     if (failOnUnresolvedSdk)
                     {
-                        loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "FailedToResolveSDK", sdk.Name);
-                    }
-
-                    foreach (string error in errors)
-                    {
-                        loggingContext.LogErrorFromText(subcategoryResourceName: null, errorCode: null, helpKeyword: null, new BuildEventFileInfo(sdkReferenceLocation), message: error);
+                        loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "FailedToResolveSDK", sdk.Name, string.Join($"{Environment.NewLine}  ", errors));
                     }
 
                     LogWarnings(loggingContext, sdkReferenceLocation, warnings);
@@ -229,12 +224,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
             if (failOnUnresolvedSdk)
             {
-                loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "FailedToResolveSDK", sdk.Name);
-            }
-
-            foreach (string error in errors)
-            {
-                loggingContext.LogErrorFromText(subcategoryResourceName: null, errorCode: null, helpKeyword: null, file: new BuildEventFileInfo(sdkReferenceLocation), message: error);
+                loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "FailedToResolveSDK", sdk.Name, string.Join($"{Environment.NewLine}  ", errors));
             }
 
             LogWarnings(loggingContext, sdkReferenceLocation, warnings);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -120,6 +120,8 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             else
             {
                 SdkResult result = ResolveSdkUsingAllResolvers(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, out IEnumerable<string> errors, out IEnumerable<string> warnings);
+
+                // Warnings are already logged on success.
                 if (!result.Success)
                 {
                     LogWarnings(loggingContext, sdkReferenceLocation, warnings);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -111,11 +111,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public virtual SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
+        public virtual SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk)
         {
             if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4))
             {
-                return ResolveSdkUsingResolversWithPatternsFirst(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, throwExceptions);
+                return ResolveSdkUsingResolversWithPatternsFirst(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, failOnUnresolvedSdk);
             }
             else
             {
@@ -124,7 +124,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 // Warnings are already logged on success.
                 if (!result.Success)
                 {
-                    if (throwExceptions)
+                    if (failOnUnresolvedSdk)
                     {
                         loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "FailedToResolveSDK", sdk.Name);
                     }
@@ -147,7 +147,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// If the first pass is unsuccessful, on the second pass all the general resolvers (i.e. resolvers without pattern), ordered by their priority, are tried one after one.
         /// After that, if the second pass is unsuccessful, sdk resolution is unsuccessful.
         /// </remarks>
-        private SdkResult ResolveSdkUsingResolversWithPatternsFirst(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool throwExceptions)
+        private SdkResult ResolveSdkUsingResolversWithPatternsFirst(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk)
         {
             if (_specificResolversManifestsRegistry == null || _generalResolversManifestsRegistry == null)
             {
@@ -227,7 +227,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             errors.AddRange(moreErrors);
             warnings.AddRange(moreWarnings);
 
-            if (throwExceptions)
+            if (failOnUnresolvedSdk)
             {
                 loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "FailedToResolveSDK", sdk.Name);
             }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -124,11 +124,17 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 // Warnings are already logged on success.
                 if (!result.Success)
                 {
-                    LogWarnings(loggingContext, sdkReferenceLocation, warnings);
+                    if (throwExceptions)
+                    {
+                        loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "FailedToResolveSDK", sdk.Name);
+                    }
+
                     foreach (string error in errors)
                     {
                         loggingContext.LogErrorFromText(subcategoryResourceName: null, errorCode: null, helpKeyword: null, new BuildEventFileInfo(sdkReferenceLocation), message: error);
                     }
+
+                    LogWarnings(loggingContext, sdkReferenceLocation, warnings);
                 }
 
                 return result;
@@ -226,11 +232,12 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 loggingContext.LogError(new BuildEventFileInfo(sdkReferenceLocation), "FailedToResolveSDK", sdk.Name);
             }
 
-            LogWarnings(loggingContext, sdkReferenceLocation, warnings);
             foreach (string error in errors)
             {
                 loggingContext.LogErrorFromText(subcategoryResourceName: null, errorCode: null, helpKeyword: null, file: new BuildEventFileInfo(sdkReferenceLocation), message: error);
             }
+
+            LogWarnings(loggingContext, sdkReferenceLocation, warnings);
 
             // No resolvers resolved the sdk.
             return new SdkResult(sdk, null, null);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -346,10 +346,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
                 SetResolverState(submissionId, sdkResolver, context.State);
 
-                if (result == null)
-                {
-                    continue;
-                }
+                result ??= (SdkResult)resultFactory.IndicateFailure(new string[] { ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverReturnedNull", sdkResolver.Name) }, Array.Empty<string>());
 
                 if (result.Success)
                 {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1840,7 +1840,8 @@ namespace Microsoft.Build.Evaluation
                 // Combine SDK path with the "project" relative path
                 try
                 {
-                    sdkResult = _sdkResolverService.ResolveSdk(_submissionId, sdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive, _isRunningInVisualStudio);
+                    sdkResult = _sdkResolverService.ResolveSdk(_submissionId, sdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive, _isRunningInVisualStudio,
+                        throwExceptions: !_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) || _loadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk));
                 }
                 catch (SdkResolverException e)
                 {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1841,7 +1841,7 @@ namespace Microsoft.Build.Evaluation
                 try
                 {
                     sdkResult = _sdkResolverService.ResolveSdk(_submissionId, sdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive, _isRunningInVisualStudio,
-                        throwExceptions: !_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) || _loadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk));
+                        failOnUnresolvedSdk: !_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) || _loadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk));
                 }
                 catch (SdkResolverException e)
                 {

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1977,7 +1977,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     </comment>
   </data>
    <data name="DefaultSDKResolverError" xml:space="preserve">
-    <value>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</value>
+    <value>The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</value>
   </data>
   <data name="SDKResolverReturnedNull" xml:space="preserve">
     <value>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1307,7 +1307,7 @@
     <value>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</value>
   </data>
   <data name="FailedToResolveSDK" xml:space="preserve">
-    <value>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</value>
+    <value>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</value>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">
     <value>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>
@@ -1977,7 +1977,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     </comment>
   </data>
    <data name="DefaultSDKResolverError" xml:space="preserve">
-    <value>The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</value>
+    <value>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</value>
   </data>
   <data name="SDKResolverReturnedNull" xml:space="preserve">
     <value>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1973,4 +1973,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       LOCALIZATION: {0} is a file path. {1} is a comma-separated list of target names
     </comment>
   </data>
+   <data name="DefaultSDKResolverError" xml:space="preserve">
+    <value>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</value>
+  </data>
 </root>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1979,4 +1979,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
    <data name="DefaultSDKResolverError" xml:space="preserve">
     <value>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</value>
   </data>
+  <data name="SDKResolverReturnedNull" xml:space="preserve">
+    <value>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</value>
+  </data>
 </root>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1307,7 +1307,8 @@
     <value>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</value>
   </data>
   <data name="FailedToResolveSDK" xml:space="preserve">
-    <value>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</value>
+    <value>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</value>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">
     <value>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1306,6 +1306,9 @@
   <data name="SDKResolverFailed" xml:space="preserve">
     <value>The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}". Exception: "{2}"</value>
   </data>
+  <data name="FailedToResolveSDK" xml:space="preserve">
+    <value>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</value>
+  </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">
     <value>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>
   </data>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1981,6 +1981,6 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</value>
   </data>
   <data name="SDKResolverReturnedNull" xml:space="preserve">
-    <value>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</value>
+    <value>SDK resolver "{0}" returned null.</value>
   </data>
 </root>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: Při zápisu do výstupních souborů mezipaměti pro výsledky v cestě {0} byla zjištěna chyba: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Na pozici {1} podmínky {0} je neočekávaná mezera. Nezapomněli jste ji odebrat?</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -370,6 +370,11 @@
         <target state="translated">Překladač sady SDK {0} selhal při pokusu o překlad sady SDK {1}. Výjimka: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: Projekt {0} přeskočil omezení izolace grafu v odkazovaném projektu {1}.</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: Došlo k pokusu o vytvoření více přepsání stejné úlohy: {0}</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: Beim Schreiben der Cachedatei für Ausgabeergebnisse im Pfad "{0}" wurde ein Fehler festgestellt: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Unerwartetes Leerzeichen an Position "{1}" der Bedingung "{0}". Haben Sie vergessen, ein Leerzeichen zu entfernen?</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: Es wurde versucht, mehrere Außerkraftsetzungen derselben Aufgabe zu erstellen: {0}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -370,6 +370,11 @@
         <target state="translated">Ausfall beim Versuch des SDK-Resolver "{0}", das SDK "{1}" aufzulösen. Ausnahme: "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: Das Projekt "{0}" hat Graphisolationseinschränkungen für das referenzierte Projekt "{1}" übersprungen.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: Error al escribir el archivo de caché de resultados de salida en la ruta de acceso "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Espacio inesperado en la posición "{1}" de la condición "{0}". ¿Olvidó quitar un espacio?</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: Se intentaron crear varias invalidaciones de la misma tarea: {0}</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -370,6 +370,11 @@
         <target state="translated">Error en el solucionador del SDK "{0}" al intentar resolver el SDK "{1}". Excepción: "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: El proyecto "{0}" ha omitido las restricciones de aislamiento de gráficos en el proyecto "{1}" al que se hace referencia.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -370,6 +370,11 @@
         <target state="translated">Échec du programme de résolution SDK «{0}» lors de la tentative de résolution du kit de développement logiciel (SDK) «{1}». Exception : "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: le projet "{0}" a ignoré les contraintes d'isolement de graphe dans le projet référencé "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: L'écriture du fichier cache des résultats de sortie dans le chemin "{0}" a rencontré une erreur : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: espace inattendu à la position "{1}" de la condition "{0}". Avez-vous oublié de supprimer un espace ?</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: Tentative de création de plusieurs remplacements de la même tâche : {0}</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: tentativo di creare più sostituzioni della stessa attività: {0}</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: durante la scrittura del file della cache dei risultati di output nel percorso "{0}" è stato rilevato un errore: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: spazio imprevisto alla posizione "{1}" della condizione "{0}". Si è dimenticato di rimuovere uno spazio?</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -370,6 +370,11 @@
         <target state="translated">Il sistema di risoluzione SDK "{0}" non è riuscito durante il tentativo di risolvere l'SDK "{1}". Eccezione: "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: il progetto "{0}" ha ignorato i vincoli di isolamento del grafico nel progetto di riferimento "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: パス "{0}" の出力結果キャッシュ ファイルに書き込む処理でエラーが発生しました: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: 条件 "{0}" の位置 "{1}" に予期しないスペースがあります。スペースを削除したか確認してください。</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: 同じタスクの複数のオーバーライドを作成しようとしました: {0}</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -370,6 +370,11 @@
         <target state="translated">SDK "{1}" を解決しようとしているときに、SDK リゾルバー "{0}" に失敗しました。例外: "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: プロジェクト "{0}" は、参照先のプロジェクト "{1}" で、グラフの分離制約をスキップしました</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: "{0}" 경로에서 출력 결과 캐시 파일을 쓰는 중 오류가 발생했습니다. {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: "{0}" 조건의 "{1}" 위치에 예기치 않은 공백이 있습니다. 공백을 제거했는지 확인하세요.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -370,6 +370,11 @@
         <target state="translated">SDK "{1}"을(를) 확인하는 동안 SDK 확인자 "{0}"이(가) 실패했습니다. 예외: "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 프로젝트 "{0}"에서 참조된 프로젝트 "{1}"의 그래프 격리 제약 조건을 건너뛰었습니다.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: 동일한 작업의 여러 재정의를 만들려고 했습니다. {0}</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: Podczas zapisywania pliku wyjściowej pamięci podręcznej wyników w ścieżce „{0}” wystąpił błąd: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Nieoczekiwana spacja na pozycji „{1}” warunku „{0}”. Czy zapomniano o usunięciu spacji?</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: Podjęto próbę utworzenia wielu zastąpień tego samego zadania: {0}</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -370,6 +370,11 @@
         <target state="translated">Wystąpił błąd programu do rozpoznawania zestawu SDK „{0}” podczas próby rozpoznania zestawu SDK „{1}”. Wyjątek: „{2}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: W przypadku projektu „{0}” pominięto ograniczenia izolacji grafu dla przywoływanego projektu „{1}”</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: a gravação do arquivo de cache do resultado de saída no caminho "{0}" encontrou um erro: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: espaço inesperado na posição "{1}" da condição "{0}". Você esqueceu de remover um espaço?</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: tentativa de criar várias substituições da mesma tarefa: {0}</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -370,6 +370,11 @@
         <target state="translated">O resolvedor do SDK "{0}" falhou ao tentar resolver o SDK "{1}". Exceção: "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: o projeto "{0}" ignorou as restrições de isolamento do gráfico no projeto referenciado "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -370,6 +370,11 @@
         <target state="translated">Сбой сопоставителя SDK "{0}" при попытке сопоставить пакет SDK "{1}". Исключение: "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: проект "{0}" пропустил ограничения изоляции графа в проекте "{1}", на который указывает ссылка.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: произошла ошибка при записи выходного файла кэша результатов в пути "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: неожиданный пробел в позиции "{1}" условия "{0}". Вы забыли удалить пробел?</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: попытка создать несколько переопределений одной задачи: {0}</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -370,6 +370,11 @@
         <target state="translated">"{0}" SDK çözümleyicisi, "{1}" SDK'sını çözümlemeye çalışırken başarısız oldu. İstisna: "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: "{0}" projesi, başvurulan "{1}" projesindeki graf yalıtımı kısıtlamalarını atladı</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: Çıkış sonucu önbellek dosyası "{0}" yoluna yazılırken bir hatayla karşılaşıldı: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: "{0}" koşulunun "{1}" konumunda beklenmeyen boşluk var. Boşluğu kaldırmayı unutmuş olabilirsiniz.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: Aynı {0} görevi için birden çok geçersiz kılma işlemi oluşturulmaya çalışıldı</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -370,6 +370,11 @@
         <target state="translated">尝试解析 SDK "{1}" 时，SDK 解析程序 "{0}" 失败。异常: "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 项目“{0}”已跳过所引用的项目“{1}”上的图形隔离约束</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: 从路径“{0}”写入输出结果缓存文件时遇到错误: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: 在条件“{0}”的位置“{1}”处出现意外空格。是否忘记了删除空格?</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: 已尝试创建同一任务的多个重写: {0}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -128,8 +128,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
-        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
+        <source>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</source>
+        <target state="new">Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
+  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -127,6 +127,11 @@
         <target state="translated">MSB4258: 在路徑 "{0}" 中寫入輸出結果快取檔案發生錯誤: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToResolveSDK">
+        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
+        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: 條件 "{0}" 的位置 "{1}" 出現非預期的空格。忘記移除空格了嗎?</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -93,8 +93,8 @@
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
       <trans-unit id="DefaultSDKResolverError">
-        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
-        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <source>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToResolveSDK">
-        <source>No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</source>
-        <target state="new">No SDK resolver succeeded in resolving SDK "{0}". Their error messages are printed below. Only one of the following indicates a real failure:</target>
+        <source>None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</source>
+        <target state="new">None of the SDK resolvers were able to resolve SDK "{0}". Their error messages are reproduced below in the order they occurred. Only one SDK resolver is expected to be able to resolve "{0}", so only one of the messages below indicates a real failure.</target>
         <note />
       </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -370,6 +370,11 @@
         <target state="translated">SDK 解析程式 "{0}" 在嘗試解析 SDK "{1}" 時失敗。例外狀況: "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverReturnedNull">
+        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
+        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 專案 "{0}" 已跳過參考專案 "{1}" 上的圖形隔離條件約束</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -92,6 +92,11 @@
         <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
     request a target to build itself (perhaps via a chain of other targets).</note>
       </trans-unit>
+      <trans-unit id="DefaultSDKResolverError">
+        <source>The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</source>
+        <target state="new">The DefaultSdkResolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DuplicateOverrideUsingTaskElement">
         <source>MSB4275: Attempted to create multiple overrides of the same task: {0}</source>
         <target state="translated">MSB4275: 已嘗試建立相同工作的多個覆寫: {0}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverReturnedNull">
-        <source>SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</source>
-        <target state="new">SDK resolver "{0}" returned null. SDK resolvers should always return success or failure. This is a bug in the SDK resolver.</target>
+        <source>SDK resolver "{0}" returned null.</source>
+        <target state="new">SDK resolver "{0}" returned null.</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">


### PR DESCRIPTION
Permits SDK resolvers to return an enumerable of messages in addition to the warnings and errors. Messages are ignored if we end up finding an SDK resolver that can resolve the SDK, but they are aggregated and printed out all at once in an InvalidProjectFileException if we fail to resolve any SDK.

This will need changes to other SDK resolvers for it to be fully effective. If this is merged, I will attempt the requisite changes to the NuGetSDKResolver and maybe the C++ SDK resolver.

Note also that this includes a breaking change, but I suspect it's seldom used, perhaps not used at all by anyone outside Microsoft.