### PR TITLE
Reduce unnecessary allocations when accessing information about global properties

### DIFF
--- a/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
+++ b/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Build.BackEnd
         public ConfigurationMetadata(Project project)
         {
             ErrorUtilities.VerifyThrowArgumentNull(project, nameof(project));
-            _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(project.GlobalProperties.Count);
-            foreach (KeyValuePair<string, string> entry in project.GlobalProperties)
+            _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(project.GlobalPropertiesCount);
+            foreach (KeyValuePair<string, string> entry in project.GlobalPropertiesEnumerable)
             {
                 _globalProperties[entry.Key] = ProjectPropertyInstance.Create(entry.Key, entry.Value);
             }

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -600,10 +600,19 @@ namespace Microsoft.Build.Evaluation
         /// </remarks>
         public IDictionary<string, string> GlobalProperties => implementation.GlobalProperties;
 
+        /// <summary>
+        /// Indicates whether the global properties dictionary contains the specified key.
+        /// </summary>
         internal bool GlobalPropertiesContains(string key) => implementation.GlobalPropertiesContains(key);
 
+        /// <summary>
+        /// Indicates how many elements are in the global properties dictionary.
+        /// </summary>
         internal int GlobalPropertiesCount => implementation.GlobalPropertiesCount();
 
+        /// <summary>
+        /// Enumerates the values in the global properties dictionary.
+        /// </summary>
         internal IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable => implementation.GlobalPropertiesEnumerable();
 
         /// <summary>
@@ -2093,16 +2102,29 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
+            /// <summary>
+            /// See <see cref="ProjectLink.GlobalPropertiesContains(string)"/>.
+            /// </summary>
+            /// <param name="key">The key to check for its value.</param>
+            /// <returns>Whether the key is in the global properties dictionary.</returns>
             public override bool GlobalPropertiesContains(string key)
             {
                 return _data.GlobalPropertiesDictionary.Contains(key);
             }
 
+            /// <summary>
+            /// See <see cref="ProjectLink.GlobalPropertiesCount()"/>.
+            /// </summary>
+            /// <returns>The number of properties in the global properties dictionary</returns>
             public override int GlobalPropertiesCount()
             {
                 return _data.GlobalPropertiesDictionary.Count;
             }
 
+            /// <summary>
+            /// See <see cref="ProjectLink.GlobalPropertiesEnumerable()"/>.
+            /// </summary>
+            /// <returns>An IEnumerable of the keys and values of the global properties dictionary</returns>
             public override IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable()
             {
                 foreach (ProjectPropertyInstance property in _data.GlobalPropertiesDictionary)

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -600,11 +600,11 @@ namespace Microsoft.Build.Evaluation
         /// </remarks>
         public IDictionary<string, string> GlobalProperties => implementation.GlobalProperties;
 
-        internal bool GlobalPropertiesContains(string key) => implementation is ProjectImpl projImpl ? projImpl.GlobalPropertiesContains(key) : GlobalProperties.ContainsKey(key);
+        internal bool GlobalPropertiesContains(string key) => implementation.GlobalPropertiesContains(key);
 
-        internal int GlobalPropertiesCount => implementation is ProjectImpl projImpl ? projImpl.GlobalPropertiesCount() : GlobalProperties.Count;
+        internal int GlobalPropertiesCount => implementation.GlobalPropertiesCount();
 
-        internal IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable => implementation is ProjectImpl projImpl ? projImpl.GlobalPropertiesEnumerable() : GlobalProperties;
+        internal IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable => implementation.GlobalPropertiesEnumerable();
 
         /// <summary>
         /// Item types in this project.
@@ -2093,25 +2093,22 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            public bool GlobalPropertiesContains(string key)
+            public override bool GlobalPropertiesContains(string key)
             {
                 return _data.GlobalPropertiesDictionary.Contains(key);
             }
 
-            public int GlobalPropertiesCount()
+            public override int GlobalPropertiesCount()
             {
                 return _data.GlobalPropertiesDictionary.Count;
             }
 
-            public IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable()
+            public override IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable()
             {
-                List<KeyValuePair<string, string>> result = new List<KeyValuePair<string, string>>();
                 foreach (ProjectPropertyInstance property in _data.GlobalPropertiesDictionary)
                 {
-                    result.Add(new KeyValuePair<string, string>(property.Name, ((IProperty)property).EvaluatedValueEscaped));
+                    yield return new KeyValuePair<string, string>(property.Name, ((IProperty)property).EvaluatedValueEscaped);
                 }
-
-                return result;
             }
 
             /// <summary>

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -600,6 +600,12 @@ namespace Microsoft.Build.Evaluation
         /// </remarks>
         public IDictionary<string, string> GlobalProperties => implementation.GlobalProperties;
 
+        internal bool GlobalPropertiesContains(string key) => implementation is ProjectImpl projImpl ? projImpl.GlobalPropertiesContains(key) : GlobalProperties.ContainsKey(key);
+
+        internal int GlobalPropertiesCount => implementation is ProjectImpl projImpl ? projImpl.GlobalPropertiesCount() : GlobalProperties.Count;
+
+        internal IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable => implementation is ProjectImpl projImpl ? projImpl.GlobalPropertiesEnumerable() : GlobalProperties;
+
         /// <summary>
         /// Item types in this project.
         /// This is an ordered collection.
@@ -2085,6 +2091,27 @@ namespace Microsoft.Build.Evaluation
 
                     return false;
                 }
+            }
+
+            public bool GlobalPropertiesContains(string key)
+            {
+                return _data.GlobalPropertiesDictionary.Contains(key);
+            }
+
+            public int GlobalPropertiesCount()
+            {
+                return _data.GlobalPropertiesDictionary.Count;
+            }
+
+            public IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable()
+            {
+                List<KeyValuePair<string, string>> result = new List<KeyValuePair<string, string>>();
+                foreach (ProjectPropertyInstance property in _data.GlobalPropertiesDictionary)
+                {
+                    result.Add(new KeyValuePair<string, string>(property.Name, ((IProperty)property).EvaluatedValueEscaped));
+                }
+
+                return result;
             }
 
             /// <summary>

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -2592,12 +2592,12 @@ namespace Microsoft.Build.Evaluation
                     return false;
                 }
 
-                if (project.GlobalProperties.Count != globalProperties.Count)
+                if (project.GlobalPropertiesCount != globalProperties.Count)
                 {
                     return false;
                 }
 
-                foreach (KeyValuePair<string, string> leftProperty in project.GlobalProperties)
+                foreach (KeyValuePair<string, string> leftProperty in project.GlobalPropertiesEnumerable)
                 {
                     if (!globalProperties.TryGetValue(leftProperty.Key, out var rightValue))
                     {

--- a/src/Build/Definition/ProjectProperty.cs
+++ b/src/Build/Definition/ProjectProperty.cs
@@ -596,7 +596,7 @@ namespace Microsoft.Build.Evaluation
             {
                 [DebuggerStepThrough]
                 get
-                { return _project.GlobalProperties.ContainsKey(Name); }
+                { return _project.GlobalPropertiesContains(Name); }
             }
 
             /// <summary>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -352,8 +352,8 @@ namespace Microsoft.Build.Execution
 
             this.CreateEvaluatedIncludeSnapshotIfRequested(keepEvaluationCache, project.Items, projectItemToInstanceMap);
 
-            _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(project.GlobalProperties.Count);
-            foreach (var property in project.GlobalProperties)
+            _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(project.GlobalPropertiesCount);
+            foreach (var property in project.GlobalPropertiesEnumerable)
             {
                 _globalProperties.Set(ProjectPropertyInstance.Create(property.Key, property.Value));
             }

--- a/src/Build/ObjectModelRemoting/DefinitionObjectsLinks/ProjectLink.cs
+++ b/src/Build/ObjectModelRemoting/DefinitionObjectsLinks/ProjectLink.cs
@@ -260,10 +260,26 @@ namespace Microsoft.Build.ObjectModelRemoting
         /// </summary>
         public abstract void Unload();
 
+        /// <summary>
+        /// Indicates whether a specified key is in the global properties dictionary. This provides a default implementation
+        /// to avoid a breaking change, but it is often overriden for performance.
+        /// </summary>
+        /// <param name="key">The key to check for in the dictionary</param>
+        /// <returns>True if the key is in the global properties; false otherwise</returns>
         public virtual bool GlobalPropertiesContains(string key) => GlobalProperties.ContainsKey(key);
 
+        /// <summary>
+        /// Indicates how many properties are in the global properties dictionary. This provides a default implementation to
+        /// avoid a breaking change, but it is often overriden for performance.
+        /// </summary>
+        /// <returns>The number of properties in the global properties dictionary</returns>
         public virtual int GlobalPropertiesCount() => GlobalProperties.Count;
 
+        /// <summary>
+        /// Allows enumeration over the keys and values in the global properties dictionary. This provides a default
+        /// implementation to avoid a breaking change, but it can be overriden for performance.
+        /// </summary>
+        /// <returns>An enumerable of the keys and values in the global properties dictionary</returns>
         public virtual IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable() => GlobalProperties;
     }
 }

--- a/src/Build/ObjectModelRemoting/DefinitionObjectsLinks/ProjectLink.cs
+++ b/src/Build/ObjectModelRemoting/DefinitionObjectsLinks/ProjectLink.cs
@@ -259,5 +259,11 @@ namespace Microsoft.Build.ObjectModelRemoting
         /// Called by the local project collection to indicate to this project that it is no longer loaded.
         /// </summary>
         public abstract void Unload();
+
+        public virtual bool GlobalPropertiesContains(string key) => GlobalProperties.ContainsKey(key);
+
+        public virtual int GlobalPropertiesCount() => GlobalProperties.Count;
+
+        public virtual IEnumerable<KeyValuePair<string, string>> GlobalPropertiesEnumerable() => GlobalProperties;
     }
 }

--- a/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -19,3 +19,6 @@ Microsoft.Build.Experimental.OutOfProcServerNode.BuildCallback
 Microsoft.Build.Experimental.OutOfProcServerNode.OutOfProcServerNode(Microsoft.Build.Experimental.OutOfProcServerNode.BuildCallback buildFunction) -> void
 Microsoft.Build.Experimental.OutOfProcServerNode.Run(out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
 static Microsoft.Build.Experimental.MSBuildClient.ShutdownServer(System.Threading.CancellationToken cancellationToken) -> bool
+virtual Microsoft.Build.ObjectModelRemoting.ProjectLink.GlobalPropertiesContains(string key) -> bool
+virtual Microsoft.Build.ObjectModelRemoting.ProjectLink.GlobalPropertiesCount() -> int
+virtual Microsoft.Build.ObjectModelRemoting.ProjectLink.GlobalPropertiesEnumerable() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>

--- a/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -19,4 +19,6 @@ Microsoft.Build.Experimental.OutOfProcServerNode.BuildCallback
 Microsoft.Build.Experimental.OutOfProcServerNode.OutOfProcServerNode(Microsoft.Build.Experimental.OutOfProcServerNode.BuildCallback buildFunction) -> void
 Microsoft.Build.Experimental.OutOfProcServerNode.Run(out System.Exception shutdownException) -> Microsoft.Build.Execution.NodeEngineShutdownReason
 static Microsoft.Build.Experimental.MSBuildClient.ShutdownServer(System.Threading.CancellationToken cancellationToken) -> bool
-
+virtual Microsoft.Build.ObjectModelRemoting.ProjectLink.GlobalPropertiesContains(string key) -> bool
+virtual Microsoft.Build.ObjectModelRemoting.ProjectLink.GlobalPropertiesCount() -> int
+virtual Microsoft.Build.ObjectModelRemoting.ProjectLink.GlobalPropertiesEnumerable() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>


### PR DESCRIPTION
Fixes #7743

CPS iterates over collections of properties to access information about them, specifically whether they are global properties or derived from the environment. The current implementation of IsGlobalProperty and IsEnvironmentProperty start by accessing the global dictionary. That call makes a copy of the dictionary before just accessing information, which impacts performance.

This gets more complicated because the global dictionary should not be modified from the outside. Based on our publicly exposed API, it should be an IDictionary, so we cannot return an ImmutableDictionary. Returning a readonly Dictionary still permits modifications, and a ReadOnlyDictionary doesn't implement IDictionary.

This attempts to circumvent the problem of returning a readonly dictionary that implements IDictionary by instead exposing a more efficient form of the few methods needed by CPS, specifically Contains, Count, and Enumerate. As CPS uses a custom ProjectLink, these new methods are exposed as overridable methods, and they're virtual to avoid making a breaking change. This permits performance wins without breaking current customers.
