### PR TITLE
Specialcase UAP == windows

### DIFF
--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Build.UnitTests
             ObjectModelHelpers.DeleteTempProjectDirectory();
 
             ObjectModelHelpers.CreateFileInTempProjectDirectory("Myapp.proj", @"
-                <Project ToolsVersionresol=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
+                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                   <Target Name =`Repro`>
                     <CreateItem Include=`**\*.txt`>
                       <Output TaskParameter=`Include` ItemName=`Text`/>

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Build.UnitTests
             ObjectModelHelpers.DeleteTempProjectDirectory();
 
             ObjectModelHelpers.CreateFileInTempProjectDirectory("Myapp.proj", @"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
+                <Project ToolsVersionresol=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                   <Target Name =`Repro`>
                     <CreateItem Include=`**\*.txt`>
                       <Output TaskParameter=`Include` ItemName=`Text`/>

--- a/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
@@ -4213,12 +4213,12 @@ namespace Microsoft.Build.UnitTests.ResolveSDKReference_Tests
                 "Release",
                 "x64",
                 new HashSet<string>() { "sdkName" },
-                false,
-                false,
+                treatErrorsAsWarnings: false,
+                prefer32Bit: false,
                 "windows",
                 new Version("1.0.2"),
-                "myProjectName",
-                true);
+                "projectName",
+                enableMaxPlatformVersionEmptyWarning: true);
 
             reference.ResolutionErrors.ShouldBeEmpty();
             reference.ResolutionWarnings.ShouldBeEmpty();

--- a/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
@@ -4207,6 +4207,7 @@ namespace Microsoft.Build.UnitTests.ResolveSDKReference_Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void VerifyPlatformAliasesWork()
         {
+            // This verifies that UAP is an alias for windows, so verifying the target platforms align. Other parts of the reference don't matter here.
             SDKReference reference = new(new TaskItem("sdkReference", new Dictionary<string, string>() { { SDKManifest.Attributes.TargetPlatform, "UAP" } }), "sdkName", "1.0.2");
             reference.Resolve(
                 new Dictionary<string, ITaskItem>() { { "sdkName, Version=1.0.2", new TaskItem(Path.GetTempFileName(), new Dictionary<string, string>() { { "PlatformVersion", "1.0.2" } }) } },
@@ -4222,6 +4223,7 @@ namespace Microsoft.Build.UnitTests.ResolveSDKReference_Tests
 
             reference.ResolutionErrors.ShouldBeEmpty();
             reference.ResolutionWarnings.ShouldBeEmpty();
+            reference.TargetPlatform.ShouldBe("UAP");
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/ResolveSDKReference_Tests.cs
@@ -15,6 +15,7 @@ using SDKReference = Microsoft.Build.Tasks.ResolveSDKReference.SDKReference;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Xunit;
+using Shouldly;
 
 #nullable disable
 
@@ -4200,6 +4201,27 @@ namespace Microsoft.Build.UnitTests.ResolveSDKReference_Tests
                     FileUtilities.DeleteDirectoryNoThrow(testDirectoryRoot, true);
                 }
             }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void VerifyPlatformAliasesWork()
+        {
+            SDKReference reference = new(new TaskItem("sdkReference", new Dictionary<string, string>() { { SDKManifest.Attributes.TargetPlatform, "UAP" } }), "sdkName", "1.0.2");
+            reference.Resolve(
+                new Dictionary<string, ITaskItem>() { { "sdkName, Version=1.0.2", new TaskItem(Path.GetTempFileName(), new Dictionary<string, string>() { { "PlatformVersion", "1.0.2" } }) } },
+                "Release",
+                "x64",
+                new HashSet<string>() { "sdkName" },
+                false,
+                false,
+                "windows",
+                new Version("1.0.2"),
+                "myProjectName",
+                true);
+
+            reference.ResolutionErrors.ShouldBeEmpty();
+            reference.ResolutionWarnings.ShouldBeEmpty();
         }
 
         [Fact]

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -1251,7 +1251,7 @@ namespace Microsoft.Build.Tasks
                     AddResolutionWarning("ResolveSDKReference.MaxPlatformVersionNotSpecified", projectName, DisplayName, Version, targetPlatformIdentifier, targetPlatformVersionFromItem.ToString(), targetPlatformIdentifier, targetPlatformVersion.ToString());
                 }
 
-                if (!String.IsNullOrEmpty(TargetPlatform) && !String.Equals(targetPlatformIdentifier, TargetPlatform))
+                if (!String.IsNullOrEmpty(TargetPlatform) && !String.Equals(targetPlatformIdentifier, TargetPlatform) && (!String.Equals("UAP", TargetPlatform, StringComparison.OrdinalIgnoreCase) || !String.Equals(targetPlatformIdentifier, "windows", StringComparison.OrdinalIgnoreCase)))
                 {
                     AddResolutionErrorOrWarning("ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch", projectName, DisplayName, Version, targetPlatformIdentifier, TargetPlatform);
                 }

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private static readonly Dictionary<string, string> PlatformAliases = new(StringComparer.OrdinalIgnoreCase)
         {
-            { "UAP", "windows" }
+            { "UAP", "Windows" }
         };
 
         /// <summary>

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Platform aliases
         /// </summary>
-        private static Dictionary<string, string> platformAliases = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, string> PlatformAliases = new(StringComparer.OrdinalIgnoreCase)
         {
             { "UAP", "windows" }
         };
@@ -1259,7 +1259,7 @@ namespace Microsoft.Build.Tasks
                     AddResolutionWarning("ResolveSDKReference.MaxPlatformVersionNotSpecified", projectName, DisplayName, Version, targetPlatformIdentifier, targetPlatformVersionFromItem.ToString(), targetPlatformIdentifier, targetPlatformVersion.ToString());
                 }
 
-                if (!String.IsNullOrEmpty(TargetPlatform) && !String.Equals(targetPlatformIdentifier, TargetPlatform) && (!platformAliases.TryGetValue(TargetPlatform, out string platform) || !String.Equals(targetPlatformIdentifier, platform, StringComparison.OrdinalIgnoreCase)))
+                if (!String.IsNullOrEmpty(TargetPlatform) && !String.Equals(targetPlatformIdentifier, TargetPlatform) && (!PlatformAliases.TryGetValue(TargetPlatform, out string platform) || !String.Equals(targetPlatformIdentifier, platform, StringComparison.OrdinalIgnoreCase)))
                 {
                     AddResolutionErrorOrWarning("ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch", projectName, DisplayName, Version, targetPlatformIdentifier, TargetPlatform);
                 }

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -26,6 +26,14 @@ namespace Microsoft.Build.Tasks
         #region fields
 
         /// <summary>
+        /// Platform aliases
+        /// </summary>
+        private static Dictionary<string, string> platformAliases = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "UAP", "windows" }
+        };
+
+        /// <summary>
         /// Regex for breaking up the sdk reference include into pieces.
         /// Example: XNA, Version=8.0
         /// </summary>
@@ -1251,7 +1259,7 @@ namespace Microsoft.Build.Tasks
                     AddResolutionWarning("ResolveSDKReference.MaxPlatformVersionNotSpecified", projectName, DisplayName, Version, targetPlatformIdentifier, targetPlatformVersionFromItem.ToString(), targetPlatformIdentifier, targetPlatformVersion.ToString());
                 }
 
-                if (!String.IsNullOrEmpty(TargetPlatform) && !String.Equals(targetPlatformIdentifier, TargetPlatform) && (!String.Equals("UAP", TargetPlatform, StringComparison.OrdinalIgnoreCase) || !String.Equals(targetPlatformIdentifier, "windows", StringComparison.OrdinalIgnoreCase)))
+                if (!String.IsNullOrEmpty(TargetPlatform) && !String.Equals(targetPlatformIdentifier, TargetPlatform) && (!platformAliases.TryGetValue(TargetPlatform, out string platform) || !String.Equals(targetPlatformIdentifier, platform, StringComparison.OrdinalIgnoreCase)))
                 {
                     AddResolutionErrorOrWarning("ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch", projectName, DisplayName, Version, targetPlatformIdentifier, TargetPlatform);
                 }


### PR DESCRIPTION
Fixes #6150

### Context
We verify that the target platform is appropriate for the target platform identifier, but that check is too specific; it doesn't permit equivalent strings from matching. So far, we only know of UAP being a windows app, hence valid for windows. This fixes that instance.

### Changes Made


### Testing
Tried to reproduce this with and without this change. The error changed, and I don't think it's related, but I'm keeping this a draft PR anyway because I'm not confident about this.

### Notes
