### PR TITLE
Ensure diagnostic logger verbosity Fixes #7780

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -466,6 +466,12 @@ namespace Microsoft.Build.Execution
 
             _previousLowPriority = parameters.LowPriority;
 
+            if (Traits.Instance.DebugEngine)
+            {
+                parameters.DetailedSummary = true;
+                parameters.LogTaskInputs = true;
+            }
+
             lock (_syncLock)
             {
                 AttachDebugger();

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2366,6 +2366,7 @@ namespace Microsoft.Build.CommandLine
                         out enableProfiler
                         );
 
+                    // We're finished with defining individual loggers' verbosity at this point, so we don't need to worry about messing them up.
                     if (Traits.Instance.DebugEngine)
                     {
                         verbosity = LoggerVerbosity.Diagnostic;

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2366,6 +2366,11 @@ namespace Microsoft.Build.CommandLine
                         out enableProfiler
                         );
 
+                    if (Traits.Instance.DebugEngine)
+                    {
+                        verbosity = LoggerVerbosity.Diagnostic;
+                    }
+
                     if (commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.DetailedSummary))
                     {
                         detailedSummary = ProcessBooleanSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.DetailedSummary], defaultValue: true, resourceName: "InvalidDetailedSummaryValue");


### PR DESCRIPTION
Fixes #7780

### Context
When using MSBuildDebugEngine, we should log everything at diagnostic verbosity. If no loggers were attached in the normal way, we still set verbosity to diagnostic (for command line builds) and manually set both DetailedSummary and LogTaskInputs on the BuildParameters in BuildManager. I believe these are the only two variables set by binlogs that weren't being set by MSBuildDebugEngine.

### Changes Made
This sets the verbosity to diagnostic in XMake and sets DetailedSummary and LogTaskInputs on BuildParameters.

### Testing


### Notes
