### PR TITLE
Update binding redirect for System.Reflection.Metadata to match referenced assembly version

### DIFF
--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -70,7 +70,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.MetadataLoadContext" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />


### PR DESCRIPTION
Update the binding redirect for System.Reflection.Metadata to match the referenced version of the assembly from the current package reference.

When this is out of date, it causes a lot of pain in consuming repos (in particular in dotnet/sdk and dotnet/runtime). It might be worth some tooling to ensure that this stays up to date.

See https://github.com/dotnet/sdk/pull/27149 for some context.

cc: @rainersigwald 
