### PR TITLE
Fix hang in VS due to EndBuild being called on a UI thread

### DIFF
--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -645,7 +645,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
                 });
             }
 
-            await Task.WhenAll(cleanupTasks);
+            await Task.WhenAll(cleanupTasks).ConfigureAwait(false);
 
             if (pluginLogger.HasLoggedErrors)
             {


### PR DESCRIPTION
This fixes a hang in VS caused by `BuildManager.EndBuild` being called on a UI thread in some scenarios. `BuildManager.EndBuild` calls `ProjectCacheService.DisposeAsync().AsTask()`, which uses `await Task.WhenAll(...)`. This simply adds a `.ConfigureAwait(false)` to the `await Task.WhenAll(...)`.

An alternate approach would be to change out `await Task.WhenAll(...)` with `Task.WaitAll(...)`, but I figured it'd be better to use `async/await`.