### PR TITLE
Log error when build is aborted

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks.Dataflow;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.BackEnd.SdkResolution;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Eventing;
 using Microsoft.Build.Exceptions;
@@ -714,6 +715,7 @@ namespace Microsoft.Build.Execution
                         {
                             BuildResult result = new BuildResult(submission.BuildRequest, new BuildAbortedException());
                             _resultsCache.AddResult(result);
+                            ((IBuildComponentHost)this).LoggingService.LogError(BuildEventContext.Invalid, new BuildEventFileInfo(ElementLocation.EmptyLocation), "BuildAborted");
                             submission.CompleteResults(result);
                         }
                     }
@@ -723,6 +725,7 @@ namespace Microsoft.Build.Execution
                         if (submission.IsStarted)
                         {
                             submission.CompleteResults(new GraphBuildResult(submission.SubmissionId, new BuildAbortedException()));
+                            ((IBuildComponentHost)this).LoggingService.LogError(BuildEventContext.Invalid, new BuildEventFileInfo(ElementLocation.EmptyLocation), "BuildAborted");
                         }
                     }
 

--- a/src/Build/BackEnd/BuildManager/BuildSubmission.cs
+++ b/src/Build/BackEnd/BuildManager/BuildSubmission.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Build.Execution
             // this one.)
             ErrorUtilities.VerifyThrow(result.ConfigurationId == BuildRequest.ConfigurationId, "BuildResult doesn't match BuildRequest configuration");
 
-            if (BuildResult == null)
+            if (BuildResult is null || (BuildResult.OverallResult == BuildResultCode.Success && result is not null))
             {
                 BuildResult = result;
             }

--- a/src/Build/BackEnd/Shared/BuildAbortedException.cs
+++ b/src/Build/BackEnd/Shared/BuildAbortedException.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Exceptions
         {
             ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out string errorCode, out _, "BuildAborted");
 
-            ErrorCode = errorCode;
+            ErrorCode = "MSB4188";
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #7287

### Context
Cancelling a build can lead to a failed build with 0 warnings and 0 errors.

### Changes Made
Ensured that we log an error when the build fails. From code inspection, this was at least one place where, if the build was cancelled, we might not log the error, though the build could still fail.

### Testing
We don't have a repro for #7287, so I could not test this properly.

### Notes
