### PR TITLE
Deduplicate list of assemblies loaded in TypeLoader

### DIFF
--- a/src/Samples/PortableTask/PortableTask.csproj
+++ b/src/Samples/PortableTask/PortableTask.csproj
@@ -15,7 +15,9 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.5.180" GeneratePathProperty="true" />
   </ItemGroup>
   <Target Name="UpdateXlf" />
-  <Target Name="CopyMSBuildUtilitiesToTemp" AfterTargets="Build">
+
+  <!-- This is only needed for a test in the MSBuild repo; it is unrelated to the PortableTask sample itself. -->
+  <Target Name="CopyMSBuildUtilitiesToNewFolder" AfterTargets="Restore">
     <Copy SourceFiles="$(PkgMicrosoft_Build_Utilities_Core)\lib\net46\Microsoft.Build.Utilities.Core.dll" DestinationFiles="$(OutDir)\OldMSBuild\Microsoft.Build.Utilities.Core.dll" />
   </Target>
 </Project>

--- a/src/Samples/PortableTask/PortableTask.csproj
+++ b/src/Samples/PortableTask/PortableTask.csproj
@@ -17,7 +17,7 @@
   <Target Name="UpdateXlf" />
 
   <!-- This is only needed for a test in the MSBuild repo; it is unrelated to the PortableTask sample itself. -->
-  <Target Name="CopyMSBuildUtilitiesToNewFolder" AfterTargets="Restore">
+  <Target Name="CopyMSBuildUtilitiesToNewFolder" AfterTargets="Build">
     <Copy SourceFiles="$(PkgMicrosoft_Build_Utilities_Core)\lib\net46\Microsoft.Build.Utilities.Core.dll" DestinationFiles="$(OutDir)\OldMSBuild\Microsoft.Build.Utilities.Core.dll" />
   </Target>
 </Project>

--- a/src/Samples/PortableTask/PortableTask.csproj
+++ b/src/Samples/PortableTask/PortableTask.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="15.5.180" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.5.180" GeneratePathProperty="true" />
-    <PackageDownload Include="Microsoft.Build.Utilities.Core" Version="[15.5.180]" />
   </ItemGroup>
   <Target Name="UpdateXlf" />
   <Target Name="CopyMSBuildUtilitiesToTemp" AfterTargets="Build">

--- a/src/Samples/PortableTask/PortableTask.csproj
+++ b/src/Samples/PortableTask/PortableTask.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UseProductOutputPath>true</UseProductOutputPath>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
@@ -17,7 +17,7 @@
   <Target Name="UpdateXlf" />
 
   <!-- This is only needed for a test in the MSBuild repo; it is unrelated to the PortableTask sample itself. -->
-  <Target Name="CopyMSBuildUtilitiesToNewFolder" AfterTargets="Build">
+  <Target Name="CopyMSBuildUtilitiesToNewFolder" BeforeTargets="CopyFilesToOutputDirectory">
     <Copy SourceFiles="$(PkgMicrosoft_Build_Utilities_Core)\lib\net46\Microsoft.Build.Utilities.Core.dll" DestinationFiles="$(OutDir)\OldMSBuild\Microsoft.Build.Utilities.Core.dll" />
   </Target>
 </Project>

--- a/src/Samples/PortableTask/PortableTask.csproj
+++ b/src/Samples/PortableTask/PortableTask.csproj
@@ -12,7 +12,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="15.5.180" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.5.180" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.5.180" GeneratePathProperty="true" />
+    <PackageDownload Include="Microsoft.Build.Utilities.Core" Version="[15.5.180]" />
   </ItemGroup>
   <Target Name="UpdateXlf" />
+  <Target Name="CopyMSBuildUtilitiesToTemp" AfterTargets="Build">
+    <Copy SourceFiles="$(PkgMicrosoft_Build_Utilities_Core)\lib\net46\Microsoft.Build.Utilities.Core.dll" DestinationFiles="$(OutDir)\OldMSBuild\Microsoft.Build.Utilities.Core.dll" />
+  </Target>
 </Project>

--- a/src/Shared/UnitTests/TypeLoader_Tests.cs
+++ b/src/Shared/UnitTests/TypeLoader_Tests.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Build.UnitTests
         private static readonly string ProjectFileFolder = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, "PortableTask");
         private const string ProjectFileName = "portableTaskTest.proj";
         private const string DLLFileName = "PortableTask.dll";
+        private static string PortableTaskFolderPath = Path.GetFullPath(
+                    Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, "..", "..", "..", "Samples", "PortableTask"));
 
         private readonly ITestOutputHelper _output;
 
@@ -100,12 +102,10 @@ namespace Microsoft.Build.UnitTests
                 string currentAssembly = Assembly.GetExecutingAssembly().Location;
                 string utilitiesName = "Microsoft.Build.Utilities.Core.dll";
                 string newAssemblyLocation = Path.Combine(folder.Path, Path.GetFileName(currentAssembly));
-                string portableTaskFolderPath = Path.GetFullPath(
-                    Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, "..", "..", "..", "Samples", "PortableTask"));
 
                 // The "first" directory is "Debug" or "Release"
-                portableTaskFolderPath = Path.Combine(Directory.GetDirectories(portableTaskFolderPath).First(), "netstandard2.0", "OldMSBuild");
-                string utilities = Path.Combine(portableTaskFolderPath, utilitiesName);
+                string portableTaskPath = Path.Combine(Directory.GetDirectories(PortableTaskFolderPath).First(), "netstandard2.0", "OldMSBuild");
+                string utilities = Path.Combine(portableTaskPath, utilitiesName);
                 File.Copy(utilities, Path.Combine(folder.Path, utilitiesName));
                 File.Copy(currentAssembly, newAssemblyLocation);
                 TypeLoader typeLoader = new(TaskLoader.IsTaskClass);

--- a/src/Shared/UnitTests/TypeLoader_Tests.cs
+++ b/src/Shared/UnitTests/TypeLoader_Tests.cs
@@ -91,6 +91,25 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void LoadTaskDependingOnMSBuild()
+        {
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                TransientTestFolder folder = env.CreateFolder(createFolder: true);
+                string currentAssembly = Assembly.GetExecutingAssembly().Location;
+                string utilitiesName = "Microsoft.Build.Utilities.Core.dll";
+                string utilities = Path.Combine(Path.GetDirectoryName(currentAssembly), utilitiesName);
+                string newAssemblyLocation = Path.Combine(folder.Path, Path.GetFileName(currentAssembly));
+                File.Copy(utilities, Path.Combine(folder.Path, utilitiesName));
+                File.Copy(currentAssembly, newAssemblyLocation);
+                TypeLoader typeLoader = new((_, _) => true);
+
+                // If we cannot accept MSBuild next to the task assembly we're loading, this will throw.
+                typeLoader.Load("TypeLoader_Tests", AssemblyLoadInfo.Create(null, newAssemblyLocation), useTaskHost: true);
+            }
+        }
+
+        [Fact]
         public void LoadOutsideAssembly()
         {
             using (var dir = new FileUtilities.TempWorkingDirectory(ProjectFileFolder))

--- a/src/Shared/UnitTests/TypeLoader_Tests.cs
+++ b/src/Shared/UnitTests/TypeLoader_Tests.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.UnitTests.Shared;
 using Xunit;
 using Xunit.Abstractions;
 using Shouldly;
+using System.Linq;
 
 #nullable disable
 
@@ -100,7 +101,10 @@ namespace Microsoft.Build.UnitTests
                 string utilitiesName = "Microsoft.Build.Utilities.Core.dll";
                 string newAssemblyLocation = Path.Combine(folder.Path, Path.GetFileName(currentAssembly));
                 string portableTaskFolderPath = Path.GetFullPath(
-                    Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, "..", "..", "..", "Samples", "PortableTask", "Debug", "netstandard2.0", "OldMSBuild"));
+                    Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, "..", "..", "..", "Samples", "PortableTask"));
+
+                // The "first" directory is "Debug" or "Release"
+                portableTaskFolderPath = Path.Combine(Directory.GetDirectories(portableTaskFolderPath).First(), "netstandard2.0", "OldMSBuild");
                 string utilities = Path.Combine(portableTaskFolderPath, utilitiesName);
                 File.Copy(utilities, Path.Combine(folder.Path, utilitiesName));
                 File.Copy(currentAssembly, newAssemblyLocation);

--- a/src/Shared/UnitTests/TypeLoader_Tests.cs
+++ b/src/Shared/UnitTests/TypeLoader_Tests.cs
@@ -98,11 +98,13 @@ namespace Microsoft.Build.UnitTests
                 TransientTestFolder folder = env.CreateFolder(createFolder: true);
                 string currentAssembly = Assembly.GetExecutingAssembly().Location;
                 string utilitiesName = "Microsoft.Build.Utilities.Core.dll";
-                string utilities = Path.Combine(Path.GetDirectoryName(currentAssembly), utilitiesName);
                 string newAssemblyLocation = Path.Combine(folder.Path, Path.GetFileName(currentAssembly));
+                string portableTaskFolderPath = Path.GetFullPath(
+                    Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, "..", "..", "..", "Samples", "PortableTask", "Debug", "netstandard2.0", "OldMSBuild"));
+                string utilities = Path.Combine(portableTaskFolderPath, utilitiesName);
                 File.Copy(utilities, Path.Combine(folder.Path, utilitiesName));
                 File.Copy(currentAssembly, newAssemblyLocation);
-                TypeLoader typeLoader = new((_, _) => true);
+                TypeLoader typeLoader = new(TaskLoader.IsTaskClass);
 
                 // If we cannot accept MSBuild next to the task assembly we're loading, this will throw.
                 typeLoader.Load("TypeLoader_Tests", AssemblyLoadInfo.Create(null, newAssemblyLocation), useTaskHost: true);


### PR DESCRIPTION
Fixes #7920

### Context
When a task ships MSBuild assemblies, we try to load both those assemblies and the assemblies next to MSBuild. This confuses the MetadataLoadContext. We should just use the MSBuild that's actually building, since we'll binding redirect to that anyway.

We also load MSBuild from the runtime, but that one isn't problematic here.

### Changes Made
Load MSBuild from one place only in TypeLoader.

### Testing


### Notes
