### PR TITLE
Exempt our env var Fixes #7922

### DIFF
--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 }
                 else
                 {
-                    properties = projectProperties.Filter(p => p is not EnvironmentDerivedProjectPropertyInstance || EnvironmentUtilities.IsReservedProperty(p.Name), p => new DictionaryEntry(p.Name, p.EvaluatedValue));
+                    properties = projectProperties.Filter(p => p is not EnvironmentDerivedProjectPropertyInstance || EnvironmentUtilities.IsWellKnownEnvironmentDerivedProperty(p.Name), p => new DictionaryEntry(p.Name, p.EvaluatedValue));
                 }
 
                 items = projectItems?.GetCopyOnReadEnumerable(item => new DictionaryEntry(item.ItemType, new TaskItem(item))) ?? Enumerable.Empty<DictionaryEntry>();

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 }
                 else
                 {
-                    properties = projectProperties.Filter(p => p is not EnvironmentDerivedProjectPropertyInstance, p => new DictionaryEntry(p.Name, p.EvaluatedValue));
+                    properties = projectProperties.Filter(p => p is not EnvironmentDerivedProjectPropertyInstance || EnvironmentUtilities.IsReservedProperty(p.Name), p => new DictionaryEntry(p.Name, p.EvaluatedValue));
                 }
 
                 items = projectItems?.GetCopyOnReadEnumerable(item => new DictionaryEntry(item.ItemType, new TaskItem(item))) ?? Enumerable.Empty<DictionaryEntry>();

--- a/src/Build/Definition/ProjectProperty.cs
+++ b/src/Build/Definition/ProjectProperty.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Build.Evaluation
             [DebuggerStepThrough]
             get
             {
-                if (this is EnvironmentDerivedProjectProperty environmentProperty && environmentProperty.loggingContext is { IsValid: true } loggingContext && !environmentProperty._loggedEnvProperty)
+                if (this is EnvironmentDerivedProjectProperty environmentProperty && environmentProperty.loggingContext is { IsValid: true } loggingContext && !environmentProperty._loggedEnvProperty && !Traits.LogAllEnvironmentVariables)
                 {
                     EnvironmentVariableReadEventArgs args = new(Name, EvaluatedValueEscapedInternal);
                     args.BuildEventContext = loggingContext.BuildEventContext;

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -824,8 +824,9 @@ namespace Microsoft.Build.Evaluation
             List<P> list = new(dictionary.Count);
             foreach (P p in dictionary)
             {
-                if (p is EnvironmentDerivedProjectPropertyInstance ||
-                    (p is ProjectProperty pp && pp.IsEnvironmentProperty))
+                if ((p is EnvironmentDerivedProjectPropertyInstance ||
+                    (p is ProjectProperty pp && pp.IsEnvironmentProperty)) &&
+                    !EnvironmentUtilities.IsReservedProperty(p.Name))
                 {
                     continue;
                 }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -824,9 +824,11 @@ namespace Microsoft.Build.Evaluation
             List<P> list = new(dictionary.Count);
             foreach (P p in dictionary)
             {
+                // This checks if a property was derived from the environment but is not one of the well-known environment variables we
+                // use to change build behavior.
                 if ((p is EnvironmentDerivedProjectPropertyInstance ||
                     (p is ProjectProperty pp && pp.IsEnvironmentProperty)) &&
-                    !EnvironmentUtilities.IsReservedProperty(p.Name))
+                    !EnvironmentUtilities.IsWellKnownEnvironmentDerivedProperty(p.Name))
                 {
                     continue;
                 }

--- a/src/Build/Instance/ProjectPropertyInstance.cs
+++ b/src/Build/Instance/ProjectPropertyInstance.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.Execution
         {
             get
             {
-                if (this is EnvironmentDerivedProjectPropertyInstance envProperty && envProperty.loggingContext?.IsValid == true && !envProperty._loggedEnvProperty)
+                if (this is EnvironmentDerivedProjectPropertyInstance envProperty && envProperty.loggingContext?.IsValid == true && !envProperty._loggedEnvProperty && !Traits.LogAllEnvironmentVariables)
                 {
                     EnvironmentVariableReadEventArgs args = new(Name, _escapedValue);
                     args.BuildEventContext = envProperty.loggingContext.BuildEventContext;

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -53,9 +53,7 @@ namespace Microsoft.Build.Logging
         //   - TargetSkippedEventArgs: added OriginallySucceeded, Condition, EvaluatedCondition
         // version 14:
         //   - TargetSkippedEventArgs: added SkipReason, OriginalBuildEventContext
-        // version 15:
-        //   - Log our own environment variables by default. (This affects the message in the structured log viewer.)
-        internal const int FileFormatVersion = 15;
+        internal const int FileFormatVersion = 14;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -53,7 +53,9 @@ namespace Microsoft.Build.Logging
         //   - TargetSkippedEventArgs: added OriginallySucceeded, Condition, EvaluatedCondition
         // version 14:
         //   - TargetSkippedEventArgs: added SkipReason, OriginalBuildEventContext
-        internal const int FileFormatVersion = 14;
+        // version 15:
+        //   - Log our own environment variables by default. (This affects the message in the structured log viewer.)
+        internal const int FileFormatVersion = 15;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
@@ -253,7 +254,7 @@ Build
             }
             else
             {
-                Write(0);
+                Write(e.BuildEnvironment.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)));
             }
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -254,7 +254,7 @@ Build
             }
             else
             {
-                Write(e.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)));
+                Write(e.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsWellKnownEnvironmentDerivedProperty(kvp.Key)));
             }
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -254,7 +254,7 @@ Build
             }
             else
             {
-                Write(e.BuildEnvironment.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)));
+                Write(e.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)));
             }
         }
 

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Build.BackEnd.Logging
             }
             else
             {
-                WriteEnvironment(e.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+                WriteEnvironment(e.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsWellKnownEnvironmentDerivedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
             }
         }
 

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -12,6 +12,7 @@ using Microsoft.Build.Utilities;
 using ColorSetter = Microsoft.Build.Logging.ColorSetter;
 using ColorResetter = Microsoft.Build.Logging.ColorResetter;
 using WriteHandler = Microsoft.Build.Logging.WriteHandler;
+using System.Linq;
 
 #nullable disable
 
@@ -234,6 +235,10 @@ namespace Microsoft.Build.BackEnd.Logging
             if (Traits.LogAllEnvironmentVariables)
             {
                 WriteEnvironment(e.BuildEnvironment);
+            }
+            else
+            {
+                WriteEnvironment(e.BuildEnvironment.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
             }
         }
 

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Build.BackEnd.Logging
             }
             else
             {
-                WriteEnvironment(e.BuildEnvironment.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+                WriteEnvironment(e.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
             }
         }
 

--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -11,6 +11,7 @@ using Microsoft.Build.Shared;
 using ColorSetter = Microsoft.Build.Logging.ColorSetter;
 using ColorResetter = Microsoft.Build.Logging.ColorResetter;
 using WriteHandler = Microsoft.Build.Logging.WriteHandler;
+using System.Linq;
 
 #nullable disable
 
@@ -111,6 +112,10 @@ namespace Microsoft.Build.BackEnd.Logging
             if (Traits.LogAllEnvironmentVariables)
             {
                 WriteEnvironment(e.BuildEnvironment);
+            }
+            else
+            {
+                WriteEnvironment(e.BuildEnvironment.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
             }
         }
 

--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Build.BackEnd.Logging
             }
             else
             {
-                WriteEnvironment(e.BuildEnvironment.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+                WriteEnvironment(e.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
             }
         }
 

--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Build.BackEnd.Logging
             }
             else
             {
-                WriteEnvironment(e.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+                WriteEnvironment(e.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsWellKnownEnvironmentDerivedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
             }
         }
 

--- a/src/Shared/EnvironmentUtilities.cs
+++ b/src/Shared/EnvironmentUtilities.cs
@@ -12,5 +12,12 @@ namespace Microsoft.Build.Shared
 
         public static bool Is64BitOperatingSystem =>
             Environment.Is64BitOperatingSystem;
+
+        public static bool IsReservedProperty(string propertyName)
+        {
+            return propertyName.StartsWith("MSBUILD") ||
+                propertyName.StartsWith("COMPLUS_") ||
+                propertyName.StartsWith("DOTNET_");
+        }
     }
 }

--- a/src/Shared/EnvironmentUtilities.cs
+++ b/src/Shared/EnvironmentUtilities.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.Shared
         public static bool Is64BitOperatingSystem =>
             Environment.Is64BitOperatingSystem;
 
-        public static bool IsReservedProperty(string propertyName)
+        public static bool IsWellKnownEnvironmentDerivedProperty(string propertyName)
         {
             return propertyName.StartsWith("MSBUILD") ||
                 propertyName.StartsWith("COMPLUS_") ||

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -862,7 +863,10 @@ namespace Microsoft.Build.Utilities
                         _firstProjectStartedEventContext = buildEvent.BuildEventContext;
 
                         // We've never seen a project started event, so raise the build started event and save this project started event.
-                        BuildStartedEventArgs startedEvent = new BuildStartedEventArgs(_buildStartedEvent.Message, _buildStartedEvent.HelpKeyword, Traits.LogAllEnvironmentVariables ? _buildStartedEvent.BuildEnvironment : null);
+                        BuildStartedEventArgs startedEvent =
+                            new BuildStartedEventArgs(_buildStartedEvent.Message,
+                            _buildStartedEvent.HelpKeyword,
+                            Traits.LogAllEnvironmentVariables ? _buildStartedEvent.BuildEnvironment : _buildStartedEvent.BuildEnvironment.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
                         RaiseBuildStartedEvent(sender, startedEvent);
                     }
 

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -866,7 +866,7 @@ namespace Microsoft.Build.Utilities
                         BuildStartedEventArgs startedEvent =
                             new BuildStartedEventArgs(_buildStartedEvent.Message,
                             _buildStartedEvent.HelpKeyword,
-                            Traits.LogAllEnvironmentVariables ? _buildStartedEvent.BuildEnvironment : _buildStartedEvent.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+                            Traits.LogAllEnvironmentVariables ? _buildStartedEvent.BuildEnvironment : _buildStartedEvent.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsWellKnownEnvironmentDerivedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
                         RaiseBuildStartedEvent(sender, startedEvent);
                     }
 

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -866,7 +866,7 @@ namespace Microsoft.Build.Utilities
                         BuildStartedEventArgs startedEvent =
                             new BuildStartedEventArgs(_buildStartedEvent.Message,
                             _buildStartedEvent.HelpKeyword,
-                            Traits.LogAllEnvironmentVariables ? _buildStartedEvent.BuildEnvironment : _buildStartedEvent.BuildEnvironment.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+                            Traits.LogAllEnvironmentVariables ? _buildStartedEvent.BuildEnvironment : _buildStartedEvent.BuildEnvironment?.Where(kvp => EnvironmentUtilities.IsReservedProperty(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
                         RaiseBuildStartedEvent(sender, startedEvent);
                     }
 


### PR DESCRIPTION
Fixes #7922

### Context
Although it's good to hide environment variables that may contain sensitive information, some variables seldom do and can be quite helpful in diagnosing build issues. This exempts environment variables that start with MSBUILD, COMPLUS_, and DOTNET_ from the normal filtering, even in the absence of MSBUILDLOGALLENVIRONMENTVARIABLES.

### Changes Made
Exempted certain environment variables. Also prevented any EnvironmentVariableReadEvents from firing if MSBUILDLOGALLENVIRONMENTVARIABLES is set.

### Testing
I built MSBuild.Dev.slnf and checked what its environment node contained.

### Notes
This will need a structured log viewer update to make it less confusing.

~Confusing to me, this only almost works. Specifically, it filtered out all environment variables except the intended ones _plus_ OS, LOCALAPPDATA, and USERPROFILE. I don't know what made those special.~