### PR TITLE
Update public pool names

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -144,21 +144,22 @@ jobs:
     continueOnError: true
     condition: always()
 
-- job: RichCodeNavIndex
-  displayName: "Windows Code Indexing"
-  pool:
-    vmImage: 'windows-2022'
-  steps:
-  - task: BatchScript@1
-    displayName: build.cmd
-    inputs:
-      filename: 'build.cmd'
-  - task: RichCodeNavIndexer@0
-    displayName: RichCodeNav Upload
-    inputs:
-      languages: 'csharp'
-    continueOnError: true
-    condition: succeeded()
+# Unavailable in dnceng-public as of 9/1/2022; should be restored soon.
+# - job: RichCodeNavIndex
+#   displayName: "Windows Code Indexing"
+#   pool:
+#     vmImage: 'windows-2022'
+#   steps:
+#   - task: BatchScript@1
+#     displayName: build.cmd
+#     inputs:
+#       filename: 'build.cmd'
+#   - task: RichCodeNavIndexer@0
+#     displayName: RichCodeNav Upload
+#     inputs:
+#       languages: 'csharp'
+#     continueOnError: true
+#     condition: succeeded()
 
 - job: CoreBootstrappedOnLinux
   displayName: "Linux Core"

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -46,7 +46,7 @@ jobs:
     # source-build builds run in Docker, including the default managed platform.
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore-Public
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Internal


### PR DESCRIPTION
This change is required to continue building PRs in the dotnet public repo.  The agents and images used in the new project / organization are identical and build regressions are not expected.  Updating files under eng/common is intentional to move as much as possible over to viable build agents (normally this is not done).

For questions / concerns, please stop by the .NET Core Engineering Services [First Responders Teams Channel](https://teams.microsoft.com/l/channel/19%3aafba3d1545dd45d7b79f34c1821f6055%40thread.skype/First%2520Responders?groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).
