### PR TITLE
Prevent InternalError exceptions on BadImages

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -14,6 +14,7 @@ using Xunit;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 using Xunit.Abstractions;
 using Shouldly;
+using Microsoft.Build.UnitTests.Shared;
 
 #nullable disable
 
@@ -92,6 +93,25 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
         public Miscellaneous(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [Fact]
+        public void test()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            TransientTestFolder folder = env.CreateFolder(createFolder: true);
+            TransientTestFile pdb = env.CreateFile(folder, "x.pdb", @"not_assembly_text");
+            ResolveAssemblyReference t = new()
+            {
+                SearchPaths = new string[] { folder.Path },
+                BuildEngine = new MockEngine(),
+                AllowedRelatedFileExtensions = new string[] { ".pdb" },
+                Assemblies = new ITaskItem[] { new TaskItem("x.dll"), new TaskItem("x.pdb") },
+                AssemblyFiles = new ITaskItem[] { new TaskItem("x.dll") }
+            };
+
+            bool success = Execute(t);
+            success.ShouldBeTrue();
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 Assemblies = new ITaskItem[] { xpdb },
                 AssemblyFiles = new ITaskItem[] { x },
                 SearchPaths = new string[] { "{RawFileName}" },
-        };
+            };
 
             bool success = Execute(t);
             success.ShouldBeTrue();

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -96,9 +96,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         }
 
         [Fact]
-        public void test()
+        public void VerifyPrimaryReferenceToBadImageDoesNotThrow()
         {
-            ITaskItem w = new TaskItem(Path.Combine(s_myComponentsRootPath, "DependsOnX.dll"));
             ITaskItem x = new TaskItem(Path.Combine(s_myComponentsRootPath, "X.dll"));
             ITaskItem xpdb = new TaskItem(Path.Combine(s_myComponentsRootPath, "X.pdb"));
             ResolveAssemblyReference t = new()
@@ -106,8 +105,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 BuildEngine = new MockEngine(),
                 AllowedRelatedFileExtensions = new string[] { ".pdb" },
                 Assemblies = new ITaskItem[] { xpdb },
-                AssemblyFiles = new ITaskItem[] { w, x },
-                SearchPaths = new string[] { s_myComponentsRootPath }
+                AssemblyFiles = new ITaskItem[] { x },
+                SearchPaths = new string[] { "{RawFileName}" },
         };
 
             bool success = Execute(t);

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -98,14 +98,15 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void test()
         {
+            ITaskItem w = new TaskItem(Path.Combine(s_myComponentsRootPath, "DependsOnX.dll"));
             ITaskItem x = new TaskItem(Path.Combine(s_myComponentsRootPath, "X.dll"));
             ITaskItem xpdb = new TaskItem(Path.Combine(s_myComponentsRootPath, "X.pdb"));
             ResolveAssemblyReference t = new()
             {
                 BuildEngine = new MockEngine(),
                 AllowedRelatedFileExtensions = new string[] { ".pdb" },
-                Assemblies = new ITaskItem[] { x, xpdb },
-                AssemblyFiles = new ITaskItem[] { x, xpdb },
+                Assemblies = new ITaskItem[] { xpdb },
+                AssemblyFiles = new ITaskItem[] { w, x },
                 SearchPaths = new string[] { s_myComponentsRootPath }
         };
 

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -98,17 +98,16 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void test()
         {
-            using TestEnvironment env = TestEnvironment.Create();
-            TransientTestFolder folder = env.CreateFolder(createFolder: true);
-            TransientTestFile pdb = env.CreateFile(folder, "x.pdb", @"not_assembly_text");
+            ITaskItem x = new TaskItem(Path.Combine(s_myComponentsRootPath, "X.dll"));
+            ITaskItem xpdb = new TaskItem(Path.Combine(s_myComponentsRootPath, "X.pdb"));
             ResolveAssemblyReference t = new()
             {
-                SearchPaths = new string[] { folder.Path },
                 BuildEngine = new MockEngine(),
                 AllowedRelatedFileExtensions = new string[] { ".pdb" },
-                Assemblies = new ITaskItem[] { new TaskItem("x.dll"), new TaskItem("x.pdb") },
-                AssemblyFiles = new ITaskItem[] { new TaskItem("x.dll") }
-            };
+                Assemblies = new ITaskItem[] { x, xpdb },
+                AssemblyFiles = new ITaskItem[] { x, xpdb },
+                SearchPaths = new string[] { s_myComponentsRootPath }
+        };
 
             bool success = Execute(t);
             success.ShouldBeTrue();

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 #if FEATURE_WIN32_REGISTRY
         internal static Microsoft.Build.Shared.OpenBaseKey openBaseKey = new Microsoft.Build.Shared.OpenBaseKey(GetBaseKey);
 #endif
+        internal Microsoft.Build.UnitTests.MockEngine.GetStringDelegate resourceDelegate = new Microsoft.Build.UnitTests.MockEngine.GetStringDelegate(AssemblyResources.GetString);
         internal static Microsoft.Build.Tasks.IsWinMDFile isWinMDFile = new Microsoft.Build.Tasks.IsWinMDFile(IsWinMDFile);
         internal static Microsoft.Build.Tasks.ReadMachineTypeFromPEHeader readMachineTypeFromPEHeader = new Microsoft.Build.Tasks.ReadMachineTypeFromPEHeader(ReadMachineTypeFromPEHeader);
 
-        internal Microsoft.Build.UnitTests.MockEngine.GetStringDelegate resourceDelegate = new Microsoft.Build.UnitTests.MockEngine.GetStringDelegate(AssemblyResources.GetString);
         // Performance checks.
         internal static Dictionary<string, int> uniqueFileExists = null;
         internal static Dictionary<string, int> uniqueGetAssemblyName = null;
@@ -1439,7 +1439,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.pdb"), StringComparison.OrdinalIgnoreCase))
             {
                 // return new AssemblyNameExtension("X, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null");
-                throw new BadImageFormatException("Bad Image");
+                throw new BadImageFormatException("X.pdb is a PDB file, not a managed assembly");
             }
 
             if (String.Equals(path, @"C:\Regress714052\X86\a.dll", StringComparison.OrdinalIgnoreCase))
@@ -2366,14 +2366,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 return new AssemblyNameExtension[]
                 {
                     new AssemblyNameExtension("Z, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null")
-                };
-            }
-
-            if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.pdb"), StringComparison.OrdinalIgnoreCase))
-            {
-                return new AssemblyNameExtension[]
-                {
-                    new AssemblyNameExtension("X, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null")
                 };
             }
 

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -545,6 +545,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Path.Combine(s_myComponentsRootPath, "V.dll"),
             Path.Combine(s_myComponents2RootPath, "W.dll"),
+            Path.Combine(s_myComponentsRootPath, "DependsOnX.dll"),
             Path.Combine(s_myComponentsRootPath, "X.dll"),
             Path.Combine(s_myComponentsRootPath, "X.pdb"),
             Path.Combine(s_myComponentsRootPath, "Y.dll"),
@@ -1438,8 +1439,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.pdb"), StringComparison.OrdinalIgnoreCase))
             {
-                // throw new BadImageReferenceException("Bad Image", null);
-                return new AssemblyNameExtension("X, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null");
+                // return new AssemblyNameExtension("X, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null");
+                throw new BadImageReferenceException("Bad Image", null);
             }
 
             if (String.Equals(path, @"C:\Regress714052\X86\a.dll", StringComparison.OrdinalIgnoreCase))
@@ -1491,6 +1492,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             if (String.Equals(path, Path.Combine(s_myComponents2RootPath, "W.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 return new AssemblyNameExtension("W, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null");
+            }
+            if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "DependsOnX.dll"), StringComparison.OrdinalIgnoreCase))
+            {
+                return new AssemblyNameExtension("DependsOnX, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null");
             }
             if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.dll"), StringComparison.OrdinalIgnoreCase))
             {
@@ -2359,6 +2364,14 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             if (String.Equals(path, Path.Combine(s_myComponents2RootPath, "W.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 return Array.Empty<AssemblyNameExtension>();
+            }
+
+            if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "DependsOnX.dll"), StringComparison.OrdinalIgnoreCase))
+            {
+                return new AssemblyNameExtension[]
+                {
+                    new AssemblyNameExtension("X, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null")
+                };
             }
 
             if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.dll"), StringComparison.OrdinalIgnoreCase))

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -545,7 +545,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Path.Combine(s_myComponentsRootPath, "V.dll"),
             Path.Combine(s_myComponents2RootPath, "W.dll"),
-            Path.Combine(s_myComponentsRootPath, "DependsOnX.dll"),
             Path.Combine(s_myComponentsRootPath, "X.dll"),
             Path.Combine(s_myComponentsRootPath, "X.pdb"),
             Path.Combine(s_myComponentsRootPath, "Y.dll"),
@@ -1440,7 +1439,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.pdb"), StringComparison.OrdinalIgnoreCase))
             {
                 // return new AssemblyNameExtension("X, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null");
-                throw new BadImageReferenceException("Bad Image", null);
+                throw new BadImageFormatException("Bad Image");
             }
 
             if (String.Equals(path, @"C:\Regress714052\X86\a.dll", StringComparison.OrdinalIgnoreCase))
@@ -1492,10 +1491,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             if (String.Equals(path, Path.Combine(s_myComponents2RootPath, "W.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 return new AssemblyNameExtension("W, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null");
-            }
-            if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "DependsOnX.dll"), StringComparison.OrdinalIgnoreCase))
-            {
-                return new AssemblyNameExtension("DependsOnX, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null");
             }
             if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.dll"), StringComparison.OrdinalIgnoreCase))
             {
@@ -2364,14 +2359,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             if (String.Equals(path, Path.Combine(s_myComponents2RootPath, "W.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 return Array.Empty<AssemblyNameExtension>();
-            }
-
-            if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "DependsOnX.dll"), StringComparison.OrdinalIgnoreCase))
-            {
-                return new AssemblyNameExtension[]
-                {
-                    new AssemblyNameExtension("X, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null")
-                };
             }
 
             if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.dll"), StringComparison.OrdinalIgnoreCase))

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 #if FEATURE_WIN32_REGISTRY
         internal static Microsoft.Build.Shared.OpenBaseKey openBaseKey = new Microsoft.Build.Shared.OpenBaseKey(GetBaseKey);
 #endif
-        internal Microsoft.Build.UnitTests.MockEngine.GetStringDelegate resourceDelegate = new Microsoft.Build.UnitTests.MockEngine.GetStringDelegate(AssemblyResources.GetString);
         internal static Microsoft.Build.Tasks.IsWinMDFile isWinMDFile = new Microsoft.Build.Tasks.IsWinMDFile(IsWinMDFile);
         internal static Microsoft.Build.Tasks.ReadMachineTypeFromPEHeader readMachineTypeFromPEHeader = new Microsoft.Build.Tasks.ReadMachineTypeFromPEHeader(ReadMachineTypeFromPEHeader);
 
+        internal Microsoft.Build.UnitTests.MockEngine.GetStringDelegate resourceDelegate = new Microsoft.Build.UnitTests.MockEngine.GetStringDelegate(AssemblyResources.GetString);
         // Performance checks.
         internal static Dictionary<string, int> uniqueFileExists = null;
         internal static Dictionary<string, int> uniqueGetAssemblyName = null;
@@ -546,6 +546,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Path.Combine(s_myComponentsRootPath, "V.dll"),
             Path.Combine(s_myComponents2RootPath, "W.dll"),
             Path.Combine(s_myComponentsRootPath, "X.dll"),
+            Path.Combine(s_myComponentsRootPath, "X.pdb"),
             Path.Combine(s_myComponentsRootPath, "Y.dll"),
             Path.Combine(s_myComponentsRootPath, "Z.dll"),
 
@@ -1433,6 +1434,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 // Simulate a strongly named assembly.
                 return new AssemblyNameExtension("D, Version=1.0.0.0, Culture=Neutral, PublicKeyToken=null");
+            }
+
+            if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.pdb"), StringComparison.OrdinalIgnoreCase))
+            {
+                // throw new BadImageReferenceException("Bad Image", null);
+                return new AssemblyNameExtension("X, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null");
             }
 
             if (String.Equals(path, @"C:\Regress714052\X86\a.dll", StringComparison.OrdinalIgnoreCase))
@@ -2359,6 +2366,14 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 return new AssemblyNameExtension[]
                 {
                     new AssemblyNameExtension("Z, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null")
+                };
+            }
+
+            if (String.Equals(path, Path.Combine(s_myComponentsRootPath, "X.pdb"), StringComparison.OrdinalIgnoreCase))
+            {
+                return new AssemblyNameExtension[]
+                {
+                    new AssemblyNameExtension("X, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null")
                 };
             }
 

--- a/src/Tasks/AssemblyDependency/CopyLocalState.cs
+++ b/src/Tasks/AssemblyDependency/CopyLocalState.cs
@@ -72,6 +72,11 @@ namespace Microsoft.Build.Tasks
         /// The property copyLocalDependenciesWhenParentReferenceInGac is set to false and all the parent source items were found in the GAC.
         /// </summary>
         NoBecauseParentReferencesFoundInGAC,
+
+        /// <summary>
+        /// The "assembly" should not be copied because it is a bad image—possibly not managed, possibly not an assembly at all.
+        /// </summary>
+        NoBecauseBadImage,
     }
 
     /// <remarks>
@@ -98,6 +103,7 @@ namespace Microsoft.Build.Tasks
                 case CopyLocalState.NoBecauseReferenceFoundInGAC:
                 case CopyLocalState.NoBecauseEmbedded:
                 case CopyLocalState.NoBecauseParentReferencesFoundInGAC:
+                case CopyLocalState.NoBecauseBadImage:
                     return false;
                 default:
                     throw new InternalErrorException("Unexpected CopyLocal flag.");

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -969,6 +969,11 @@ namespace Microsoft.Build.Tasks
             ReferenceTable referenceTable
         )
         {
+            if (IsBadImage)
+            {
+                CopyLocal = CopyLocalState.NoBecauseBadImage;
+            }
+
             // If this item was unresolvable, then copy-local is false.
             if (IsUnresolvable)
             {

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -972,6 +972,7 @@ namespace Microsoft.Build.Tasks
             if (IsBadImage)
             {
                 CopyLocal = CopyLocalState.NoBecauseBadImage;
+                return;
             }
 
             // If this item was unresolvable, then copy-local is false.

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Build.Tasks
             public static string LogAttributeFormat;
             public static string LogTaskPropertyFormat;
             public static string NoBecauseParentReferencesFoundInGac;
+            public static string NoBecauseBadImage;
             public static string NotCopyLocalBecauseConflictVictim;
             public static string NotCopyLocalBecauseEmbedded;
             public static string NotCopyLocalBecauseFrameworksFiles;
@@ -132,6 +133,7 @@ namespace Microsoft.Build.Tasks
                 IsAWinMdFile = GetResourceFourSpaces("ResolveAssemblyReference.IsAWinMdFile");
                 LogAttributeFormat = GetResourceEightSpaces("ResolveAssemblyReference.LogAttributeFormat");
                 LogTaskPropertyFormat = GetResource("ResolveAssemblyReference.LogTaskPropertyFormat");
+                NoBecauseBadImage = GetResourceFourSpaces("ResolveAssemblyReference.NoBecauseBadImage");
                 NoBecauseParentReferencesFoundInGac = GetResourceFourSpaces("ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac");
                 NotCopyLocalBecauseConflictVictim = GetResourceFourSpaces("ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim");
                 NotCopyLocalBecauseEmbedded = GetResourceFourSpaces("ResolveAssemblyReference.NotCopyLocalBecauseEmbedded");
@@ -1938,6 +1940,10 @@ namespace Microsoft.Build.Tasks
 
                     case CopyLocalState.NoBecauseParentReferencesFoundInGAC:
                         Log.LogMessage(importance, Strings.NoBecauseParentReferencesFoundInGac);
+                        break;
+
+                    case CopyLocalState.NoBecauseBadImage:
+                        Log.LogMessage(importance, Strings.NoBecauseBadImage);
                         break;
 
                     default:

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1074,7 +1074,7 @@ namespace Microsoft.Build.Tasks
                         string fusionName = assemblyName.FullName;
                         Reference primaryCandidate = dependencyTable.GetReference(assemblyName);
 
-                        if (primaryCandidate.IsPrimary && !(primaryCandidate.IsConflictVictim && primaryCandidate.IsCopyLocal))
+                        if (primaryCandidate.IsPrimary && !(primaryCandidate.IsConflictVictim && primaryCandidate.IsCopyLocal) && primaryCandidate.CopyLocal != CopyLocalState.NoBecauseBadImage)
                         {
                             LogReference(primaryCandidate, fusionName);
                         }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1074,7 +1074,7 @@ namespace Microsoft.Build.Tasks
                         string fusionName = assemblyName.FullName;
                         Reference primaryCandidate = dependencyTable.GetReference(assemblyName);
 
-                        if (primaryCandidate.IsPrimary && !(primaryCandidate.IsConflictVictim && primaryCandidate.IsCopyLocal) && primaryCandidate.CopyLocal != CopyLocalState.NoBecauseBadImage)
+                        if (primaryCandidate.IsPrimary && !(primaryCandidate.IsConflictVictim && primaryCandidate.IsCopyLocal))
                         {
                             LogReference(primaryCandidate, fusionName);
                         }

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1618,7 +1618,7 @@
   <data name="ResolveAssemblyReference.NoBecauseBadImage">
     <value>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</value>
     <comment>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </comment>
   </data>
   <data name="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1615,6 +1615,12 @@
         LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
    </comment>
   </data>
+  <data name="ResolveAssemblyReference.NoBecauseBadImage">
+    <value>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</value>
+    <comment>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </comment>
+  </data>
   <data name="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
     <value>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</value>
     <comment>

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1616,7 +1616,7 @@
    </comment>
   </data>
   <data name="ResolveAssemblyReference.NoBecauseBadImage">
-    <value>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</value>
+    <value>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</value>
     <comment>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </comment>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">Umístění AssemblyFoldersEx: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Byla uvažována umístění AssemblyFoldersEx.</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">Speicherort von AssemblyFoldersEx: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Berücksichtigte Speicherorte von AssemblyFoldersEx.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">Ubicación de AssemblyFoldersEx: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Ubicaciones de AssemblyFoldersEx consideradas.</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">Emplacement d'AssemblyFoldersEx : "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Emplacements d'AssemblyFoldersEx envisagés.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">Percorso AssemblyFoldersEx: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Percorsi AssemblyFoldersEx considerati.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">AssemblyFoldersEx の場所:"{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">AssemblyFoldersEx の場所が考慮されました。</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">AssemblyFoldersEx 위치: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">AssemblyFoldersEx 위치로 간주했습니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">Lokalizacja klucza rejestru AssemblyFoldersEx: „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Wybrano lokalizacje klucza rejestru AssemblyFoldersEx.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">Localização de AssemblyFoldersEx: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Localizações de AssemblyFoldersEx consideradas.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">Расположение AssemblyFoldersEx: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Рассмотрены расположения AssemblyFoldersEx.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">AssemblyFoldersEx konumu: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">AssemblyFoldersEx konumları dikkate alındı.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">AssemblyFoldersEx 位置:“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">已考虑 AssemblyFoldersEx 位置。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1616,7 +1616,7 @@
         <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
         <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
         <note>
-      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1612,6 +1612,13 @@
         <target state="translated">AssemblyFoldersEx 位置: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <note>
+      LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+    </note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">已考慮 AssemblyFoldersEx 位置。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1613,8 +1613,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResolveAssemblyReference.NoBecauseBadImage">
-        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</source>
-        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native assembly, or it may not be an assembly at all.</target>
+        <source>This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</source>
+        <target state="new">This reference is not "CopyLocal" because it is a bad image. It may be a native binary, or it may not be an assembly at all.</target>
         <note>
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>


### PR DESCRIPTION
Fixes internally reported issue.

### Context
We currently skip resolving information about bad images, and that includes not setting whether they are CopyLocal. When we get to logging our results, we assume it's set, since it's set for all not-BadImages. This ensures we only access IsCopyLocal if it has been set.

### Changes Made
Check for IsBadImage before accessing IsCopyLocal.

### Testing


### Notes
