### PR TITLE
Fix processor count on Windows for multiple processor groups

### DIFF
--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -509,13 +509,7 @@ internal static class NativeMethods
         // .NET Core on Windows returns a core count limited to the current NUMA node
         //     https://github.com/dotnet/runtime/issues/29686
         // so always double-check it.
-        if (IsWindows
-#if NETFRAMEWORK
-            // .NET Framework calls Windows APIs that have a core count limit (32/64 depending on process bitness).
-            // So if we get a high core count on full framework, double-check it.
-            && (numberOfCpus >= 32)
-#endif
-            )
+        if (IsWindows)
         {
             var result = GetLogicalCoreCountOnWindows();
             if (result != -1)

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -478,15 +478,21 @@ internal static class NativeMethods
 
     public static int GetLogicalCoreCount()
     {
+        int numberOfCpus = Environment.ProcessorCount;
 #if !MONO
         // .NET Core on Windows returns a core count limited to the current NUMA node
         //     https://github.com/dotnet/runtime/issues/29686
         if (IsWindows)
         {
-            return GetLogicalCoreCountOnWindows();
+            var result = GetLogicalCoreCountOnWindows();
+
+            if (result != 0)
+            {
+                numberOfCpus = result;
+            }
         }
 #endif
-        return Environment.ProcessorCount;
+        return numberOfCpus;
     }
 
     /// <summary>

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -478,21 +478,15 @@ internal static class NativeMethods
 
     public static int GetLogicalCoreCount()
     {
-        int numberOfCpus = Environment.ProcessorCount;
 #if !MONO
         // .NET Core on Windows returns a core count limited to the current NUMA node
         //     https://github.com/dotnet/runtime/issues/29686
         if (IsWindows)
         {
-            var result = GetLogicalCoreCountOnWindows();
-
-            if (result != 0)
-            {
-                numberOfCpus = result;
-            }
+            return GetLogicalCoreCountOnWindows();
         }
 #endif
-        return numberOfCpus;
+        return Environment.ProcessorCount;
     }
 
     /// <summary>

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -128,6 +128,32 @@ internal static class NativeMethods
         PROCESS_QUERY_INFORMATION = 0x0400,
         PROCESS_ALL_ACCESS = SYNCHRONIZE | 0xFFF
     }
+#pragma warning disable 0649, 0169
+    internal enum LOGICAL_PROCESSOR_RELATIONSHIP
+    {
+        RelationProcessorCore,
+        RelationNumaNode,
+        RelationCache,
+        RelationProcessorPackage,
+        RelationGroup,
+        RelationAll = 0xffff
+    }
+    internal struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX
+    {
+        public LOGICAL_PROCESSOR_RELATIONSHIP Relationship;
+        public uint Size;
+        public PROCESSOR_RELATIONSHIP Processor;
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct PROCESSOR_RELATIONSHIP
+    {
+        public byte Flags;
+        private byte EfficiencyClass;
+        private fixed byte Reserved[20];
+        public ushort GroupCount;
+        public IntPtr GroupInfo;
+    }
+#pragma warning restore 0169, 0149
 
     /// <summary>
     /// Flags for CoWaitForMultipleHandles
@@ -478,15 +504,28 @@ internal static class NativeMethods
 
     public static int GetLogicalCoreCount()
     {
+        int numberOfCpus = Environment.ProcessorCount;
 #if !MONO
         // .NET Core on Windows returns a core count limited to the current NUMA node
         //     https://github.com/dotnet/runtime/issues/29686
-        if (IsWindows)
+        // so always double-check it.
+        if (IsWindows
+#if NETFRAMEWORK
+            // .NET Framework calls Windows APIs that have a core count limit (32/64 depending on process bitness).
+            // So if we get a high core count on full framework, double-check it.
+            && (numberOfCpus >= 32)
+#endif
+            )
         {
-            return GetLogicalCoreCountOnWindows();
+            var result = GetLogicalCoreCountOnWindows();
+            if (result != -1)
+            {
+                numberOfCpus = result;
+            }
         }
 #endif
-        return Environment.ProcessorCount;
+
+        return numberOfCpus;
     }
 
     /// <summary>
@@ -498,7 +537,41 @@ internal static class NativeMethods
     [SupportedOSPlatform("windows")]
     private unsafe static int GetLogicalCoreCountOnWindows()
     {
-        return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+        uint len = 0;
+        const int ERROR_INSUFFICIENT_BUFFER = 122;
+
+        if (!GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore, IntPtr.Zero, ref len) &&
+            Marshal.GetLastWin32Error() == ERROR_INSUFFICIENT_BUFFER)
+        {
+            // Allocate that much space
+            var buffer = new byte[len];
+            fixed (byte* bufferPtr = buffer)
+            {
+                // Call GetLogicalProcessorInformationEx with the allocated buffer
+                if (GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore, (IntPtr)bufferPtr, ref len))
+                {
+                    // Walk each SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX in the buffer, where the Size of each dictates how
+                    // much space it's consuming.  For each group relation, count the number of active processors in each of its group infos.
+                    int processorCount = 0;
+                    byte* ptr = bufferPtr;
+                    byte* endPtr = bufferPtr + len;
+                    while (ptr < endPtr)
+                    {
+                        var current = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)ptr;
+                        if (current->Relationship == LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore)
+                        {
+                            // Flags is 0 if the core has a single logical proc, LTP_PC_SMT if more than one
+                            // for now, assume "more than 1" == 2, as it has historically been for hyperthreading
+                            processorCount += (current->Processor.Flags == 0) ? 1 : 2;
+                        }
+                        ptr += current->Size;
+                    }
+                    return processorCount;
+                }
+            }
+        }
+
+        return -1;
     }
 
 #endregion
@@ -822,11 +895,9 @@ internal static class NativeMethods
     [SupportedOSPlatform("windows")]
     internal static extern void GetNativeSystemInfo(ref SYSTEM_INFO lpSystemInfo);
 
-    const ushort ALL_PROCESSOR_GROUPS = 0xFFFF;
-
-    [DllImport("kernel32.dll")]
+    [DllImport("kernel32.dll", SetLastError = true)]
     [SupportedOSPlatform("windows")]
-    internal static extern int GetActiveProcessorCount(ushort GroupNumber);
+    internal static extern bool GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP RelationshipType, IntPtr Buffer, ref uint ReturnedLength);
 
     /// <summary>
     /// Get the last write time of the fullpath to a directory. If the pointed path is not a directory, or

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -506,7 +506,7 @@ internal static class NativeMethods
     {
         int numberOfCpus = Environment.ProcessorCount;
 #if !MONO
-        // .NET Core on Windows returns a core count limited to the current NUMA node
+        // .NET on Windows returns a core count limited to the current NUMA node
         //     https://github.com/dotnet/runtime/issues/29686
         // so always double-check it.
         if (IsWindows)

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -128,32 +128,6 @@ internal static class NativeMethods
         PROCESS_QUERY_INFORMATION = 0x0400,
         PROCESS_ALL_ACCESS = SYNCHRONIZE | 0xFFF
     }
-#pragma warning disable 0649, 0169
-    internal enum LOGICAL_PROCESSOR_RELATIONSHIP
-    {
-        RelationProcessorCore,
-        RelationNumaNode,
-        RelationCache,
-        RelationProcessorPackage,
-        RelationGroup,
-        RelationAll = 0xffff
-    }
-    internal struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX
-    {
-        public LOGICAL_PROCESSOR_RELATIONSHIP Relationship;
-        public uint Size;
-        public PROCESSOR_RELATIONSHIP Processor;
-    }
-    [StructLayout(LayoutKind.Sequential)]
-    internal unsafe struct PROCESSOR_RELATIONSHIP
-    {
-        public byte Flags;
-        private byte EfficiencyClass;
-        private fixed byte Reserved[20];
-        public ushort GroupCount;
-        public IntPtr GroupInfo;
-    }
-#pragma warning restore 0169, 0149
 
     /// <summary>
     /// Flags for CoWaitForMultipleHandles
@@ -504,28 +478,15 @@ internal static class NativeMethods
 
     public static int GetLogicalCoreCount()
     {
-        int numberOfCpus = Environment.ProcessorCount;
 #if !MONO
         // .NET Core on Windows returns a core count limited to the current NUMA node
         //     https://github.com/dotnet/runtime/issues/29686
-        // so always double-check it.
-        if (IsWindows
-#if NETFRAMEWORK
-            // .NET Framework calls Windows APIs that have a core count limit (32/64 depending on process bitness).
-            // So if we get a high core count on full framework, double-check it.
-            && (numberOfCpus >= 32)
-#endif
-            )
+        if (IsWindows)
         {
-            var result = GetLogicalCoreCountOnWindows();
-            if (result != -1)
-            {
-                numberOfCpus = result;
-            }
+            return GetLogicalCoreCountOnWindows();
         }
 #endif
-
-        return numberOfCpus;
+        return Environment.ProcessorCount;
     }
 
     /// <summary>
@@ -537,41 +498,7 @@ internal static class NativeMethods
     [SupportedOSPlatform("windows")]
     private unsafe static int GetLogicalCoreCountOnWindows()
     {
-        uint len = 0;
-        const int ERROR_INSUFFICIENT_BUFFER = 122;
-
-        if (!GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore, IntPtr.Zero, ref len) &&
-            Marshal.GetLastWin32Error() == ERROR_INSUFFICIENT_BUFFER)
-        {
-            // Allocate that much space
-            var buffer = new byte[len];
-            fixed (byte* bufferPtr = buffer)
-            {
-                // Call GetLogicalProcessorInformationEx with the allocated buffer
-                if (GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore, (IntPtr)bufferPtr, ref len))
-                {
-                    // Walk each SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX in the buffer, where the Size of each dictates how
-                    // much space it's consuming.  For each group relation, count the number of active processors in each of its group infos.
-                    int processorCount = 0;
-                    byte* ptr = bufferPtr;
-                    byte* endPtr = bufferPtr + len;
-                    while (ptr < endPtr)
-                    {
-                        var current = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)ptr;
-                        if (current->Relationship == LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore)
-                        {
-                            // Flags is 0 if the core has a single logical proc, LTP_PC_SMT if more than one
-                            // for now, assume "more than 1" == 2, as it has historically been for hyperthreading
-                            processorCount += (current->Processor.Flags == 0) ? 1 : 2;
-                        }
-                        ptr += current->Size;
-                    }
-                    return processorCount;
-                }
-            }
-        }
-
-        return -1;
+        return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
     }
 
 #endregion
@@ -895,9 +822,11 @@ internal static class NativeMethods
     [SupportedOSPlatform("windows")]
     internal static extern void GetNativeSystemInfo(ref SYSTEM_INFO lpSystemInfo);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
+    const ushort ALL_PROCESSOR_GROUPS = 0xFFFF;
+
+    [DllImport("kernel32.dll")]
     [SupportedOSPlatform("windows")]
-    internal static extern bool GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP RelationshipType, IntPtr Buffer, ref uint ReturnedLength);
+    internal static extern int GetActiveProcessorCount(ushort GroupNumber);
 
     /// <summary>
     /// Get the last write time of the fullpath to a directory. If the pointed path is not a directory, or


### PR DESCRIPTION
Fixes #7943

### Context
MSBuild detects the wrong processor count on Windows when debugging processor groups

### Changes Made
Replaces GetLogicalProcessorInformationEx with GetActiveProcessorCount and removes an incorrect check for >32 processors which is incompatible with Windows boot parameters for debugging processor groups.


### Testing


### Notes
