### PR TITLE
Use targets from the .NET SDK

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -310,8 +310,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </Target>
 
     <PropertyGroup>
-        <!-- Design-time builds require a newer version than 1.0 to succeed, so override back to inbox in that case -->
-        <CSharpCoreTargetsPath Condition="'$(CSharpCoreTargetsPath)' == '' or ('$(DesignTimeBuild)' == 'true' and $(CSharpCoreTargetsPath.Contains('Microsoft.Net.Compilers.1.0.0')))">$(RoslynTargetsPath)\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
+      <!-- If the SDK specified a path to a .NET Core version of the targets (from the SDK), use that so we align with their version but allow the user to override this. -->
+      <CSharpCoreTargetsPath Condition="'$(CSharpCoreTargetsPath)' == ''">$(CSharpCoreTargetsFromSdkPath)</CSharpCoreTargetsPath>
+
+      <!-- Design-time builds require a newer version than 1.0 to succeed, so override back to inbox in that case -->
+      <CSharpCoreTargetsPath Condition="'$(CSharpCoreTargetsPath)' == '' or ('$(DesignTimeBuild)' == 'true' and $(CSharpCoreTargetsPath.Contains('Microsoft.Net.Compilers.1.0.0')))">$(RoslynTargetsPath)\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
     </PropertyGroup>
 
     <Import Project="$(CSharpCoreTargetsPath)" />


### PR DESCRIPTION
Fixes the MSBuild side of #7832 

Specifically, the plan is that Roslyn will restructure their nupkg to include framework bits in a standard location. The SDK will then xcopy those somewhere then set this path. MSBuild will see that path (if it's set) and know to use that specific version of the roslyn targets to avoid version mismatches.

There isn't any required ordering between this part and the other two, and since it should have ~0 impact without the other two parts, I think it's fine to put it in now.

### Context


### Changes Made


### Testing


### Notes
