### PR TITLE
Support for Arm64 immutable directories fast file up to date check

### DIFF
--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -446,12 +446,7 @@ namespace Microsoft.Build.Evaluation
                     string frameworksPathPrefix64 = rootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPath64")?.EvaluatedValue?.Trim());
                     FileClassifier.Shared.RegisterImmutableDirectory(frameworksPathPrefix64);
                     // example: C:\Windows\Microsoft.NET\FrameworkArm64
-                    // TODO: Apply MSBuildFrameworkToolsPathArm64 or equivalent as soon as there is one
-                    string frameworksPathPrefixArm64 = rootOrNull(frameworksPathPrefix32 ?? frameworksPathPrefix64);
-                    if (!string.IsNullOrEmpty(frameworksPathPrefixArm64))
-                    {
-                        frameworksPathPrefixArm64 = Path.Combine(frameworksPathPrefixArm64, "FrameworkArm64");
-                    }
+                    string frameworksPathPrefixArm64 = rootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPathArm64")?.EvaluatedValue?.Trim());
                     FileClassifier.Shared.RegisterImmutableDirectory(frameworksPathPrefixArm64);
 
                     if (toolset != null)

--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -440,13 +440,13 @@ namespace Microsoft.Build.Evaluation
 
                     // Register toolset paths into list of immutable directories
                     // example: C:\Windows\Microsoft.NET\Framework
-                    string frameworksPathPrefix32 = rootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPath32")?.EvaluatedValue?.Trim());
+                    string frameworksPathPrefix32 = existingRootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPath32")?.EvaluatedValue?.Trim());
                     FileClassifier.Shared.RegisterImmutableDirectory(frameworksPathPrefix32);
                     // example: C:\Windows\Microsoft.NET\Framework64
-                    string frameworksPathPrefix64 = rootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPath64")?.EvaluatedValue?.Trim());
+                    string frameworksPathPrefix64 = existingRootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPath64")?.EvaluatedValue?.Trim());
                     FileClassifier.Shared.RegisterImmutableDirectory(frameworksPathPrefix64);
                     // example: C:\Windows\Microsoft.NET\FrameworkArm64
-                    string frameworksPathPrefixArm64 = rootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPathArm64")?.EvaluatedValue?.Trim());
+                    string frameworksPathPrefixArm64 = existingRootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPathArm64")?.EvaluatedValue?.Trim());
                     FileClassifier.Shared.RegisterImmutableDirectory(frameworksPathPrefixArm64);
 
                     if (toolset != null)
@@ -456,7 +456,7 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            string rootOrNull(string path)
+            string existingRootOrNull(string path)
             {
                 if (!string.IsNullOrEmpty(path))
                 {

--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -463,6 +463,11 @@ namespace Microsoft.Build.Evaluation
                     try
                     {
                         path = Directory.GetParent(FileUtilities.EnsureNoTrailingSlash(path))?.FullName;
+
+                        if (!Directory.Exists(path))
+                        {
+                            path = null;
+                        }
                     }
                     catch
                     {

--- a/src/Framework/FileClassifier.cs
+++ b/src/Framework/FileClassifier.cs
@@ -76,17 +76,15 @@ namespace Microsoft.Build.Framework
         /// </remarks>
         public FileClassifier()
         {
-            string? programFiles32 = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
-            string? programFiles64 = Environment.GetEnvironmentVariable("ProgramW6432");
-
-            if (!string.IsNullOrEmpty(programFiles32))
+            // Register Microsoft "Reference Assemblies" as immutable
+            string[] programFilesEnvs = new[] { "ProgramFiles(x86)", "ProgramW6432", "ProgramFiles(Arm)" };
+            foreach (string programFilesEnv in programFilesEnvs)
             {
-                RegisterImmutableDirectory(Path.Combine(programFiles32, "Reference Assemblies", "Microsoft"));
-            }
-
-            if (!string.IsNullOrEmpty(programFiles64))
-            {
-                RegisterImmutableDirectory(Path.Combine(programFiles64, "Reference Assemblies", "Microsoft"));
+                string? programFiles = Environment.GetEnvironmentVariable(programFilesEnv);
+                if (!string.IsNullOrEmpty(programFiles))
+                {
+                    RegisterImmutableDirectory(Path.Combine(programFiles, "Reference Assemblies", "Microsoft"));
+                }
             }
 
 #if !RUNTIME_TYPE_NETCORE

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -177,6 +177,7 @@
         <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsPath32" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsPath64" value="$(SystemRoot)\Microsoft.NET\Framework64\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsPathArm64" value="$(SystemRoot)\Microsoft.NET\FrameworkArm64\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsRoot" value="$(SystemRoot)\Microsoft.NET\Framework\" />
         <property name="SDK35ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
         <property name="SDK40ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8\WinSDK-NetFx40Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -147,6 +147,7 @@
         <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsPath32" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsPath64" value="$(SystemRoot)\Microsoft.NET\Framework64\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsPathArm64" value="$(SystemRoot)\Microsoft.NET\FrameworkArm64\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsRoot" value="$(SystemRoot)\Microsoft.NET\Framework\" />
         <property name="SDK35ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
         <property name="SDK40ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8\WinSDK-NetFx40Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />


### PR DESCRIPTION
Fixes #7951

### Context
During testing Arm64 MSBuild we detected regression caused by not considering some Arm64 known directories as immutable for files up to date check.

### Changes Made
Adding arm64 directories in file classifier.

### Testing
Local and Arm64 device.
