### PR TITLE
Avoid stomping on SatelliteDllsProjectOutputGroupDependsOn

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6249,7 +6249,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
     -->
   <PropertyGroup>
-    <SatelliteDllsProjectOutputGroupDependsOn>PrepareForBuild;PrepareResourceNames</SatelliteDllsProjectOutputGroupDependsOn>
+    <SatelliteDllsProjectOutputGroupDependsOn>$(SatelliteDllsProjectOutputGroupDependsOn);PrepareForBuild;PrepareResourceNames</SatelliteDllsProjectOutputGroupDependsOn>
   </PropertyGroup>
 
   <Target


### PR DESCRIPTION
### Context

The `SatelliteDllsProjectOutputGroupDependsOn` msbuild property is written unconditionally and without regard to its previous value. 

### Changes Made

In this change, the targets we require are *appended* to any prior value, thereby making extensibility easier.

### Testing

⛔None. What would you suggest?

This *should* theoretically be safe, since no one would reasonably set this value to anything above this point in msbuild evaluation since it would be clobbered. But if they did anyway, then it no longer being clobbered could theoretically break something. Although it seems more likely that it would *fix* or guarantee target build order where it was broken before.
