### PR TITLE
Eliminate project string cache under a change wave.

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -23,6 +23,9 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 
 ## Current Rotation of Change Waves
 
+### 17.6
+- [Eliminate project string cache](https://github.com/dotnet/msbuild/pull/7965)
+
 ### 17.4
 - [Respect deps.json when loading assemblies](https://github.com/dotnet/msbuild/pull/7520)
 - [Consider `Platform` as default during Platform Negotiation](https://github.com/dotnet/msbuild/pull/7511)

--- a/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
@@ -21,6 +21,7 @@ using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFil
 using ProjectCollection = Microsoft.Build.Evaluation.ProjectCollection;
 using Shouldly;
 using Xunit;
+using Microsoft.Build.Framework;
 
 #nullable disable
 
@@ -1853,6 +1854,10 @@ true, true, true)]
         public void ReloadDoesNotLeakCachedXmlDocuments()
         {
             using var env = TestEnvironment.Create();
+            ChangeWaves.ResetStateForTests();
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+            BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+
             var testFiles = env.CreateTestProjectWithFiles("", new[] { "build.proj" });
             var projectFile = testFiles.CreatedFiles.First();
 

--- a/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
@@ -1855,7 +1855,7 @@ true, true, true)]
         {
             using var env = TestEnvironment.Create();
             ChangeWaves.ResetStateForTests();
-            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
             BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
             var testFiles = env.CreateTestProjectWithFiles("", new[] { "build.proj" });

--- a/src/Build.UnitTests/Evaluation/ProjectStringCache_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectStringCache_Tests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
                 string content = ObjectModelHelpers.CleanupFileContents(@"
@@ -89,7 +89,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
                 string content = ObjectModelHelpers.CleanupFileContents(@"
@@ -167,7 +167,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
                 string content = ObjectModelHelpers.CleanupFileContents(@"
@@ -252,7 +252,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
                 ProjectStringCache cache = new ProjectStringCache();
@@ -294,7 +294,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
                 ProjectStringCache cache = new ProjectStringCache();
@@ -341,7 +341,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
                 ProjectStringCache cache = new ProjectStringCache();
@@ -380,7 +380,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
                 ProjectStringCache cache = new ProjectStringCache();
@@ -425,7 +425,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
                 ProjectStringCache cache = new ProjectStringCache();
@@ -465,7 +465,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_6.ToString());
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
                 ProjectStringCache cache = new ProjectStringCache();

--- a/src/Build.UnitTests/Evaluation/ProjectStringCache_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectStringCache_Tests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Xml;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Xunit;
 
@@ -27,7 +28,13 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         [Trait("Category", "netcore-linux-failing")]
         public void ContentIsSameAcrossInstances()
         {
-            string content = ObjectModelHelpers.CleanupFileContents(@"
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                ChangeWaves.ResetStateForTests();
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+
+                string content = ObjectModelHelpers.CleanupFileContents(@"
                     <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
                         <ItemGroup>
                            Item group content
@@ -35,38 +42,39 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
                     </Project>
                     ");
 
-            string path = FileUtilities.GetTemporaryFile();
+                string path = FileUtilities.GetTemporaryFile();
 
-            try
-            {
-                File.WriteAllText(path, content);
+                try
+                {
+                    File.WriteAllText(path, content);
 
-                ProjectStringCache cache = new ProjectStringCache();
-                XmlDocumentWithLocation document1 = new XmlDocumentWithLocation();
-                document1.StringCache = cache;
-                document1.Load(path);
+                    ProjectStringCache cache = new ProjectStringCache();
+                    XmlDocumentWithLocation document1 = new XmlDocumentWithLocation();
+                    document1.StringCache = cache;
+                    document1.Load(path);
 
-                XmlDocumentWithLocation document2 = new XmlDocumentWithLocation();
-                document2.StringCache = cache;
-                document2.Load(path);
+                    XmlDocumentWithLocation document2 = new XmlDocumentWithLocation();
+                    document2.StringCache = cache;
+                    document2.Load(path);
 
-                XmlNodeList nodes1 = document1.GetElementsByTagName("ItemGroup");
-                XmlNodeList nodes2 = document2.GetElementsByTagName("ItemGroup");
+                    XmlNodeList nodes1 = document1.GetElementsByTagName("ItemGroup");
+                    XmlNodeList nodes2 = document2.GetElementsByTagName("ItemGroup");
 
-                Assert.Equal(1, nodes1.Count);
-                Assert.Equal(1, nodes2.Count);
+                    Assert.Equal(1, nodes1.Count);
+                    Assert.Equal(1, nodes2.Count);
 
-                XmlNode node1 = nodes1[0].FirstChild;
-                XmlNode node2 = nodes2[0].FirstChild;
+                    XmlNode node1 = nodes1[0].FirstChild;
+                    XmlNode node2 = nodes2[0].FirstChild;
 
-                Assert.NotNull(node1);
-                Assert.NotNull(node2);
-                Assert.NotSame(node1, node2);
-                Assert.Same(node1.Value, node2.Value);
-            }
-            finally
-            {
-                File.Delete(path);
+                    Assert.NotNull(node1);
+                    Assert.NotNull(node2);
+                    Assert.NotSame(node1, node2);
+                    Assert.Same(node1.Value, node2.Value);
+                }
+                finally
+                {
+                    File.Delete(path);
+                }
             }
         }
 
@@ -78,7 +86,13 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         [Trait("Category", "netcore-linux-failing")]
         public void ContentCanBeModified()
         {
-            string content = ObjectModelHelpers.CleanupFileContents(@"
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                ChangeWaves.ResetStateForTests();
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+
+                string content = ObjectModelHelpers.CleanupFileContents(@"
                     <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
                         <ItemGroup attr1='attr1value'>
                            Item group content
@@ -86,57 +100,58 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
                     </Project>
                     ");
 
-            string path = FileUtilities.GetTemporaryFile();
+                string path = FileUtilities.GetTemporaryFile();
 
-            try
-            {
-                File.WriteAllText(path, content);
-                ProjectStringCache cache = new ProjectStringCache();
-                XmlDocumentWithLocation document1 = new XmlDocumentWithLocation();
-                document1.StringCache = cache;
-                document1.Load(path);
+                try
+                {
+                    File.WriteAllText(path, content);
+                    ProjectStringCache cache = new ProjectStringCache();
+                    XmlDocumentWithLocation document1 = new XmlDocumentWithLocation();
+                    document1.StringCache = cache;
+                    document1.Load(path);
 
-                XmlDocumentWithLocation document2 = new XmlDocumentWithLocation();
-                document2.StringCache = cache;
-                document2.Load(path);
+                    XmlDocumentWithLocation document2 = new XmlDocumentWithLocation();
+                    document2.StringCache = cache;
+                    document2.Load(path);
 
-                string outerXml1 = document1.OuterXml;
-                string outerXml2 = document2.OuterXml;
-                Assert.Equal(outerXml1, outerXml2);
+                    string outerXml1 = document1.OuterXml;
+                    string outerXml2 = document2.OuterXml;
+                    Assert.Equal(outerXml1, outerXml2);
 
-                XmlNodeList nodes1 = document1.GetElementsByTagName("ItemGroup");
-                XmlNodeList nodes2 = document2.GetElementsByTagName("ItemGroup");
+                    XmlNodeList nodes1 = document1.GetElementsByTagName("ItemGroup");
+                    XmlNodeList nodes2 = document2.GetElementsByTagName("ItemGroup");
 
-                Assert.Equal(1, nodes1.Count);
-                Assert.Equal(1, nodes2.Count);
+                    Assert.Equal(1, nodes1.Count);
+                    Assert.Equal(1, nodes2.Count);
 
-                XmlNode node1 = nodes1[0];
-                XmlNode node2 = nodes2[0];
-                Assert.NotNull(node1);
-                Assert.NotNull(node2);
-                Assert.NotSame(node1, node2);
-                Assert.Single(node1.Attributes);
-                Assert.Single(node2.Attributes);
-                Assert.Same(node1.Attributes[0].Value, node2.Attributes[0].Value);
+                    XmlNode node1 = nodes1[0];
+                    XmlNode node2 = nodes2[0];
+                    Assert.NotNull(node1);
+                    Assert.NotNull(node2);
+                    Assert.NotSame(node1, node2);
+                    Assert.Single(node1.Attributes);
+                    Assert.Single(node2.Attributes);
+                    Assert.Same(node1.Attributes[0].Value, node2.Attributes[0].Value);
 
-                node2.Attributes[0].Value = "attr1value";
-                Assert.Equal(node1.Attributes[0].Value, node2.Attributes[0].Value);
-                Assert.NotSame(node1.Attributes[0].Value, node2.Attributes[0].Value);
+                    node2.Attributes[0].Value = "attr1value";
+                    Assert.Equal(node1.Attributes[0].Value, node2.Attributes[0].Value);
+                    Assert.NotSame(node1.Attributes[0].Value, node2.Attributes[0].Value);
 
-                node1 = nodes1[0].FirstChild;
-                node2 = nodes2[0].FirstChild;
-                Assert.NotSame(node1, node2);
-                Assert.Same(node1.Value, node2.Value);
+                    node1 = nodes1[0].FirstChild;
+                    node2 = nodes2[0].FirstChild;
+                    Assert.NotSame(node1, node2);
+                    Assert.Same(node1.Value, node2.Value);
 
-                XmlText newText = document2.CreateTextNode("New Value");
-                XmlNode parent = node2.ParentNode;
-                parent.ReplaceChild(newText, node2);
+                    XmlText newText = document2.CreateTextNode("New Value");
+                    XmlNode parent = node2.ParentNode;
+                    parent.ReplaceChild(newText, node2);
 
-                Assert.NotEqual(outerXml1, document2.OuterXml);
-            }
-            finally
-            {
-                File.Delete(path);
+                    Assert.NotEqual(outerXml1, document2.OuterXml);
+                }
+                finally
+                {
+                    File.Delete(path);
+                }
             }
         }
 
@@ -149,74 +164,81 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         [Trait("Category", "netcore-linux-failing")]
         public void RemovingFilesRemovesEntries()
         {
-            string content = ObjectModelHelpers.CleanupFileContents(@"
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                ChangeWaves.ResetStateForTests();
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+
+                string content = ObjectModelHelpers.CleanupFileContents(@"
                     <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
                         <ItemGroup>Content</ItemGroup>
                     </Project>
                     ");
 
-            string path = FileUtilities.GetTemporaryFile();
+                string path = FileUtilities.GetTemporaryFile();
 
-            try
-            {
-                File.WriteAllText(path, content);
+                try
+                {
+                    File.WriteAllText(path, content);
 
-                ProjectStringCache cache = new ProjectStringCache();
-                ProjectCollection collection = new ProjectCollection();
-                int entryCount;
+                    ProjectStringCache cache = new ProjectStringCache();
+                    ProjectCollection collection = new ProjectCollection();
+                    int entryCount;
 
-                ProjectRootElement pre1 = ProjectRootElement.Create(collection);
-                pre1.XmlDocument.StringCache = cache;
-                pre1.FullPath = path;
-                pre1.XmlDocument.Load(path);
+                    ProjectRootElement pre1 = ProjectRootElement.Create(collection);
+                    pre1.XmlDocument.StringCache = cache;
+                    pre1.FullPath = path;
+                    pre1.XmlDocument.Load(path);
 
-                entryCount = cache.Count;
-                Assert.True(entryCount > 0);
+                    entryCount = cache.Count;
+                    Assert.True(entryCount > 0);
 
-                ProjectRootElement pre2 = ProjectRootElement.Create(collection);
-                pre2.XmlDocument.StringCache = cache;
-                pre2.FullPath = path;
-                pre2.XmlDocument.Load(path);
+                    ProjectRootElement pre2 = ProjectRootElement.Create(collection);
+                    pre2.XmlDocument.StringCache = cache;
+                    pre2.FullPath = path;
+                    pre2.XmlDocument.Load(path);
 
-                // Entry count should not have changed
-                Assert.Equal(entryCount, cache.Count);
+                    // Entry count should not have changed
+                    Assert.Equal(entryCount, cache.Count);
 
-                string itemGroupContent = cache.Get("Content");
-                Assert.NotNull(itemGroupContent);
+                    string itemGroupContent = cache.Get("Content");
+                    Assert.NotNull(itemGroupContent);
 
-                XmlNodeList nodes1 = pre1.XmlDocument.GetElementsByTagName("ItemGroup");
-                XmlNodeList nodes2 = pre2.XmlDocument.GetElementsByTagName("ItemGroup");
+                    XmlNodeList nodes1 = pre1.XmlDocument.GetElementsByTagName("ItemGroup");
+                    XmlNodeList nodes2 = pre2.XmlDocument.GetElementsByTagName("ItemGroup");
 
-                Assert.Equal(1, nodes1.Count);
-                Assert.Equal(1, nodes2.Count);
+                    Assert.Equal(1, nodes1.Count);
+                    Assert.Equal(1, nodes2.Count);
 
-                XmlNode node1 = nodes1[0];
-                XmlNode node2 = nodes2[0];
-                Assert.NotNull(node1);
-                Assert.NotNull(node2);
-                Assert.NotSame(node1, node2);
-                Assert.Same(node1.Value, node2.Value);
+                    XmlNode node1 = nodes1[0];
+                    XmlNode node2 = nodes2[0];
+                    Assert.NotNull(node1);
+                    Assert.NotNull(node2);
+                    Assert.NotSame(node1, node2);
+                    Assert.Same(node1.Value, node2.Value);
 
-                // Now remove one document
-                collection.UnloadProject(pre1);
+                    // Now remove one document
+                    collection.UnloadProject(pre1);
 
-                // We should still be able to get Content
-                itemGroupContent = cache.Get("Content");
-                Assert.NotNull(itemGroupContent);
+                    // We should still be able to get Content
+                    itemGroupContent = cache.Get("Content");
+                    Assert.NotNull(itemGroupContent);
 
-                // Now remove the second document
-                collection.UnloadProject(pre2);
+                    // Now remove the second document
+                    collection.UnloadProject(pre2);
 
-                // Now we should not be able to get Content
-                itemGroupContent = cache.Get("Content");
-                Assert.Null(itemGroupContent);
+                    // Now we should not be able to get Content
+                    itemGroupContent = cache.Get("Content");
+                    Assert.Null(itemGroupContent);
 
-                // And there should be no entries
-                Assert.Equal(0, cache.Count);
-            }
-            finally
-            {
-                File.Delete(path);
+                    // And there should be no entries
+                    Assert.Equal(0, cache.Count);
+                }
+                finally
+                {
+                    File.Delete(path);
+                }
             }
         }
 
@@ -227,32 +249,39 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         [Fact]
         public void AddReturnsSameInstanceForSameDocument()
         {
-            ProjectStringCache cache = new ProjectStringCache();
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                ChangeWaves.ResetStateForTests();
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
-            XmlDocument document = new XmlDocument();
+                ProjectStringCache cache = new ProjectStringCache();
 
-            string stringToAdd = "Test1";
-            string return1 = cache.Add(stringToAdd, document);
+                XmlDocument document = new XmlDocument();
 
-            // Content of string should be the same.
-            Assert.Equal(1, cache.Count);
-            Assert.Equal(stringToAdd, return1);
+                string stringToAdd = "Test1";
+                string return1 = cache.Add(stringToAdd, document);
 
-            // Build a new string guaranteed not to be optimized by the compiler into the same instance.
-            StringBuilder builder = new StringBuilder();
-            builder.Append("Test");
-            builder.Append('1');
+                // Content of string should be the same.
+                Assert.Equal(1, cache.Count);
+                Assert.Equal(stringToAdd, return1);
 
-            string return2 = cache.Add(builder.ToString(), document);
+                // Build a new string guaranteed not to be optimized by the compiler into the same instance.
+                StringBuilder builder = new StringBuilder();
+                builder.Append("Test");
+                builder.Append('1');
 
-            // Content of string should be the same.            
-            Assert.Equal(builder.ToString(), return2);
+                string return2 = cache.Add(builder.ToString(), document);
 
-            // Returned references should be the same
-            Assert.Same(return1, return2);
+                // Content of string should be the same.            
+                Assert.Equal(builder.ToString(), return2);
 
-            // Should not have added any new string instances to the cache.
-            Assert.Equal(1, cache.Count);
+                // Returned references should be the same
+                Assert.Same(return1, return2);
+
+                // Should not have added any new string instances to the cache.
+                Assert.Equal(1, cache.Count);
+            }
         }
 
         /// <summary>
@@ -262,32 +291,39 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         [Fact]
         public void AddReturnsSameInstanceForDifferentDocument()
         {
-            ProjectStringCache cache = new ProjectStringCache();
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                ChangeWaves.ResetStateForTests();
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
-            XmlDocument document = new XmlDocument();
+                ProjectStringCache cache = new ProjectStringCache();
 
-            string stringToAdd = "Test1";
-            string return1 = cache.Add(stringToAdd, document);
+                XmlDocument document = new XmlDocument();
 
-            // Content of string should be the same.
-            Assert.Equal(stringToAdd, return1);
+                string stringToAdd = "Test1";
+                string return1 = cache.Add(stringToAdd, document);
 
-            // Build a new string guaranteed not to be optimized by the compiler into the same instance.
-            StringBuilder builder = new StringBuilder();
-            builder.Append("Test");
-            builder.Append('1');
-            XmlDocument document2 = new XmlDocument();
+                // Content of string should be the same.
+                Assert.Equal(stringToAdd, return1);
 
-            string return2 = cache.Add(builder.ToString(), document2);
+                // Build a new string guaranteed not to be optimized by the compiler into the same instance.
+                StringBuilder builder = new StringBuilder();
+                builder.Append("Test");
+                builder.Append('1');
+                XmlDocument document2 = new XmlDocument();
 
-            // Content of string should be the same.
-            Assert.Equal(builder.ToString(), return2);
+                string return2 = cache.Add(builder.ToString(), document2);
 
-            // Returned references should be the same
-            Assert.Same(return1, return2);
+                // Content of string should be the same.
+                Assert.Equal(builder.ToString(), return2);
 
-            // Should not have added any new string instances to the cache.
-            Assert.Equal(1, cache.Count);
+                // Returned references should be the same
+                Assert.Same(return1, return2);
+
+                // Should not have added any new string instances to the cache.
+                Assert.Equal(1, cache.Count);
+            }
         }
 
         /// <summary>
@@ -302,28 +338,35 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         [Fact]
         public void RemoveLastInstanceDeallocatesEntry()
         {
-            ProjectStringCache cache = new ProjectStringCache();
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                ChangeWaves.ResetStateForTests();
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
-            XmlDocument document = new XmlDocument();
+                ProjectStringCache cache = new ProjectStringCache();
 
-            string stringToAdd = "Test1";
-            string return1 = cache.Add(stringToAdd, document);
+                XmlDocument document = new XmlDocument();
 
-            cache.Clear(document);
+                string stringToAdd = "Test1";
+                string return1 = cache.Add(stringToAdd, document);
 
-            // Should be no instances left.
-            Assert.Equal(0, cache.Count);
+                cache.Clear(document);
 
-            // Build a new string guaranteed not to be optimized by the compiler into the same instance.
-            StringBuilder builder = new StringBuilder();
-            builder.Append("Test");
-            builder.Append('1');
-            XmlDocument document2 = new XmlDocument();
+                // Should be no instances left.
+                Assert.Equal(0, cache.Count);
 
-            string return2 = cache.Add(builder.ToString(), document2);
+                // Build a new string guaranteed not to be optimized by the compiler into the same instance.
+                StringBuilder builder = new StringBuilder();
+                builder.Append("Test");
+                builder.Append('1');
+                XmlDocument document2 = new XmlDocument();
 
-            // Returned references should NOT be the same
-            Assert.NotSame(return1, return2);
+                string return2 = cache.Add(builder.ToString(), document2);
+
+                // Returned references should NOT be the same
+                Assert.NotSame(return1, return2);
+            }
         }
 
         /// <summary>
@@ -334,36 +377,43 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         [Fact]
         public void RemoveOneInstance()
         {
-            ProjectStringCache cache = new ProjectStringCache();
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                ChangeWaves.ResetStateForTests();
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
-            XmlDocument document = new XmlDocument();
+                ProjectStringCache cache = new ProjectStringCache();
 
-            string stringToAdd = "Test1";
-            string return1 = cache.Add(stringToAdd, document);
-            Assert.Equal(1, cache.Count);
+                XmlDocument document = new XmlDocument();
 
-            XmlDocument document2 = new XmlDocument();
-            cache.Add(stringToAdd, document2);
-            Assert.Equal(1, cache.Count);
+                string stringToAdd = "Test1";
+                string return1 = cache.Add(stringToAdd, document);
+                Assert.Equal(1, cache.Count);
 
-            cache.Clear(document2);
+                XmlDocument document2 = new XmlDocument();
+                cache.Add(stringToAdd, document2);
+                Assert.Equal(1, cache.Count);
 
-            // Since there is still one document referencing the string, it should remain.
-            Assert.Equal(1, cache.Count);
+                cache.Clear(document2);
 
-            // Build a new string guaranteed not to be optimized by the compiler into the same instance.
-            StringBuilder builder = new StringBuilder();
-            builder.Append("Test");
-            builder.Append('1');
-            XmlDocument document3 = new XmlDocument();
+                // Since there is still one document referencing the string, it should remain.
+                Assert.Equal(1, cache.Count);
 
-            string return3 = cache.Add(builder.ToString(), document3);
+                // Build a new string guaranteed not to be optimized by the compiler into the same instance.
+                StringBuilder builder = new StringBuilder();
+                builder.Append("Test");
+                builder.Append('1');
+                XmlDocument document3 = new XmlDocument();
 
-            // Returned references should be the same
-            Assert.Same(return1, return3);
+                string return3 = cache.Add(builder.ToString(), document3);
 
-            // Still should only be one cached instance.
-            Assert.Equal(1, cache.Count);
+                // Returned references should be the same
+                Assert.Same(return1, return3);
+
+                // Still should only be one cached instance.
+                Assert.Equal(1, cache.Count);
+            }
         }
 
         /// <summary>
@@ -372,31 +422,38 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         [Fact]
         public void DifferentStringsSameDocument()
         {
-            ProjectStringCache cache = new ProjectStringCache();
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                ChangeWaves.ResetStateForTests();
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
-            XmlDocument document = new XmlDocument();
+                ProjectStringCache cache = new ProjectStringCache();
 
-            string stringToAdd = "Test1";
-            cache.Add(stringToAdd, document);
-            Assert.Equal(1, cache.Count);
+                XmlDocument document = new XmlDocument();
 
-            stringToAdd = "Test2";
-            string return2 = cache.Add(stringToAdd, document);
+                string stringToAdd = "Test1";
+                cache.Add(stringToAdd, document);
+                Assert.Equal(1, cache.Count);
 
-            // The second string gets its own instance.
-            Assert.Equal(2, cache.Count);
+                stringToAdd = "Test2";
+                string return2 = cache.Add(stringToAdd, document);
 
-            // Build a new string guaranteed not to be optimized by the compiler into the same instance.
-            StringBuilder builder = new StringBuilder();
-            builder.Append("Test");
-            builder.Append('2');
-            string return3 = cache.Add(builder.ToString(), document);
+                // The second string gets its own instance.
+                Assert.Equal(2, cache.Count);
 
-            // The new string should be the same as the other one already in the collection.
-            Assert.Same(return2, return3);
+                // Build a new string guaranteed not to be optimized by the compiler into the same instance.
+                StringBuilder builder = new StringBuilder();
+                builder.Append("Test");
+                builder.Append('2');
+                string return3 = cache.Add(builder.ToString(), document);
 
-            // No new instances for string with the same content.
-            Assert.Equal(2, cache.Count);
+                // The new string should be the same as the other one already in the collection.
+                Assert.Same(return2, return3);
+
+                // No new instances for string with the same content.
+                Assert.Equal(2, cache.Count);
+            }
         }
 
         /// <summary>
@@ -405,33 +462,40 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         [Fact]
         public void DifferentStringsDifferentDocuments()
         {
-            ProjectStringCache cache = new ProjectStringCache();
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                ChangeWaves.ResetStateForTests();
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_4.ToString());
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
 
-            XmlDocument document = new XmlDocument();
+                ProjectStringCache cache = new ProjectStringCache();
 
-            string stringToAdd = "Test1";
-            cache.Add(stringToAdd, document);
-            Assert.Equal(1, cache.Count);
+                XmlDocument document = new XmlDocument();
 
-            stringToAdd = "Test2";
-            XmlDocument document2 = new XmlDocument();
-            string return2 = cache.Add(stringToAdd, document2);
+                string stringToAdd = "Test1";
+                cache.Add(stringToAdd, document);
+                Assert.Equal(1, cache.Count);
 
-            // The second string gets its own instance.
-            Assert.Equal(2, cache.Count);
+                stringToAdd = "Test2";
+                XmlDocument document2 = new XmlDocument();
+                string return2 = cache.Add(stringToAdd, document2);
 
-            // Build a new string guaranteed not to be optimized by the compiler into the same instance.
-            StringBuilder builder = new StringBuilder();
-            builder.Append("Test");
-            builder.Append('2');
-            XmlDocument document3 = new XmlDocument();
-            string return3 = cache.Add(builder.ToString(), document3);
+                // The second string gets its own instance.
+                Assert.Equal(2, cache.Count);
 
-            // The new string should be the same as the other one already in the collection.
-            Assert.Same(return2, return3);
+                // Build a new string guaranteed not to be optimized by the compiler into the same instance.
+                StringBuilder builder = new StringBuilder();
+                builder.Append("Test");
+                builder.Append('2');
+                XmlDocument document3 = new XmlDocument();
+                string return3 = cache.Add(builder.ToString(), document3);
 
-            // No new instances for string with the same content.
-            Assert.Equal(2, cache.Count);
+                // The new string should be the same as the other one already in the collection.
+                Assert.Same(return2, return3);
+
+                // No new instances for string with the same content.
+                Assert.Equal(2, cache.Count);
+            }
         }
     }
 }

--- a/src/Build/ElementLocation/XmlDocumentWithLocation.cs
+++ b/src/Build/ElementLocation/XmlDocumentWithLocation.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Xml;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 

--- a/src/Build/ElementLocation/XmlDocumentWithLocation.cs
+++ b/src/Build/ElementLocation/XmlDocumentWithLocation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Xml;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 
@@ -225,7 +226,9 @@ namespace Microsoft.Build.Construction
                 text = String.Empty;
             }
 
-            string interned = StringCache.Add(text, this);
+            // Remove string interning in ChangeWave 17.4
+            // Note: When ready to remove the ChangeWaves under 17.4, please follow the PR https://github.com/dotnet/msbuild/pull/7952 to remove all related and no more used code.
+            string interned = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) ? text : StringCache.Add(text, this);
             return base.CreateWhitespace(interned);
         }
 
@@ -241,7 +244,7 @@ namespace Microsoft.Build.Construction
                 text = String.Empty;
             }
 
-            string interned = StringCache.Add(text, this);
+            string interned = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) ? text : StringCache.Add(text, this);
             return base.CreateSignificantWhitespace(interned);
         }
 
@@ -251,7 +254,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public override XmlText CreateTextNode(string text)
         {
-            string textNode = StringCache.Add(text, this);
+            string textNode = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) ? text : StringCache.Add(text, this);
             return base.CreateTextNode(textNode);
         }
 
@@ -266,7 +269,7 @@ namespace Microsoft.Build.Construction
                 data = String.Empty;
             }
 
-            string interned = StringCache.Add(data, this);
+            string interned = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) ? data : StringCache.Add(data, this);
             return base.CreateComment(interned);
         }
 

--- a/src/Build/ElementLocation/XmlDocumentWithLocation.cs
+++ b/src/Build/ElementLocation/XmlDocumentWithLocation.cs
@@ -226,9 +226,7 @@ namespace Microsoft.Build.Construction
                 text = String.Empty;
             }
 
-            // Remove string interning in ChangeWave 17.4
-            // Note: When ready to remove the ChangeWaves under 17.4, please follow the PR https://github.com/dotnet/msbuild/pull/7952 to remove all related and no more used code.
-            string interned = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) ? text : StringCache.Add(text, this);
+            string interned = StringCache.Add(text, this);
             return base.CreateWhitespace(interned);
         }
 
@@ -244,7 +242,7 @@ namespace Microsoft.Build.Construction
                 text = String.Empty;
             }
 
-            string interned = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) ? text : StringCache.Add(text, this);
+            string interned = StringCache.Add(text, this);
             return base.CreateSignificantWhitespace(interned);
         }
 
@@ -254,7 +252,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public override XmlText CreateTextNode(string text)
         {
-            string textNode = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) ? text : StringCache.Add(text, this);
+            string textNode = StringCache.Add(text, this);
             return base.CreateTextNode(textNode);
         }
 
@@ -269,7 +267,7 @@ namespace Microsoft.Build.Construction
                 data = String.Empty;
             }
 
-            string interned = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4) ? data : StringCache.Add(data, this);
+            string interned = StringCache.Add(data, this);
             return base.CreateComment(interned);
         }
 

--- a/src/Build/Evaluation/ProjectStringCache.cs
+++ b/src/Build/Evaluation/ProjectStringCache.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Build.Construction
         public string Add(string key, XmlDocument document)
         {
             // Remove string interning in ChangeWave 17.4
-            // Note: When ready to remove the ChangeWaves under 17.4, please remove all related and no more used code (see the PR https://github.com/dotnet/msbuild/pull/7952).
+            // Note: When ready to remove the ChangeWaves under 17.4, please delete this entire class and all references to it. (See the PR https://github.com/dotnet/msbuild/pull/7952).
             if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4))
             {
                 return key;

--- a/src/Build/Evaluation/ProjectStringCache.cs
+++ b/src/Build/Evaluation/ProjectStringCache.cs
@@ -85,9 +85,9 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public string Add(string key, XmlDocument document)
         {
-            // Remove string interning in ChangeWave 17.4
-            // Note: When ready to remove the ChangeWaves under 17.4, please delete this entire class and all references to it. (See the PR https://github.com/dotnet/msbuild/pull/7952).
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4))
+            // Remove string interning in ChangeWave 17.6
+            // Note: When ready to remove the ChangeWaves under 17.6, please delete this entire class and all references to it. (See the PR https://github.com/dotnet/msbuild/pull/7952).
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_6))
             {
                 return key;
             }

--- a/src/Build/Evaluation/ProjectStringCache.cs
+++ b/src/Build/Evaluation/ProjectStringCache.cs
@@ -8,6 +8,7 @@ using System.Xml;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Collections;
+using Microsoft.Build.Framework;
 
 #nullable disable
 
@@ -84,6 +85,13 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public string Add(string key, XmlDocument document)
         {
+            // Remove string interning in ChangeWave 17.4
+            // Note: When ready to remove the ChangeWaves under 17.4, please remove all related and no more used code (see the PR https://github.com/dotnet/msbuild/pull/7952).
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4))
+            {
+                return key;
+            }
+
             if (key.Length == 0)
             {
                 return String.Empty;

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave17_0 = new Version(17, 0);
         internal static readonly Version Wave17_2 = new Version(17, 2);
         internal static readonly Version Wave17_4 = new Version(17, 4);
-        internal static readonly Version[] AllWaves = { Wave17_0, Wave17_2, Wave17_4 };
+        internal static readonly Version Wave17_6 = new Version(17, 6);
+        internal static readonly Version[] AllWaves = { Wave17_0, Wave17_2, Wave17_4, Wave17_6 };
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.


### PR DESCRIPTION
Fixes #5444

Context
The `ProjectStringCache` does seem to have a memory leak problem when used from VS.
The reason of the leak is that it clears memory on the event from `ProjectRootElementCache`, which is raised when project is moved out of the strong cache. The unproper use of `ProjectRootElementCache` might lead to `ProjectStringCache` not freeing memory.

Also, there were doubts if this cache adds anything at all to performance. Experiments does not show significant difference for the two cases.

We decided to remove `ProjectStringCache` under a change wave.

Changes Made
- Put usage of `ProjectStringCache` under change waves below 17.6.

Testing
Unit tests
Experimental insertion

Notes
- The previous PR (that eliminates the `ProjectStringCache` altogether with the related code): #7952.
- Another option is to use string interning from `StringTools` instead.