### PR TITLE
Use old opt-prof data for main and exp branches.

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -23,9 +23,12 @@ variables:
   - name: SourceBranch
     value: $(IbcSourceBranchName)
   # If we're not on a vs* branch, use main as our optprof collection branch
+  # NOTE: the code is temporarily fixed. For the branches that should use opt-prof from the main branch we should use the latest working Opt-Prof 20220901.6-001 collected from main 20220901.6.
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
+    - name: OptProfDrop
+      value: 'OptimizationData/DotNet-msbuild-Trusted/main/20220901.6/1387996/1'
     - name: SourceBranch
-      value: main
+      value: ''
   # if OptProfDropName is set as a parameter, set OptProfDrop to the parameter and unset SourceBranch
   - ${{ if ne(parameters.OptProfDropName, 'default') }}:
     - name: OptProfDrop


### PR DESCRIPTION
This should temporarily fix our build pipeline. 
All the branches except those which starts with `vs` will use the latest good OptProf data from main branch (hardcoded).