### PR TITLE
ngen arm64 binaries as arm64

### DIFF
--- a/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
+++ b/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
@@ -9,11 +9,11 @@ vs.relatedProcessFiles
   vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\arm64\Microsoft.Build.Tasks.Core.dll"
 
 folder InstallDir:\MSBuild\Current\Bin\arm64
-  file source=$(Arm64BinPath)MSBuild.exe vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)MSBuild.exe vs.file.ngenArchitecture=arm64
   file source=$(Arm64BinPath)MSBuild.exe.config
 
   file source=$(FrameworkBinPath)x64\Microsoft.Build.Framework.tlb
-  file source=$(Arm64BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
+  file source=$(Arm64BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=arm64
   file source=$(Arm64BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(Arm64BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(Arm64BinPath)Microsoft.Common.overridetasks


### PR DESCRIPTION
### Customer Impact
Slower arm64 MSBuild due to assemblies NOT being ngen'd for the arm64 architecture.

### Testing
Verified no regressions in https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/426628

### Code Reviewers
raines
Forgind

### Description of fix
Change setting in our .swr file to ngen relevant assemblies as `arm64`.
