### PR TITLE
Support ItemDefinitionGroup in Choose/When

### DIFF
--- a/src/Build.UnitTests/Parser_Tests.cs
+++ b/src/Build.UnitTests/Parser_Tests.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Build.UnitTests
                             </ItemGroup>
                             <ItemDefinitionGroup>
                                 <A>
-                                    <m>m1</m>
+                                    <m>m2</m>
                                     <n>n2</n>
                                 </A>
                             </ItemDefinitionGroup>
@@ -579,12 +579,21 @@ namespace Microsoft.Build.UnitTests
             var projectItem = project.GetItems("A").FirstOrDefault();
             Assert.Equal("bar", projectItem.EvaluatedInclude);
 
+            var metadatam = projectItem.GetMetadata("m");
+            if (context)
+            {
+                // Go to when 
+                Assert.Equal("m1", metadatam.EvaluatedValue);
+            }
+            else
+            {
+                // Go to Otherwise
+                Assert.Equal("m2", metadatam.EvaluatedValue);
+            }
+
             var metadatan = projectItem.GetMetadata("n");
             Assert.Equal("n1", metadatan.EvaluatedValue);
             Assert.Equal("n2", metadatan.Predecessor.EvaluatedValue);
-
-            var metadatam = projectItem.GetMetadata("m");
-            Assert.Equal("m1", metadatam.EvaluatedValue);
         }
     }
 }

--- a/src/Build.UnitTests/Parser_Tests.cs
+++ b/src/Build.UnitTests/Parser_Tests.cs
@@ -215,16 +215,16 @@ namespace Microsoft.Build.UnitTests
             Console.WriteLine("ItemFuncParseTest()");
 
             Parser p = new Parser();
-            GenericExpressionNode tree = p.Parse("@(item->foo('ab'))", 
+            GenericExpressionNode tree = p.Parse("@(item->foo('ab'))",
                 ParserOptions.AllowProperties | ParserOptions.AllowItemLists, _elementLocation);
             Assert.IsType<StringExpressionNode>(tree);
             Assert.Equal("@(item->foo('ab'))", tree.GetUnexpandedValue(null));
 
-            tree = p.Parse("!@(item->foo())", 
+            tree = p.Parse("!@(item->foo())",
                 ParserOptions.AllowProperties | ParserOptions.AllowItemLists, _elementLocation);
             Assert.IsType<NotExpressionNode>(tree);
 
-            tree = p.Parse("(@(item->foo('ab')) and @(item->foo('bc')))", 
+            tree = p.Parse("(@(item->foo('ab')) and @(item->foo('bc')))",
                 ParserOptions.AllowProperties | ParserOptions.AllowItemLists, _elementLocation);
             Assert.IsType<AndExpressionNode>(tree);
         }
@@ -526,6 +526,30 @@ namespace Microsoft.Build.UnitTests
 
             // Make sure the log contains the correct strings.
             Assert.DoesNotContain("MSB4130:", ml.FullLog); // "No need to warn for this expression - ($(a) == 1 or $(b) == 2) and $(c) == 3."
+        }
+
+        // see https://github.com/dotnet/msbuild/issues/5436
+        [Fact]
+        public void SupportItemDefinationGroupInWhenOtherwise()
+        {
+            MockLogger ml = ObjectModelHelpers.BuildProjectExpectSuccess(@"
+                    <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
+                        <Choose>
+                            <When Condition=` '$(OutputType)'=='Library' `>
+                                <ItemDefinitionGroup>
+                                </ItemDefinitionGroup>
+                            </When>
+                            <Otherwise>
+                                <ItemDefinitionGroup>
+                                </ItemDefinitionGroup>
+                            </Otherwise>
+                        </Choose>
+                        <Target Name=`Build`>
+                        </Target>
+                    </Project>
+                ");
+
+            Assert.Equal(0, ml.ErrorCount);
         }
     }
 }

--- a/src/Build.UnitTests/Parser_Tests.cs
+++ b/src/Build.UnitTests/Parser_Tests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-
+using System.Linq;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Xunit;
@@ -529,27 +529,62 @@ namespace Microsoft.Build.UnitTests
         }
 
         // see https://github.com/dotnet/msbuild/issues/5436
-        [Fact]
-        public void SupportItemDefinationGroupInWhenOtherwise()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SupportItemDefinationGroupInWhenOtherwise(bool context)
         {
-            MockLogger ml = ObjectModelHelpers.BuildProjectExpectSuccess(@"
-                    <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
-                        <Choose>
-                            <When Condition=` '$(OutputType)'=='Library' `>
-                                <ItemDefinitionGroup>
-                                </ItemDefinitionGroup>
-                            </When>
-                            <Otherwise>
-                                <ItemDefinitionGroup>
-                                </ItemDefinitionGroup>
-                            </Otherwise>
-                        </Choose>
-                        <Target Name=`Build`>
-                        </Target>
-                    </Project>
-                ");
+            var projectContent = $@"
+                <Project ToolsVersion= `msbuilddefaulttoolsversion` xmlns= `msbuildnamespace`>
+                    <Choose>
+                        <When Condition= `{context}`>
+                            <PropertyGroup>
+                                <Foo>bar</Foo>
+                            </PropertyGroup>
+                            <ItemGroup>
+                                <A Include= `$(Foo)`>
+                                    <n>n1</n>
+                                </A>
+                            </ItemGroup>
+                            <ItemDefinitionGroup>
+                                <A>
+                                    <m>m1</m>
+                                    <n>n2</n>
+                                </A>
+                            </ItemDefinitionGroup>
+                        </When>
+                        <Otherwise>
+                            <PropertyGroup>
+                                <Foo>bar</Foo>
+                            </PropertyGroup>
+                            <ItemGroup>
+                                <A Include= `$(Foo)`>
+                                    <n>n1</n>
+                                </A>
+                            </ItemGroup>
+                            <ItemDefinitionGroup>
+                                <A>
+                                    <m>m1</m>
+                                    <n>n2</n>
+                                </A>
+                            </ItemDefinitionGroup>
+                        </Otherwise>
+                    </Choose>
+                </Project>
+                ".Cleanup();
 
-            Assert.Equal(0, ml.ErrorCount);
+
+            var project = ObjectModelHelpers.CreateInMemoryProject(projectContent);
+
+            var projectItem = project.GetItems("A").FirstOrDefault();
+            Assert.Equal("bar", projectItem.EvaluatedInclude);
+
+            var metadatan = projectItem.GetMetadata("n");
+            Assert.Equal("n1", metadatan.EvaluatedValue);
+            Assert.Equal("n2", metadatan.Predecessor.EvaluatedValue);
+
+            var metadatam = projectItem.GetMetadata("m");
+            Assert.Equal("m1", metadatam.EvaluatedValue);
         }
     }
 }

--- a/src/Build/Construction/ProjectItemDefinitionGroupElement.cs
+++ b/src/Build/Construction/ProjectItemDefinitionGroupElement.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Initialize a parented ProjectItemDefinitionGroupElement
         /// </summary>
-        internal ProjectItemDefinitionGroupElement(XmlElement xmlElement, ProjectRootElement parent, ProjectRootElement containingProject)
+        internal ProjectItemDefinitionGroupElement(XmlElement xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
             ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1539,6 +1539,9 @@ namespace Microsoft.Build.Evaluation
                         case ProjectChooseElement choose:
                             EvaluateChooseElement(choose);
                             break;
+                        case ProjectItemDefinitionGroupElement itemDefinition:
+                            _itemDefinitionGroupElements.Add(itemDefinition);
+                            break;
                         default:
                             ErrorUtilities.ThrowInternalError("Unexpected child type");
                             break;

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Build.Construction
                         break;
 
                     case XMakeElements.itemDefinitionGroup:
-                        _project.AppendParentedChildNoChecks(ParseProjectItemDefinitionGroupElement(childElement));
+                        _project.AppendParentedChildNoChecks(ParseProjectItemDefinitionGroupElement(childElement, _project));
                         break;
 
                     case XMakeElements.choose:
@@ -709,11 +709,11 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Parse a ProjectItemDefinitionGroupElement
         /// </summary>
-        private ProjectItemDefinitionGroupElement ParseProjectItemDefinitionGroupElement(XmlElementWithLocation element)
+        private ProjectItemDefinitionGroupElement ParseProjectItemDefinitionGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
             ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
 
-            ProjectItemDefinitionGroupElement itemDefinitionGroup = new ProjectItemDefinitionGroupElement(element, _project, _project);
+            ProjectItemDefinitionGroupElement itemDefinitionGroup = new ProjectItemDefinitionGroupElement(element, parent, _project);
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
@@ -863,6 +863,10 @@ namespace Microsoft.Build.Construction
 
                     case XMakeElements.choose:
                         child = ParseProjectChooseElement(childElement, parent, nestingDepth);
+                        break;
+
+                    case XMakeElements.itemDefinitionGroup:
+                        child = ParseProjectItemDefinitionGroupElement(childElement, parent);
                         break;
 
                     default:


### PR DESCRIPTION
Fixes [#5436](https://github.com/dotnet/msbuild/issues/5436)

### Context


### Changes Made
There is a significant error in the original Constuctor ProjectItemDefinitionGroupElement(XmlElement xmlElement, ProjectRootElement parent, ProjectRootElement containingProject). The second parameter and third parameter types are the same. Fix the constructor bug and parse ItemDefinationGroup in when and otherwise.

### Testing
Add one test SupportItemDefinationGroupInWhenOtherwise()

### Notes
