### PR TITLE
Exp/new 6.0 sdk

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,9 +3,9 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "6.0.200",
+    "dotnet": "6.0.401",
     "vs": {
-      "version": "17.0"
+      "version": "17.2.1"
     }
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -6,7 +6,8 @@
     "dotnet": "6.0.401",
     "vs": {
       "version": "17.2.1"
-    }
+    },
+    "xcopy-msbuild": "17.2.1"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
Resolves a component governance alert related to building with the old SDK.

Successful internal build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=6697148