### PR TITLE
Fix issue 7828: enabling the binary logger adds console output

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,10 +3,11 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "6.0.200",
+    "dotnet": "6.0.401",
     "vs": {
-      "version": "17.0"
-    }
+      "version": "17.2.1"
+    },
+    "xcopy-msbuild": "17.2.1"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -300,13 +300,13 @@ namespace Microsoft.Build.UnitTests
                 TransientTestFile projectFile1 = env.CreateFile(testFolder, "testProject01.proj", contents);
                 string consoleOutput1 = RunnerUtilities.ExecMSBuild($"{projectFile1.Path} -bl:{logger.Parameters} -verbosity:q -nologo", out bool success1);
                 success1.ShouldBeTrue();
-                var expected1 = $"MSBuild.exe -nologo -bl:{logger.Parameters} -verbosity:q {projectFile1.Path}";
+                var expected1 = $"-nologo -bl:{logger.Parameters} -verbosity:q {projectFile1.Path}";
                 consoleOutput1.ShouldNotContain(expected1);
 
                 TransientTestFile projectFile2 = env.CreateFile(testFolder, "testProject02.proj", contents);
                 string consoleOutput2 = RunnerUtilities.ExecMSBuild($"{projectFile2.Path} -bl:{logger.Parameters} -verbosity:m -nologo", out bool success2);
                 success2.ShouldBeTrue();
-                var expected2 = $"MSBuild.exe -nologo -bl:{logger.Parameters} -verbosity:m {projectFile2.Path}";
+                var expected2 = $"-nologo -bl:{logger.Parameters} -verbosity:m {projectFile2.Path}";
                 consoleOutput2.ShouldContain(expected2); ;
             }
         }

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -279,11 +279,11 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         /// <remarks>
         /// This test verifies,
-        /// 1. When binary log and verbosity=quiet are both set, the equivalent command line is NOT printed
-        /// 2. When binary log and non-quiet verbosity are set, the equivalent command line is still printed
+        /// 1. When binary log and verbosity=diagnostic are both set, the equivalent command line is printed.
+        /// 2. When binary log and non-diag verbosity are set, the equivalent command line is NOT printed.
         /// </remarks>
         [Fact]
-        public void NoOutputWhenBinaryLoggerAndQuietVerbosityBothSet()
+        public void SuppressCommandOutputForNonDiagVerbosity()
         {
             using (TestEnvironment env = TestEnvironment.Create())
             {
@@ -298,16 +298,19 @@ namespace Microsoft.Build.UnitTests
                 TransientTestFolder testFolder = env.CreateFolder(createFolder: true);
 
                 TransientTestFile projectFile1 = env.CreateFile(testFolder, "testProject01.proj", contents);
-                string consoleOutput1 = RunnerUtilities.ExecMSBuild($"{projectFile1.Path} -bl:{logger.Parameters} -verbosity:q -nologo", out bool success1);
+                string consoleOutput1 = RunnerUtilities.ExecMSBuild($"{projectFile1.Path} -bl:{logger.Parameters} -verbosity:diag -nologo", out bool success1);
                 success1.ShouldBeTrue();
-                var expected1 = $"-nologo -bl:{logger.Parameters} -verbosity:q {projectFile1.Path}";
-                consoleOutput1.ShouldNotContain(expected1);
+                var expected1 = $"-nologo -bl:{logger.Parameters} -verbosity:diag {projectFile1.Path}";
+                consoleOutput1.ShouldContain(expected1);
 
-                TransientTestFile projectFile2 = env.CreateFile(testFolder, "testProject02.proj", contents);
-                string consoleOutput2 = RunnerUtilities.ExecMSBuild($"{projectFile2.Path} -bl:{logger.Parameters} -verbosity:m -nologo", out bool success2);
-                success2.ShouldBeTrue();
-                var expected2 = $"-nologo -bl:{logger.Parameters} -verbosity:m {projectFile2.Path}";
-                consoleOutput2.ShouldContain(expected2); ;
+                foreach (var verbosity in new string[] { "q", "m", "n", "d" })
+                {
+                    TransientTestFile projectFile2 = env.CreateFile(testFolder, $"testProject_{verbosity}.proj", contents);
+                    string consoleOutput2 = RunnerUtilities.ExecMSBuild($"{projectFile2.Path} -bl:{logger.Parameters} -verbosity:{verbosity} -nologo", out bool success2);
+                    success2.ShouldBeTrue();
+                    var expected2 = $"-nologo -bl:{logger.Parameters} -verbosity:{verbosity} {projectFile2.Path}";
+                    consoleOutput2.ShouldNotContain(expected2);
+                }
             }
         }
 

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -274,6 +274,43 @@ namespace Microsoft.Build.UnitTests
                 .OverallResult.ShouldBe(BuildResultCode.Success);
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/dotnet/msbuild/issues/7828
+        /// </summary>
+        /// <remarks>
+        /// This test verifies,
+        /// 1. When binary log and verbosity=quiet are both set, the equivalent command line is NOT printed
+        /// 2. When binary log and non-quiet verbosity are set, the equivalent command line is still printed
+        /// </remarks>
+        [Fact]
+        public void NoOutputWhenBinaryLoggerAndQuietVerbosityBothSet()
+        {
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                var contents = @"
+                    <Project>
+                        <Target Name='Target2'>
+                            <Exec Command='echo a'/>
+                        </Target>
+                    </Project>";
+                BinaryLogger logger = new();
+                logger.Parameters = _logFile;
+                TransientTestFolder testFolder = env.CreateFolder(createFolder: true);
+
+                TransientTestFile projectFile1 = env.CreateFile(testFolder, "testProject01.proj", contents);
+                string consoleOutput1 = RunnerUtilities.ExecMSBuild($"{projectFile1.Path} -bl:{logger.Parameters} -verbosity:q -nologo", out bool success1);
+                success1.ShouldBeTrue();
+                var expected1 = $"MSBuild.exe -nologo -bl:{logger.Parameters} -verbosity:q {projectFile1.Path}";
+                consoleOutput1.ShouldNotContain(expected1);
+
+                TransientTestFile projectFile2 = env.CreateFile(testFolder, "testProject02.proj", contents);
+                string consoleOutput2 = RunnerUtilities.ExecMSBuild($"{projectFile2.Path} -bl:{logger.Parameters} -verbosity:m -nologo", out bool success2);
+                success2.ShouldBeTrue();
+                var expected2 = $"MSBuild.exe -nologo -bl:{logger.Parameters} -verbosity:m {projectFile2.Path}";
+                consoleOutput2.ShouldContain(expected2); ;
+            }
+        }
+
         public void Dispose()
         {
             _env.Dispose();

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -678,6 +678,7 @@ namespace Microsoft.Build.CommandLine
                 Dictionary<string, string> restoreProperties = null;
                 ILogger[] loggers = Array.Empty<ILogger>();
                 LoggerVerbosity verbosity = LoggerVerbosity.Normal;
+                LoggerVerbosity originalVerbosity = LoggerVerbosity.Normal;
                 List<DistributedLoggerRecord> distributedLoggerRecords = null;
 #if FEATURE_XML_SCHEMA_VALIDATION
                 bool needToValidateProject = false;
@@ -715,6 +716,7 @@ namespace Microsoft.Build.CommandLine
                                             ref globalProperties,
                                             ref loggers,
                                             ref verbosity,
+                                            ref originalVerbosity,
                                             ref distributedLoggerRecords,
 #if FEATURE_XML_SCHEMA_VALIDATION
                                             ref needToValidateProject,
@@ -2176,6 +2178,7 @@ namespace Microsoft.Build.CommandLine
             ref Dictionary<string, string> globalProperties,
             ref ILogger[] loggers,
             ref LoggerVerbosity verbosity,
+            ref LoggerVerbosity originalVerbosity,
             ref List<DistributedLoggerRecord> distributedLoggerRecords,
 #if FEATURE_XML_SCHEMA_VALIDATION
             ref bool needToValidateProject,
@@ -2291,6 +2294,7 @@ namespace Microsoft.Build.CommandLine
                                                            ref globalProperties,
                                                            ref loggers,
                                                            ref verbosity,
+                                                           ref originalVerbosity,
                                                            ref distributedLoggerRecords,
 #if FEATURE_XML_SCHEMA_VALIDATION
                                                            ref needToValidateProject,
@@ -2398,6 +2402,7 @@ namespace Microsoft.Build.CommandLine
                         groupedFileLoggerParameters,
                         out distributedLoggerRecords,
                         out verbosity,
+                        out originalVerbosity,
                         cpuCount,
                         out profilerLogger,
                         out enableProfiler
@@ -2428,7 +2433,7 @@ namespace Microsoft.Build.CommandLine
                         Console.WriteLine(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("PickedUpSwitchesFromAutoResponse", autoResponseFileName));
                     }
 
-                    if (verbosity == LoggerVerbosity.Diagnostic)
+                    if (verbosity == LoggerVerbosity.Diagnostic && originalVerbosity != LoggerVerbosity.Quiet)
                     {
                         string equivalentCommandLine = commandLineSwitches.GetEquivalentCommandLineExceptProjectFile();
                         Console.WriteLine($"{Path.Combine(s_exePath, s_exeName)} {equivalentCommandLine} {projectFile}");
@@ -3181,18 +3186,19 @@ namespace Microsoft.Build.CommandLine
             string[][] groupedFileLoggerParameters,
             out List<DistributedLoggerRecord> distributedLoggerRecords,
             out LoggerVerbosity verbosity,
+            out LoggerVerbosity originalVerbosity,
             int cpuCount,
             out ProfilerLogger profilerLogger,
             out bool enableProfiler
         )
         {
             // if verbosity level is not specified, use the default
-            verbosity = LoggerVerbosity.Normal;
+            originalVerbosity = verbosity = LoggerVerbosity.Normal;
 
             if (verbositySwitchParameters.Length > 0)
             {
                 // Read the last verbosity switch found
-                verbosity = ProcessVerbositySwitch(verbositySwitchParameters[verbositySwitchParameters.Length - 1]);
+                originalVerbosity = verbosity = ProcessVerbositySwitch(verbositySwitchParameters[verbositySwitchParameters.Length - 1]);
             }
 
             var loggers = ProcessLoggerSwitch(loggerSwitchParameters, verbosity);

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3193,12 +3193,14 @@ namespace Microsoft.Build.CommandLine
         )
         {
             // if verbosity level is not specified, use the default
-            originalVerbosity = verbosity = LoggerVerbosity.Normal;
+            originalVerbosity = LoggerVerbosity.Normal;
+            verbosity = originalVerbosity;
 
             if (verbositySwitchParameters.Length > 0)
             {
                 // Read the last verbosity switch found
-                originalVerbosity = verbosity = ProcessVerbositySwitch(verbositySwitchParameters[verbositySwitchParameters.Length - 1]);
+                originalVerbosity = ProcessVerbositySwitch(verbositySwitchParameters[verbositySwitchParameters.Length - 1]);
+                verbosity = originalVerbosity;
             }
 
             var loggers = ProcessLoggerSwitch(loggerSwitchParameters, verbosity);

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2433,7 +2433,7 @@ namespace Microsoft.Build.CommandLine
                         Console.WriteLine(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("PickedUpSwitchesFromAutoResponse", autoResponseFileName));
                     }
 
-                    if (verbosity == LoggerVerbosity.Diagnostic && originalVerbosity != LoggerVerbosity.Quiet)
+                    if (originalVerbosity == LoggerVerbosity.Diagnostic)
                     {
                         string equivalentCommandLine = commandLineSwitches.GetEquivalentCommandLineExceptProjectFile();
                         Console.WriteLine($"{Path.Combine(s_exePath, s_exeName)} {equivalentCommandLine} {projectFile}");


### PR DESCRIPTION
Fixes #7828 

### Context
Binary logger option overrides verbosity by diagnostic and prints a line even verbosity is set to quiet.

### Changes Made
The fix introduces a variable to store the original verbosity, if the "original verbosity" is quiet, it suppresses the console output when binary logger is requested. 

### Testing


### Notes
