### PR TITLE
Make ProjectShouldBuild public

### DIFF
--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -252,8 +252,9 @@ namespace Microsoft.Build.Construction
 
         #region Methods
 
-        internal bool ProjectShouldBuild(string projectFile)
+        public bool ProjectShouldBuild(string projectFile)
         {
+            ErrorUtilities.VerifyThrowInvalidOperation(_solutionFile is not null, "SolutionFilterAccessedBeforeParse");
             return _solutionFilter?.Contains(FileUtilities.FixFilePath(projectFile)) != false;
         }
 

--- a/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.Build.Construction.SolutionFile.ProjectShouldBuild(string projectFile) -> bool
 Microsoft.Build.Evaluation.ProjectCollection.ProjectCollection(System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool useAsynchronousLogging, bool reuseProjectRootElementCache) -> void
 Microsoft.Build.Experimental.MSBuildClient
 Microsoft.Build.Experimental.MSBuildClient.Execute(System.Threading.CancellationToken cancellationToken) -> Microsoft.Build.Experimental.MSBuildClientExitResult

--- a/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Build/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.Build.Construction.SolutionFile.ProjectShouldBuild(string projectFile) -> bool
 Microsoft.Build.Evaluation.ProjectCollection.ProjectCollection(System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool useAsynchronousLogging, bool reuseProjectRootElementCache) -> void
 Microsoft.Build.Experimental.MSBuildClient
 Microsoft.Build.Experimental.MSBuildClient.Execute(System.Threading.CancellationToken cancellationToken) -> Microsoft.Build.Experimental.MSBuildClientExitResult

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -919,6 +919,10 @@
     <value>MSB4160: A circular dependency involving project "{0}" has been detected.</value>
     <comment>{StrBegin="MSB4160: "}</comment>
   </data>
+  <data name="SolutionFilterAccessedBeforeParse" xml:space="preserve">
+    <value>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</value>
+    <comment>SolutionFile.Parse and ProjectShouldBuild should not be localized.</comment>
+  </data>
   <data name="SolutionInvalidSolutionConfiguration" xml:space="preserve">
     <value>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</value>
     <comment>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</comment>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">MSB4264: Neplatná vlastnost $(SolutionPath): {0}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: Ungültige $(SolutionPath)-Eigenschaft: {0}"</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: Propiedad $(SolutionPath) no válida: {0}"</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: propriété $(SolutionPath) non valide : {0}"</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: la proprietà $(SolutionPath) non è valida: {0}"</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: 無効な $(SolutionPath) プロパティ: {0}"</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: 잘못된 $(SolutionPath) 속성: {0}"</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">„MSB4264: nieprawidłowa właściwość $(SolutionPath): {0}”</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: propriedade $(SolutionPath) inválida: {0}"</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: недопустимое свойство $(SolutionPath) — {0}"</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: $(SolutionPath) özelliği geçersiz: {0}"</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">“MSB4264: $(SolutionPath) 属性无效: {0}”</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -351,6 +351,11 @@
       LOCALIZATION: {0} and {1} are file paths
     </note>
       </trans-unit>
+      <trans-unit id="SolutionFilterAccessedBeforeParse">
+        <source>Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</source>
+        <target state="new">Cannot access whether a solution filter filtered out a particular project until the solution has been parsed. Call SolutionFile.Parse before ProjectShouldBuild.</target>
+        <note>SolutionFile.Parse and ProjectShouldBuild should not be localized.</note>
+      </trans-unit>
       <trans-unit id="SolutionPathPropertyMustBeSetOnVSSubmissions">
         <source>"MSB4264: Invalid $(SolutionPath) property: {0}"</source>
         <target state="translated">"MSB4264: $(SolutionPath) 屬性無效: {0}"</target>


### PR DESCRIPTION
### Context
NuGet wants to access whether a particular project was filtered out by a solution filter file. They had previously called SolutionFile.Parse. We have a ProjectShouldBuild method that can be called on a SolutionFile. This makes that method public, hence accessible.