### PR TITLE
Skip passing Satellite Assemblies to ResolveManifestFile in Single-File Mode of ClickOnce publish

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4370,9 +4370,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                                             Exclude="@(ReferenceCopyLocalPaths);@(_NETStandardLibraryNETFrameworkLib)" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(PublishSingleFile)' != 'true'">
+      <_ClickOnceSatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
+    </ItemGroup>
+
     <!-- Flag primary dependencies-certain warnings emitted during application manifest generation apply only to them. -->
     <ItemGroup>
-      <_SatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
       <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)"
                                  Condition="('%(Extension)' == '.dll' Or '%(Extension)' == '.exe' Or '%(Extension)' == '.md') and ('%(ReferenceCopyLocalPaths.CopyToPublishDirectory)' != 'false')">
         <IsPrimary>true</IsPrimary>
@@ -4383,7 +4386,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Include managed references in clickonce manifest only if single file publish is false -->
     <ItemGroup Condition="'$(PublishSingleFile)' != 'true'">
       <_ManifestManagedReferences Include="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly);@(ReferenceCOMWrappersToCopyLocal)"
-                               Exclude="@(_SatelliteAssemblies);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)" />
+                               Exclude="@(_ClickOnceSatelliteAssemblies);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)" />
     </ItemGroup>
 
     <!-- Include the following files in clickonce manifest only if single file publish is false -->
@@ -4474,7 +4477,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"
         PublishFiles="@(PublishFile)"
         RuntimePackAssets="@(RuntimePackAsset)"
-        SatelliteAssemblies="@(_SatelliteAssemblies)"
+        SatelliteAssemblies="@(_ClickOnceSatelliteAssemblies)"
         SigningManifests="$(SignManifests)"
         TargetCulture="$(TargetCulture)"
         TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"


### PR DESCRIPTION

Fixes [AB#1619029](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1619029)

### Context
During Single-File publish, the satellite assemblies are embedded in the EXE. The ClickOnce manifest should exclude satellite assemblies in this mode but it is not doing so currently.

### Changes Made
Satellite Assemblies item group is now being conditionally populated when SF mode is false.

### Testing
Verified with repro provided by customer. Additional testing done by CTI team for all ClickOnce configurations.

### Notes
