### PR TITLE
Log each inner exception of an aggregate exception in TaskLoggingHelper.LogErrorFromException()

### DIFF
--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -923,6 +923,17 @@ namespace Microsoft.Build.Utilities
             // global state.
             ErrorUtilities.VerifyThrowArgumentNull(exception, nameof(exception));
 
+            // For an AggregateException call LogErrorFromException on each inner exception
+            if (exception is AggregateException aggregateException)
+            {
+                foreach (Exception innerException in aggregateException.Flatten().InnerExceptions)
+                {
+                    LogErrorFromException(innerException, showStackTrace, showDetail, file);
+                }
+
+                return;
+            }
+
             string message;
 
             if (!showDetail && (Environment.GetEnvironmentVariable("MSBUILDDIAGNOSTICS") == null)) // This env var is also used in ToolTask

--- a/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
+++ b/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.Build.Exceptions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
@@ -282,6 +283,30 @@ namespace Microsoft.Build.UnitTests
                 engine.AssertLogContains(stackTrace);
                 engine.AssertLogContains("InvalidOperationException");
             }
+        }
+
+        /// <summary>
+        /// Verify that <see cref="TaskLoggingHelper.LogErrorFromException(Exception, bool, bool, string)" /> logs inner exceptions from an <see cref="AggregateException" />.
+        /// </summary>
+        [Fact]
+        public void TestLogFromExceptionWithAggregateException()
+        {
+            AggregateException aggregateException = new AggregateException(
+                new InvalidOperationException("The operation was invalid"),
+                new IOException("An I/O error occurred"));
+
+            MockEngine engine = new MockEngine();
+            MockTask task = new MockTask
+            {
+                BuildEngine = engine
+            };
+
+            task.Log.LogErrorFromException(aggregateException);
+
+            engine.Errors.ShouldBe(2);
+
+            engine.AssertLogContains("The operation was invalid");
+            engine.AssertLogContains("An I/O error occurred");
         }
     }
 }


### PR DESCRIPTION
Fixes #7985 

### Context
`TaskLoggingHelper.LogErrorFromException()` does not currently take into account the relatively new `AggregateException` which has inner exceptions but an outer exception with very little details.

### Changes Made
I've updated `TaskLoggingHelper.LogErrorFromException()` to check if the specified exception is an `AggregateException` and call the method again for each inner exception, respecting all of the arguments passed in around showing details or a stack trace.

### Testing
A unit test was added

### Notes
Unfortunately, I can't add the other improvement around an `InvalidProjectFileException` since `TaskLoggingHelper` is compiled into `Microsoft.Build.Utilities.Core` and that assembly does not reference `Microsoft.Build.dll` so it doesn't have access to the `InvalidProjectFileException` class 😢 