### PR TITLE
Fallback when server launch fail due to create mutex error

### DIFF
--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Build.Experimental
 
             return (acceptAnsiColorCodes: acceptAnsiColorCodes, outputIsScreen: outputIsScreen);
         }
-
+        
         private int QueryConsoleBufferWidth()
         {
             int consoleBufferWidth = -1;
@@ -454,22 +454,23 @@ namespace Microsoft.Build.Experimental
         private bool TryLaunchServer()
         {
             string serverLaunchMutexName = $@"Global\msbuild-server-launch-{_handshake.ComputeHash()}";
-            using var serverLaunchMutex = ServerNamedMutex.OpenOrCreateMutex(serverLaunchMutexName, out bool mutexCreatedNew);
-            if (!mutexCreatedNew)
-            {
-                // Some other client process launching a server and setting a build request for it. Fallback to usual msbuild app build.
-                CommunicationsUtilities.Trace("Another process launching the msbuild server, falling back to former behavior.");
-                _exitResult.MSBuildClientExitType = MSBuildClientExitType.ServerBusy;
-                return false;
-            }
-
-            string[] msBuildServerOptions = new string[] {
-                "/nologo",
-                "/nodemode:8"
-            };
-
             try
             {
+                // For unknown root cause, opening mutex can sometimes throw 'Connection timed out' exception. See: https://github.com/dotnet/msbuild/issues/7993
+                using var serverLaunchMutex = ServerNamedMutex.OpenOrCreateMutex(serverLaunchMutexName, out bool mutexCreatedNew);
+                if (!mutexCreatedNew)
+                {
+                    // Some other client process launching a server and setting a build request for it. Fallback to usual msbuild app build.
+                    CommunicationsUtilities.Trace("Another process launching the msbuild server, falling back to former behavior.");
+                    _exitResult.MSBuildClientExitType = MSBuildClientExitType.ServerBusy;
+                    return false;
+                }
+
+                string[] msBuildServerOptions = new string[] {
+                    "/nologo",
+                    "/nodemode:8"
+                };
+
                 NodeLauncher nodeLauncher = new NodeLauncher();
                 CommunicationsUtilities.Trace("Starting Server...");
                 Process msbuildProcess = nodeLauncher.Start(_msbuildLocation, string.Join(" ", msBuildServerOptions));


### PR DESCRIPTION
Fixes #7993, https://github.com/dotnet/runtime/issues/75867

### Context
There were reported issues, when mutex logic failed with unhandled IOException.

### Changes Made
Extend TryLaunchServer try-catch scope to Include opening mutex and if it throws fallback to non-server behavior.

### Testing
Unit test, CI.
