### PR TITLE
Fix condition of the ClickOnce's CleanPublishFolder target.

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5715,7 +5715,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <RemoveDir
         Directories="$(ClickOncePublishDir)"
-        Condition="'$(ClickOncePublishDir)'=='$(OutputPath)app.publish\' and Exists('$(ClickOncePublishDir)')"/>
+        Condition="Exists('$(ClickOncePublishDir)')"/>
 
   </Target>
 


### PR DESCRIPTION
Fixes #[1620098](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1620098/)

### Context
ClickOnce publish has an intermediate publish location pointed to by PublishDir property. Depending on the publish configuration, it can be in a different location than under OutputPath. The PublishDir location has to be cleaned before each publish step to prevent leftover artifacts from previous publish getting copied to the final publish location.
The CleanPublishFolder target that does this is currently conditioned to run only if the PublishDir is under OutputPath which results in PublishDir not getting cleaned up depending on the configuration.

### Changes Made
Change the condition on the CleanPublishFolder to clean up the folder before publish.

### Testing
Tested all ClickOnce configurations.

### Notes
