### PR TITLE
dotnet watch causing server to always fail

### DIFF
--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Build.Experimental
             _shutdownEvent.Set();
         }
 
-        private static void HandleBuildCancel() 
+        private void HandleBuildCancel()
         {
             CommunicationsUtilities.Trace("Received request to cancel build running on MSBuild Server. MSBuild server will shutdown.}");
             _cancelRequested = true;

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -67,6 +67,10 @@ namespace Microsoft.Build.Experimental
         /// </summary>
         private Exception? _shutdownException = null;
 
+        /// <summary>
+        /// Indicate that cancel has been requested and initiated.
+        /// </summary>        
+        private bool _cancelRequested = false;
         private string _serverBusyMutexName = default!;
 
         public OutOfProcServerNode(BuildCallback buildFunction)
@@ -312,7 +316,11 @@ namespace Microsoft.Build.Experimental
             _shutdownEvent.Set();
         }
 
-        private static void HandleBuildCancel() => BuildManager.DefaultBuildManager.CancelAllSubmissions();
+        private static void HandleBuildCancel() 
+        {
+            CommunicationsUtilities.Trace("Received request to cancel build running on MSBuild Server. MSBuild server will shutdown.}");
+            BuildManager.DefaultBuildManager.CancelAllSubmissions();
+        }
 
         private void HandleServerNodeBuildCommandAsync(ServerNodeBuildCommand command)
         {
@@ -411,10 +419,10 @@ namespace Microsoft.Build.Experimental
             var response = new ServerNodeBuildResult(buildResult.exitCode, buildResult.exitType);
             SendPacket(response);
 
-            _shutdownReason = NodeEngineShutdownReason.BuildCompleteReuse;
+            // Shutdown server if cancel was requested. This is consistent with nodes behavior.
+            _shutdownReason = _cancelRequested ? NodeEngineShutdownReason.BuildComplete : NodeEngineShutdownReason.BuildCompleteReuse;
             _shutdownEvent.Set();
         }
-
         internal sealed class RedirectConsoleWriter : StringWriter
         {
             private readonly Action<string> _writeCallback;

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -319,6 +319,7 @@ namespace Microsoft.Build.Experimental
         private static void HandleBuildCancel() 
         {
             CommunicationsUtilities.Trace("Received request to cancel build running on MSBuild Server. MSBuild server will shutdown.}");
+            _cancelRequested = true;
             BuildManager.DefaultBuildManager.CancelAllSubmissions();
         }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -956,6 +956,9 @@ namespace Microsoft.Build.CommandLine
                 s_buildComplete.Set();
                 Console.CancelKeyPress -= cancelHandler;
 
+                // Wait for any pending cancel, so that we get any remaining messages
+                s_cancelComplete.WaitOne();
+
 #if FEATURE_GET_COMMANDLINE
                 MSBuildEventSource.Log.MSBuildExeStop(commandLine);
 #else
@@ -963,8 +966,6 @@ namespace Microsoft.Build.CommandLine
                     MSBuildEventSource.Log.MSBuildExeStop(string.Join(" ", commandLine));
                 }
 #endif
-                // Wait for any pending cancel, so that we get any remaining messages
-                s_cancelComplete.WaitOne();
             }
             /**********************************************************************************************************************
              * WARNING: Do NOT add any more catch blocks above!
@@ -1034,10 +1035,10 @@ namespace Microsoft.Build.CommandLine
                 }
                 finally
                 {
-                    // Server node shall terminate, if it received CancelKey press and gracefully cancelled all its submissions.
+                    // Server node shall terminate after it received CancelKey press.
                     if (s_isServerNode)
                     {
-                        Environment.Exit(1); // the process will now be terminated rudely
+                        Environment.Exit(0); // the process cab now be terminated as everything has already been gracefully cancelled.
                     }
                 }
             };

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -956,9 +956,6 @@ namespace Microsoft.Build.CommandLine
                 s_buildComplete.Set();
                 Console.CancelKeyPress -= cancelHandler;
 
-                // Wait for any pending cancel, so that we get any remaining messages
-                s_cancelComplete.WaitOne();
-
 #if FEATURE_GET_COMMANDLINE
                 MSBuildEventSource.Log.MSBuildExeStop(commandLine);
 #else
@@ -966,6 +963,8 @@ namespace Microsoft.Build.CommandLine
                     MSBuildEventSource.Log.MSBuildExeStop(string.Join(" ", commandLine));
                 }
 #endif
+                // Wait for any pending cancel, so that we get any remaining messages
+                s_cancelComplete.WaitOne();
             }
             /**********************************************************************************************************************
              * WARNING: Do NOT add any more catch blocks above!
@@ -993,8 +992,8 @@ namespace Microsoft.Build.CommandLine
                 return;
             }
 
-            s_buildCancellationSource.Cancel();
 
+            s_buildCancellationSource.Cancel();
             Console.WriteLine(ResourceUtilities.GetResourceString("AbortingBuild"));
 
             // The OS takes a lock in
@@ -1031,6 +1030,12 @@ namespace Microsoft.Build.CommandLine
                 }
 
                 s_cancelComplete.Set(); // This will release our main Execute method so we can finally exit.
+
+                // Server node shall terminate, if it received CancelKey press and gracefully cancelled all its submissions.
+                if (s_isServerNode)
+                {
+                    Environment.Exit(1); // the process will now be terminated rudely
+                }
             };
 
             ThreadPoolExtensions.QueueThreadPoolWorkItemWithCulture(callback, CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1038,7 +1038,7 @@ namespace Microsoft.Build.CommandLine
                     // Server node shall terminate after it received CancelKey press.
                     if (s_isServerNode)
                     {
-                        Environment.Exit(0); // the process cab now be terminated as everything has already been gracefully cancelled.
+                        Environment.Exit(0); // the process can now be terminated as everything has already been gracefully cancelled.
                     }
                 }
             };

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -992,9 +992,8 @@ namespace Microsoft.Build.CommandLine
                 return;
             }
 
-
-            s_buildCancellationSource.Cancel();
             Console.WriteLine(ResourceUtilities.GetResourceString("AbortingBuild"));
+            s_buildCancellationSource.Cancel();
 
             // The OS takes a lock in
             // kernel32.dll!_SetConsoleCtrlHandler, so if a task

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1005,36 +1005,41 @@ namespace Microsoft.Build.CommandLine
             // We're already on a threadpool thread anyway.
             WaitCallback callback = delegate
             {
-                s_cancelComplete.Reset();
-
-                // If the build is already complete, just exit.
-                if (s_buildComplete.WaitOne(0))
+                try 
                 {
-                    s_cancelComplete.Set();
-                    return;
+                    s_cancelComplete.Reset();
+
+                    // If the build is already complete, just exit.
+                    if (s_buildComplete.WaitOne(0))
+                    {
+                        s_cancelComplete.Set();
+                        return;
+                    }
+
+                    // If the build has already started (or already finished), we will cancel it
+                    // If the build has not yet started, it will cancel itself, because
+                    // we set alreadyCalled=1
+                    bool hasBuildStarted;
+                    lock (s_buildLock)
+                    {
+                        hasBuildStarted = s_hasBuildStarted;
+                    }
+
+                    if (hasBuildStarted)
+                    {
+                        BuildManager.DefaultBuildManager.CancelAllSubmissions();
+                        s_buildComplete.WaitOne();
+                    }
+
+                    s_cancelComplete.Set(); // This will release our main Execute method so we can finally exit.
                 }
-
-                // If the build has already started (or already finished), we will cancel it
-                // If the build has not yet started, it will cancel itself, because
-                // we set alreadyCalled=1
-                bool hasBuildStarted;
-                lock (s_buildLock)
+                finally
                 {
-                    hasBuildStarted = s_hasBuildStarted;
-                }
-
-                if (hasBuildStarted)
-                {
-                    BuildManager.DefaultBuildManager.CancelAllSubmissions();
-                    s_buildComplete.WaitOne();
-                }
-
-                s_cancelComplete.Set(); // This will release our main Execute method so we can finally exit.
-
-                // Server node shall terminate, if it received CancelKey press and gracefully cancelled all its submissions.
-                if (s_isServerNode)
-                {
-                    Environment.Exit(1); // the process will now be terminated rudely
+                    // Server node shall terminate, if it received CancelKey press and gracefully cancelled all its submissions.
+                    if (s_isServerNode)
+                    {
+                        Environment.Exit(1); // the process will now be terminated rudely
+                    }
                 }
             };
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/8009

### Context
Theory: dotnet watch stopping was sending Ctrl+C (SIGINT) to its child processes, which is unexpected as CTRL+C is propagated from client by build server packet command through its named pipe. 
Server set its cancellation token and all subsequent build has been therefore considered as to be cancelled.

### Changes Made
When server recieves Ctrl+C (SIGINT) it now gracefully shut down its build submissions and then terminate.

### Testing
Can't repro after code changes.

### Notes
