### PR TITLE
Ignore case when checking for pseudolocales

### DIFF
--- a/src/Tasks.UnitTests/AssignCulture_Tests.cs
+++ b/src/Tasks.UnitTests/AssignCulture_Tests.cs
@@ -259,5 +259,24 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal($"MyResource.{culture}.resx", t.AssignedFiles[0].ItemSpec);
             Assert.Equal("MyResource.resx", t.CultureNeutralAssignedFiles[0].ItemSpec);
         }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "This is a net core codepath")]
+        public void Pseudolocales_CaseInsensitive()
+        {
+            string culture = "qps-Ploc";
+            AssignCulture t = new AssignCulture();
+            t.BuildEngine = new MockEngine();
+            ITaskItem i = new TaskItem($"MyResource.{culture}.resx");
+            t.Files = new ITaskItem[] { i };
+            t.Execute();
+
+            Assert.Single(t.AssignedFiles);
+            Assert.Single(t.CultureNeutralAssignedFiles);
+            Assert.True(t.AssignedFiles[0].GetMetadata("WithCulture").Equals("true"));
+            Assert.Equal(culture, t.AssignedFiles[0].GetMetadata("Culture"));
+            Assert.Equal($"MyResource.{culture}.resx", t.AssignedFiles[0].ItemSpec);
+            Assert.Equal("MyResource.resx", t.CultureNeutralAssignedFiles[0].ItemSpec);
+        }
     }
 }

--- a/src/Tasks.UnitTests/AssignCulture_Tests.cs
+++ b/src/Tasks.UnitTests/AssignCulture_Tests.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.Single(t.AssignedFiles);
             Assert.Single(t.CultureNeutralAssignedFiles);
-            Assert.True(t.AssignedFiles[0].GetMetadata("WithCulture").Equals("true"));
+            Assert.Equal(t.AssignedFiles[0].GetMetadata("WithCulture"), "true");
             Assert.Equal(culture, t.AssignedFiles[0].GetMetadata("Culture"));
             Assert.Equal($"MyResource.{culture}.resx", t.AssignedFiles[0].ItemSpec);
             Assert.Equal("MyResource.resx", t.CultureNeutralAssignedFiles[0].ItemSpec);

--- a/src/Tasks.UnitTests/AssignCulture_Tests.cs
+++ b/src/Tasks.UnitTests/AssignCulture_Tests.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "This is a net core codepath")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Pseudoloc is special-cased in .NET relative to Framework.")]
         public void Pseudolocales_CaseInsensitive()
         {
             string culture = "qps-Ploc";

--- a/src/Tasks.UnitTests/AssignCulture_Tests.cs
+++ b/src/Tasks.UnitTests/AssignCulture_Tests.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.Single(t.AssignedFiles);
             Assert.Single(t.CultureNeutralAssignedFiles);
-            Assert.Equal(t.AssignedFiles[0].GetMetadata("WithCulture"), "true");
+            Assert.Equal("true", t.AssignedFiles[0].GetMetadata("WithCulture"));
             Assert.Equal(culture, t.AssignedFiles[0].GetMetadata("Culture"));
             Assert.Equal($"MyResource.{culture}.resx", t.AssignedFiles[0].ItemSpec);
             Assert.Equal("MyResource.resx", t.CultureNeutralAssignedFiles[0].ItemSpec);

--- a/src/Tasks/CultureInfoCache.cs
+++ b/src/Tasks/CultureInfoCache.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Build.Tasks
                 catch
                 {
                     // Second attempt: try pseudolocales (see above)
-                    return pseudoLocales.Contains(name);
+                    return pseudoLocales.Contains(name, StringComparer.OrdinalIgnoreCase);
                 }
             }
 #endif


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/27890

### Customer Impact
Customer resources containing pseudolocales were no longer recognized due to case sensitivity. This prevented resources being generated of the given pseudolocale.

### Testing
Added regression test
Tested locally by manually patching the SDK

### Code Reviewers

### Description of fix
When determining culture-validity on pseudolocales, ensure **case-insensitivity** during the check.

### Notes
This wasn't an issue before because these items were added to a **case insensitive hashset.** This new codepath checks the array directly, but I forgot to pass along `OrdinalIgnoreCase`.