### PR TITLE
Restore newline auto return

### DIFF
--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -354,15 +354,14 @@ namespace Microsoft.Build.Experimental
                     if (NativeMethodsShared.GetConsoleMode(stdOut, out uint consoleMode))
                     {
                         bool success;
-                        if ((consoleMode & NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING) == NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING &&
-                            (consoleMode & NativeMethodsShared.DISABLE_NEWLINE_AUTO_RETURN) == NativeMethodsShared.DISABLE_NEWLINE_AUTO_RETURN)
+                        if ((consoleMode & NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING) == NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
                         {
                             // Console is already in required state
                             success = true;
                         }
                         else
                         {
-                            consoleMode |= NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING | NativeMethodsShared.DISABLE_NEWLINE_AUTO_RETURN;
+                            consoleMode |= NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
                             success = NativeMethodsShared.SetConsoleMode(stdOut, consoleMode);
                         }
 

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -36,7 +36,6 @@ internal static class NativeMethods
     internal const uint RUNTIME_INFO_DONT_SHOW_ERROR_DIALOG = 0x40;
     internal const uint FILE_TYPE_CHAR = 0x0002;
     internal const Int32 STD_OUTPUT_HANDLE = -11;
-    internal const uint DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
     internal const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
     internal const uint RPC_S_CALLPENDING = 0x80010115;
     internal const uint E_ABORT = (uint)0x80004004;


### PR DESCRIPTION
Fixes #8008

### Context
With the MSBuild server, I added support for VT100, which meant we could understand colorization and such from an older command prompt, but I also added DISABLE_NEWLINE_AUTO_RETURN, which made the UI look worse.

### Customer Impact
Customers using MSBuild server  and trying to print newlines (`\n`) will see output with extra space.

### Testing
Manually tested the change: ran the proposed repro project and saw the bug. Overwrote the MSBuild in that SDK with custom bits from this PR and retested it, and I could no longer reproduce the issue. Tried using MSBuild.exe on a random project, and the important part of the VT100 change was preserved.

### Code Reviewers
rokonec

### Description of fix
Removed the DISABLE_NEWLINE_AUTO_RETURN argument
