### PR TITLE
Restore console mode after server build

### DIFF
--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -200,7 +200,6 @@ namespace Microsoft.Build.Experimental
             // Send build command.
             // Let's send it outside the packet pump so that we easier and quicker deal with possible issues with connection to server.
             MSBuildEventSource.Log.MSBuildServerBuildStart(descriptiveCommandLine);
-            IntPtr stdOut = NativeMethodsShared.GetStdHandle(NativeMethodsShared.STD_OUTPUT_HANDLE);
             if (TrySendBuildCommand())
             {
                 _numConsoleWritePackets = 0;
@@ -214,11 +213,11 @@ namespace Microsoft.Build.Experimental
 
             if (NativeMethodsShared.IsWindows && _originalConsoleMode is not null)
             {
+                IntPtr stdOut = NativeMethodsShared.GetStdHandle(NativeMethodsShared.STD_OUTPUT_HANDLE);
                 NativeMethodsShared.SetConsoleMode(stdOut, _originalConsoleMode.Value);
             }
 
             return _exitResult;
-
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -363,7 +363,6 @@ namespace Microsoft.Build.Experimental
                     IntPtr stdOut = NativeMethodsShared.GetStdHandle(NativeMethodsShared.STD_OUTPUT_HANDLE);
                     if (NativeMethodsShared.GetConsoleMode(stdOut, out uint consoleMode))
                     {
-                        _originalConsoleMode = consoleMode;
                         bool success;
                         if ((consoleMode & NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING) == NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING &&
                             (consoleMode & NativeMethodsShared.DISABLE_NEWLINE_AUTO_RETURN) == NativeMethodsShared.DISABLE_NEWLINE_AUTO_RETURN)
@@ -373,6 +372,7 @@ namespace Microsoft.Build.Experimental
                         }
                         else
                         {
+                            _originalConsoleMode = consoleMode;
                             consoleMode |= NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING | NativeMethodsShared.DISABLE_NEWLINE_AUTO_RETURN;
                             success = NativeMethodsShared.SetConsoleMode(stdOut, consoleMode);
                         }

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Build.Experimental
         private readonly Dictionary<string, string> _serverEnvironmentVariables;
 
         /// <summary>
+        /// The console mode we had before the build.
+        /// </summary>
+        private uint? _originalConsoleMode;
+
+        /// <summary>
         /// Full path to current MSBuild.exe if executable is MSBuild.exe,
         /// or to version of MSBuild.dll found to be associated with the current process.
         /// </summary>
@@ -195,8 +200,14 @@ namespace Microsoft.Build.Experimental
             // Send build command.
             // Let's send it outside the packet pump so that we easier and quicker deal with possible issues with connection to server.
             MSBuildEventSource.Log.MSBuildServerBuildStart(descriptiveCommandLine);
+            IntPtr stdOut = NativeMethodsShared.GetStdHandle(NativeMethodsShared.STD_OUTPUT_HANDLE);
             if (!TrySendBuildCommand())
             {
+                if (_originalConsoleMode is not null)
+                {
+                    NativeMethodsShared.SetConsoleMode(stdOut, _originalConsoleMode.Value);
+                }
+
                 return _exitResult;
             }
 
@@ -207,6 +218,12 @@ namespace Microsoft.Build.Experimental
 
             MSBuildEventSource.Log.MSBuildServerBuildStop(descriptiveCommandLine, _numConsoleWritePackets, _sizeOfConsoleWritePackets, _exitResult.MSBuildClientExitType.ToString(), _exitResult.MSBuildAppExitTypeString);
             CommunicationsUtilities.Trace("Build finished.");
+
+            if (_originalConsoleMode is not null)
+            {
+                NativeMethodsShared.SetConsoleMode(stdOut, _originalConsoleMode.Value);
+            }
+
             return _exitResult;
         }
 
@@ -353,6 +370,7 @@ namespace Microsoft.Build.Experimental
                     IntPtr stdOut = NativeMethodsShared.GetStdHandle(NativeMethodsShared.STD_OUTPUT_HANDLE);
                     if (NativeMethodsShared.GetConsoleMode(stdOut, out uint consoleMode))
                     {
+                        _originalConsoleMode = consoleMode;
                         bool success;
                         if ((consoleMode & NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING) == NativeMethodsShared.ENABLE_VIRTUAL_TERMINAL_PROCESSING &&
                             (consoleMode & NativeMethodsShared.DISABLE_NEWLINE_AUTO_RETURN) == NativeMethodsShared.DISABLE_NEWLINE_AUTO_RETURN)


### PR DESCRIPTION
Fixes #8008

### Context
With MSBuild server, we adjust the console mode to be able to handle VT100 codes. We should undo that after each build to make it obvious to users mistakenly emitting VT100 codes that they should add code to properly handle them.

### Customer Impact
Console settings we enable while building with MSBuild server persist after the build. In particular, if a customer is outputting raw VT100 codes, they  will be properly formatted if their code is run using `dotnet run`, but their customers will see the raw codes because they will not inherit anything from MSBuild.

### Testing
Verified that building the project from #8008 no longer had unexpected spacing when these private bits were deployed to an SDK.
Verified that the bug motivating our original support for VT100 codes is still resolved.
Unit tests.

### Code Reviewers
rainersigwald, rokonec

### Description of the fix
Reset VT100 codes after each build.
