### PR TITLE
Sourcebuild 7.0: scoped ref for latest Roslyn

### DIFF
--- a/src/StringTools/InternableString.cs
+++ b/src/StringTools/InternableString.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NET.StringTools
             /// </summary>
             private int _charIndex;
 
-            internal Enumerator(ref InternableString str)
+            internal Enumerator(scoped ref InternableString str)
             {
                 _string = str;
                 _spanIndex = -1;

--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -6,7 +6,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>true</IsPackable>
     <GenerateReferenceAssemblySource>true</GenerateReferenceAssemblySource>
-    <LangVersion>8.0</LangVersion>
     <PackageId>Microsoft.NET.StringTools</PackageId>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 


### PR DESCRIPTION
This change is required because of new C# features interacting with `ref` captures.

Per @jaredpar:

> How `ref` capture works is a core problem we've been struggling with in the `ref` field design. The initial design went too far into the "let everything be captured" space, that lead to a number of compat breaks so we tweaked on aspect severely in the other direction, and after more refinement ended up in a more explainable place. Essentially any `ref` can be captured in the return of the method or `out` parameters. In this case it's a ctor, it has a `ref` so that can be captured but you don't intend that here so `scoped` to tell us it can't happen.

This is required to remove a 7.0 sourcebuild patch.