### PR TITLE
Update docker tag to the latest schema

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -233,4 +233,4 @@ jobs:
   parameters:
     platform:
       name: 'Managed'
-      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
+      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -251,7 +251,7 @@ stages:
     parameters:
       platform:
         name: 'Managed'
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
 
   - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:


### PR DESCRIPTION
As a part of https://github.com/dotnet/arcade/issues/10123, we are moving all docker containers to the new tagging schema