### PR TITLE
Fallback when server client fails due to mutex connection timeout error.

### DIFF
--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Build.Experimental
                     CommunicationsUtilities.Trace("Server was not running. Starting server now.");
                     if (!TryLaunchServer())
                     {
-                        _exitResult.MSBuildClientExitType = MSBuildClientExitType.LaunchError;
+                        _exitResult.MSBuildClientExitType = (_exitResult.MSBuildClientExitType == MSBuildClientExitType.Success) ? MSBuildClientExitType.LaunchError : _exitResult.MSBuildClientExitType;
                         return _exitResult;
                     }
                 }

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq;
 using System.Threading;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Client;
@@ -165,33 +164,45 @@ namespace Microsoft.Build.Experimental
 #endif
 
             CommunicationsUtilities.Trace("Executing build with command line '{0}'", descriptiveCommandLine);
-            bool serverIsAlreadyRunning = ServerIsRunning();
-            if (KnownTelemetry.BuildTelemetry != null)
+
+            try
             {
-                KnownTelemetry.BuildTelemetry.InitialServerState = serverIsAlreadyRunning ? "hot" : "cold";
-            }
-            if (!serverIsAlreadyRunning)
-            {
-                CommunicationsUtilities.Trace("Server was not running. Starting server now.");
-                if (!TryLaunchServer())
+                bool serverIsAlreadyRunning = ServerIsRunning();
+                if (KnownTelemetry.BuildTelemetry != null)
                 {
-                    _exitResult.MSBuildClientExitType = MSBuildClientExitType.LaunchError;
+                    KnownTelemetry.BuildTelemetry.InitialServerState = serverIsAlreadyRunning ? "hot" : "cold";
+                }
+                if (!serverIsAlreadyRunning)
+                {
+                    CommunicationsUtilities.Trace("Server was not running. Starting server now.");
+                    if (!TryLaunchServer())
+                    {
+                        _exitResult.MSBuildClientExitType = MSBuildClientExitType.LaunchError;
+                        return _exitResult;
+                    }
+                }
+
+                // Check that server is not busy.
+                bool serverWasBusy = ServerWasBusy();
+                if (serverWasBusy)
+                {
+                    CommunicationsUtilities.Trace("Server is busy, falling back to former behavior.");
+                    _exitResult.MSBuildClientExitType = MSBuildClientExitType.ServerBusy;
+                    return _exitResult;
+                }
+
+                // Connect to server.
+                if (!TryConnectToServer(serverIsAlreadyRunning ? 1_000 : 20_000))
+                {
                     return _exitResult;
                 }
             }
-
-            // Check that server is not busy.
-            bool serverWasBusy = ServerWasBusy();
-            if (serverWasBusy)
+            catch (IOException ex) when (ex is not PathTooLongException)
             {
-                CommunicationsUtilities.Trace("Server is busy, falling back to former behavior.");
-                _exitResult.MSBuildClientExitType = MSBuildClientExitType.ServerBusy;
-                return _exitResult;
-            }
-
-            // Connect to server.
-            if (!TryConnectToServer(serverIsAlreadyRunning ? 1_000 : 20_000))
-            {
+                // For unknown root cause, Mutex.TryOpenExisting can sometimes throw 'Connection timed out' exception preventing to obtain the build server state through it (Running or not, Busy or not).
+                // See: https://github.com/dotnet/msbuild/issues/7993
+                CommunicationsUtilities.Trace("Failed to obtain the current build server state: {0}", ex);
+                _exitResult.MSBuildClientExitType = MSBuildClientExitType.UnknownServerState;
                 return _exitResult;
             }
 

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -476,10 +476,12 @@ namespace Microsoft.Build.Experimental
         private bool TryLaunchServer()
         {
             string serverLaunchMutexName = $@"Global\msbuild-server-launch-{_handshake.ComputeHash()}";
+
             try
             {
                 // For unknown root cause, opening mutex can sometimes throw 'Connection timed out' exception. See: https://github.com/dotnet/msbuild/issues/7993
                 using var serverLaunchMutex = ServerNamedMutex.OpenOrCreateMutex(serverLaunchMutexName, out bool mutexCreatedNew);
+
                 if (!mutexCreatedNew)
                 {
                     // Some other client process launching a server and setting a build request for it. Fallback to usual msbuild app build.
@@ -487,12 +489,20 @@ namespace Microsoft.Build.Experimental
                     _exitResult.MSBuildClientExitType = MSBuildClientExitType.ServerBusy;
                     return false;
                 }
+            }
+            catch (IOException ex) when (ex is not PathTooLongException)
+            {
+                CommunicationsUtilities.Trace("Failed to obtain the current build server state: {0}",  ex);
+                _exitResult.MSBuildClientExitType = MSBuildClientExitType.UnknownServerState;
+                return false;
+            }
 
+            try
+            {
                 string[] msBuildServerOptions = new string[] {
                     "/nologo",
                     "/nodemode:8"
                 };
-
                 NodeLauncher nodeLauncher = new NodeLauncher();
                 CommunicationsUtilities.Trace("Starting Server...");
                 Process msbuildProcess = nodeLauncher.Start(_msbuildLocation, string.Join(" ", msBuildServerOptions));

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -202,6 +202,7 @@ namespace Microsoft.Build.Experimental
                 // For unknown root cause, Mutex.TryOpenExisting can sometimes throw 'Connection timed out' exception preventing to obtain the build server state through it (Running or not, Busy or not).
                 // See: https://github.com/dotnet/msbuild/issues/7993
                 CommunicationsUtilities.Trace("Failed to obtain the current build server state: {0}", ex);
+                CommunicationsUtilities.Trace("HResult: {0}.", ex.HResult);
                 _exitResult.MSBuildClientExitType = MSBuildClientExitType.UnknownServerState;
                 return _exitResult;
             }
@@ -493,6 +494,7 @@ namespace Microsoft.Build.Experimental
             catch (IOException ex) when (ex is not PathTooLongException)
             {
                 CommunicationsUtilities.Trace("Failed to obtain the current build server state: {0}",  ex);
+                CommunicationsUtilities.Trace("HResult: {0}.", ex.HResult);
                 _exitResult.MSBuildClientExitType = MSBuildClientExitType.UnknownServerState;
                 return false;
             }

--- a/src/Build/BackEnd/Client/MSBuildClientExitType.cs
+++ b/src/Build/BackEnd/Client/MSBuildClientExitType.cs
@@ -24,6 +24,13 @@ namespace Microsoft.Build.Experimental
         /// The build stopped unexpectedly, for example,
         /// because a named pipe between the server and the client was unexpectedly closed.
         /// </summary>
-        Unexpected
+        Unexpected,
+        /// <summary>
+        /// The client is not able to identify the server state.
+        /// </summary>
+        /// <remarks>
+        /// This may happen when mutex that is regulating the server state throws.
+        /// </remarks>
+        UnknownServerState
     }
 }

--- a/src/Build/BackEnd/Client/MSBuildClientExitType.cs
+++ b/src/Build/BackEnd/Client/MSBuildClientExitType.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Build.Experimental
         /// </summary>
         /// <remarks>
         /// This may happen when mutex that is regulating the server state throws.
+        /// See: https://github.com/dotnet/msbuild/issues/7993.
         /// </remarks>
         UnknownServerState
     }

--- a/src/MSBuild/MSBuildClientApp.cs
+++ b/src/MSBuild/MSBuildClientApp.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Build.CommandLine
 
             if (exitResult.MSBuildClientExitType == MSBuildClientExitType.ServerBusy ||
                 exitResult.MSBuildClientExitType == MSBuildClientExitType.UnableToConnect ||
+                exitResult.MSBuildClientExitType == MSBuildClientExitType.UnknownServerState ||
                 exitResult.MSBuildClientExitType == MSBuildClientExitType.LaunchError)
             {
                 if (KnownTelemetry.BuildTelemetry != null)


### PR DESCRIPTION
Fixes #7993

### Summary
In the MSBuild server, we identify the state of the server via mutexes. Sometimes, for reason yet unknown to us, mutex could throw the exception `System.IO.IOException: Connection timed out`. When this occurs, we fallback to old behavior building without server. We fixed some of those in #8000, but now found more situations when this happens.

### Customer Impact
MSBuild non-Windows users could have intermittent error when building with `dotnet build`. 
This does not affect Visual Studio. 

### Regression?
Yes, this is a regression.

### Testing
Unit tests.

### Risk
Low risk. The fix adds additional try-catch blocks to process this situation.

### Code Reviewers
[TODO]

### Description of the fix
- Add a try-catch block to catch and process the `IOException` exception when mutexes are used.
- Add a new client exit type for this kind of error.
