### PR TITLE
Update branding to 17.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ The [changelog](documentation/Changelog.md) has detailed information about chang
 
 ### Build Status
 
-The current development branch is `main`. Changes in `main` will go into a future update of MSBuild, which will release with Visual Studio 17.4 and a corresponding version of the .NET Core SDK.
+The current development branch is `main`. Changes in `main` will go into a future update of MSBuild, which will release with Visual Studio 17.5 and a corresponding version of the .NET Core SDK.
 
 [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=main)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=887&branchName=main)
 
-We have forked for MSBuild 17.3 in the branch [`vs17.3`](https://github.com/Microsoft/msbuild/tree/vs17.3). Changes to that branch need special approval.
+We have forked for MSBuild 17.4 in the branch [`vs17.4`](https://github.com/Microsoft/msbuild/tree/vs17.4). Changes to that branch need special approval.
 
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs17.3)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=887&branchName=vs17.3)
+[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs17.4)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=887&branchName=vs17.4)
 
 17.2 builds from the branch [`vs17.2`](https://github.com/Microsoft/msbuild/tree/vs17.2). Only high-priority bugfixes will be considered for servicing 17.2.
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.4.0</VersionPrefix>
+    <VersionPrefix>17.5.0</VersionPrefix>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>


### PR DESCRIPTION
Is 16.9 out of support yet? Wondering if we can remove that one.