### PR TITLE
[Project Cache] Fix CacheResult.CreateTaskItem

### DIFF
--- a/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
@@ -127,13 +127,8 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
         private static ProjectItemInstance.TaskItem CreateTaskItem(ITaskItem2 taskItemInterface)
         {
-            var taskItem = new ProjectItemInstance.TaskItem(taskItemInterface.EvaluatedIncludeEscaped, null);
-
-            foreach (string metadataName in taskItemInterface.MetadataNames)
-            {
-                taskItem.SetMetadata(metadataName, taskItemInterface.GetMetadataValueEscaped(metadataName));
-            }
-
+            var taskItem = new ProjectItemInstance.TaskItem(taskItemInterface.EvaluatedIncludeEscaped, definingFileEscaped: null);
+            taskItemInterface.CopyMetadataTo(taskItem);
             return taskItem;
         }
     }


### PR DESCRIPTION
Currently `CacheResult.CreateTaskItem` is iterating the input task item's `MetadataNames` and populating the return value's metadata. This iteration includes built-in (reserved) metadata like `DefiningProjectExtension`. This kind of metadata isn't allowed to be defined directly, although it doesn't throw here but instead later when provided to RAR which makes another copy the item (`ReferenceTable.SetItemMetadata`) and that's where it throws.

This change uses `CopyMetadataTo` which should "do the right thing" to copy metadata from one item to another.