### PR TITLE
Fix Microsoft.NET.StringTools netstandard2.0 pack

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -81,7 +81,7 @@
   </PropertyGroup>
 
   <!-- Produce ONLY reference assemblies and SKIP roslyn analyzers for netstandard2.0 builds. -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' and '$(MSBuildProjectFile)' != 'PortableTask.csproj'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' and '$(MSBuildProjectFile)' != 'PortableTask.csproj' and '$(MSBuildProjectFile)' != 'StringTools.csproj'">
     <!-- ProduceOnlyReferenceAssembly and ProduceReferenceAssembly are mutually exclusive compiler flags. -->
     <ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>

--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -16,6 +16,13 @@
     <PackageDescription>This package contains the $(AssemblyName) assembly which implements common string-related functionality such as weak interning.</PackageDescription>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <!-- Place the netstandard2.0 ref assembly to /ref instead of /lib to work around a NuGet pack misbehavior. -->
+    <!-- Without this customization both the ref and implementation assembly would go to /lib, creating a conflict. -->
+    <TargetsForTfmSpecificBuildOutput />
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackRefAssembly</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
     <AssemblyName>Microsoft.NET.StringTools.net35</AssemblyName>
   </PropertyGroup>
@@ -35,4 +42,10 @@
     <Compile Remove="InternableString.Simple.cs" />
     <Compile Remove="WeakStringCache.Locking.cs" />
   </ItemGroup>
+
+  <Target Name="PackRefAssembly">
+      <ItemGroup>
+        <TfmSpecificPackageFile Include="$(TargetRefPath);@(FinalDocFile)" PackagePath="ref/$(TargetFramework)" />
+      </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes #8039

### Description

Microsoft.NET.StringTools currently contains a netstandard2.0 ref assembly but no matching implementation assembly. This causes a run-time bind failure when the library is used by a 3.1 app, for example.

### Customer Impact

The package is being picked up MessagePack which targets netstandard2.0. The issue [blocks it from updating to a newer version of the library](https://github.com/neuecc/MessagePack-CSharp/pull/1515).

### Regression?

Yes, this regressed in 17.3.0. Only the initial version of the package was correct.

### Risk

Low.

### Testing

Built the package locally and inspected its contents.

### Notes

This pull request uses a [documented workaround](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#advanced-extension-points-to-create-customized-package).

Package contents without the fix:
```
/lib
    net35
    net472
    net7.0
/ref
    net35
    net472
    net7.0
    netstandard2.0
```

Package contents with the fix:
```
/lib
    net35
    net472
    net7.0
    netstandard2.0
/ref
    net35
    net472
    net7.0
    netstandard2.0
```