### PR TITLE
Avoid losing the exception stack in BuildManager.EndBuild

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -957,10 +957,10 @@ namespace Microsoft.Build.Execution
 
                 if (e is AggregateException ae && ae.InnerExceptions.Count == 1)
                 {
-                    e = ae.InnerExceptions.First();
+                    ExceptionDispatchInfo.Capture(ae.InnerExceptions[0]).Throw();
                 }
 
-                throw e;
+                throw;
             }
             finally
             {


### PR DESCRIPTION
While investigating a flaky unit test I noticed the exception stack trace was basically useless:

Stack trace:
```
   at Microsoft.Build.Execution.BuildManager.EndBuild() in /_/src/Build/BackEnd/BuildManager/BuildManager.cs:line 963
   at Microsoft.Build.UnitTests.Helpers.BuildManagerSession.Dispose() in D:\a\1\s\src\Shared\UnitTests\ObjectModelHelpers.cs:line 2104
   at Microsoft.Build.Engine.UnitTests.ProjectCache.ProjectCacheTests.MultiplePlugins() in D:\a\1\s\src\Build.UnitTests\ProjectCache\ProjectCacheTests.cs:line 1049
```

This is due to rethrowing the exception incorrectly (`throw e;` vs `throw;`). Looks like this was done in order to flatten an `AggregateException`, but the original stack trace can be preserved there as well using `ExceptionDispatchInfo`.