### PR TITLE
Fix race condition with ProjectCacheService disposal and background initialization

### DIFF
--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -1035,7 +1035,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
 ");
             var mockCache = new InstanceMockCache();
 
-            var buildParameters =  new BuildParameters
+            var buildParameters = new BuildParameters
             {
                 ProjectCacheDescriptor = ProjectCacheDescriptor.FromInstance(mockCache),
             };
@@ -1047,7 +1047,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 logger = buildSession.Logger;
                 graphResult = buildSession.BuildGraph(graph);
             }
-            
+
             graphResult.ShouldHaveSucceeded();
         }
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1846,8 +1846,7 @@ namespace Microsoft.Build.Execution
 
             if (submission.BuildRequestData.GraphBuildOptions.Build)
             {
-                // Kick off project cache initialization frontloading
-                Task.Run(() => _projectCacheService.InitializePluginsForGraph(projectGraph, _executionCancellationTokenSource.Token));
+                _projectCacheService.InitializePluginsForGraph(projectGraph, _executionCancellationTokenSource.Token);
 
                 var targetListTask = projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames);
 


### PR DESCRIPTION
`ProjectCacheTests.MultiplePlugins` has been slightly flaky since its inception and throws a `IndexOutOfRangeException`. After (finally) investigating, I believe it's an actual race condition in the product.

In `ProjectCacheService.DisposeAsync`, there is the following snippet:

```cs
Task[] cleanupTasks = new Task[_projectCachePlugins.Count];
int idx = 0;
foreach (KeyValuePair<ProjectCacheDescriptor, Lazy<Task<ProjectCachePlugin>>> kvp in _projectCachePlugins)
{
    cleanupTasks[idx++] = Task.Run(async () => ...);
}
```

Additionally, `BuildManager` does the following:

```cs
Task.Run(() => _projectCacheService.InitializePluginsForGraph(projectGraph, _executionCancellationTokenSource.Token));
```

And `ProjectCacheService.InitializePluginsForGraph` may add to its `_projectCachePlugins`.

So my belief is that there is a race here where:
1. `InitializePluginsForGraph` is kicked off in the background
2. The build shuts down for any reason (not currently known why though), which disposes the `ProjectCacheService`
3. `ProjectCacheService.DisposeAsync` sees `_projectCachePlugins.Count` with value 1, so the `cleanupTasks` array has length 1.
4. `InitializePluginsForGraph` does more work in the other thread and ends up initializing and adding a second plugin to `_projectCachePlugins`
5. Back in `ProjectCacheService.DisposeAsync`, `_projectCachePlugins` is iterated (now with 2 things in it) and overruns the `cleanupTasks` array!

I haven't been able to confirm this completely due to it being a rare race condition and because of the UT issue fixed with #8069, but from a visual inspection it seems like it's an issue regardless.