### PR TITLE
Fix wrong architecture detection in tests.

### DIFF
--- a/src/Shared/UnitTests/XmakeAttributes_Tests.cs
+++ b/src/Shared/UnitTests/XmakeAttributes_Tests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestArchitectureValuesMatch()
         {
-            string currentArchitecture = EnvironmentUtilities.Is64BitProcess ? XMakeAttributes.MSBuildArchitectureValues.x64 : XMakeAttributes.MSBuildArchitectureValues.x86;
+            string currentArchitecture = XMakeAttributes.GetCurrentMSBuildArchitecture();
             string notCurrentArchitecture = EnvironmentUtilities.Is64BitProcess ? XMakeAttributes.MSBuildArchitectureValues.x86 : XMakeAttributes.MSBuildArchitectureValues.x64;
 
             Assert.True(XMakeAttributes.ArchitectureValuesMatch(XMakeAttributes.MSBuildArchitectureValues.any, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture));
@@ -147,7 +147,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TestMergeArchitectureValues()
         {
-            string currentArchitecture = EnvironmentUtilities.Is64BitProcess ? XMakeAttributes.MSBuildArchitectureValues.x64 : XMakeAttributes.MSBuildArchitectureValues.x86;
+            string currentArchitecture = XMakeAttributes.GetCurrentMSBuildArchitecture();
             string notCurrentArchitecture = EnvironmentUtilities.Is64BitProcess ? XMakeAttributes.MSBuildArchitectureValues.x86 : XMakeAttributes.MSBuildArchitectureValues.x64;
 
             string mergedArchitecture;


### PR DESCRIPTION
Concerns #7576.
Architecture detection in two tests is not working well for arm64 scenario.
