### PR TITLE
Fixed some URLs in the documentation

### DIFF
--- a/documentation/wiki/Binary-Log.md
+++ b/documentation/wiki/Binary-Log.md
@@ -9,7 +9,7 @@ Goals:
  * structure (preserves the exact build event args that can later be replayed to reconstruct the exact events and information as if a real build was running). File logs erase structure and are harder to parse (especially for multicore /m builds). Build analyzer tools are conceivable that could benefit from the structure in a binary log. An API is available to load and query binary logs.
  * optionally collect the project files (and all imported targets files) used during the build. This can help analyzing the logs and even view preprocessed source for all projects (with all imported projects inlined).
 
-See http://msbuildlog.com for more information.
+See https://msbuildlog.com/ for more information.
 
 # Creating a binary log during a build
 
@@ -62,7 +62,7 @@ Once you have the `StructuredLogger.dll` on disk you can pass it to MSBuild like
 # Using MSBuild Structured Log Viewer
 
 You can use the MSBuild Structured Log Viewer tool to view `.binlog` files:
-http://msbuildlog.com
+https://msbuildlog.com/
 
 # Collecting binary logs from Visual Studio builds
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
@@ -10,13 +10,13 @@ MSBuild can be successfully built on Windows, OS X 10.13, Ubuntu 14.04, and Ubun
 
 ## The easy way
 
-Install the latest .NET Core SDK from http://dot.net/core. That will ensure all prerequisites for our build are met.
+Install the latest .NET SDK from https://dotnet.microsoft.com/download. That will ensure all prerequisites for our build are met.
 
 ## Manually installing required packages for OSX & Ubuntu
 
-[.NET Core prerequisites](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md).
+[.NET Core prerequisites](https://github.com/dotnet/core/blob/main/Documentation/prereqs.md).
 
-* *OpenSSL*: MSBuild uses the .Net CLI during its build process. The CLI requires a recent OpenSSL library available in `/usr/lib`. This can be downloaded using [brew](http://brew.sh/) on OS X (`brew install openssl`) and apt-get (`apt-get install openssl`) on Ubuntu, or [building from source](https://wiki.openssl.org/index.php/Compilation_and_Installation#Mac). If you use a different package manager and see an error that says `Unable to load DLL 'System.Security.Cryptography.Native'`, `dotnet` may be looking in the wrong place for the library.
+* *OpenSSL*: MSBuild uses the .Net CLI during its build process. The CLI requires a recent OpenSSL library available in `/usr/lib`. This can be downloaded using [brew](https://brew.sh/) on OS X (`brew install openssl`) and apt-get (`apt-get install openssl`) on Ubuntu, or [building from source](https://wiki.openssl.org/index.php/Compilation_and_Installation#Mac). If you use a different package manager and see an error that says `Unable to load DLL 'System.Security.Cryptography.Native'`, `dotnet` may be looking in the wrong place for the library.
 
 ## Build
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -4,7 +4,7 @@ These instructions refer to working with the `master` branch.
 
 ## Required Software
 
-**Latest Microsoft Visual Studio 2022**: You can download the Visual Studio Community edition from [https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx).
+**Latest Microsoft Visual Studio 2022**: You can download the Visual Studio Community edition from [visualstudio.microsoft.com/vs/community/](https://visualstudio.microsoft.com/vs/community/).
 
 All command lines should be executed from a Visual Studio developer command prompt.
 
@@ -31,7 +31,7 @@ The CI does two builds. In the second build, it uses the binaries from the first
 
 ## Contributing
 
-Please see [Contributing Code](https://github.com/dotnet/msbuild/blob/master/documentation/wiki/Contributing-Code.md) for details on contributing changes back to the code. Please read this carefully and engage with us early to ensure work is not wasted.
+Please see [Contributing Code](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Contributing-Code.md) for details on contributing changes back to the code. Please read this carefully and engage with us early to ensure work is not wasted.
 
 ## Walkthroughs
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Mono-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Mono-MSBuild.md
@@ -6,7 +6,7 @@ Mono maintains a fork of msbuild (for now) at `https://github.com/mono/msbuild/`
 
 **Required packages for OSX & Ubuntu**
 
-MSBuild requires a stable version of [Mono](http://www.mono-project.com/download/) to build itself.
+MSBuild requires a stable version of [Mono](https://www.mono-project.com/download/stable/) to build itself.
 
 ## Build process ##
 
@@ -23,9 +23,9 @@ If you encounter errors, see [Something's wrong in my build](Something's-wrong-i
 `./install-mono-prefix.sh </your/mono/prefix>`
 
 ## Getting Mono MSBuild binaries without building the code ##
-The best way to get Mono MSBuild for OSX/macOS is to get the official [Mono package](http://www.mono-project.com/download/#download-mac). After installing it, you can run `msbuild`.
+The best way to get Mono MSBuild for OSX/macOS is to get the official [Mono package](https://www.mono-project.com/download/stable/#download-mac). After installing it, you can run `msbuild`.
 <br/>
-For Linux, you can install mono and msbuild from [here](http://www.mono-project.com/download/#download-lin).
+For Linux, you can install mono and msbuild from [here](https://www.mono-project.com/download/stable/#download-lin).
 
 ## Debugging
 

--- a/documentation/wiki/Contributing-Code.md
+++ b/documentation/wiki/Contributing-Code.md
@@ -7,7 +7,7 @@ Because our focus right now is on maintaining backwards compatibility, the team 
 - Only contributions referencing an approved Issue will be accepted.
 - Pull requests that do not merge easily with the tip of the master branch will be declined. The author will be asked to merge with tip and submit a new pull request.
 - Submissions must meet functional and performance expectations, including scenarios for which the team doesn't yet have open source tests. This means you may be asked to fix and resubmit your pull request against a new open test case if it fails one of these tests.
-- Submissions must follow the [.NET Runtime Coding Guidelines](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md)
+- Submissions must follow the [.NET Runtime Coding Guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md)
 
 When you are ready to proceed with making a change, get set up to [build](Home.md "See 'Building Testing and Debugging'") the code and familiarize yourself with our workflow and our coding conventions. These two blogs posts on contributing code to open source projects are good too: [Open Source Contribution Etiquette by Miguel de Icaza](https://tirania.org/blog/archive/2010/Dec-31.html) and [Don’t “Push” Your Pull Requests by Ilya Grigorik](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/).
 
@@ -33,4 +33,4 @@ Please follow these guidelines when creating new issues in the issue tracker:
 - Subscribe to notifications for the created issue in case there are any follow up questions.
 
 ### Coding Conventions
-- Use the coding style outlined in the [.NET Runtime Coding Guidelines](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md)
+- Use the coding style outlined in the [.NET Runtime Coding Guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md)

--- a/documentation/wiki/Contributing-Tasks.md
+++ b/documentation/wiki/Contributing-Tasks.md
@@ -13,15 +13,15 @@ The following requirements are in place for contributed tasks:
 3. The task must have unit tests in place to prevent regressions.
 
 ## Developing a new Task
-Review the existing documentation on [Task Writing](https://docs.microsoft.com/en-us/visualstudio/msbuild/task-writing) to learn about the fundamentals.  You can also looking at existing tasks in the [Microsoft.Build.Tasks.Core assembly](https://github.com/dotnet/msbuild/tree/master/src/Tasks) for a great starting point.
+Review the existing documentation on [Task Writing](https://learn.microsoft.com/visualstudio/msbuild/task-writing) to learn about the fundamentals.  You can also looking at existing tasks in the [Microsoft.Build.Tasks.Core assembly](https://github.com/dotnet/msbuild/tree/main/src/Tasks) for a great starting point.
 
 Tasks are generally simple and should not require much effort to develop.  If you find a task becoming very complicated, consider breaking it up into smaller tasks which can be run together in a target.
 
 ## Developing unit tests
-Contributed tasks must have unit tests in place to prove they work and to prevent regressions caused by other code changes.  There are a lot of examples in the [Microsoft.Build.Tasks.UnitTests](https://github.com/dotnet/msbuild/tree/master/src/Tasks.UnitTests) project.  Please provide a reasonable amount of test coverage so ensure the quality of the product.
+Contributed tasks must have unit tests in place to prove they work and to prevent regressions caused by other code changes.  There are a lot of examples in the [Microsoft.Build.Tasks.UnitTests](https://github.com/dotnet/msbuild/tree/main/src/Tasks.UnitTests) project.  Please provide a reasonable amount of test coverage so ensure the quality of the product.
 
 ## Documentation
-You can document the new task in the [visualstudio-docs](https://github.com/MicrosoftDocs/visualstudio-docs/tree/master/docs/msbuild) repository.  This helps users discover the new functionality.  The easiest way is to copy the documentation page for an existing task as a template.
+You can document the new task in the [visualstudio-docs](https://github.com/MicrosoftDocs/visualstudio-docs/tree/main/docs/msbuild) repository.  This helps users discover the new functionality.  The easiest way is to copy the documentation page for an existing task as a template.
 
 ## Ship schedule
 MSBuild ships regularly with Visual Studio.  It also is updated in Preview releases.  Once your contribution is merged, expect it to be available in the next release.

--- a/documentation/wiki/Localization.md
+++ b/documentation/wiki/Localization.md
@@ -6,7 +6,7 @@
 - `Strings.shared.resx` is a shared resource and gets embedded into all msbuild dlls
 - each neutral resource has a directory named `xlf` besides it which contains its localized strings in .xlf format
 - there is one language per xlf
-- the logical name for a resource is: `<Assembly Name>.<Neutral Resx File Name>.resources`. In the ResourceManager this appears as `<Assembly Name>.<Neutral Resx File Name>` (without the trailing `.resources`). For example, the `Microsoft.Build` assembly uses the `Microsoft.Build.Strings.resources` [logical resource name](https://github.com/dotnet/msbuild/blob/master/src/XMakeBuildEngine/Microsoft.Build.csproj#L659) (the resource file is `Strings.resx`), and its corresponding [ResourceManager](https://github.com/dotnet/msbuild/blob/master/src/XMakeBuildEngine/Resources/AssemblyResources.cs#L116) uses `Microsoft.Build.Strings`.
+- the logical name for a resource is: `<Assembly Name>.<Neutral Resx File Name>.resources`. In the ResourceManager this appears as `<Assembly Name>.<Neutral Resx File Name>` (without the trailing `.resources`). For example, the `Microsoft.Build` assembly uses the `Microsoft.Build.Strings.resources` [logical resource name](https://github.com/dotnet/msbuild/blob/cc3db358d34ad4cd1ec0c67e17582d7ca2a15040/src/Build/Microsoft.Build.csproj#L792) (the resource file is `Strings.resx`), and its corresponding [ResourceManager](https://github.com/dotnet/msbuild/blob/518c041f4511a6bc23eb40703b69a94ea46c65fd/src/Build/Resources/AssemblyResources.cs#L118) uses `Microsoft.Build.Strings`.
 
 ## How to edit a resource
 

--- a/documentation/wiki/MSBuild-Resources.md
+++ b/documentation/wiki/MSBuild-Resources.md
@@ -1,21 +1,21 @@
 # General Resources
- * [MSBuild Concepts](https://msdn.microsoft.com/en-us/library/dd637714.aspx)
- * [MSBuild Reserved and Well-Known Properties](https://msdn.microsoft.com/en-us/library/ms164309.aspx)
+ * [MSBuild Concepts](https://learn.microsoft.com/visualstudio/msbuild/msbuild-concepts)
+ * [MSBuild Reserved and Well-Known Properties](https://learn.microsoft.com/visualstudio/msbuild/msbuild-reserved-and-well-known-properties)
  * [MSBuild Tips & Tricks](MSBuild-Tips-&-Tricks.md)
  * [Target Maps](Target-Maps.md)
 
 # MSBuild Source Code
  * [https://github.com/dotnet/msbuild](https://github.com/dotnet/msbuild)
  * [https://source.dot.net](https://source.dot.net)
- * Use [http://referencesource.microsoft.com](http://referencesource.microsoft.com) or [http://source.roslyn.io](http://source.roslyn.io) to browse Microsoft MSBuild targets. Examples:
-   * search for "[_FindDependencies MSBuildProperty](http://referencesource.microsoft.com/#q=_FindDependencies%20MSBuildProperty)"
-   * find targets [http://referencesource.microsoft.com/#MSBuildTarget=ResolveAssemblyReferences](http://referencesource.microsoft.com/#MSBuildTarget=ResolveAssemblyReferences)
+ * Use [referencesource.microsoft.com](https://referencesource.microsoft.com) or [sourceroslyn.io/](https://sourceroslyn.io/) to browse Microsoft MSBuild targets. Examples:
+   * search for "[_FindDependencies MSBuildProperty](https://referencesource.microsoft.com/#q=_FindDependencies%20MSBuildProperty)"
+   * find targets [referencesource.microsoft.com/#MSBuildTarget=ResolveAssemblyReferences](https://referencesource.microsoft.com/#MSBuildTarget=ResolveAssemblyReferences)
 
 # Tools
 **Note:** These are third party tools
- * [MSBuildStructuredLog](http://msbuildlog.com/)
+ * [MSBuildStructuredLog](https://msbuildlog.com/)
    * A log viewer that displays a structured representation of executed targets, tasks, property and item values.
- * [MSBuildExtensionPack](http://www.msbuildextensionpack.com)
+ * [MSBuildExtensionPack](https://github.com/mikefourie-zz/MSBuildExtensionPack) (also via [NuGet](https://www.nuget.org/packages/MSBuild.Extension.Pack))
    * Provides a large collection of MSBuild Tasks, MSBuild Loggers and MSBuild TaskFactories.
  * [MSBuilder](https://github.com/MobileEssentials/MSBuilder)
    * Reusable blocks of MSBuild helpers; MSBuilder's goal is to provide fine-grained nuget packages that can be installed when only a certain MSBuild extension (task, property, target) is needed.
@@ -34,13 +34,13 @@
    * Lets you build Visual Studio solutions and projects as well as any MSBuild file through a context menu without opening Visual Studio.
 
 # Books
- * [Inside the Microsoft Build Engine: Using MSBuild and Team Foundation Build (2nd Edition) by Sayed Hashimi, William Bartholomew](http://www.amazon.com/Inside-Microsoft-Build-Engine-Foundation/dp/0735645248)
- * [MSBuild Trickery: 99 Ways to Bend the Build Engine to Your Will, by Brian Kretzler](http://www.amazon.com/MSBuild-Trickery-Ways-Build-Engine/dp/061550907X)
+ * [Inside the Microsoft Build Engine: Using MSBuild and Team Foundation Build (2nd Edition) by Sayed Hashimi, William Bartholomew](https://www.amazon.com/Inside-Microsoft-Build-Engine-Foundation/dp/0735645248)
+ * [MSBuild Trickery: 99 Ways to Bend the Build Engine to Your Will, by Brian Kretzler](https://www.amazon.com/MSBuild-Trickery-Ways-Build-Engine/dp/061550907X)
 
 # Blogs
- * [https://blogs.msdn.microsoft.com/msbuild](https://blogs.msdn.microsoft.com/msbuild)
- * [Sayed Hashimi's blog http://sedodream.com](http://sedodream.com)
+ * [MSBuild Team Blog](https://learn.microsoft.com/archive/blogs/msbuild/) (archive)
+ * [Sayed Hashimi's blog at sedodream.com](http://sedodream.com)
  * [Mike Fourie's blog https://mikefourie.wordpress.com](https://mikefourie.wordpress.com)
 
 # MSBuild Assemblies
-![MSBuild Assemblies](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/master/docs/MSBuildAssemblies.png)
+![MSBuild Assemblies](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/main/docs/MSBuildAssemblies.png)

--- a/documentation/wiki/MSBuild-Tips-&-Tricks.md
+++ b/documentation/wiki/MSBuild-Tips-&-Tricks.md
@@ -1,5 +1,5 @@
 # MSBuild Command-Line Switches
-See the [MSBuild Command-Line Reference](https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference) for more information on switches.
+See the [MSBuild Command-Line Reference](https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference) for more information on switches.
  * `MSBuild.exe -pp:<FILE>`
    * MSBuild preprocessor. Pass /pp to the command line to create a single huge XML project file with all project imports inlined in the correct order. This is useful to investigate the ordering of imports and property and target overrides during evaluation.
    * Example usage: `msbuild MyProject.csproj /pp:inlined.xml`
@@ -14,13 +14,13 @@ See the [MSBuild Command-Line Reference](https://docs.microsoft.com/visualstudio
 
 # Environment Variables
  * `MSBUILDTARGETOUTPUTLOGGING=1`
-   * Set this to enable [printing all target outputs to the log](https://blogs.msdn.microsoft.com/msbuild/2010/03/31/displaying-target-output-items-using-the-console-logger).
+   * Set this to enable [printing all target outputs to the log](https://learn.microsoft.com/archive/blogs/msbuild/displaying-target-output-items-using-the-console-logger).
  * `MSBUILDLOGTASKINPUTS=1`
    * Log task inputs (not needed if there are any diagnostic loggers already).
  * `MSBUILDEMITSOLUTION=1`
    * Save the generated .proj file for the .sln that is used to build the solution.
  * `MSBUILDENABLEALLPROPERTYFUNCTIONS=1`
-   * Enable [additional property functions](https://blogs.msdn.microsoft.com/visualstudio/2010/04/02/msbuild-property-functions).
+   * Enable [additional property functions](https://devblogs.microsoft.com/visualstudio/msbuild-property-functions/).
  * `MSBUILDLOGVERBOSERARSEARCHRESULTS=1`
    * In ResolveAssemblyReference task, log verbose search results.
  * `MSBUILDLOGCODETASKFACTORYOUTPUT=1`
@@ -45,7 +45,7 @@ If MSBuild.exe is passed properties on the command line, such as `/p:Platform=An
 This will make sure that your local assignments to the `Platform` property are respected. You can specify multiple properties in `TreatAsLocalProperty` separated by semicolon.
 
 # Visual Studio Background Builds
-Set the `TRACEDESIGNTIME=true` environment variable to output design-time build logs to TEMP: read more here: https://blogs.msdn.microsoft.com/jeremykuhne/2016/06/06/vs-background-builds
+Set the `TRACEDESIGNTIME=true` environment variable to output design-time build logs to TEMP: read more here: https://learn.microsoft.com/archive/blogs/jeremykuhne/vs-background-builds
 
 # Visual Studio Design-time (IntelliSense) builds
 
@@ -56,7 +56,7 @@ Use this command-line to approximate what the design-time build does:
 ```
 
 # Extend all builds (at system-wide level)
-See https://www.simple-talk.com/dotnet/.net-tools/extending-msbuild, "Extending all builds" section. Also read about [MSBuildUserExtensionsPath](http://referencesource.microsoft.com/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/Microsoft.Common.props,33), [CustomBeforeMicrosoftCommonProps](http://referencesource.microsoft.com/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/Microsoft.Common.props,68), [CustomBeforeMicrosoftCommonTargets](http://referencesource.microsoft.com/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/bin_/amd64/Microsoft.Common.targets,71), and CustomAfterMicrosoftCommonProps/CustomAfterMicrosoftCommonTargets.
+See https://www.simple-talk.com/dotnet/.net-tools/extending-msbuild, "Extending all builds" section. Also read about [MSBuildUserExtensionsPath](https://referencesource.microsoft.com/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/Microsoft.Common.props,33), [CustomBeforeMicrosoftCommonProps](https://referencesource.microsoft.com/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/Microsoft.Common.props,68), [CustomBeforeMicrosoftCommonTargets](https://referencesource.microsoft.com/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/bin_/amd64/Microsoft.Common.targets,71), and CustomAfterMicrosoftCommonProps/CustomAfterMicrosoftCommonTargets.
 
 Example:
 Create this file (Custom.props) in `C:\Users\username\AppData\Local\Microsoft\MSBuild\Current\Microsoft.Common.targets\ImportAfter`:

--- a/documentation/wiki/Microsoft.Build.Framework.md
+++ b/documentation/wiki/Microsoft.Build.Framework.md
@@ -1,7 +1,7 @@
 ### Microsoft.Build.Framework
 It you have looked carefully, you might notice some odd behavior around this assembly (Microsoft.Build.Framework). We released the source here, but in some cases if you use our `BuildAndCopy.cmd` script, you will reference the one on your machine instead of the one you just built! Here's why.
 
-Microsoft.Build.Framework contains the types and interfaces for extensibility in MSBuild. If you've ever written a custom Task, you might recognize them as ITask, ITaskItem, etc. After you build your Task, let's say targeting `Microsoft.Build.Framework, Version=12.0.0.0, PublicKeyToken=b03f5f7f11d50a3a` (Visual Studio 2013), anyone with MSBuild 12.0 or later can use your Task. In later versions of MSBuild, say version 14.0, we will use a [binding redirect](https://msdn.microsoft.com/en-us/library/eftw1fys(v=vs.110).aspx) to point you to the newer version of Microsoft.Build.Framework. Assuming we did our jobs right with compatibility, your Task should run without ever knowing the difference. The crucial point of detail here is that the public key token for the Framework assembly **did not change** between version. If it does, binding redirection is not allowed.
+Microsoft.Build.Framework contains the types and interfaces for extensibility in MSBuild. If you've ever written a custom Task, you might recognize them as ITask, ITaskItem, etc. After you build your Task, let's say targeting `Microsoft.Build.Framework, Version=12.0.0.0, PublicKeyToken=b03f5f7f11d50a3a` (Visual Studio 2013), anyone with MSBuild 12.0 or later can use your Task. In later versions of MSBuild, say version 14.0, we will use a [binding redirect](https://learn.microsoft.com/dotnet/framework/configure-apps/file-schema/runtime/bindingredirect-element) to point you to the newer version of Microsoft.Build.Framework. Assuming we did our jobs right with compatibility, your Task should run without ever knowing the difference. The crucial point of detail here is that the public key token for the Framework assembly **did not change** between version. If it does, binding redirection is not allowed.
 
 ## Option 1 - Project Reference
 By default this is enabled. This means that all MSBuild code will reference Microsoft.Build.Framework as a project reference and therefore will not have the same public key token as the retail version.
@@ -25,7 +25,7 @@ This will set the property for you and create a drop of MSBuild and dependencies
 
 ## Option 3 - Test or Delay Signing
 For the advanced user, another option here is to delay sign this version of MSBuild with our public key. Since that part of the key is public, it's very easy to extract (using `Sn.exe`) and delay sign. You can get more information on that here:
- * [Delay Signing](https://blogs.msdn.microsoft.com/shawnfa/2004/03/17/delay-signing/)
- * [Test Key Signing](http://blogs.msdn.com/b/shawnfa/archive/2005/10/24/484170.aspx)
+ * [Delay Signing](https://learn.microsoft.com/archive/blogs/shawnfa/delay-signing)
+ * [Test Key Signing](https://web.archive.org/web/20101005012428/http://blogs.msdn.com/b/shawnfa/archive/2005/10/24/484170.aspx)
 
 Delay signing is the easiest, but it modifies your system to allow it to load and trust an assembly (Microsoft.Build.Framework) even when it's not signed at all, from any source. The Test Key Signing allows for a much more secure approach (as long as you keep your private key private), but is more complicated to setup. We are providing this as a reference, but please only try this if you: really want to customize Microsoft.Build.Framework and use existing custom Tasks, you feel comfortable with the security implications, and you acknowledge this is all at your own risk.

--- a/documentation/wiki/Rebuilding-when-nothing-changed.md
+++ b/documentation/wiki/Rebuilding-when-nothing-changed.md
@@ -4,11 +4,11 @@ There is a class of problems with build where when you build twice, it still reb
 
 There are multiple tools to investigate and fix broken incrementality. Start with the blog posts below.
 
- * [https://blogs.msdn.microsoft.com/kirillosenkov/2014/08/04/how-to-investigate-rebuilding-in-visual-studio-when-nothing-has-changed/](https://blogs.msdn.microsoft.com/kirillosenkov/2014/08/04/how-to-investigate-rebuilding-in-visual-studio-when-nothing-has-changed/)
- * [https://blogs.msdn.microsoft.com/kirillosenkov/2015/05/12/msbuild-unnecessary-rebuilds-because-of-generated-assemblyattributes-cs/](https://blogs.msdn.microsoft.com/kirillosenkov/2015/05/12/msbuild-unnecessary-rebuilds-because-of-generated-assemblyattributes-cs/)
- * [http://www.andreas-reiff.de/2012/02/when-visual-studio-keeps-rebuilding-projects-that-have-not-changed/](http://www.andreas-reiff.de/2012/02/when-visual-studio-keeps-rebuilding-projects-that-have-not-changed/)
- * [MSDN: How to build incrementally](https://msdn.microsoft.com/en-us/library/ms171483.aspx)
- * [https://docs.microsoft.com/en-us/visualstudio/msbuild/incremental-builds?view=vs-2019](https://docs.microsoft.com/en-us/visualstudio/msbuild/incremental-builds?view=vs-2019)
+ * [How to investigate Rebuilding in Visual Studio when nothing has changed](https://learn.microsoft.com/archive/blogs/kirillosenkov/how-to-investigate-rebuilding-in-visual-studio-when-nothing-has-changed)
+ * [MSBuild: unnecessary rebuilds because of generated AssemblyAttributes.cs](https://learn.microsoft.com/archive/blogs/kirillosenkov/msbuild-unnecessary-rebuilds-because-of-generated-assemblyattributes-cs)
+ * [When Visual Studio keeps rebuilding Projects that have not changed](https://web.archive.org/web/20120321204616/http://www.andreas-reiff.de/2012/02/when-visual-studio-keeps-rebuilding-projects-that-have-not-changed/)
+ * [How to build incrementally](https://learn.microsoft.com/visualstudio/msbuild/how-to-build-incrementally)
+ * [Incremental builds](https://learn.microsoft.com/visualstudio/msbuild/incremental-builds)
 
 Strings to search for in the build logs:
  * `Building target "CoreCompile" completely`
@@ -16,4 +16,4 @@ Strings to search for in the build logs:
  * `out-of-date`
  * `missing`
 
-Consider using http://msbuildlog.com to help with searching through the build log.
+Consider using https://msbuildlog.com to help with searching through the build log.

--- a/documentation/wiki/ResolveAssemblyReference.md
+++ b/documentation/wiki/ResolveAssemblyReference.md
@@ -13,7 +13,7 @@ https://github.com/dotnet/msbuild/blob/a936b97e30679dcea4d99c362efa6f732c9d3587/
 This is where the RAR task is invoked in the targets file.
 
 The source code for RAR is at:
-https://github.com/dotnet/msbuild/blob/master/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+https://github.com/dotnet/msbuild/blob/main/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
 
 ## Inputs
 RAR is very detailed about logging its inputs:

--- a/documentation/wiki/Target-Maps.md
+++ b/documentation/wiki/Target-Maps.md
@@ -1,4 +1,4 @@
-[Build Target Map](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/master/docs/BuildTargets.png)
-![Build Target Map](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/master/docs/BuildTargets.png)
-[Compile Target Map](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/master/docs/CompileTargets.png)
-![Compile Target Map](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/master/docs/CompileTargets.png)
+[Build Target Map](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/main/docs/BuildTargets.png)
+![Build Target Map](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/main/docs/BuildTargets.png)
+[Compile Target Map](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/main/docs/CompileTargets.png)
+![Compile Target Map](https://raw.githubusercontent.com/KirillOsenkov/MSBuildStructuredLog/main/docs/CompileTargets.png)

--- a/documentation/wiki/UnGAC.md
+++ b/documentation/wiki/UnGAC.md
@@ -2,7 +2,7 @@
 
 ## What is the GAC?
 
-See the [public documentation](https://docs.microsoft.com/dotnet/framework/app-domains/gac). The GAC is a folder where different installations of VS on the same machine look for assemblies that are commonly used. If an assembly is in the GAC, it will be prioritized over any other assembly.
+See the [public documentation](https://learn.microsoft.com/dotnet/framework/app-domains/gac). The GAC is a folder where different installations of VS on the same machine look for assemblies that are commonly used. If an assembly is in the GAC, it will be prioritized over any other assembly.
 
 The only MSBuild assemblies you may see in the GAC are version 4.8. There is no reason any modern (15.1+) MSBuild assembly should be in the GAC today.
 


### PR DESCRIPTION
- Changed http:// links to https:// where that was the case (a handful of http:// links remain), but all changed ones were checked
- Where GitHub links changed from `master` to `main`
- Where source lines were referenced it now points to a given revision, because pointing to a branch name means the line number may be incorrect. NB: so this was very much intentional!
- Linked to the archived page for dead links
- Updated old MSDN and docs.microsoft.com and blog links to point to the current location (even if it's the archive on learn.microsoft.com)
- One wrong link (http://source.roslyn.io/#MSBuildFiles/C/ProgramFiles(x86)/MSBuild/14.0/bin_/amd64/Microsoft.Common.CurrentVersion.targets,1820) remains in ResolveAssemblyReference.md
