### PR TITLE
Respect a path in MSBuildDebugEngine

### DIFF
--- a/src/Shared/Debugging/DebugUtils.cs
+++ b/src/Shared/Debugging/DebugUtils.cs
@@ -28,6 +28,16 @@ namespace Microsoft.Build.Shared.Debugging
 
             if (Traits.Instance.DebugEngine)
             {
+                string debugEngineValue = FileUtilities.TrimAndStripAnyQuotes(Environment.GetEnvironmentVariable("MSBuildDebugEngine"));
+
+                if (string.IsNullOrWhiteSpace(debugDirectory)
+                    && !string.IsNullOrWhiteSpace(debugEngineValue)
+                    && Path.IsPathRooted(debugEngineValue))
+                {
+                    // DebugEngine value is a path, so use it as the directory, unless DEBUGPATH was set.
+                    debugDirectory = debugEngineValue;
+                }
+
                 if (!string.IsNullOrWhiteSpace(debugDirectory) && FileUtilities.CanWriteToDirectory(debugDirectory))
                 {
                     // Debug directory is writable; no need for fallbacks


### PR DESCRIPTION
It's been bothering me that we have to specify both `MSBuildDebugEngine=1` and `MSBUILDDEBUGPATH=s:\ome\path`. Can we do it together?
