### PR TITLE
#5982 adding FEATURE_OS_APIS ifdef.

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -32,6 +32,7 @@ using Xunit;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Shared.FileSystem;
 using Shouldly;
+using System.Collections.Concurrent;
 
 #nullable disable
 
@@ -2849,6 +2850,18 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             Assert.Equal(expectedExpansion, result);
         }
+
+        [Fact]
+        public void TestFeatureOSAPIs()
+        {
+            var availableStaticMethods = new ConcurrentDictionary<string, Tuple<string, Type>>(StringComparer.OrdinalIgnoreCase);
+
+            var operatingSystemType = new Tuple<string, Type>(null, typeof(OperatingSystem));
+            availableStaticMethods.TryAdd("System.OperatingSystem", operatingSystemType);
+            Assert.Equal(availableStaticMethods.Count, 1);
+            Assert.NotNull(operatingSystemType);
+        }
+
 
         [Theory]
         [InlineData("AString", "x12x456789x11", "$(AString.IndexOf('x', 1))", "3")]

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -294,6 +294,10 @@ namespace Microsoft.Build.Internal
                         var runtimeInformationType = new Tuple<string, Type>(null, typeof(RuntimeInformation));
                         var osPlatformType = new Tuple<string, Type>(null, typeof(OSPlatform));
 
+                        #if FEATURE_OS_APIS
++                           var operatingSystemType = new Tuple<string, Type>(null, typeof(OperatingSystem));
+                        #endif
+
                         // Make specific static methods available (Assembly qualified type names are *NOT* supported, only null which means mscorlib):
                         availableStaticMethods.TryAdd("System.Environment::ExpandEnvironmentVariables", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::GetEnvironmentVariable", environmentType);
@@ -365,6 +369,10 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("Microsoft.Build.Utilities.ToolLocationHelper", new Tuple<string, Type>("Microsoft.Build.Utilities.ToolLocationHelper, Microsoft.Build.Utilities.Core, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null));
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.RuntimeInformation", runtimeInformationType);
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.OSPlatform", osPlatformType);
+
+                        #if FEATURE_OS_APIS
++                           availableStaticMethods.TryAdd("System.OperatingSystem", operatingSystemType);
+                        #endif
 
                         s_availableStaticMethods = availableStaticMethods;
                     }

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Build.Internal
                         var osPlatformType = new Tuple<string, Type>(null, typeof(OSPlatform));
 
                         #if FEATURE_OS_APIS
-+                           var operatingSystemType = new Tuple<string, Type>(null, typeof(OperatingSystem));
+                           var operatingSystemType = new Tuple<string, Type>(null, typeof(OperatingSystem));
                         #endif
 
                         // Make specific static methods available (Assembly qualified type names are *NOT* supported, only null which means mscorlib):
@@ -371,7 +371,7 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.OSPlatform", osPlatformType);
 
                         #if FEATURE_OS_APIS
-+                           availableStaticMethods.TryAdd("System.OperatingSystem", operatingSystemType);
+                            availableStaticMethods.TryAdd("System.OperatingSystem", operatingSystemType);
                         #endif
 
                         s_availableStaticMethods = availableStaticMethods;

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -117,4 +117,8 @@
     <FeatureMSIORedist>true</FeatureMSIORedist>
   </PropertyGroup>
 
+   <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <DefineConstants>$(DefineConstants);FEATURE_OS_APIS</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -97,6 +97,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == '$(LatestDotNetCoreForMSBuild)'">
     <DefineConstants>$(DefineConstants);FEATURE_PIPEOPTIONS_CURRENTUSERONLY</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_OS_APIS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GenerateReferenceAssemblySource)' != 'true'">
@@ -115,10 +116,6 @@
   <PropertyGroup Condition="'$(MonoBuild)' != 'true' and '$(DotNetBuildFromSource)' != 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">
     <DefineConstants>$(DefineConstants);FEATURE_MSIOREDIST</DefineConstants>
     <FeatureMSIORedist>true</FeatureMSIORedist>
-  </PropertyGroup>
-
-   <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <DefineConstants>$(DefineConstants);FEATURE_OS_APIS</DefineConstants>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
#5982 

The above collaboration makes sense for this specific issue, these Operating Systems APIs are only available in .NET 5.0 so adding the const FEATURE_OS_APIS only when it is available in .NET 5.0 and defining those ifdefs in the constant file to ensure it only gets added to the dictionary at that point in time.


