### PR TITLE
Define VSToolsPath property properly

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -924,6 +924,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "No Visual Studio for .net")]
         public void VSToolsPathExists()
         {
             string project = @"

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -923,6 +923,24 @@ namespace Microsoft.Build.UnitTests
             output.ShouldContain(RunnerUtilities.PathToCurrentlyRunningMsBuildExe + (NativeMethodsShared.IsWindows ? " /v:diag " : " -v:diag ") + _pathToArbitraryBogusFile, Case.Insensitive);
         }
 
+        [Fact]
+        public void VSToolsPathExists()
+        {
+            string project = @"
+<Project>
+  <Target Name=""Test"">
+    <Error Condition=""'$(VSToolsPath)' == ''"" Text=""VSToolsPath should have a predefined value."" />
+  </Target>
+</Project>";
+
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                TransientTestFile file = env.CreateFile(".proj", project);
+                RunnerUtilities.ExecMSBuild(file.Path, out bool success);
+                success.ShouldBeTrue();
+            }
+        }
+
         /// <summary>
         /// Any msbuild.rsp in the directory of the specified project/solution should be read, and should
         /// take priority over any other response files.

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -186,7 +186,8 @@
         <property name="MSBuildToolsRoot" value="$(VsInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
         <property name="MSBuildExtensionsPath32" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
-
+        <property name="MSBuildExtensionsPath64" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
+        <property name="VSToolsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())\Microsoft\VisualStudio\v17.0"/>
         <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
 
         <!-- VC Specific Paths -->
@@ -197,14 +198,6 @@
         <property name="VCTargetsPath10" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath10)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\'))" />
         <property name="AndroidTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\Android\V150\" />
         <property name="iOSTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\iOS\V150\" />
-        <projectImportSearchPaths>
-          <searchPaths os="windows">
-            <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>
-            <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
-            <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
-            <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
-          </searchPaths>
-        </projectImportSearchPaths>
       </toolset>
     </msbuildToolsets>
   </configuration>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -188,6 +188,7 @@
         <property name="MSBuildExtensionsPath32" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
         <property name="MSBuildExtensionsPath64" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
         <property name="VSToolsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())\Microsoft\VisualStudio\v17.0"/>
+
         <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
 
         <!-- VC Specific Paths -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -156,6 +156,8 @@
         <property name="MSBuildToolsRoot" value="$(VsInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
         <property name="MSBuildExtensionsPath32" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
+        <property name="MSBuildExtensionsPath64" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
+        <property name="VSToolsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())\Microsoft\VisualStudio\v17.0"/>
 
         <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
 
@@ -167,14 +169,6 @@
         <property name="VCTargetsPath10" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath10)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\'))" />
         <property name="AndroidTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\Android\V150\" />
         <property name="iOSTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\iOS\V150\" />
-        <projectImportSearchPaths>
-          <searchPaths os="windows">
-            <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>
-            <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
-            <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
-            <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
-          </searchPaths>
-        </projectImportSearchPaths>
       </toolset>
     </msbuildToolsets>
   </configuration>


### PR DESCRIPTION
Fixes #6607

### Context
MSBuild theoretically defines the VSToolsPath property in its app.config/app.amd.config files, but it doesn't actually fire in practice. (You can tell since two of the properties next to it were pulled out and properly defined elsewhere, and that didn't cause "duplicate definition" errors.)

### Changes Made
Move both the VSToolsPath and the MSBuildExtensionsPath64 out of the condition and give them proper values. I did have to hardcode 17.0, but that is done in several other places, so I think it appropriate.

### Testing
I tried the provided repro before and after this change. This made it not happen anymore.

Also added a unit test.
