### PR TITLE
AsOrdered was removed

### DIFF
--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2784,16 +2784,16 @@ namespace Microsoft.Build.Evaluation
 
                 return projectItemElements
                     .AsParallel()
-                    .Select((item, index) => ComputeProvenanceResult(itemToMatch, item, index))
+                    .Select((item, index) => (Result: ComputeProvenanceResult(itemToMatch, item), Index: index))
+                    .Where(pair => pair.Result != null)
                     .AsSequential()
                     .OrderBy(pair => pair.Index)
                     .Select(pair => pair.Result)
-                    .Where(r => r != null)
                     .ToList();
             }
 
             // TODO: cache result?
-            private (ProvenanceResult Result, int Index) ComputeProvenanceResult(string itemToMatch, ProjectItemElement itemElement, int index)
+            private ProvenanceResult ComputeProvenanceResult(string itemToMatch, ProjectItemElement itemElement)
             {
                 ProvenanceResult SingleItemSpecProvenance(string itemSpec, IElementLocation elementLocation, Operation operation)
                 {
@@ -2808,11 +2808,9 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 ProvenanceResult result = SingleItemSpecProvenance(itemElement.Include, itemElement.IncludeLocation, Operation.Include);
-                result = result == null ?
+                return result == null ?
                     SingleItemSpecProvenance(itemElement.Update, itemElement.UpdateLocation, Operation.Update) ?? SingleItemSpecProvenance(itemElement.Remove, itemElement.RemoveLocation, Operation.Remove) :
                     SingleItemSpecProvenance(itemElement.Exclude, itemElement.ExcludeLocation, Operation.Exclude) ?? result;
-
-                return (result, index);
             }
 
             /// <summary>

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// * and ? are invalid file name characters, but they occur in globs as wild cards.
         /// </summary>
-        private static readonly char[] s_invalidGlobChars = FileUtilities.InvalidFileNameChars.Where(c => c != '*' && c != '?' && c!= '/' && c != '\\' && c != ':').ToArray();
+        private static readonly char[] s_invalidGlobChars = FileUtilities.InvalidFileNameChars.Where(c => c != '*' && c != '?' && c != '/' && c != '\\' && c != ':').ToArray();
 
         /// <summary>
         /// Context to log messages and events in.
@@ -2782,17 +2782,18 @@ namespace Microsoft.Build.Evaluation
                     return new List<ProvenanceResult>();
                 }
 
-                return
-                    projectItemElements
+                return projectItemElements
                     .AsParallel()
-                    .AsOrdered()
-                    .Select(i => ComputeProvenanceResult(itemToMatch, i))
+                    .Select((item, index) => ComputeProvenanceResult(itemToMatch, item, index))
+                    .AsSequential()
+                    .OrderBy(pair => pair.Index)
+                    .Select(pair => pair.Result)
                     .Where(r => r != null)
                     .ToList();
             }
 
             // TODO: cache result?
-            private ProvenanceResult ComputeProvenanceResult(string itemToMatch, ProjectItemElement itemElement)
+            private (ProvenanceResult Result, int Index) ComputeProvenanceResult(string itemToMatch, ProjectItemElement itemElement, int index)
             {
                 ProvenanceResult SingleItemSpecProvenance(string itemSpec, IElementLocation elementLocation, Operation operation)
                 {
@@ -2807,9 +2808,11 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 ProvenanceResult result = SingleItemSpecProvenance(itemElement.Include, itemElement.IncludeLocation, Operation.Include);
-                return result == null ?
+                result = result == null ?
                     SingleItemSpecProvenance(itemElement.Update, itemElement.UpdateLocation, Operation.Update) ?? SingleItemSpecProvenance(itemElement.Remove, itemElement.RemoveLocation, Operation.Remove) :
                     SingleItemSpecProvenance(itemElement.Exclude, itemElement.ExcludeLocation, Operation.Exclude) ?? result;
+
+                return (result, index);
             }
 
             /// <summary>


### PR DESCRIPTION
Fixes [AB#1618509](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1618509)

### Context
AsOrdered causes UI delays in VS due to thread blocking.

### Changes Made
Processing items is still parallel, but sorting is now done classically based on original item index. 

### Testing
Existing unit tests are passing
