### PR TITLE
Batch metadata updates for better performance

### DIFF
--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -629,11 +629,11 @@ namespace Microsoft.Build.Execution
         /// which legally have built-in metadata. If necessary we can calculate it on the new items we're making if requested.
         /// We don't copy them too because tasks shouldn't set them (they might become inconsistent)
         /// </summary>
-        internal void SetMetadataOnTaskOutput(string name, string evaluatedValueEscaped)
+        internal void SetMetadataOnTaskOutput(IEnumerable<KeyValuePair<string, string>> items)
         {
             _project.VerifyThrowNotImmutable();
 
-            _taskItem.SetMetadataOnTaskOutput(name, evaluatedValueEscaped);
+            _taskItem.SetMetadataOnTaskOutput(items);
         }
 
         /// <summary>
@@ -1789,6 +1789,18 @@ namespace Microsoft.Build.Execution
                     ProjectMetadataInstance metadatum = new ProjectMetadataInstance(name, evaluatedValueEscaped, true /* may be built-in metadata name */);
                     _directMetadata.Set(metadatum);
                 }
+            }
+
+            internal void SetMetadataOnTaskOutput(IEnumerable<KeyValuePair<string, string>> items)
+            {
+                ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
+                _directMetadata ??= new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
+
+                var metadata = items
+                    .Where(item => !FileUtilities.ItemSpecModifiers.IsDerivableItemSpecModifier(item.Value))
+                    .Select(item => new ProjectMetadataInstance(item.Key, item.Value, true /* may be built-in metadata name */));
+
+                _directMetadata.ImportProperties(metadata);
             }
 
             /// <summary>


### PR DESCRIPTION
Improves https://github.com/dotnet/sdk/issues/27738 

### Context
I was looking for a reason why "design-time-builds" are slow (see https://github.com/dotnet/sdk/issues/27738).
One method that stands out in the performance profiler is a method called `GatherTaskOutputs`.
It copies the output of the executed task into a new `ProjectItemInstance`. Copying the output metadata involves creating and populating the `ImmutableDicitionary` in the newly created `ProjectItemInstance`. The copying process turns out to be a noticeably slow operation.

### Changes Made

Instead of copying metadata properties one by one, all properties will be copied with a single [SetItems](https://learn.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutabledictionary-2.setitems) operation.
According to BenchmarkDotNet using a single operation to populate the ImmutableDictionary is twice as fast.

### Testing
Benchmarking using scenario from https://github.com/dotnet/sdk/issues/27738#issue-1364794138.

- before:
Time Elapsed 00:01:23.18
Time Elapsed 00:01:23.36
Time Elapsed 00:01:23.91
Time Elapsed 00:01:23.18
Time Elapsed 00:01:23.25

- after:
Time Elapsed 00:01:20.87
Time Elapsed 00:01:20.21
Time Elapsed 00:01:20.71
Time Elapsed 00:01:20.49
Time Elapsed 00:01:20.60

This change improves performance of the tested scenario by 3-4%!

### Notes
