### PR TITLE
Build multitargeting nodes w/ GeneratePackageOnBuild (#8056)

### DIFF
--- a/src/Build.UnitTests/Graph/GraphTestingUtilities.cs
+++ b/src/Build.UnitTests/Graph/GraphTestingUtilities.cs
@@ -26,6 +26,14 @@ namespace Microsoft.Build.Graph.UnitTests
                                                                         <InnerBuildPropertyValues>{InnerBuildPropertiesName}</InnerBuildPropertyValues>
                                                                         <{InnerBuildPropertiesName}>a;b</{InnerBuildPropertiesName}>
                                                                      </PropertyGroup>";
+
+        public const string MultitargetingSpecificationPropertyGroupWithGeneratePackageOnBuild = $@"<PropertyGroup>
+                                                                                                  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+                                                                                                  <InnerBuildProperty>{InnerBuildPropertyName}</InnerBuildProperty>
+                                                                                                  <InnerBuildPropertyValues>{InnerBuildPropertiesName}</InnerBuildPropertyValues>
+                                                                                                  <{InnerBuildPropertiesName}>a;b</{InnerBuildPropertiesName}>
+                                                                                               </PropertyGroup>";
+
         public const string HardCodedInnerBuildWithMultitargetingSpecification = $@"<PropertyGroup>
                                                                         <InnerBuildProperty>{InnerBuildPropertyName}</InnerBuildProperty>
                                                                         <InnerBuildPropertyValues>{InnerBuildPropertiesName}</InnerBuildPropertyValues>

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -1299,6 +1299,23 @@ $@"
             }
         }
 
+        [Fact]
+        public void EnsureReferencedMultitargetingNodeWithGeneratePackageOnBuildPropTargetListContainsBuild()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                TransientTestFile entryProject = CreateProjectFile(env, 1, projectReferences: new[] { 2 }, extraContent: @$"
+<ItemGroup>
+    <ProjectReferenceTargets Include='Build' Targets='Build' />
+    <ProjectReferenceTargets Include='Build' Targets='OuterBuild' OuterBuild='true' />
+</ItemGroup>");
+                CreateProjectFile(env, 2, extraContent: MultitargetingSpecificationPropertyGroupWithGeneratePackageOnBuild);
+                var graph = new ProjectGraph(entryProject.Path);
+                IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = graph.GetTargetLists(null);
+                targetLists[key: GetOuterBuild(graph, 2)].ShouldBe(expected: new[] { "OuterBuild", "Build" });
+            }
+        }
+
         public static IEnumerable<object[]> Graphs
         {
             get

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -151,8 +151,8 @@ namespace Microsoft.Build.Graph
 
         internal static ProjectType GetProjectType(ProjectInstance project)
         {
-            var isOuterBuild = String.IsNullOrWhiteSpace(GetInnerBuildPropertyValue(project)) && !String.IsNullOrWhiteSpace(GetInnerBuildPropertyValues(project));
-            var isInnerBuild = !String.IsNullOrWhiteSpace(GetInnerBuildPropertyValue(project));
+            bool isOuterBuild = IsOuterBuild(project);
+            bool isInnerBuild = IsInnerBuild(project);
 
             ErrorUtilities.VerifyThrow(!(isOuterBuild && isInnerBuild), $"A project cannot be an outer and inner build at the same time: ${project.FullPath}");
 
@@ -161,6 +161,46 @@ namespace Microsoft.Build.Graph
                 : isInnerBuild
                     ? ProjectType.InnerBuild
                     : ProjectType.NonMultitargeting;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> iff the <paramref name="project"/> is an
+        /// outer build.
+        /// </summary>
+        /// <param name="project">The project to determine if it's an outer
+        /// build.</param>
+        /// <returns><c>true</c> iff the <paramref name="project"/> is an outer
+        /// build.</returns>
+        private static bool IsOuterBuild(ProjectInstance project)
+        {
+            return string.IsNullOrWhiteSpace(GetInnerBuildPropertyValue(project)) && !string.IsNullOrWhiteSpace(GetInnerBuildPropertyValues(project));
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> iff the <paramref name="project"/> is an
+        /// inner build.
+        /// </summary>
+        /// <param name="project">The project to determine if it's an inner
+        /// build.</param>
+        /// <returns><c>true</c> iff the <paramref name="project"/> is an inner
+        /// build.</returns>
+        private static bool IsInnerBuild(ProjectInstance project)
+        {
+            return !string.IsNullOrWhiteSpace(GetInnerBuildPropertyValue(project));
+        }
+
+        /// <summary>
+        /// Return <c>true</c> iff the <paramref name="project"/> is an outer
+        /// build with the <c>GeneratePackageOnBuild</c> property set to <c>true</c>.
+        /// </summary>
+        /// <param name="project">The project to determine where it contains
+        /// a <c>GeneratePackageOnBuild</c> property that's set to <c>true</c>.</param>
+        /// <returns><c>true</c> iff the <paramref name="project"/> is an
+        /// outer build with the <c>GeneratePackageOnBuild</c>
+        /// property set to <c>true</c>.</returns>
+        public static bool IsOuterBuildWithGeneratePackageOnBuildPropertySetToTrue(ProjectInstance project)
+        {
+            return IsOuterBuild(project) && MSBuildStringIsTrue(project.GetPropertyValue("GeneratePackageOnBuild"));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #8056 

### Context
 As described in #8056, in graph builds the only target called on referenced multitargeting nodes with the `GeneratePackageOnBuild` property set to `true` is `GetTargetFrameworks`, so `Pack` never gets executed and no `*.nupkg` file is created.

### Changes Made
If an outer build node has the `GeneratePackageOnBuild` property set to `true`, then add `Build` to its target list, which will result in `Pack` getting hooked and called.

### Testing
Verified that a referenced outer build node with the `GeneratePackageOnBuild` property set to `true` has `Build` added to its target list.
