### PR TITLE
Use `EntryPointNodes` in lieu of `GraphRoots` in `GetTargetLists` (#8…

### DIFF
--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -1278,15 +1278,15 @@ $@"
         }
 
         [Fact]
-        public void ReferencedMultitargetingEntryPointNodeTargetListContainsBuildTarget()
+        public void ReferencedMultitargetingEntryPointNodeTargetListContainsDefaultTarget()
         {
             using (var env = TestEnvironment.Create())
             {
-                TransientTestFile entryProject1 = CreateProjectFile(env, 1, projectReferences: new[] { 2 });
-                TransientTestFile entryProject2 = CreateProjectFile(env, 2, extraContent: MultitargetingSpecificationPropertyGroup);
+                TransientTestFile entryProject1 = CreateProjectFile(env, 1, projectReferences: new[] { 2 }, defaultTargets: "A", extraContent: ProjectReferenceTargetsWithMultitargeting);
+                TransientTestFile entryProject2 = CreateProjectFile(env, 2, defaultTargets: "A", extraContent: OuterBuildSpecificationWithProjectReferenceTargets);
                 var graph = new ProjectGraph(new HashSet<string> { entryProject1.Path, entryProject2.Path });
                 IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = graph.GetTargetLists(null);
-                targetLists[key: GetOuterBuild(graph, 2)].ShouldBe(expected: new[] { "Build" });
+                targetLists[key: GetOuterBuild(graph, 2)].ShouldBe(expected: OuterBuildTargets.Prepend("A"));
             }
         }
 

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -776,28 +776,6 @@ namespace Microsoft.Build.Graph.UnitTests
         }
 
         [Fact]
-        public void GetTargetsListsShouldApplyDefaultTargetsOnlyToGraphRoots()
-        {
-            using (var env = TestEnvironment.Create())
-            {
-                var root1 = CreateProjectFile(env: env, projectNumber: 1, projectReferences: new[] {2}, projectReferenceTargets: new Dictionary<string, string[]> {{"A", new[] {"B"}}}, defaultTargets: "A").Path;
-                var root2 = CreateProjectFile(env: env, projectNumber: 2, projectReferences: new[] {3}, projectReferenceTargets: new Dictionary<string, string[]> {{"B", new[] {"C"}}, {"X", new[] {"Y"}}}, defaultTargets: "X").Path;
-                CreateProjectFile(env: env, projectNumber: 3);
-
-
-                var projectGraph = new ProjectGraph(new []{root1, root2});
-                projectGraph.ProjectNodes.Count.ShouldBe(3);
-
-                IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = projectGraph.GetTargetLists(null);
-
-                targetLists.Count.ShouldBe(projectGraph.ProjectNodes.Count);
-                targetLists[GetFirstNodeWithProjectNumber(projectGraph, 1)].ShouldBe(new[] { "A" });
-                targetLists[GetFirstNodeWithProjectNumber(projectGraph, 2)].ShouldBe(new[] { "B" });
-                targetLists[GetFirstNodeWithProjectNumber(projectGraph, 3)].ShouldBe(new[] { "C" });
-            }
-        }
-
-        [Fact]
         public void GetTargetsListReturnsEmptyTargetsForNodeIfNoTargetsPropagatedToIt()
         {
             using (var env = TestEnvironment.Create())
@@ -1296,6 +1274,19 @@ $@"
                 targetLists[key: GetFirstNodeWithProjectNumber(graph: projectGraph, projectNum: 3)].ShouldBe(expected: new[] { "Build" });
                 targetLists[key: GetFirstNodeWithProjectNumber(graph: projectGraph, projectNum: 4)].ShouldBe(expected: new[] { "Build" });
                 targetLists[key: GetFirstNodeWithProjectNumber(graph: projectGraph, projectNum: 5)].ShouldBe(expected: new[] { "T51", "T2", "T53", "T54", "T3", "D51", "D52", "T4" });
+            }
+        }
+
+        [Fact]
+        public void ReferencedMultitargetingEntryPointNodeTargetListContainsBuildTarget()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                TransientTestFile entryProject1 = CreateProjectFile(env, 1, projectReferences: new[] { 2 });
+                TransientTestFile entryProject2 = CreateProjectFile(env, 2, extraContent: MultitargetingSpecificationPropertyGroup);
+                var graph = new ProjectGraph(new HashSet<string> { entryProject1.Path, entryProject2.Path });
+                IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = graph.GetTargetLists(null);
+                targetLists[key: GetOuterBuild(graph, 2)].ShouldBe(expected: new[] { "Build" });
             }
         }
 

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -588,9 +588,8 @@ namespace Microsoft.Build.Graph
         ///     This method uses the ProjectReferenceTargets items to determine the targets to run per node. The results can then
         ///     be used to start building each project individually, assuming a given project is built after its references.
         /// </remarks>
-        /// <param name="entryProjectTargets">
-        ///     The target list for the <see cref="GraphRoots" />. May be null or empty, in which case the entry projects' default
-        ///     targets will be used.
+        /// <param name="entryProjectTargets">The target list for the entry project. May be null or empty, in which case the entry
+        /// projects' default targets will be used.
         /// </param>
         /// <returns>
         ///     A dictionary containing the target list for each node. If a node's target list is empty, then no targets were
@@ -606,8 +605,7 @@ namespace Microsoft.Build.Graph
             var encounteredEdges = new HashSet<ProjectGraphBuildRequest>();
             var edgesToVisit = new Queue<ProjectGraphBuildRequest>();
 
-            // Initial state for the graph roots
-            foreach (var entryPointNode in GraphRoots)
+            foreach (ProjectGraphNode entryPointNode in EntryPointNodes)
             {
                 var entryTargets = entryProjectTargets == null || entryProjectTargets.Count == 0
                     ? ImmutableList.CreateRange(entryPointNode.ProjectInstance.DefaultTargets)


### PR DESCRIPTION
Fixes #8056 

### Context

`GraphRoots` won't contain referenced projects (even if they're entry points), so use `EntryPointNodes` when obtaining the entry point nodes in `GetTargetLists`. This will result in `Build` being added to the referenced project's target list, which will in the case of #8056 result in `Pack` being called.

### Changes Made
`GetTargetLists` now uses `EntryPointNodes` in lieu of `GraphRoots` in obtaining the entry point nodes.

### Testing
Verified that a referenced entry project has the default target in its target list.

### Notes
`EntryPointNodes` was initially used (see https://github.com/dotnet/msbuild/commit/a1ac094e14c59d806ad4a621779a9ec5d96de09a) but was later changed to `GraphRoots` [here](https://github.com/dotnet/msbuild/pull/4218/commits/335267ca3f55741d97df191e94bff114e8ef1fc8).

@rainersigwald Do you have any insight as to why this change was made? You made [this comment](https://github.com/dotnet/msbuild/pull/4218#pullrequestreview-217423992) about non-graph-root outer build -- it seems relevant to the change made, so I was wondering if you could elaborate on it.