### PR TITLE
Fixing overbuilding of platform negotiated projects

### DIFF
--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Build.Shared
                     log?.LogWarningWithCodeFromResources("GetCompatiblePlatform.NoCompatiblePlatformFound", projectPath);
                 }
                 // If the referenced project has a defined `Platform` that's compatible, it will build that way by default.
-                // Don't set `buildProjectReferenceAs` and the `_GetProjectReferencePlatformProperties` target will handle the rest.
+                // If we're about to tell the reference to build using its default platform, don't pass it as a global property.
                 if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(buildProjectReferenceAs, StringComparison.OrdinalIgnoreCase))
                 {
                     log?.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", projectPath, referencedProjectPlatform);

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.Shared
                     log?.LogWarningWithCodeFromResources("GetCompatiblePlatform.NoPlatformsListed", projectPath);
                     return string.Empty;
                 }
- 
+
                 // Pull platformLookupTable metadata from the referenced project. This allows custom
                 // mappings on a per-ProjectReference basis.
                 Dictionary<string, string>? projectReferenceLookupTable = ExtractLookupTable(projectReferenceLookupTableMetadata, log);

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Shared
                 }
 
                 string buildProjectReferenceAs = string.Empty;
- 
+
                 // If the referenced project has a defined `Platform` that's compatible, it will build that way by default.
                 // Don't set `buildProjectReferenceAs` and the `_GetProjectReferencePlatformProperties` target will handle the rest.
                 if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(currentProjectPlatform, StringComparison.OrdinalIgnoreCase))

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.Shared
                     log?.LogWarningWithCodeFromResources("GetCompatiblePlatform.NoPlatformsListed", projectPath);
                     return string.Empty;
                 }
-
+ 
                 // Pull platformLookupTable metadata from the referenced project. This allows custom
                 // mappings on a per-ProjectReference basis.
                 Dictionary<string, string>? projectReferenceLookupTable = ExtractLookupTable(projectReferenceLookupTableMetadata, log);

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Build.Shared
                 string buildProjectReferenceAs = string.Empty;
                 if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(currentProjectPlatform, StringComparison.OrdinalIgnoreCase))
                 {
-                    buildProjectReferenceAs = currentProjectPlatform;
+                    log?.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", projectPath, referencedProjectPlatform);
                 }
                 // Prefer matching platforms
                 else if (projectReferencePlatforms.Contains(currentProjectPlatform))

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -36,14 +36,7 @@ namespace Microsoft.Build.Shared
 
                 string buildProjectReferenceAs = string.Empty;
 
-                // If the referenced project has a defined `Platform` that's compatible, it will build that way by default.
-                // Don't set `buildProjectReferenceAs` and the `_GetProjectReferencePlatformProperties` target will handle the rest.
-                if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(currentProjectPlatform, StringComparison.OrdinalIgnoreCase))
-                {
-                    log?.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", projectPath, referencedProjectPlatform);
-                }
-                // Prefer matching platforms
-                else if (projectReferencePlatforms.Contains(currentProjectPlatform))
+                if (projectReferencePlatforms.Contains(currentProjectPlatform))
                 {
                     buildProjectReferenceAs = currentProjectPlatform;
                     log?.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.SamePlatform");
@@ -76,6 +69,13 @@ namespace Microsoft.Build.Shared
                     // Keep NearestPlatform empty, log a warning. Common.CurrentVersion.targets will undefine 
                     // Platform/PlatformTarget when this is the case.
                     log?.LogWarningWithCodeFromResources("GetCompatiblePlatform.NoCompatiblePlatformFound", projectPath);
+                }
+                // If the referenced project has a defined `Platform` that's compatible, it will build that way by default.
+                // Don't set `buildProjectReferenceAs` and the `_GetProjectReferencePlatformProperties` target will handle the rest.
+                if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(buildProjectReferenceAs, StringComparison.OrdinalIgnoreCase))
+                {
+                    log?.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", projectPath, referencedProjectPlatform);
+                    buildProjectReferenceAs = string.Empty;
                 }
             return buildProjectReferenceAs;
         }

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Build.Shared
                 }
 
                 string buildProjectReferenceAs = string.Empty;
+ 
                 // If the referenced project has a defined `Platform` that's compatible, it will build that way by default.
                 // Don't set `buildProjectReferenceAs` and the `_GetProjectReferencePlatformProperties` target will handle the rest.
                 if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(currentProjectPlatform, StringComparison.OrdinalIgnoreCase))

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Build.Shared
                 }
 
                 string buildProjectReferenceAs = string.Empty;
+                // If the referenced project has a defined `Platform` that's compatible, it will build that way by default.
+                // Don't set `buildProjectReferenceAs` and the `_GetProjectReferencePlatformProperties` target will handle the rest.
                 if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(currentProjectPlatform, StringComparison.OrdinalIgnoreCase))
                 {
                     log?.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", projectPath, referencedProjectPlatform);

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -35,8 +35,12 @@ namespace Microsoft.Build.Shared
                 }
 
                 string buildProjectReferenceAs = string.Empty;
-
-                if (projectReferencePlatforms.Contains(currentProjectPlatform))
+                if (!string.IsNullOrEmpty(referencedProjectPlatform) && referencedProjectPlatform.Equals(currentProjectPlatform, StringComparison.OrdinalIgnoreCase))
+                {
+                    buildProjectReferenceAs = currentProjectPlatform;
+                }
+                // Prefer matching platforms
+                else if (projectReferencePlatforms.Contains(currentProjectPlatform))
                 {
                     buildProjectReferenceAs = currentProjectPlatform;
                     log?.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.SamePlatform");

--- a/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
+++ b/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
@@ -246,8 +246,6 @@ namespace Microsoft.Build.Tasks.UnitTests
 
             task.Execute().ShouldBeTrue();
 
-            // A ProjectReference PlatformLookupTable should take priority, but is thrown away when
-            // it has an invalid format. The current project's PLT should be the next priority.
             task.AssignedProjectsWithPlatform[0].GetMetadata("NearestPlatform").ShouldBe(string.Empty);
             task.Log.HasLoggedErrors.ShouldBeFalse();
         }

--- a/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
+++ b/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
@@ -84,6 +84,28 @@ namespace Microsoft.Build.Tasks.UnitTests
 
             task.AssignedProjectsWithPlatform[0].GetMetadata("NearestPlatform").ShouldBe("AnyCPU");
         }
+        
+        [Fact]
+        public void ResolvesViaAnyCPUDefaultWithDefaultPlatformEnabled()
+        {
+            // No valid mapping via the lookup table, should default to AnyCPU when the current project
+            // and ProjectReference platforms don't match.
+            TaskItem projectReference = new TaskItem("foo.bar");
+            projectReference.SetMetadata("Platforms", "x64;AnyCPU");
+            projectReference.SetMetadata("Platform", "AnyCPU");
+
+            GetCompatiblePlatform task = new GetCompatiblePlatform()
+            {
+                BuildEngine = new MockEngine(_output),
+                CurrentProjectPlatform = "x86",
+                PlatformLookupTable = "AnyCPU=x64", 
+                AnnotatedProjects = new TaskItem[] { projectReference }
+            };
+
+            task.Execute().ShouldBeTrue();
+
+            task.AssignedProjectsWithPlatform[0].GetMetadata("NearestPlatform").ShouldBe(string.Empty);
+        }
 
         [Fact]
         public void ResolvesViaSamePlatform()

--- a/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
+++ b/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
@@ -226,5 +226,30 @@ namespace Microsoft.Build.Tasks.UnitTests
             task.AssignedProjectsWithPlatform[0].GetMetadata("NearestPlatform").ShouldBe(string.Empty);
             task.Log.HasLoggedErrors.ShouldBeFalse();
         }
+        
+        // When `Platform` is retrieved in "GetTargetFrameworks" and that platform matches what the task has decided the project should be built as
+        // through negotiation. build that project _without_ a global property for Platform.
+        [Fact]
+        public void ChosenPlatformMatchesDefault()
+        {
+            TaskItem projectReference = new TaskItem("foo.bar");
+            projectReference.SetMetadata("Platforms", "AnyCPU");
+            projectReference.SetMetadata("Platform", "AnyCPU");
+
+            GetCompatiblePlatform task = new GetCompatiblePlatform()
+            {
+                BuildEngine = new MockEngine(_output),
+                CurrentProjectPlatform = "x86",
+                PlatformLookupTable = "", // invalid format
+                AnnotatedProjects = new TaskItem[] { projectReference },
+            };
+
+            task.Execute().ShouldBeTrue();
+
+            // A ProjectReference PlatformLookupTable should take priority, but is thrown away when
+            // it has an invalid format. The current project's PLT should be the next priority.
+            task.AssignedProjectsWithPlatform[0].GetMetadata("NearestPlatform").ShouldBe(string.Empty);
+            task.Log.HasLoggedErrors.ShouldBeFalse();
+        }
     }
 }

--- a/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
+++ b/src/Tasks.UnitTests/GetCompatiblePlatform_Tests.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Build.Tasks.UnitTests
         public void ChosenPlatformMatchesDefault()
         {
             TaskItem projectReference = new TaskItem("foo.bar");
-            projectReference.SetMetadata("Platforms", "AnyCPU");
+            projectReference.SetMetadata("Platforms", "AnyCPU;x64");
             projectReference.SetMetadata("Platform", "AnyCPU");
 
             GetCompatiblePlatform task = new GetCompatiblePlatform()


### PR DESCRIPTION
### Context
Platform negotiation still ends up in situations where project A explicitly tells project B to build as B's default platform. This leads to an unnecessary global property being passed, which leads to an unnecessary evaluation, and in some cases an overbuild.

This PR adds a catch-all that empties out the global Platform property whenever we fall into this case.

### Changes Made
Add catch-all if statement that prevents global property Platform to be passed to referenced projects when redundant (the project would have built as that platform anyway).

### Testing


### Notes
This will unblock the implementation of this feature in VS. the only thing currently blocking adoption of this in VS is our datacenter build(cloudbuild) graph validation. it sees two project nodes with different platform global properties evaluating to the same configuration and throws an error to prevent race conditions. 