### PR TITLE
enable producing reference assemblies by default

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -185,7 +185,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DocumentationFileProduced Condition="'$(DocumentationFile)'==''">false</_DocumentationFileProduced>
 
     <!-- Whether or not a reference assembly is produced. -->
-    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == ''">false</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == ''">true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
This change allows producing reference assemblies by default for both legacy and SDK project systems

The corresponding changes were merged for legacy project system
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1341885