### PR TITLE
Create problematic test path on current tmp path

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -471,7 +471,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             try
             {
-                string problematicTmpPath = @"C:\Users\}\blabla\temp";
+                // Check if } do not cause it to crash due to usage of String.Format or such on code path
+                string problematicTmpPath = Path.Combine(originalTmp,  "}", "blabla", "temp");
                 Environment.SetEnvironmentVariable("TMP", problematicTmpPath);
                 Environment.SetEnvironmentVariable("TEMP", problematicTmpPath);
 


### PR DESCRIPTION
### Context
Test CacheTest2 was failing on local test runs `build.cmd -test`
It was caused by creating folder at `C:\Users\}\...` which is allowed only for admin elevated processes.

### Changes Made
Problematic path created as subfolder of current path.
Only test was changed

### Testing
Local run.
