### PR TITLE
Added logging message for tasks that fail without error

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
-    "sdk": {
-        "allowPrerelease": true
-    },
+  "sdk": {
+    "allowPrerelease": true
+  },
   "tools": {
     "dotnet": "7.0.100-rc.2.22477.23",
     "vs": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
-  "sdk": {
-    "allowPrerelease": true
-  },
+    "sdk": {
+        "allowPrerelease": true,
+        "version": "7.0.100-rc.2.22477.23"
+    },
   "tools": {
     "dotnet": "7.0.100-rc.2.22477.23",
     "vs": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
     "sdk": {
-        "allowPrerelease": true,
-        "version": "7.0.100-rc.2.22477.23"
+        "allowPrerelease": true
     },
   "tools": {
     "dotnet": "7.0.100-rc.2.22477.23",

--- a/src/Build.UnitTests/BackEnd/OnError_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/OnError_Tests.cs
@@ -583,6 +583,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             else
             {
                 logger.ErrorCount.ShouldBe(0);
+                logger.AssertLogContains( String.Format(MockLogger.GetString("TaskReturnedFalseButDidNotLogError"), "FailingTask") );
             }
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -963,12 +963,13 @@ namespace Microsoft.Build.BackEnd
                     && (be is TaskHost th ? th.BuildRequestsSucceeded : false)
                     && !(_cancellationToken.CanBeCanceled && _cancellationToken.IsCancellationRequested)) // and it wasn't cancelled
                 {
-                    // If is allowed to fail without error
+                    // Then decide how to log MSB4181
                     if (be is IBuildEngine7 be7 && be7.AllowFailureWithoutError)
                     {
+                        // If it's allowed to fail without error, log as a message
                         taskLoggingContext.LogComment(MessageImportance.Normal, "TaskReturnedFalseButDidNotLogError", _taskNode.Name);
                     }
-                    // Then decide how to log MSB4181
+
                     else if (_continueOnError == ContinueOnError.WarnAndContinue)
                     {
                         taskLoggingContext.LogWarning(null,

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -969,7 +969,6 @@ namespace Microsoft.Build.BackEnd
                         // If it's allowed to fail without error, log as a message
                         taskLoggingContext.LogComment(MessageImportance.Normal, "TaskReturnedFalseButDidNotLogError", _taskNode.Name);
                     }
-
                     else if (_continueOnError == ContinueOnError.WarnAndContinue)
                     {
                         taskLoggingContext.LogWarning(null,

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -961,11 +961,15 @@ namespace Microsoft.Build.BackEnd
                     && !taskResult // and it returned false
                     && !taskLoggingContext.HasLoggedErrors // and it didn't log any errors
                     && (be is TaskHost th ? th.BuildRequestsSucceeded : false)
-                    && (be is IBuildEngine7 be7 ? !be7.AllowFailureWithoutError : true) // and it's not allowed to fail unless it logs an error
                     && !(_cancellationToken.CanBeCanceled && _cancellationToken.IsCancellationRequested)) // and it wasn't cancelled
                 {
+                    // If is allowed to fail without error
+                    if (be is IBuildEngine7 be7 && be7.AllowFailureWithoutError)
+                    {
+                        taskLoggingContext.LogComment(MessageImportance.Normal, "TaskReturnedFalseButDidNotLogError", _taskNode.Name);
+                    }
                     // Then decide how to log MSB4181
-                    if (_continueOnError == ContinueOnError.WarnAndContinue)
+                    else if (_continueOnError == ContinueOnError.WarnAndContinue)
                     {
                         taskLoggingContext.LogWarning(null,
                             new BuildEventFileInfo(_targetChildInstance.Location),


### PR DESCRIPTION
Fixes #6633


### Context


### Changes Made
Added check for tasks that fail without error messages, so that a normal priority message is shown.

### Testing
Extended existing tests to validate new behavior. Also validated that in dotnet test scenarios, the new message is not visible. 

### Notes
