### PR TITLE
Remove Bootstrap Property from Onboarding Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,13 @@ To get started on **Visual Studio 2022**:
   - .NET desktop development
   - .NET Core cross-platform development
 2. Ensure [long path support](https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later) is enabled at the Windows level.
-3. Open a `Developer Command Prompt for VS 2022` prompt.
-4. Clone the source code: `git clone https://github.com/dotnet/msbuild`
+3. [Install The Latest .NET SDK](https://dotnet.microsoft.com/en-us/download/dotnet)
+  - This will ensure you have the correct ASP.NET runtime packs.
+4. Open a `Developer Command Prompt for VS 2022` prompt.
+5. Clone the source code: `git clone https://github.com/dotnet/msbuild`
   - You may have to [download Git](https://git-scm.com/downloads) first.
-5. Run `.\build.cmd` from the root of the repo to build the code. This also restores packages needed to open the projects in Visual Studio.
-6. Open `MSBuild.sln` or `MSBuild.Dev.slnf` in Visual Studio 2022.
-
-Note: To create a usable MSBuild with your changes, run `.\build.cmd /p:CreateBootstrap=true`.
-To build release, add `-c Release`: `.\build.cmd -c Release /p:CreateBootstrap=true`.
+6. Run `.\build.cmd` from the root of the repo to build the code. This also restores packages needed to open the projects in Visual Studio.
+7. Open `MSBuild.sln` or `MSBuild.Dev.slnf` in Visual Studio 2022.
 
 This newly-built MSBuild will be located at `artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe`. It may not work for all scenarios, including C++ builds.
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,11 @@ To get started on **Visual Studio 2022**:
   - .NET desktop development
   - .NET Core cross-platform development
 2. Ensure [long path support](https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later) is enabled at the Windows level.
-3. [Install The Latest .NET SDK](https://dotnet.microsoft.com/en-us/download/dotnet)
-  - This will ensure you have the correct ASP.NET runtime packs.
-4. Open a `Developer Command Prompt for VS 2022` prompt.
-5. Clone the source code: `git clone https://github.com/dotnet/msbuild`
+3. Open a `Developer Command Prompt for VS 2022` prompt.
+4. Clone the source code: `git clone https://github.com/dotnet/msbuild`
   - You may have to [download Git](https://git-scm.com/downloads) first.
-6. Run `.\build.cmd` from the root of the repo to build the code. This also restores packages needed to open the projects in Visual Studio.
-7. Open `MSBuild.sln` or `MSBuild.Dev.slnf` in Visual Studio 2022.
+5. Run `.\build.cmd` from the root of the repo to build the code. This also restores packages needed to open the projects in Visual Studio.
+6. Open `MSBuild.sln` or `MSBuild.Dev.slnf` in Visual Studio 2022.
 
 This newly-built MSBuild will be located at `artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe`. It may not work for all scenarios, including C++ builds.
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
@@ -40,7 +40,7 @@ Set the environment variable `MSBUILDDEBUGONSTART` to `2`, then attach a debugge
 
 ### Using the repository binaries to perform builds
 
-To build projects using the MSBuild binaries from the repository, you first need to do a build (command: `build.cmd /p:CreateBootstrap=true`) which produces a bootstrap directory mimicking a Visual Studio (full framework flavor) or dotnet CLI (.net core flavor) installation.
+To build projects using the MSBuild binaries from the repository, you first need to do a build (command: `build.cmd`) which produces a bootstrap directory mimicking a Visual Studio (full framework flavor) or dotnet CLI (.net core flavor) installation.
 
 Now, just point `dotnet ./artifacts/bin/bootstrap/<TARGET_FRAMEWORK>/MSBuild/MSBuild.dll` at a project file. (Change <TARGET_FRAMEWORK> to current target framework, for example net7.0, net8.0) 
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -40,7 +40,7 @@ Please see [Contributing Code](https://github.com/dotnet/msbuild/blob/main/docum
 To build projects using the MSBuild binaries from the repository, you first need to do a build which produces
 a "bootstrap" directory. The "bootstrap" directory mimics a Visual Studio installation by acquiring additional
 dependencies (Roslyn compilers, NuGet, etc.) from packages or from your local machine (e.g. props/targets
-from Visual Studio). This will happen automatically by default when running `.\build.cmd`. The bootstrap can be disabled by running `.\build.cmd /p:CreateBootstrap=false`.
+from Visual Studio). This will happen by default when running `.\build.cmd`. The bootstrap can be disabled by running `.\build.cmd /p:CreateBootstrap=false`.
 
 Now, just point `artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe` at a project file.
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -38,9 +38,9 @@ Please see [Contributing Code](https://github.com/dotnet/msbuild/blob/main/docum
 ### Using the repository binaries to perform builds
 
 To build projects using the MSBuild binaries from the repository, you first need to do a build which produces
-a "bootstrap" directory. The "bootstrap" directory mimics a Visual Studio installation by aquiring additional
+a "bootstrap" directory. The "bootstrap" directory mimics a Visual Studio installation by acquiring additional
 dependencies (Roslyn compilers, NuGet, etc.) from packages or from your local machine (e.g. props/targets
-from Visual Studio). To produce a bootstrap build, run `.\build.cmd /p:CreateBootstrap=true` from the root of your enlistment.
+from Visual Studio). This will happen automatically by default when running `.\build.cmd`. The bootstrap can be disabled by running `.\build.cmd /p:CreateBootstrap=false`.
 
 Now, just point `artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe` at a project file.
 
@@ -49,7 +49,7 @@ Now, just point `artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe`
 Sometimes it's useful to patch your copy of Visual Studio in order to test or debug your local MSBuild changes from Visual Studio. You can use the [Deploy-MSBuild script](../Deploy-MSBuild.md) for copying your locally built MSBuild binaries over the MSBuild binaries shipping with Visual Studio. Example usage:
 ```
 # bootstrap build
-.\build.cmd /p:CreateBootstrap=true
+.\build.cmd
 
 # copy the bootstrap build output over the MSBuild binaries in Visual Studio
 .\scripts\Deploy-MSBuild.ps1 -destination "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"


### PR DESCRIPTION
# Mostly Wholistic Summary
- Forgind made a PR where the bootstrap flag is set automatically when building which simplifies the dev process a lot.
- Some of the documentation wasn't changed when that got merged in and we didn't notice until onboarding a new teammate 

So, this PR does the following:
- Change all of the inferences to bootstrap except on bootstrapped_msbuild.sh files, though it's likely also not needed there
- Also mention installing the SDK as installing workloads may not get the needed ASP.NET Runtime Packs for 7.0
- Also fixes a typo lol

# Further Context
Follow up to https://github.com/dotnet/msbuild/pull/7485 

@rainersigwald  @edvilme If there were additional things you needed to do to resolve the failures, we should add them to this PR.

cc @Forgind 