### PR TITLE
Revert "enable producing reference assemblies by default"

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -185,7 +185,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DocumentationFileProduced Condition="'$(DocumentationFile)'==''">false</_DocumentationFileProduced>
 
     <!-- Whether or not a reference assembly is produced. -->
-    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == ''">true</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == ''">false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Reverts dotnet/msbuild#8111

### Revert reason
To unblock SDK insertions
It produces test errors:
> Microsoft.NET.Build.Tests.GivenThatWeWantToProduceReferenceAssembly.It_produces_ref_assembly_for_appropriate_frameworks(targetFramework: "netcoreapp3.1", extension: ".csproj", expectedExists: False) [FAIL]
[31;1m[m[37m      Expected boolean to be False, but found True.
[m[30;1m      Stack Trace:
[m[37m           at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
[m[37m           at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
[m[37m           at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
[m[37m           at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
[m[37m           at FluentAssertions.Execution.AssertionScope.FailWith(String message, Object[] args)
[m[37m           at FluentAssertions.Primitives.BooleanAssertions`1.Be(Boolean expected, String because, Object[] becauseArgs)
[m[37m        /_/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToProduceReferenceAssembly.cs(46,0): at Microsoft.NET.Build.Tests.GivenThatWeWantToProduceReferenceAssembly.It_produces_ref_assembly_for_appropriate_frameworks(String targetFramework, String extension, Boolean expectedExists)
[m[37m           at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
[m[37m           at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
[m[30;1m      Output:
[m[37m        > /root/helix/work/correlation/d/dotnet msbuild /t:Build /root/helix/work/workitem/e/testExecutionDirectory/It_produces_r---834E60D2_2/ProduceRefAssembly/ProduceRefAssembly.csproj /restore
[m[37m        MSBuild version 17.5.0-preview-22554-02+85317edac for .NET
[m[37m          Determining projects to restore...
[m[37m          Restored /root/helix/work/workitem/e/testExecutionDirectory/It_produces_r---834E60D2_2/ProduceRefAssembly/ProduceRefAssembly.csproj (in 221 ms).
[m[37m        /root/helix/work/correlation/d/sdk/8.0.100-ci/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(256,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/root/helix/work/workitem/e/testExecutionDirectory/It_produces_r---834E60D2_2/ProduceRefAssembly/ProduceRefAssembly.csproj]
[m[37m          ProduceRefAssembly -> /root/helix/work/workitem/e/testExecutionDirectory/It_produces_r---834E60D2_2/ProduceRefAssembly/bin/Debug/netcoreapp3.1/ProduceRefAssembly.dll

Full log: https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-sdk-refs-pull-28869-merge-8f9f8233c70b48fb90/Microsoft.NET.Build.Tests.dll.16/3/console.0ea8ad16.log?helixlogtype=result
