### PR TITLE
Copy XSDs only in outer build

### DIFF
--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -241,8 +241,10 @@
     <ProjectReference Include="..\Tasks\Microsoft.Build.Tasks.csproj" />
   </ItemGroup>
 
+  <!-- Xsds are not TF or arch-specific so copy once them in the outer build -->
   <Target Name="CopyXsds"
-          BeforeTargets="AfterBuild">
+          BeforeTargets="Build"
+          Condition="'$(IsInnerBuild)' != 'true'">
     <Copy SourceFiles="@(XsdsForVS)"
           DestinationFiles="@(XsdsForVS->'$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'xsd'))%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"


### PR DESCRIPTION
Fixes a build race condition observed in a PR build that manifested as:

    src\MSBuild\MSBuild.csproj(246,5): error MSB3026: (NETCORE_ENGINEERING_TELEMETRY=Build) Could not copy "MSBuild\Microsoft.Build.CommonTypes.xsd" to "D:\a\1\s\artifacts\xsd\MSBuild\Microsoft.Build.CommonTypes.xsd". Beginning retry 1 in 1000ms. The process cannot access the file 'D:\a\1\s\artifacts\xsd\MSBuild\Microsoft.Build.CommonTypes.xsd' because it is being used by another process.
