### PR TITLE
Set BuildParameters.StartupDirectory upon build command

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -630,8 +630,16 @@ namespace Microsoft.Build.Execution
 
         /// <summary>
         /// Gets the startup directory.
+        /// It is current directory from which MSBuild command line was recently invoked.
+        /// It is communicated to working nodes as part NodeConfiguration deserialization once node manager acquire particular node.
+        /// This deserialization assign this value to static backing field making it accessible from rest of build thread.
+        /// In MSBuild server node, this value is set once <see cref="ServerNodeBuildCommand"></see> is received.
         /// </summary>
-        internal static string StartupDirectory => s_startupDirectory;
+        internal static string StartupDirectory
+        {
+            get { return s_startupDirectory; }
+            set { s_startupDirectory = value; }
+        }
 
         /// <summary>
         /// Indicates whether the build plan is enabled or not.

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -631,7 +631,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Gets the startup directory.
         /// It is current directory from which MSBuild command line was recently invoked.
-        /// It is communicated to working nodes as part NodeConfiguration deserialization once node manager acquire particular node.
+        /// It is communicated to working nodes as part of NodeConfiguration deserialization once the node manager acquires a particular node.
         /// This deserialization assign this value to static backing field making it accessible from rest of build thread.
         /// In MSBuild server node, this value is set once <see cref="ServerNodeBuildCommand"></see> is received.
         /// </summary>

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -361,6 +361,10 @@ namespace Microsoft.Build.Experimental
             Thread.CurrentThread.CurrentCulture = command.Culture;
             Thread.CurrentThread.CurrentUICulture = command.UICulture;
 
+            // Reconfigure static BuildParameters.StartupDirectory to have this value
+            // same as startup directory of msbuild entry client or dotnet CLI.
+            BuildParameters.StartupDirectory = command.StartupDirectory;
+
             // Configure console configuration so Loggers can change their behavior based on Target (client) Console properties.
             ConsoleConfiguration.Provider = command.ConsoleConfiguration;
 

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -281,6 +281,44 @@ namespace Microsoft.Build.Engine.UnitTests
             pidOfInitialProcess.ShouldBe(pidOfServerProcess, "We started a server node even when build is interactive.");
         }
 
+        [Fact]
+        public void PropertyMSBuildStartupDirectoryOnServer()
+        {
+            string reportMSBuildStartupDirectoryProperty = @$"
+<Project>
+    <UsingTask TaskName=""ProcessIdTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />
+	<Target Name=""DisplayMessages"">
+        <ProcessIdTask>
+            <Output PropertyName=""PID"" TaskParameter=""Pid"" />
+        </ProcessIdTask>
+        <Message Text=""Server ID is $(PID)"" Importance=""High"" />
+		<Message Text="":MSBuildStartupDirectory:$(MSBuildStartupDirectory):"" Importance=""high"" />
+	</Target> 
+</Project>";
+
+            TransientTestFile project = _env.CreateFile("testProject.proj", reportMSBuildStartupDirectoryProperty);
+            _env.SetEnvironmentVariable("MSBUILDUSESERVER", "1");
+
+            // Start on current working directory
+            string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, $"/t:DisplayMessages {project.Path}", out bool success, false, _output);
+            success.ShouldBeTrue();
+            int pidOfServerProcess = ParseNumber(output, "Server ID is ");
+            _env.WithTransientProcess(pidOfServerProcess);
+            output.ShouldContain($@":MSBuildStartupDirectory:{Environment.CurrentDirectory}:");
+
+            // Start on transient project directory
+            _env.SetCurrentDirectory(Path.GetDirectoryName(project.Path));
+            output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, $"/t:DisplayMessages {project.Path}", out success, false, _output);
+            int pidOfNewServerProcess = ParseNumber(output, "Server ID is ");
+            if (pidOfServerProcess != pidOfNewServerProcess)
+            {
+                // Register process to clean up (be killed) after tests ends.
+                _env.WithTransientProcess(pidOfNewServerProcess);
+            }
+            pidOfNewServerProcess.ShouldBe(pidOfServerProcess);
+            output.ShouldContain($@":MSBuildStartupDirectory:{Environment.CurrentDirectory}:");
+        }
+
         private int ParseNumber(string searchString, string toFind)
         {
             Regex regex = new(@$"{toFind}(\d+)");


### PR DESCRIPTION
Fixes #8094

### Context
Server have cached `BuildParameters.StartupDirectory` in static variable. When consequent builds starts from different directory, this value will have incorrect value of previous builds.
`BuildParameters.StartupDirectory` was also used for creating build-in `MSBuildStartupDirectory` property.

### Changes Made
Set `BuildParameters.StartupDirectory` when `ServerNodeBuildCommand` is received by server.

### Testing
After fixes, cant repro issues from #8094

### Notes
Changes can possible affect only server behavior.
