### PR TITLE
Use OptProf v2 data in CI builds 

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -23,12 +23,9 @@ variables:
   - name: SourceBranch
     value: $(IbcSourceBranchName)
   # If we're not on a vs* branch, use main as our optprof collection branch
-  # NOTE: the code is temporarily fixed. For the branches that should use opt-prof from the main branch we should use the latest working Opt-Prof 20220901.6-001 collected from main 20220901.6.
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
-    - name: OptProfDrop
-      value: 'OptimizationData/DotNet-msbuild-Trusted/main/20220901.6/1387996/1'
     - name: SourceBranch
-      value: ''
+      value: main
   # if OptProfDropName is set as a parameter, set OptProfDrop to the parameter and unset SourceBranch
   - ${{ if ne(parameters.OptProfDropName, 'default') }}:
     - name: OptProfDrop


### PR DESCRIPTION
### Context
We revert the temporary fix "Use old opt-prof data for main and exp branches. (#7973)" since the new optprof pipeline (see PR #8085) started to produce new optimization data.

### Changes Made
This reverts commit 6033e4c95bcd9fa31ebe9b52462c15521cda8f62.

### Testing
experimental CI run