### PR TITLE
Add tests for user's system configuration

### DIFF
--- a/src/Framework.UnitTests/SystemSetup_Tests.cs
+++ b/src/Framework.UnitTests/SystemSetup_Tests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Build.Framework
         [Fact]
         public void VerifyLongPaths()
         {
-            NativeMethodsShared.MaxPath.ShouldBeGreaterThan(10000);
+            NativeMethodsShared.MaxPath.ShouldBeGreaterThan(10000, "Long paths are not enabled. Enable long paths via the registry.");
         }
 
 #if NETCOREAPP
@@ -28,7 +28,7 @@ namespace Microsoft.Build.Framework
             {
                 string symLink = File.CreateSymbolicLink(path, file.Path).FullName;
                 string contents = File.ReadAllText(path);
-                contents.ShouldBe("fileContents");
+                contents.ShouldBe("fileContents", "You do not have permissions to create symbolic links.");
             }
             finally
             {

--- a/src/Framework.UnitTests/SystemSetup_Tests.cs
+++ b/src/Framework.UnitTests/SystemSetup_Tests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Microsoft.Build.UnitTests;
+using Shouldly;
+using Xunit;
+
+
+namespace Microsoft.Build.Framework
+{
+    public sealed class SystemSetup_Tests
+    {
+        [Fact]
+        public void VerifyLongPaths()
+        {
+            NativeMethodsShared.MaxPath.ShouldBeGreaterThan(10000);
+        }
+
+#if NETCOREAPP
+        [Fact]
+        public void VerifySymLinksEnabled()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            TransientTestFile file = env.CreateFile("fileName.tmp", "fileContents");
+            string path = Path.Combine(Path.GetTempPath(), "symLink");
+            try
+            {
+                string symLink = File.CreateSymbolicLink(path, file.Path).FullName;
+                string contents = File.ReadAllText(path);
+                contents.ShouldBe("fileContents");
+            }
+            finally
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+#endif
+    }
+}

--- a/src/Framework.UnitTests/SystemSetup_Tests.cs
+++ b/src/Framework.UnitTests/SystemSetup_Tests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Build.Framework
             NativeMethodsShared.MaxPath.ShouldBeGreaterThan(10000, "Long paths are not enabled. Enable long paths via the registry.");
         }
 
-#if NETCOREAPP
         [Fact]
         public void VerifySymLinksEnabled()
         {
@@ -26,7 +25,8 @@ namespace Microsoft.Build.Framework
             string path = Path.Combine(Path.GetTempPath(), "symLink");
             try
             {
-                string symLink = File.CreateSymbolicLink(path, file.Path).FullName;
+                string errorMessage = string.Empty;
+                NativeMethods.MakeSymbolicLink(path, file.Path, ref errorMessage).ShouldBeTrue(errorMessage);
                 string contents = File.ReadAllText(path);
                 contents.ShouldBe("fileContents", "You do not have permissions to create symbolic links.");
             }
@@ -38,6 +38,5 @@ namespace Microsoft.Build.Framework
                 }
             }
         }
-#endif
     }
 }


### PR DESCRIPTION
Currently includes verifying long paths are enabled and they can create symlinks. As more issues come up, we should add to this list.