### PR TITLE
Fix Copy with UseSymbolicLinksIfPossible = true

### DIFF
--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2397,77 +2397,63 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CopyToDestinationFolderWithSymbolicLinkCheck()
         {
-            var isPrivileged = true;
-
-            if (NativeMethodsShared.IsWindows)
+            string sourceFile = FileUtilities.GetTemporaryFile();
+            string temp = Path.GetTempPath();
+            string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");
+            string destFile = Path.Combine(destFolder, Path.GetFileName(sourceFile));
+            try
             {
-                if (!new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null)))
+                File.WriteAllText(sourceFile, "This is a source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
+
+                // Don't create the dest folder, let task do that
+                ITaskItem[] sourceFiles = { new TaskItem(sourceFile) };
+
+                var me = new MockEngine(true);
+                var t = new Copy
                 {
-                    isPrivileged = false;
-                    Assert.True(true, "It seems that you don't have the permission to create symbolic links. Try to run this test again with higher privileges");
-                }
+                    RetryDelayMilliseconds = 1,  // speed up tests!
+                    BuildEngine = me,
+                    SourceFiles = sourceFiles,
+                    DestinationFolder = new TaskItem(destFolder),
+                    SkipUnchangedFiles = true,
+                    UseSymboliclinksIfPossible = true
+                };
+
+                bool success = t.Execute();
+
+                Assert.True(success); // "success"
+                Assert.True(File.Exists(destFile)); // "destination exists"
+                Assert.True((File.GetAttributes(destFile) & FileAttributes.ReparsePoint) != 0);
+
+                MockEngine.GetStringDelegate resourceDelegate = AssemblyResources.GetString;
+
+                me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.SymbolicLinkComment", sourceFile, destFile);
+
+                string destinationFileContents = File.ReadAllText(destFile);
+                Assert.Equal("This is a source temp file.", destinationFileContents); // "Expected the destination symbolic linked file to contain the contents of source file."
+
+                Assert.Single(t.DestinationFiles);
+                Assert.Single(t.CopiedFiles);
+                Assert.Equal(destFile, t.DestinationFiles[0].ItemSpec);
+                Assert.Equal(destFile, t.CopiedFiles[0].ItemSpec);
+
+                // Now we will write new content to the source file
+                // we'll then check that the destination file automatically
+                // has the same content (i.e. it's been hard linked)
+
+                File.WriteAllText(sourceFile, "This is another source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
+
+                // Read the destination file (it should have the same modified content as the source)
+                destinationFileContents = File.ReadAllText(destFile);
+                Assert.Equal("This is another source temp file.", destinationFileContents); // "Expected the destination hard linked file to contain the contents of source file. Even after modification of the source"
+
+                ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3891"); // Didn't do retries
             }
-
-            if (isPrivileged)
+            finally
             {
-                string sourceFile = FileUtilities.GetTemporaryFile();
-                string temp = Path.GetTempPath();
-                string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");
-                string destFile = Path.Combine(destFolder, Path.GetFileName(sourceFile));
-                try
-                {
-                    File.WriteAllText(sourceFile, "This is a source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
-
-                    // Don't create the dest folder, let task do that
-
-                    ITaskItem[] sourceFiles = { new TaskItem(sourceFile) };
-
-                    var me = new MockEngine(true);
-                    var t = new Copy
-                    {
-                        RetryDelayMilliseconds = 1,  // speed up tests!
-                        BuildEngine = me,
-                        SourceFiles = sourceFiles,
-                        DestinationFolder = new TaskItem(destFolder),
-                        SkipUnchangedFiles = true,
-                        UseSymboliclinksIfPossible = true
-                    };
-
-                    bool success = t.Execute();
-
-                    Assert.True(success); // "success"
-                    Assert.True(File.Exists(destFile)); // "destination exists"
-
-                    MockEngine.GetStringDelegate resourceDelegate = AssemblyResources.GetString;
-
-                    me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.SymbolicLinkComment", sourceFile, destFile);
-
-                    string destinationFileContents = File.ReadAllText(destFile);
-                    Assert.Equal("This is a source temp file.", destinationFileContents); // "Expected the destination symbolic linked file to contain the contents of source file."
-
-                    Assert.Single(t.DestinationFiles);
-                    Assert.Single(t.CopiedFiles);
-                    Assert.Equal(destFile, t.DestinationFiles[0].ItemSpec);
-                    Assert.Equal(destFile, t.CopiedFiles[0].ItemSpec);
-
-                    // Now we will write new content to the source file
-                    // we'll then check that the destination file automatically
-                    // has the same content (i.e. it's been hard linked)
-
-                    File.WriteAllText(sourceFile, "This is another source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
-
-                    // Read the destination file (it should have the same modified content as the source)
-                    destinationFileContents = File.ReadAllText(destFile);
-                    Assert.Equal("This is another source temp file.", destinationFileContents); // "Expected the destination hard linked file to contain the contents of source file. Even after modification of the source"
-
-                    ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3891"); // Didn't do retries
-                }
-                finally
-                {
-                    File.Delete(sourceFile);
-                    File.Delete(destFile);
-                    FileUtilities.DeleteWithoutTrailingBackslash(destFolder, true);
-                }
+                File.Delete(sourceFile);
+                File.Delete(destFile);
+                FileUtilities.DeleteWithoutTrailingBackslash(destFolder, true);
             }
         }
 

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2397,6 +2397,13 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CopyToDestinationFolderWithSymbolicLinkCheck()
         {
+            if (NativeMethodsShared.IsWindows && osVersion.Major < 11 (osVersion.Major < 10 || osVersion.Build < 14972))
+            {
+                // Symlink creation depends on having a high enough OS version on windows unless you explicitly enable the setting for
+                // the current user or are running as admin. Skip this test.
+                return;
+            }
+
             string sourceFile = FileUtilities.GetTemporaryFile();
             string temp = Path.GetTempPath();
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2397,14 +2397,6 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CopyToDestinationFolderWithSymbolicLinkCheck()
         {
-            Version osVersion = Environment.OSVersion.Version;
-            if (NativeMethodsShared.IsWindows && osVersion.Major < 11 && (osVersion.Major < 10 || osVersion.Build < 14972))
-            {
-                // Symlink creation depends on having a high enough OS version on windows unless you explicitly enable the setting for
-                // the current user or are running as admin. Skip this test.
-                return;
-            }
-
             string sourceFile = FileUtilities.GetTemporaryFile();
             string temp = Path.GetTempPath();
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2397,6 +2397,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CopyToDestinationFolderWithSymbolicLinkCheck()
         {
+            Version osVersion = Environment.OSVersion.Version;
             if (NativeMethodsShared.IsWindows && osVersion.Major < 11 (osVersion.Major < 10 || osVersion.Build < 14972))
             {
                 // Symlink creation depends on having a high enough OS version on windows unless you explicitly enable the setting for

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2423,7 +2423,7 @@ namespace Microsoft.Build.UnitTests
 
                 Assert.True(success); // "success"
                 Assert.True(File.Exists(destFile)); // "destination exists"
-                Assert.True((File.GetAttributes(destFile) & FileAttributes.ReparsePoint) != 0);
+                Assert.True((File.GetAttributes(destFile) & FileAttributes.ReparsePoint) != 0, "File was copied but is not a symlink");
 
                 MockEngine.GetStringDelegate resourceDelegate = AssemblyResources.GetString;
 

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2398,7 +2398,7 @@ namespace Microsoft.Build.UnitTests
         public void CopyToDestinationFolderWithSymbolicLinkCheck()
         {
             Version osVersion = Environment.OSVersion.Version;
-            if (NativeMethodsShared.IsWindows && osVersion.Major < 11 (osVersion.Major < 10 || osVersion.Build < 14972))
+            if (NativeMethodsShared.IsWindows && osVersion.Major < 11 && (osVersion.Major < 10 || osVersion.Build < 14972))
             {
                 // Symlink creation depends on having a high enough OS version on windows unless you explicitly enable the setting for
                 // the current user or are running as admin. Skip this test.

--- a/src/Tasks/NativeMethods.cs
+++ b/src/Tasks/NativeMethods.cs
@@ -833,7 +833,14 @@ namespace Microsoft.Build.Tasks
             bool symbolicLinkCreated;
             if (NativeMethodsShared.IsWindows)
             {
-                symbolicLinkCreated = CreateSymbolicLink(newFileName, exitingFileName, SymbolicLink.File);
+                Version osVersion = Environment.OSVersion.Version;
+                SymbolicLink flags = SymbolicLink.File;
+                if (osVersion.Major >= 11 || (osVersion.Major == 10 && osVersion.Build >= 14972))
+                {
+                    flags |= (SymbolicLink)0x2;
+                }
+
+                symbolicLinkCreated = CreateSymbolicLink(newFileName, exitingFileName, flags);
                 errorMessage = symbolicLinkCreated ? null : Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()).Message;
             }
             else

--- a/src/Tasks/NativeMethods.cs
+++ b/src/Tasks/NativeMethods.cs
@@ -517,7 +517,8 @@ namespace Microsoft.Build.Tasks
     internal enum SymbolicLink
     {
         File = 0,
-        Directory = 1
+        Directory = 1,
+        AllowUnprivilegedCreate = 2,
     }
 
     /// <summary>
@@ -837,7 +838,7 @@ namespace Microsoft.Build.Tasks
                 SymbolicLink flags = SymbolicLink.File;
                 if (osVersion.Major >= 11 || (osVersion.Major == 10 && osVersion.Build >= 14972))
                 {
-                    flags |= (SymbolicLink)0x2;
+                    flags |= SymbolicLink.AllowUnprivilegedCreate;
                 }
 
                 symbolicLinkCreated = CreateSymbolicLink(newFileName, exitingFileName, flags);


### PR DESCRIPTION
### Changes Made
Fix symlink creation

### Testing
I tried creating a symlink with this, and it succeeded, both in the unit test and in the wild. I also tweaked the unit test to verify that the reparse point is not 0 for the created file. I removed the early exit if the user doesn't have the expected permission.

### Notes
Once both this and #8149 are merged, we should modify the test in #8149 to use this to create a symlink on windows.