### PR TITLE
Fix Opt-Prof v2 pipeline for the release branches.

### DIFF
--- a/.opt-prof.yml
+++ b/.opt-prof.yml
@@ -46,6 +46,7 @@ stages:
     optOptimizationInputsDropName: $(OptimizationInputsDropName)
     testLabPoolName: VS-Platform # The test lab pool to run your tests in
     testMachineImageName: Windows-10-Enterprise-20H2
+    visualStudioSigning: Test
     variables:
     - name: branchName # The branch in the VS repo the bootstrapper was based on
       value: $[replace(variables['resources.pipeline.ComponentBuildUnderTest.sourceBranch'],'refs/heads/','')]


### PR DESCRIPTION
### Context
Opt-prof v2 pipeline is failing for "vs*" branches on the machine deployment stage, during the VS installation. 
This PR should fix the issue. 

### Testing
Experimental runs of Opt-Prof v2 pipeline for vs17.2 and main branches.
