### PR TITLE
Fix vs tools path error when condition is false

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ConstructionEditing_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ConstructionEditing_Tests.cs
@@ -787,7 +787,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         public delegate void AddMetadata(ProjectItemElement element);
 
-        public static IEnumerable<object[]> InsertMetadataElemenetAfterSiblingsTestData
+        public static IEnumerable<object[]> InsertMetadataElementAfterSiblingsTestData
         {
             get
             {
@@ -892,7 +892,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         }
 
         [Theory]
-        [MemberData(nameof(InsertMetadataElemenetAfterSiblingsTestData))]
+        [MemberData(nameof(InsertMetadataElementAfterSiblingsTestData))]
         public void InsertMetadataElementAfterSiblings(AddMetadata addMetadata, int position, string expectedItem)
         {
             Action<ProjectItemElement, ProjectMetadataElement, ProjectMetadataElement> act = (i, c, r) => { i.InsertAfterChild(c, r); };
@@ -900,7 +900,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             AssertMetadataConstruction(addMetadata, position, expectedItem, act);
         }
 
-        public static IEnumerable<object[]> InsertMetadataElemenetBeforeSiblingsTestData
+        public static IEnumerable<object[]> InsertMetadataElementBeforeSiblingsTestData
         {
             get
             {
@@ -934,7 +934,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         }
 
         [Theory]
-        [MemberData(nameof(InsertMetadataElemenetBeforeSiblingsTestData))]
+        [MemberData(nameof(InsertMetadataElementBeforeSiblingsTestData))]
         public void InsertMetadataElementBeforeSiblings(AddMetadata addMetadata, int position, string expectedItem)
         {
             Action<ProjectItemElement, ProjectMetadataElement, ProjectMetadataElement> act = (i, c, r) => { i.InsertBeforeChild(c, r); };

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -79,26 +79,33 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
 
+        // Some of these are also tested elsewhere, but this consolidates related tests in one spot.
         public static IEnumerable<object[]> ImportLoadingScenarioTestData
         {
             get
             {
+                // This first section tests our behavior if a folder does not exist. Conditions and whether there are wildcards should affect whether it fails if it fails to find a file.
                 yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist.csproj")}"" Condition=""Exists('{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist.csproj")}')""", true };
                 yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist.csproj")}"" Condition=""'true'""", false };
                 yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist.csproj")}""", false };
                 yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "*.*proj")}""", true };
 
+                // This section tests if the folder does exist, but the project does not.
                 yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist.csproj")}"" Condition=""Exists('{Path.Combine("realFolder", "projectThatDoesNotExist.csproj")}')""", true };
                 yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist.csproj")}"" Condition=""'true'""", false };
                 yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist.csproj")}""", false };
                 yield return new object[] { $@"Project=""{Path.Combine("realFolder", "*.*proj")}""", true };
 
+                // This tests if the folder and the file exist.
                 yield return new object[] { $@"Project=""{Path.Combine("realFolder", "realFile.csproj")}"" Condition=""Exists('{Path.Combine("realFolder", "realFile.csproj")}')""", true };
                 yield return new object[] { $@"Project=""{Path.Combine("realFolder", "realFile.csproj")}"" Condition=""'true'""", true };
                 yield return new object[] { $@"Project=""{Path.Combine("realFolder", "realFile.csproj")}""", true };
                 yield return new object[] { $@"Project=""{Path.Combine("realFolder", "*.*proj")}""", true };
 
-                yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "projectThatDoesNotExist.csproj")}"" Condition=""'false'""", true };
+                // If we fail to find a particular import along one project path, we have a few properties that can be expanded in different ways, including VSToolsPath. In other words,
+                // if the property isn't defined to somewhere that exists, we may still find it in a fallback path. Error behavior in this case is more complicated, as the file may
+                // exist along one search path but not another, in which case we should not error.
+                yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "projectThatDoesNotExist.csproj")}"" Condition=""Exists('{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "projectThatDoesNotExist.csproj")}')""", true };
                 yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "projectThatDoesNotExist.csproj")}"" Condition=""'true'""", false };
                 yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "projectThatDoesNotExist.csproj")}""", false };
                 yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "*.*proj")}""", true };

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -52,16 +52,30 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
         [Theory]
         [MemberData(nameof(ImportLoadingScenarioTestData))]
-        public void VerifyLoadingImportScenarios(string importParameter)
+        public void VerifyLoadingImportScenarios(string importParameter, bool shouldSucceed)
         {
             using (TestEnvironment env = TestEnvironment.Create())
             {
-                TransientTestFolder existentDirectory = env.CreateFolder("realFolder");
+                TransientTestFolder existentDirectory = env.CreateFolder(createFolder: true);
+                TransientTestFile realFile = env.CreateFile(existentDirectory, "realFile.csproj", @"<Project> </Project>");
                 TransientTestFile projectFile = env.CreateFile("project.proj", @$"
 <Project>
   <Import {importParameter.Replace("realFolder", existentDirectory.Path)} />
+
+  <Target Name=""MyTarget"">
+    <Message Text=""Target working!"" />
+  </Target>
 </Project>
 ");
+                bool result = false;
+                try
+                {
+                    Project project = new(projectFile.Path);
+                    MockLogger logger = new();
+                    result = project.Build(logger);
+                }
+                catch (InvalidProjectFileException) { }
+                result.ShouldBe(shouldSucceed);
             }
         }
 
@@ -69,15 +83,26 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             get
             {
-                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")}"" Condition=""Exists({Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")})""" };
-                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")}"" Condition=""true""" };
-                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")}""" };
-                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "*.*")}""" };
+                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist.csproj")}"" Condition=""Exists('{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist.csproj")}')""", true };
+                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist.csproj")}"" Condition=""'true'""", false };
+                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist.csproj")}""", false };
+                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "*.*proj")}""", true };
 
-                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist")}"" Condition=""Exists({Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")})""" };
-                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist")}"" Condition=""true""" };
-                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist")}""" };
-                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "*.*")}""" };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist.csproj")}"" Condition=""Exists('{Path.Combine("realFolder", "projectThatDoesNotExist.csproj")}')""", true };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist.csproj")}"" Condition=""'true'""", false };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist.csproj")}""", false };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "*.*proj")}""", true };
+
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "realFile.csproj")}"" Condition=""Exists('{Path.Combine("realFolder", "realFile.csproj")}')""", true };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "realFile.csproj")}"" Condition=""'true'""", true };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "realFile.csproj")}""", true };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "*.*proj")}""", true };
+
+                yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "projectThatDoesNotExist.csproj")}"" Condition=""'false'""", true };
+                yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "projectThatDoesNotExist.csproj")}"" Condition=""'true'""", false };
+                yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "projectThatDoesNotExist.csproj")}""", false };
+                yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "nonexistentDirectory", "*.*proj")}""", true };
+                yield return new object[] { $@"Project=""{Path.Combine("$(VSToolsPath)", "*.*proj")}""", true };
             }
         }
 

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -50,6 +50,37 @@ namespace Microsoft.Build.UnitTests.Evaluation
             GC.Collect();
         }
 
+        [Theory]
+        [MemberData(nameof(ImportLoadingScenarioTestData))]
+        public void VerifyLoadingImportScenarios(string importParameter)
+        {
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                TransientTestFolder existentDirectory = env.CreateFolder("realFolder");
+                TransientTestFile projectFile = env.CreateFile("project.proj", @$"
+<Project>
+  <Import {importParameter.Replace("realFolder", existentDirectory.Path)} />
+</Project>
+");
+            }
+        }
+
+        public static IEnumerable<object[]> ImportLoadingScenarioTestData
+        {
+            get
+            {
+                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")}"" Condition=""Exists({Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")})""" };
+                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")}"" Condition=""true""" };
+                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")}""" };
+                yield return new object[] { $@"Project=""{Path.Combine("nonexistentDirectory", "*.*")}""" };
+
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist")}"" Condition=""Exists({Path.Combine("nonexistentDirectory", "projectThatDoesNotExist")})""" };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist")}"" Condition=""true""" };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "projectThatDoesNotExist")}""" };
+                yield return new object[] { $@"Project=""{Path.Combine("realFolder", "*.*")}""" };
+            }
+        }
+
         /// <summary>
         /// Verify Exist condition used in Import or ImportGroup elements will succeed when in-memory project is available inside projectCollection.
         /// </summary>

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1638,7 +1638,9 @@ namespace Microsoft.Build.Evaluation
             // paths will be returned (union of all files that match).
             var allProjects = new List<ProjectRootElement>();
             bool containsWildcards = FileMatcher.HasWildcards(importElement.Project);
-            bool noDirectoryExists = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_6);
+
+            // Initially set to log an error if the change wave is enabled.
+            bool foundDirectoryDuringProbeOrConditionWasFalse = !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_6);
 
             // Try every extension search path, till we get a Hit:
             // 1. 1 or more project files loaded
@@ -1656,7 +1658,7 @@ namespace Microsoft.Build.Evaluation
                 if (!EvaluateConditionCollectingConditionedProperties(importElement, newExpandedCondition, ExpanderOptions.ExpandProperties, ParserOptions.AllowProperties,
                             _projectRootElementCache))
                 {
-                    noDirectoryExists = false;
+                    foundDirectoryDuringProbeOrConditionWasFalse = true;
                     continue;
                 }
 
@@ -1665,7 +1667,7 @@ namespace Microsoft.Build.Evaluation
                     continue;
                 }
 
-                noDirectoryExists = false;
+                foundDirectoryDuringProbeOrConditionWasFalse = true;
 
                 var newExpandedImportPath = importElement.Project.Replace(extensionPropertyRefAsString, extensionPathExpanded, StringComparison.OrdinalIgnoreCase);
                 _evaluationLoggingContext.LogComment(MessageImportance.Low, "TryingExtensionsPath", newExpandedImportPath, extensionPathExpanded);
@@ -1716,7 +1718,7 @@ namespace Microsoft.Build.Evaluation
             // atleastOneExactFilePathWasLookedAtAndNotFound would be false, eg, if the expression
             // was a wildcard and it resolved to zero files!
             if (allProjects.Count == 0 &&
-                (atleastOneExactFilePathWasLookedAtAndNotFound || noDirectoryExists) &&
+                (atleastOneExactFilePathWasLookedAtAndNotFound || !foundDirectoryDuringProbeOrConditionWasFalse) &&
                 (_loadSettings & ProjectLoadSettings.IgnoreMissingImports) == 0)
             {
                 ThrowForImportedProjectWithSearchPathsNotFound(fallbackSearchPathMatch, importElement);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1638,9 +1638,7 @@ namespace Microsoft.Build.Evaluation
             // paths will be returned (union of all files that match).
             var allProjects = new List<ProjectRootElement>();
             bool containsWildcards = FileMatcher.HasWildcards(importElement.Project);
-
-            // Initially set to log an error if the change wave is enabled.
-            bool foundDirectoryDuringProbeOrConditionWasFalse = !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_6);
+            bool missingDirectoryDespiteTrueCondition = false;
 
             // Try every extension search path, till we get a Hit:
             // 1. 1 or more project files loaded
@@ -1658,16 +1656,16 @@ namespace Microsoft.Build.Evaluation
                 if (!EvaluateConditionCollectingConditionedProperties(importElement, newExpandedCondition, ExpanderOptions.ExpandProperties, ParserOptions.AllowProperties,
                             _projectRootElementCache))
                 {
-                    foundDirectoryDuringProbeOrConditionWasFalse = true;
                     continue;
                 }
 
                 if (!_fallbackSearchPathsCache.DirectoryExists(extensionPathExpanded))
                 {
+                    // Set to log an error only if the change wave is enabled.
+                    missingDirectoryDespiteTrueCondition = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_6);
                     continue;
                 }
 
-                foundDirectoryDuringProbeOrConditionWasFalse = true;
 
                 var newExpandedImportPath = importElement.Project.Replace(extensionPropertyRefAsString, extensionPathExpanded, StringComparison.OrdinalIgnoreCase);
                 _evaluationLoggingContext.LogComment(MessageImportance.Low, "TryingExtensionsPath", newExpandedImportPath, extensionPathExpanded);
@@ -1718,7 +1716,7 @@ namespace Microsoft.Build.Evaluation
             // atleastOneExactFilePathWasLookedAtAndNotFound would be false, eg, if the expression
             // was a wildcard and it resolved to zero files!
             if (allProjects.Count == 0 &&
-                (atleastOneExactFilePathWasLookedAtAndNotFound || !foundDirectoryDuringProbeOrConditionWasFalse) &&
+                (atleastOneExactFilePathWasLookedAtAndNotFound || missingDirectoryDespiteTrueCondition) &&
                 (_loadSettings & ProjectLoadSettings.IgnoreMissingImports) == 0)
             {
                 ThrowForImportedProjectWithSearchPathsNotFound(fallbackSearchPathMatch, importElement);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1659,6 +1659,8 @@ namespace Microsoft.Build.Evaluation
                     continue;
                 }
 
+                // If the whole fallback folder doesn't exist, short-circuit and don't
+                // bother constructing an exact file path.
                 if (!_fallbackSearchPathsCache.DirectoryExists(extensionPathExpanded))
                 {
                     // Set to log an error only if the change wave is enabled.

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1652,19 +1652,20 @@ namespace Microsoft.Build.Evaluation
 
                 string extensionPathExpanded = _data.ExpandString(extensionPath);
 
+                var newExpandedCondition = importElement.Condition.Replace(extensionPropertyRefAsString, extensionPathExpanded, StringComparison.OrdinalIgnoreCase);
+                if (!EvaluateConditionCollectingConditionedProperties(importElement, newExpandedCondition, ExpanderOptions.ExpandProperties, ParserOptions.AllowProperties,
+                            _projectRootElementCache))
+                {
+                    noDirectoryExists = false;
+                    continue;
+                }
+
                 if (!_fallbackSearchPathsCache.DirectoryExists(extensionPathExpanded))
                 {
                     continue;
                 }
 
                 noDirectoryExists = false;
-
-                var newExpandedCondition = importElement.Condition.Replace(extensionPropertyRefAsString, extensionPathExpanded, StringComparison.OrdinalIgnoreCase);
-                if (!EvaluateConditionCollectingConditionedProperties(importElement, newExpandedCondition, ExpanderOptions.ExpandProperties, ParserOptions.AllowProperties,
-                            _projectRootElementCache))
-                {
-                    continue;
-                }
 
                 var newExpandedImportPath = importElement.Project.Replace(extensionPropertyRefAsString, extensionPathExpanded, StringComparison.OrdinalIgnoreCase);
                 _evaluationLoggingContext.LogComment(MessageImportance.Low, "TryingExtensionsPath", newExpandedImportPath, extensionPathExpanded);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1666,7 +1666,6 @@ namespace Microsoft.Build.Evaluation
                     continue;
                 }
 
-
                 var newExpandedImportPath = importElement.Project.Replace(extensionPropertyRefAsString, extensionPathExpanded, StringComparison.OrdinalIgnoreCase);
                 _evaluationLoggingContext.LogComment(MessageImportance.Low, "TryingExtensionsPath", newExpandedImportPath, extensionPathExpanded);
 


### PR DESCRIPTION
Fixes #8167 and Fixes #8168

### Context
The VS tools path "directory does not exist" error check did not take into account a condition on the import element. This resolves that issue.

### Changes Made
Move the condition check earlier and have it suppress the error.

### Testing
Manual testing with repro from #8168.

### Notes
