### PR TITLE
Revert "Batch metadata updates for better performance"

### DIFF
--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -24,7 +24,6 @@ using Microsoft.Build.Shared;
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 using Task = System.Threading.Tasks.Task;
 using System.Linq;
-using Microsoft.Build.Collections;
 
 #nullable disable
 
@@ -1436,8 +1435,11 @@ namespace Microsoft.Build.BackEnd
                                     // Probably a Microsoft.Build.Utilities.TaskItem.  Not quite as good, but we can still preserve escaping. 
                                     newItem = new ProjectItemInstance(_projectInstance, outputTargetName, outputAsITaskItem2.EvaluatedIncludeEscaped, parameterLocationEscaped);
 
-                                    // It would be nice to be copy-on-write here, but Utilities.TaskItem doesn't know about CopyOnWritePropertyDictionary.
-                                    newItem.SetMetadataOnTaskOutput(outputAsITaskItem2.CloneCustomMetadataEscaped().Cast<KeyValuePair<string, string>>());
+                                    // It would be nice to be copy-on-write here, but Utilities.TaskItem doesn't know about CopyOnWritePropertyDictionary. 
+                                    foreach (DictionaryEntry entry in outputAsITaskItem2.CloneCustomMetadataEscaped())
+                                    {
+                                        newItem.SetMetadataOnTaskOutput((string)entry.Key, (string)entry.Value);
+                                    }
                                 }
                                 else
                                 {
@@ -1445,9 +1447,10 @@ namespace Microsoft.Build.BackEnd
                                     // Setting an item spec expects the escaped value, as does setting metadata. 
                                     newItem = new ProjectItemInstance(_projectInstance, outputTargetName, EscapingUtilities.Escape(output.ItemSpec), parameterLocationEscaped);
 
-                                    newItem.SetMetadataOnTaskOutput(output.CloneCustomMetadata()
-                                        .Cast<KeyValuePair<string, string>>()
-                                        .Select(x => new KeyValuePair<string, string>(x.Key, EscapingUtilities.Escape(x.Value))));
+                                    foreach (DictionaryEntry entry in output.CloneCustomMetadata())
+                                    {
+                                        newItem.SetMetadataOnTaskOutput((string)entry.Key, EscapingUtilities.Escape((string)entry.Value));
+                                    }
                                 }
                             }
 

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -629,11 +629,11 @@ namespace Microsoft.Build.Execution
         /// which legally have built-in metadata. If necessary we can calculate it on the new items we're making if requested.
         /// We don't copy them too because tasks shouldn't set them (they might become inconsistent)
         /// </summary>
-        internal void SetMetadataOnTaskOutput(IEnumerable<KeyValuePair<string, string>> items)
+        internal void SetMetadataOnTaskOutput(string name, string evaluatedValueEscaped)
         {
             _project.VerifyThrowNotImmutable();
 
-            _taskItem.SetMetadataOnTaskOutput(items);
+            _taskItem.SetMetadataOnTaskOutput(name, evaluatedValueEscaped);
         }
 
         /// <summary>
@@ -1789,18 +1789,6 @@ namespace Microsoft.Build.Execution
                     ProjectMetadataInstance metadatum = new ProjectMetadataInstance(name, evaluatedValueEscaped, true /* may be built-in metadata name */);
                     _directMetadata.Set(metadatum);
                 }
-            }
-
-            internal void SetMetadataOnTaskOutput(IEnumerable<KeyValuePair<string, string>> items)
-            {
-                ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
-                _directMetadata ??= new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
-
-                var metadata = items
-                    .Where(item => !FileUtilities.ItemSpecModifiers.IsDerivableItemSpecModifier(item.Value))
-                    .Select(item => new ProjectMetadataInstance(item.Key, item.Value, true /* may be built-in metadata name */));
-
-                _directMetadata.ImportProperties(metadata);
             }
 
             /// <summary>


### PR DESCRIPTION
Reverts dotnet/msbuild#8098 which causes #8153. We should investigate and consider bringing it back (with test coverage for whatever it is we missed!).