### PR TITLE
SimpleVersion.Parse() ignores leading and trailing whitespace

### DIFF
--- a/src/Build.UnitTests/Evaluation/SimpleVersion_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/SimpleVersion_Tests.cs
@@ -213,9 +213,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
         public static IEnumerable<object[]> Parse_Valid_TestData()
         {
-            foreach (var prefix in new[] { "", "v",  "V"})
+            foreach (var prefix in new[] { "", "v", "V", " ", "\t", "\tv" })
             {
-                foreach (var suffix in new[] { "", "-pre", "-pre+metadata", "+metadata"})
+                foreach (var suffix in new[] { "", "-pre", "-pre+metadata", "+metadata", " ", "\n", "-pre \r\n" })
                 {
                     yield return new object[] { $"{prefix}1{suffix}", new SimpleVersion(1) };
                     yield return new object[] { $"{prefix}1.2{suffix}", new SimpleVersion(1, 2) };
@@ -257,7 +257,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             yield return new object[] { "1.2.2147483648.4", typeof(FormatException) }; // Input contains a value > int.MaxValue
             yield return new object[] { "1.2.3.2147483648", typeof(FormatException) }; // Input contains a value > int.MaxValue
 
-            // System.Version allows whitespace around components, but we don't
+            // System.Version allows whitespace around components, but we only allow it at the beginning and end of the string.
             yield return new object[] { "2  .3.    4.  \t\r\n15  ", typeof(FormatException) };
             yield return new object[] { "   2  .3.    4.  \t\r\n15  ", typeof(FormatException) };
 


### PR DESCRIPTION
Fixes #8177 

### Context
Inadvertent whitespace in a .NET version string, for example, may be tricky for a customer to diagnose and can be trimmed with minimal performance and code complexity impacts.

### Changes Made
SimpleVersion.RemoveTrivia() trims whitespace before performing its other operations.
New tests in SimpleVersion_Tests.cs.
Update source code documentation to reflect the change.

### Testing
SimpleVersion_Tests run clean for both net472 and net7.0.

### Notes
All string manipulation is done with Span, to preserve the goal of no heap allocations when parsing a version string.
