### PR TITLE
Remove StringTools compatibility package dependencies on .NET 7.

### DIFF
--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -27,7 +27,7 @@
     <AssemblyName>Microsoft.NET.StringTools.net35</AssemblyName>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net35'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net35' AND '$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Memory" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>


### PR DESCRIPTION
### Context

These packages are inbox on .NET 7 and not needed.

### Changes Made

Removed `System.Memory` and `System.Runtime.CompilerServices.Unsafe` when targeting .NET 7+.

### Testing

N/A, no executable code was changed.

### Notes