### PR TITLE
Build DetermineWhetherSerializedObjectLoads less

### DIFF
--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -1974,7 +1974,6 @@ namespace Microsoft.Build.Tasks
             // Return true to err on the side of caution. Error will appear later.
             return true;
         }
-#endif
 
         /// <summary>
         /// Deserializes a base64 block from a resx in order to figure out if its type is in the GAC.
@@ -1995,6 +1994,7 @@ namespace Microsoft.Build.Tasks
                 return result != null;
             }
         }
+#endif
 
         /// <summary>
         /// Chars that should be ignored in the nicely justified block of base64


### PR DESCRIPTION
This method was used only in the immediately preceding method, which was compiled conditionally. Compile it conditionally, too, for clarity.