### PR TITLE
Drop the net35 asset from the StringTools package

### DIFF
--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' != 'Core' and '$(MonoBuild)' != 'true'">$(LibraryTargetFrameworks);net35</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks);net35</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>true</IsPackable>
@@ -14,6 +13,11 @@
 
     <AssemblyName>Microsoft.NET.StringTools</AssemblyName>
     <PackageDescription>This package contains the $(AssemblyName) assembly which implements common string-related functionality such as weak interning.</PackageDescription>
+    
+    <IncludeBuildOutput Condition="'$(TargetFramework)' == 'net35'">false</IncludeBuildOutput>
+    <!-- Don't publish the reference assembly if the build output isn't included. -->
+    <TargetsForTfmSpecificBuildOutput Condition="'$(IncludeBuildOutput)' != 'true'" />
+    <NoWarn Condition="'$(IncludeBuildOutput)' != 'true'">$(NoWarn),NU5128</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks);net35</TargetFrameworks>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' != 'Core' and '$(MonoBuild)' != 'true'">$(LibraryTargetFrameworks);net35</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>true</IsPackable>
@@ -16,8 +17,8 @@
     
     <IncludeBuildOutput Condition="'$(TargetFramework)' == 'net35'">false</IncludeBuildOutput>
     <!-- Don't publish the reference assembly if the build output isn't included. -->
-    <TargetsForTfmSpecificBuildOutput Condition="'$(IncludeBuildOutput)' != 'true'" />
-    <NoWarn Condition="'$(IncludeBuildOutput)' != 'true'">$(NoWarn),NU5128</NoWarn>
+    <TargetsForTfmSpecificBuildOutput Condition="'$(IncludeBuildOutput)' == 'false'" />
+    <NoWarn Condition="'$(IncludeBuildOutput)' == 'false'">$(NoWarn),NU5128</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -18,7 +18,8 @@
     <IncludeBuildOutput Condition="'$(TargetFramework)' == 'net35'">false</IncludeBuildOutput>
     <!-- Don't publish the reference assembly if the build output isn't included. -->
     <TargetsForTfmSpecificBuildOutput Condition="'$(IncludeBuildOutput)' == 'false'" />
-    <NoWarn Condition="'$(IncludeBuildOutput)' == 'false'">$(NoWarn),NU5128</NoWarn>
+    <!-- NU5128: Add lib or ref assemblies for the net35 target framework. -->
+    <NoWarn>$(NoWarn),NU5128</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -19,7 +19,7 @@
     <!-- Don't publish the reference assembly if the build output isn't included. -->
     <TargetsForTfmSpecificBuildOutput Condition="'$(IncludeBuildOutput)' == 'false'" />
     <!-- NU5128: Add lib or ref assemblies for the net35 target framework. -->
-    <NoWarn>$(NoWarn),NU5128</NoWarn>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
As discussed offline, the StringTools package is currently not authored correctly as the StringTools assembly is differently named between target frameworks. More precisely, the net35 assembly is named differently than the rest of the builds: Microsoft.NET.StringTools.net35.dll. Reason for that is that this assembly is binplaced into a common folder with another tfm build of the same library.

By dropping the net35 asset from the package, assembly FileNotFoundExceptions are avoided.

Contributes to https://github.com/dotnet/msbuild/pull/8116