### PR TITLE
Undo change to delete PublishDir unconditionally

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5717,7 +5717,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <RemoveDir
         Directories="$(ClickOncePublishDir)"
-        Condition="Exists('$(ClickOncePublishDir)')"/>
+        Condition="'$(ClickOncePublishDir)'=='$(OutputPath)app.publish\' and Exists('$(ClickOncePublishDir)')"/>
 
   </Target>
 


### PR DESCRIPTION
Fixes #8196

Work item (Internal use): [AB#1680332](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1680332)

### Summary

Commit 789fa9a8d changed the `CleanPublishFolder` target to remove PublishDir unconditionally. The previous condition removed the dir only if it was set to `$OutputPath\app.publish`.

Users override `PublishDir` to custom paths and don't expect their publish dir to be deleted during clean. The change broke that behavior. 

### Customer Impact

Customers who customize `$(PublishDir)` to a central location (not uncommon, but not default) encounter build breaks on `Rebuild`, because each project tries to delete the same directory.

Other users will be confused because `Clean` deletes more than it used to.

Multiple customer reports on GitHub and via VS Feedback. A workaround exists that can be applied to a repo, but it is inconvenient.

### Regression?

Yes, from VS 17.3/SDK 6.0.400.

### Testing

Manual testing + confirmation of workaround from customers (the workaround is basically identical to this change).

### Risk

Low: reversion to the behavior from a release ago.