### PR TITLE
CopyTask: Fallback to SymbolicLinks if HardLinks fail

### DIFF
--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2051,8 +2051,15 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CopyWithHardAndSymbolicLinks()
         {
+            // Workaround: For some reason when this test runs with all other tests we are getting
+            // the incorrect result from CreateHardLink error message (a message associated with
+            // another test). Calling GetHRForLastWin32Error / GetExceptionForHR seems to clear
+            // out the previous message and allow us to get the right message in the Copy task.
+            int errorCode = Marshal.GetHRForLastWin32Error();
+            Marshal.GetExceptionForHR(errorCode);
+
             string sourceFile = FileUtilities.GetTemporaryFile();
-            const string temp = @"d:\temp";
+            const string temp = @"d:\\temp";
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");
             string destFile = Path.Combine(destFolder, Path.GetFileName(sourceFile));
 
@@ -2089,9 +2096,9 @@ namespace Microsoft.Build.UnitTests
                 bool success = t.Execute();
 
                 Assert.True(success);
-
+                me.AssertLogContains("0x80070011");
                 MockEngine.GetStringDelegate resourceDelegate = AssemblyResources.GetString;
-                me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.SymbolicLinkComment", sourceFile, destFile, String.Empty);
+                me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.SymbolicLinkComment", sourceFile, destFile);
             }
             finally
             {

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2051,6 +2051,13 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CopyWithHardAndSymbolicLinks()
         {
+            // Workaround: For some reason when this test runs with all other tests we are getting
+            // the incorrect result from CreateHardLink error message (a message associated with
+            // another test). Calling GetHRForLastWin32Error / GetExceptionForHR seems to clear
+            // out the previous message and allow us to get the right message in the Copy task.
+            int errorCode = Marshal.GetHRForLastWin32Error();
+            Marshal.GetExceptionForHR(errorCode);
+            
             string sourceFile = FileUtilities.GetTemporaryFile();
             const string temp = @"d:\\temp";
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security.Principal;
 using System.Threading;
 #if FEATURE_SECURITY_PERMISSIONS
 using System.Security.AccessControl;
@@ -2056,6 +2055,20 @@ namespace Microsoft.Build.UnitTests
             const string temp = @"\\localhost\c$\temp";
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");
             string destFile = Path.Combine(destFolder, Path.GetFileName(sourceFile));
+
+            try
+            {
+                Directory.CreateDirectory(destFolder);
+                string nothingFile = Path.Combine(destFolder, "nothing.txt");
+                File.WriteAllText(nothingFile, "nothing");
+                File.Delete(nothingFile);
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("CopyWithHardAndSymbolicLinks test could not access the network.");
+                // Something caused us to not be able to access our "network" share, don't fail.
+                return;
+            }
 
             try
             {

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2054,7 +2054,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CopyWithHardAndSymbolicLinks()
         {
-            
+
             string sourceFile = FileUtilities.GetTemporaryFile();
             string temp = Path.GetTempPath();
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");
@@ -2065,7 +2065,7 @@ namespace Microsoft.Build.UnitTests
                 ITaskItem[] sourceFiles = { new TaskItem(sourceFile) };
 
                 MockEngine me = new MockEngine(true);
-                Copy t = new Copy 
+                Copy t = new Copy
                 {
                     RetryDelayMilliseconds = 1, // speed up tests!
                     UseHardlinksIfPossible = true,

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2048,41 +2048,24 @@ namespace Microsoft.Build.UnitTests
 
     public class CopyHardAndSymbolicLink_Tests
     {
+        /// <summary>
+        /// Verify build sucessfully when UseHardlinksIfPossible and UseSymboliclinksIfPossible are true 
+        /// </summary>
         [Fact]
         public void CopyWithHardAndSymbolicLinks()
         {
-            // Workaround: For some reason when this test runs with all other tests we are getting
-            // the incorrect result from CreateHardLink error message (a message associated with
-            // another test). Calling GetHRForLastWin32Error / GetExceptionForHR seems to clear
-            // out the previous message and allow us to get the right message in the Copy task.
-            int errorCode = Marshal.GetHRForLastWin32Error();
-            Marshal.GetExceptionForHR(errorCode);
             
             string sourceFile = FileUtilities.GetTemporaryFile();
-            const string temp = @"d:\\temp";
+            string temp = Path.GetTempPath();
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");
             string destFile = Path.Combine(destFolder, Path.GetFileName(sourceFile));
-
-            try
-            {
-                Directory.CreateDirectory(destFolder);
-                string nothingFile = Path.Combine(destFolder, "nothing.txt");
-                File.WriteAllText(nothingFile, "nothing");
-                File.Delete(nothingFile);
-            }
-            catch (Exception)
-            {
-                Console.WriteLine("CopyWithHardAndSymbolicLinks test could not access the detination folder.");
-                // Something caused us to not be able to access our the detination folder, don't fail.
-                return;
-            }
 
             try
             {
                 ITaskItem[] sourceFiles = { new TaskItem(sourceFile) };
 
                 MockEngine me = new MockEngine(true);
-                Copy t = new Copy
+                Copy t = new Copy 
                 {
                     RetryDelayMilliseconds = 1, // speed up tests!
                     UseHardlinksIfPossible = true,
@@ -2096,9 +2079,8 @@ namespace Microsoft.Build.UnitTests
                 bool success = t.Execute();
 
                 Assert.True(success);
-                me.AssertLogContains("0x80070011");
                 MockEngine.GetStringDelegate resourceDelegate = AssemblyResources.GetString;
-                me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.SymbolicLinkComment", sourceFile, destFile);
+                me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.HardLinkComment", sourceFile, destFile);
             }
             finally
             {

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2051,13 +2051,6 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CopyWithHardAndSymbolicLinks()
         {
-            // Workaround: For some reason when this test runs with all other tests we are getting
-            // the incorrect result from CreateHardLink error message (a message associated with
-            // another test). Calling GetHRForLastWin32Error / GetExceptionForHR seems to clear
-            // out the previous message and allow us to get the right message in the Copy task.
-            int errorCode = Marshal.GetHRForLastWin32Error();
-            Marshal.GetExceptionForHR(errorCode);
-
             string sourceFile = FileUtilities.GetTemporaryFile();
             const string temp = @"d:\\temp";
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2054,7 +2054,6 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CopyWithHardAndSymbolicLinks()
         {
-
             string sourceFile = FileUtilities.GetTemporaryFile();
             string temp = Path.GetTempPath();
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2091,7 +2091,6 @@ namespace Microsoft.Build.UnitTests
                 Assert.True(success);
 
                 MockEngine.GetStringDelegate resourceDelegate = AssemblyResources.GetString;
-                me.AssertLogContains("0x80070011");
                 me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.SymbolicLinkComment", sourceFile, destFile, String.Empty);
             }
             finally

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2053,7 +2053,7 @@ namespace Microsoft.Build.UnitTests
         public void CopyWithHardAndSymbolicLinks()
         {
             string sourceFile = FileUtilities.GetTemporaryFile();
-            string temp = Path.GetTempPath();
+            const string temp = @"\\localhost\c$\temp";
             string destFolder = Path.Combine(temp, "2A333ED756AF4dc392E728D0F864A398");
             string destFile = Path.Combine(destFolder, Path.GetFileName(sourceFile));
 
@@ -2075,10 +2075,11 @@ namespace Microsoft.Build.UnitTests
 
                 bool success = t.Execute();
 
-                Assert.False(success);
+                Assert.True(success);
 
                 MockEngine.GetStringDelegate resourceDelegate = AssemblyResources.GetString;
-                me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.ExactlyOneTypeOfLink", "UseHardlinksIfPossible", "UseSymboliclinksIfPossible");
+                me.AssertLogContains("0x80070011");
+                me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.SymbolicLinkComment", sourceFile, destFile, String.Empty);
             }
             finally
             {

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -276,15 +276,15 @@ namespace Microsoft.Build.Tasks
                 destinationFileExists = destinationFileState.FileExists;
             }
 
-            bool symboliclinkCreated = false;
-            bool hardlinkCreated = false;
+            bool symbolicLinkCreated = false;
+            bool hardLinkCreated = false;
             string errorMessage = string.Empty;
 
             // If we want to create hard or symbolic links, then try that first
             if (UseHardlinksIfPossible)
             {
-                TryCopyViaLink(HardLinkComment, MessageImportance.Normal, sourceFileState, destinationFileState, ref destinationFileExists, out hardlinkCreated, ref errorMessage, (source, destination, errMessage) => NativeMethods.MakeHardLink(destination, source, ref errorMessage));
-                if(!hardlinkCreated)
+                TryCopyViaLink(HardLinkComment, MessageImportance.Normal, sourceFileState, destinationFileState, ref destinationFileExists, out hardLinkCreated, ref errorMessage, (source, destination, errMessage) => NativeMethods.MakeHardLink(destination, source, ref errorMessage));
+                if(!hardLinkCreated)
                 {
                     if(UseSymboliclinksIfPossible)
                     {
@@ -297,17 +297,16 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            if (!hardlinkCreated && UseSymboliclinksIfPossible)
+            if (!hardLinkCreated && UseSymboliclinksIfPossible)
             {
-                TryCopyViaLink(SymbolicLinkComment, MessageImportance.Normal, sourceFileState, destinationFileState, ref destinationFileExists, out symboliclinkCreated, ref errorMessage, (source, destination, errMessage) => NativeMethods.MakeSymbolicLink(destination, source, ref errorMessage));
-                if(!symboliclinkCreated)
+                TryCopyViaLink(SymbolicLinkComment, MessageImportance.Normal, sourceFileState, destinationFileState, ref destinationFileExists, out symbolicLinkCreated, ref errorMessage, (source, destination, errMessage) => NativeMethods.MakeSymbolicLink(destination, source, ref errorMessage));
+                if(!symbolicLinkCreated)
                 {
-
                     Log.LogMessage(MessageImportance.Normal, RetryingAsFileCopy, sourceFileState.Name, destinationFileState.Name, errorMessage);
                 }
             }
 
-            if (ErrorIfLinkFails && !hardlinkCreated && !symboliclinkCreated)
+            if (ErrorIfLinkFails && !hardLinkCreated && !symbolicLinkCreated)
             {
                 Log.LogErrorWithCodeFromResources("Copy.LinkFailed", sourceFileState.Name, destinationFileState.Name);
                 return false;
@@ -315,7 +314,7 @@ namespace Microsoft.Build.Tasks
 
             // If the link was not created (either because the user didn't want one, or because it couldn't be created)
             // then let's copy the file
-            if (!hardlinkCreated && !symboliclinkCreated)
+            if (!hardLinkCreated && !symbolicLinkCreated)
             {
                 // Do not log a fake command line as well, as it's superfluous, and also potentially expensive
                 string sourceFilePath = FileUtilities.GetFullPathNoThrow(sourceFileState.Name);

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Build.Tasks
             bool hardLinkCreated = false;
             string errorMessage = string.Empty;
 
-            // If we want to create hard or symbolic links, then try that first
+            // Create hard links if UseHardlinksIfPossible is true
             if (UseHardlinksIfPossible)
             {
                 TryCopyViaLink(HardLinkComment, MessageImportance.Normal, sourceFileState, destinationFileState, ref destinationFileExists, out hardLinkCreated, ref errorMessage, (source, destination, errMessage) => NativeMethods.MakeHardLink(destination, source, ref errorMessage));
@@ -288,6 +288,7 @@ namespace Microsoft.Build.Tasks
                 {
                     if(UseSymboliclinksIfPossible)
                     {
+                        // This is a message for fallback to SymbolicLinks if HardLinks fail when UseHardlinksIfPossible and UseSymboliclinksIfPossible are true
                         Log.LogMessage(MessageImportance.Normal, RetryingAsSymbolicLink, sourceFileState.Name, destinationFileState.Name, errorMessage);
                     }
                     else
@@ -297,6 +298,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
+            // Create symbolic link if UseSymboliclinksIfPossible is true and hard link is not created
             if (!hardLinkCreated && UseSymboliclinksIfPossible)
             {
                 TryCopyViaLink(SymbolicLinkComment, MessageImportance.Normal, sourceFileState, destinationFileState, ref destinationFileExists, out symbolicLinkCreated, ref errorMessage, (source, destination, errMessage) => NativeMethods.MakeSymbolicLink(destination, source, ref errorMessage));

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -251,6 +251,10 @@
     <value>Could not use a link to copy "{0}" to "{1}". Copying the file instead. {2}</value>
     <comment>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</comment>
   </data>
+  <data name="Copy.RetryingAsSymbolicLink">
+    <value>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</value>
+    <comment>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</comment>
+  </data>
   <data name="Copy.NeedsDestination">
     <value>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</value>
     <comment>{StrBegin="MSB3023: "}</comment>

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2730,9 +2730,6 @@
         MSB3891 - MSB3900   Targets: Copy Overflow
         If this bucket overflows, pls. contact 'vsppbdev'.
   -->
-  <data name="Copy.ExactlyOneTypeOfLink">
-    <value>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</value>
-  </data>
   <data name="Copy.ErrorIfLinkFailsSetWithoutLinkOption" xml:space="preserve">
     <value>MSB3892: ErrorIfLinkFails requires UseHardlinksIfPossible or UseSymbolicLinksIfPossible to be set.</value>
     <comment>{StrBegin="MSB3892: "} LOCALIZATION: Do not localize "ErrorIfLinkFails", "UseHardLinksIfPossible", or "UseSymbolicLinksIfPossible".</comment>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Konfigurační soubor AssemblyFolder ({0}) zadaný v Microsoft.Common.CurrentVersion.targets byl neplatný. Chyba: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: V souboru projektu jste zadali jak položku {0}, tak i {1}. Zvolte buď jednu, nebo druhou.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: Nešlo přečíst existující soubor {0}, aby se zjistilo, jestli je jeho obsah aktuální. Přepíše se.</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -201,6 +201,11 @@
         <target state="translated">Probíhá odebírání atributu pouze pro čtení z položky {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: Zdrojový soubor {0} je ve skutečnosti adresář.  Úloha kopírování nepodporuje kopírování adresářů.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -201,6 +201,11 @@
         <target state="translated">Das schreibgeschützte Attribut wird aus "{0}" entfernt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: Die Quelldatei "{0}" ist keine Datei, sondern ein Verzeichnis.  Mit der Copy-Aufgabe können keine Verzeichnisse kopiert werden.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Die in Microsoft.Common.CurrentVersion.targets festgelegte AssemblyFolder-Konfigurationsdatei ({0}) ist ungültig. Fehler: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: "{0}" und "{1}" wurden in der Projektdatei angegeben. Verwenden Sie nur einen dieser Werte.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: Die vorhandene Datei "{0}" konnte nicht gelesen werden, um zu bestimmen, ob ihr Inhalt aktuell ist. Die Datei wird überschrieben.</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -201,6 +201,11 @@
         <target state="translated">Se quitará el atributo de solo lectura de "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: El archivo de origen "{0}" es un directorio.  La tarea "Copy" no permite copiar directorios.</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">El archivo de configuración ('{0}') de AssemblyFolder especificado en Microsoft.Common.CurrentVersion.targets no es válido. Error: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: Se especificó "{0}" y "{1}" en el archivo de proyecto. Elija solo uno de los dos.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: No se pudo leer el archivo existente "{0}"para determinar si su contenido está actualizado. Sobrescribiéndolo.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -201,6 +201,11 @@
         <target state="translated">Suppression de l'attribut de lecture seule de "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: Le fichier source "{0}" est en fait un répertoire.  La tâche "Copy" ne prend pas en charge la copie des répertoires.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Le fichier config AssemblyFolder ('{0}') spécifié dans Microsoft.Common.CurrentVersion.targets est non valide. Erreur : {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: "{0}" et "{1}" ont été spécifiés dans le fichier projet. Choisissez l'un ou l'autre.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: Impossible de lire le fichier existant "{0}" pour déterminer si son contenu est à jour. Remplacement du fichier.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -201,6 +201,11 @@
         <target state="translated">Rimozione dell'attributo di sola lettura da "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: il file di origine "{0}" è in realtà una directory. L'attività "Copia" non supporta la copia di directory.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Il file config AssemblyFolder ('{0}') specificato in Microsoft.Common.CurrentVersion.targets non è valido. Errore: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: nel file di progetto sono stati specificati sia "{0}" che "{1}". Sceglierne uno.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: non è stato possibile leggere il file esistente "{0}" per determinare se il relativo contenuto è aggiornato. Verrà sovrascritto.</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Microsoft.Common.CurrentVersion.targets に指定されている AssemblyFolder 構成ファイル ('{0}') が無効です。エラー: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: "{0}" と "{1}" の両方がプロジェクト ファイルで指定されました。いずれか 1 つを選択してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: ファイル "{0}" のコンテンツが最新であるかを判断するため、そのファイルを読み取ることができませんでした。ファイルは上書きされます。</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -201,6 +201,11 @@
         <target state="translated">"{0}" から読み取り専用属性を削除しています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: ソース ファイル "{0}" はディレクトリです。"Copy" タスクはディレクトリのコピーをサポートしません。</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Microsoft.Common.CurrentVersion.targets에 지정된 AssemblyFolder 구성 파일('{0}')이 잘못되었습니다. 오류: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: 프로젝트 파일에서 "{0}" 및 "{1}"을(를) 모두 지정했습니다. 둘 중 하나만 선택하세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: 기존 파일 "{0}"을(를) 읽을 수 없어 콘텐츠가 최신 상태인지 확인할 수 없습니다. 덮어씁니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -201,6 +201,11 @@
         <target state="translated">"{0}"에서 읽기 전용 특성을 제거하고 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: 소스 파일 "{0}"은(는) 실제로 디렉터리입니다.  "Copy" 작업으로는 디렉터리를 복사할 수 없습니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Plik konfiguracji AssemblyFolder („{0}”) określony w elemencie Microsoft.Common.CurrentVersion.targets był nieprawidłowy. Błąd: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: W pliku projektu określono elementy „{0}” i „{1}”. Wybierz jeden z nich.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: nie można odczytać istniejącego pliku „{0}” w celu sprawdzenia, czy jego zawartość jest aktualna. Zostanie on zastąpiony.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -201,6 +201,11 @@
         <target state="translated">Usuwanie atrybutu tylko do odczytu z elementu „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: Plik źródłowy „{0}” jest w rzeczywistości katalogiem.  Zadanie „Copy” nie obsługuje kopiowania katalogów.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -201,6 +201,11 @@
         <target state="translated">Removendo o atributo somente leitura de "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: O arquivo de origem "{0}" é, na verdade, um diretório.  A tarefa "Copy" não dá suporte à cópia de diretórios.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">O arquivo de configuração AssemblyFolder ('{0}') especificado em Microsoft.Common.CurrentVersion.targets era inválido. O erro era: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: "{0}" e "{1}" foram especificados no arquivo do projeto. Escolha um ou outro.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: não foi possível ler o arquivo existente "{0}" para determinar se seus conteúdos estão atualizados. Substituindo-o.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -201,6 +201,11 @@
         <target state="translated">Удаление доступного только для чтения атрибута из "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: исходный файл "{0}" в действительности является каталогом.  Задача Copy не поддерживает копирование каталогов.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Файл конфигурации AssemblyFolder ("{0}"), указанный в Microsoft.Common.CurrentVersion.targets, недопустим. Ошибка: {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: в файле проекта указан как "{0}", так и "{1}". Укажите только один из них.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: не удалось считать данные из существующего файла ("{0}") и определить, актуально ли его содержимое. Файл перезаписывается.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Microsoft.Common.CurrentVersion.targets içinde belirtilen AssemblyFolder yapılandırma dosyası ('{0}') geçersiz. Hata: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: Proje dosyasında hem "{0}" hem de "{1}" belirtilmiş. Lütfen yalnızca birini seçin.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: İçeriğinin güncel olup olmadığını belirlemek üzere "{0}" adlı mevcut dosya okunamadı. Dosyanın üzerine yazılıyor.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -201,6 +201,11 @@
         <target state="translated">"{0}" öğesinin salt okunur özniteliği kaldırılıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: "{0}" kaynak dosyası aslında bir dizindir.  "Kopyala" görevi, dizinleri kopyalamayı desteklemez.</target>

--- a/src/Tasks/Resources/xlf/Strings.xlf
+++ b/src/Tasks/Resources/xlf/Strings.xlf
@@ -2387,10 +2387,6 @@
         <source>The AssemblyFolder config file ('{0}') specified in Microsoft.Common.CurrentVersion.targets was invalid. The error was: {1}</source>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <note>{StrBegin="MSB3491: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -201,6 +201,11 @@
         <target state="translated">正在从“{0}”中移除只读特性。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: 源文件“{0}”实际上是一个目录。“Copy”任务不支持复制目录。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Microsoft.Common.CurrentVersion.targets 中指定的 AssemblyFolder 配置文件(“{0}”)无效。错误为: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: 项目文件中同时指定了“{0}”和“{1}”。请任选其一。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: 无法读取现有文件“{0}”以确定其内容是否是最新的。覆盖此文件。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -3285,11 +3285,6 @@
         <target state="translated">Microsoft.Common.CurrentVersion.targets 中所指定的 AssemblyFolder 組態檔 ('{0}') 無效。錯誤為: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Copy.ExactlyOneTypeOfLink">
-        <source>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</source>
-        <target state="translated">MSB3891: 專案檔中已同時指定 "{0}" 和 "{1}"。請選擇使用其中一個。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorReadingFile">
         <source>MSB3492: Could not read existing file "{0}" to determine whether its contents are up to date. Overwriting it.</source>
         <target state="translated">MSB3492: 無法讀取現有的檔案 "{0}"，所以無法判斷其是否包含最新的內容。將予覆寫。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -201,6 +201,11 @@
         <target state="translated">正在從 "{0}" 移除唯讀屬性。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Copy.RetryingAsSymbolicLink">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
         <target state="translated">MSB3025: 來源檔案 "{0}" 其實是目錄。"Copy" 工作不支援複製目錄。</target>


### PR DESCRIPTION
Fixes [#6247 ](https://github.com/dotnet/msbuild/issues/6247)

### Context
MSB3891: Both "UseHardlinksIfPossible" and "UseSymboliclinksIfPossible" were specified in the project file. Please choose one or the other.

### Changes Made
Support both UseHardlinksIfPossible and UseSymboliclinksIfPossible are on. Initialize variable hardLinkCreated and symbolicLinkCreated. When source file and destination file are not in the same folder. It failed to create hard link and fallback to  create symbolic link.

### Testing
Update test case CopyWithHardAndSymbolicLinks() to support both UseHardlinksIfPossible and UseSymboliclinksIfPossible on

**Manually test in different drivers when don't have permission create symbolic link**
**Output is as bellow:**
CopyFiles:
  Creating hard link to copy "Program.cs" to "c:\MyProject\Destination\Program.cs".
  Could not use a hard link to copy "Program.cs" to "c:\MyProject\Destination\Program.cs". Copying the file with symbolic link instead. The system cannot move the file to a different disk drive. (Exception from HRESULT: 0
  x80070011)
  Creating symbolic link to copy "Program.cs" to "c:\MyProject\Destination\Program.cs".
  Could not use a link to copy "Program.cs" to "c:\MyProject\Destination\Program.cs". Copying the file instead. A required privilege is not held by the client. (Exception from HRESULT: 0x80070522)
  Copying file from "E:\Test\ConsoleApp2\ConsoleApp2\Program.cs" to "c:\MyProject\Destination\Program.cs".
Done Building Project "E:\Test\ConsoleApp2\ConsoleApp2\ConsoleApp2.csproj" (default targets).

**Manually test in different drivers when developers have permission create symbolic link**

CopyFiles:
  Creating hard link to copy "Program.cs" to "c:\MyProject\Destination\Program.cs".
  Could not use a hard link to copy "Program.cs" to "c:\MyProject\Destination\Program.cs". Copying the file with symbolic link instead. The system cannot move the file to a different disk drive. (Exception from HRESULT: 0
  x80070011)
  Creating symbolic link to copy "Program.cs" to "c:\MyProject\Destination\Program.cs".
Done Building Project "E:\Test\ConsoleApp2\ConsoleApp2\ConsoleApp2.csproj" (default targets).