### PR TITLE
Add support for symlink files embedding to binlog

### DIFF
--- a/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
@@ -6,6 +6,10 @@ MSBuild can be successfully built on Windows, OS X 10.13, Ubuntu 14.04, and Ubun
 
 `build.cmd -msbuildEngine dotnet`
 
+## Tests
+
+Follow [Running Unit Tests](Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md#running-unit-tests) section of the .NET Framework guide
+
 # Unix
 
 ## The easy way

--- a/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
@@ -8,7 +8,7 @@ MSBuild can be successfully built on Windows, OS X 10.13, Ubuntu 14.04, and Ubun
 
 ## Tests
 
-Follow [Running Unit Tests](Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md#running-unit-tests) section of the .NET Framework guide
+Follow [Running Unit Tests](Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md#running-unit-tests) section of the developer guide chapter for .NET Framework
 
 # Unix
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -26,8 +26,8 @@ To run the unit tests from Visual Studio:
 To build MSBuild and run all unit tests from the command line, use `.\build.cmd -test`.
 
 Some tests are creating symlinks to test associated functionality - in order for them to succeed you have two options:
-* Run those tests elevated
 * Enable [Development Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) on your machine.
+* Or run those tests elevated
 
 To mimic our CI job use `eng\CIBuild.cmd`. Be aware that this command may delete your local NuGet cache.
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -25,6 +25,8 @@ To run the unit tests from Visual Studio:
 
 To build MSBuild and run all unit tests from the command line, use `.\build.cmd -test`.
 
+Some tests are creating symlinks to test associated functionality - in order for them to succeed you'll need to enable [Development Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) on your machine or run those tests elevated.
+
 To mimic our CI job use `eng\CIBuild.cmd`. Be aware that this command may delete your local NuGet cache.
 
 The CI does two builds. In the second build, it uses the binaries from the first build to build the repository again.

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -25,7 +25,9 @@ To run the unit tests from Visual Studio:
 
 To build MSBuild and run all unit tests from the command line, use `.\build.cmd -test`.
 
-Some tests are creating symlinks to test associated functionality - in order for them to succeed you'll need to enable [Development Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) on your machine or run those tests elevated.
+Some tests are creating symlinks to test associated functionality - in order for them to succeed you have two options:
+* Run those tests elevated
+* Enable [Development Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) on your machine.
 
 To mimic our CI job use `eng\CIBuild.cmd`. Be aware that this command may delete your local NuGet cache.
 

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -207,6 +207,55 @@ namespace Microsoft.Build.UnitTests
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
         }
 
+#if FEATURE_SYMLINK_TARGET
+        [Fact]
+        public void BinaryLoggerShouldEmbedSymlinkFilesViaTaskOutput()
+        {
+            string testFileName = "foobar.txt";
+            TransientTestFolder testFolder = _env.DefaultTestDirectory.CreateDirectory("TestDir");
+            TransientTestFolder testFolder2 = _env.DefaultTestDirectory.CreateDirectory("TestDir2");
+            TransientTestFile testFile = testFolder.CreateFile(testFileName, string.Join(Environment.NewLine, new[] { "123", "456" }));
+            string symlinkPath = Path.Combine(testFolder2.Path, testFileName);
+
+            File.CreateSymbolicLink(symlinkPath, testFile.Path);
+
+            using var buildManager = new BuildManager();
+            var binaryLogger = new BinaryLogger()
+            {
+                Parameters = $"LogFile={_logFile}",
+                CollectProjectImports = BinaryLogger.ProjectImportsCollectionMode.ZipFile,
+            };
+            var testProjectFmt = @"
+<Project>
+    <Target Name=""Build"" Inputs=""{0}"" Outputs=""testtaskoutputfile.txt"">
+        <ReadLinesFromFile
+            File=""{0}"" >
+            <Output
+                TaskParameter=""Lines""
+                ItemName=""ItemsFromFile""/>
+        </ReadLinesFromFile>
+        <WriteLinesToFile File=""testtaskoutputfile.txt"" Lines=""@(ItemsFromFile);abc;def;ghi""/>
+        <CreateItem Include=""testtaskoutputfile.txt"">
+            <Output TaskParameter=""Include"" ItemName=""EmbedInBinlog"" />
+        </CreateItem>
+        <CreateItem Include=""{0}"">
+            <Output TaskParameter=""Include"" ItemName=""EmbedInBinlog"" />
+        </CreateItem>
+    </Target>
+</Project>";
+            var testProject = string.Format(testProjectFmt, symlinkPath);
+            ObjectModelHelpers.BuildProjectExpectSuccess(testProject, binaryLogger);
+            var projectImportsZipPath = Path.ChangeExtension(_logFile, ".ProjectImports.zip");
+            using var fileStream = new FileStream(projectImportsZipPath, FileMode.Open);
+            using var zipArchive = new ZipArchive(fileStream, ZipArchiveMode.Read);
+
+            // Can't just compare `Name` because `ZipArchive` does not handle unix directory separators well
+            // thus producing garbled fully qualified paths in the actual .ProjectImports.zip entries
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(testFileName));
+        }
+#endif
+
         [Fact]
         public void BinaryLoggerShouldNotThrowWhenMetadataCannotBeExpanded()
         {

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -207,7 +207,6 @@ namespace Microsoft.Build.UnitTests
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
         }
 
-#if FEATURE_SYMLINK_TARGET
         [Fact]
         public void BinaryLoggerShouldEmbedSymlinkFilesViaTaskOutput()
         {
@@ -217,7 +216,8 @@ namespace Microsoft.Build.UnitTests
             TransientTestFile testFile = testFolder.CreateFile(testFileName, string.Join(Environment.NewLine, new[] { "123", "456" }));
             string symlinkPath = Path.Combine(testFolder2.Path, testFileName);
 
-            File.CreateSymbolicLink(symlinkPath, testFile.Path);
+            string errorMessage = string.Empty;
+            Assert.True(NativeMethodsShared.MakeSymbolicLink(symlinkPath, testFile.Path, ref errorMessage), errorMessage);
 
             using var buildManager = new BuildManager();
             var binaryLogger = new BinaryLogger()
@@ -254,7 +254,6 @@ namespace Microsoft.Build.UnitTests
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(testFileName));
         }
-#endif
 
         [Fact]
         public void BinaryLoggerShouldNotThrowWhenMetadataCannotBeExpanded()

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -211,13 +211,17 @@ namespace Microsoft.Build.UnitTests
         public void BinaryLoggerShouldEmbedSymlinkFilesViaTaskOutput()
         {
             string testFileName = "foobar.txt";
+            string symlinkName = "symlink1.txt";
+            string symlinkLvl2Name = "symlink2.txt";
             TransientTestFolder testFolder = _env.DefaultTestDirectory.CreateDirectory("TestDir");
             TransientTestFolder testFolder2 = _env.DefaultTestDirectory.CreateDirectory("TestDir2");
             TransientTestFile testFile = testFolder.CreateFile(testFileName, string.Join(Environment.NewLine, new[] { "123", "456" }));
-            string symlinkPath = Path.Combine(testFolder2.Path, testFileName);
+            string symlinkPath = Path.Combine(testFolder2.Path, symlinkName);
+            string symlinkLvl2Path = Path.Combine(testFolder2.Path, symlinkLvl2Name);
 
             string errorMessage = string.Empty;
             Assert.True(NativeMethodsShared.MakeSymbolicLink(symlinkPath, testFile.Path, ref errorMessage), errorMessage);
+            Assert.True(NativeMethodsShared.MakeSymbolicLink(symlinkLvl2Path, symlinkPath, ref errorMessage), errorMessage);
 
             using var buildManager = new BuildManager();
             var binaryLogger = new BinaryLogger()
@@ -241,9 +245,12 @@ namespace Microsoft.Build.UnitTests
         <CreateItem Include=""{0}"">
             <Output TaskParameter=""Include"" ItemName=""EmbedInBinlog"" />
         </CreateItem>
+        <CreateItem Include=""{1}"">
+            <Output TaskParameter=""Include"" ItemName=""EmbedInBinlog"" />
+        </CreateItem>
     </Target>
 </Project>";
-            var testProject = string.Format(testProjectFmt, symlinkPath);
+            var testProject = string.Format(testProjectFmt, symlinkPath, symlinkLvl2Path);
             ObjectModelHelpers.BuildProjectExpectSuccess(testProject, binaryLogger);
             var projectImportsZipPath = Path.ChangeExtension(_logFile, ".ProjectImports.zip");
             using var fileStream = new FileStream(projectImportsZipPath, FileMode.Open);
@@ -252,7 +259,8 @@ namespace Microsoft.Build.UnitTests
             // Can't just compare `Name` because `ZipArchive` does not handle unix directory separators well
             // thus producing garbled fully qualified paths in the actual .ProjectImports.zip entries
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
-            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(testFileName));
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkName));
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkLvl2Name));
         }
 
         [Fact]

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -130,16 +130,7 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            var fileInfo = new FileInfo(filePath);
-
-#if FEATURE_SYMLINK_TARGET
-            if (fileInfo.Length == 0 && fileInfo.Exists && !string.IsNullOrEmpty(fileInfo.LinkTarget))
-            {
-                fileInfo = new FileInfo(fileInfo.LinkTarget);
-            }
-#endif
-
-            if (!fileInfo.Exists || fileInfo.Length == 0)
+            if (!File.Exists(filePath))
             {
                 _processedFiles.Add(filePath);
                 return;
@@ -153,11 +144,9 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            using (Stream entryStream = OpenArchiveEntry(filePath))
-            using (FileStream content = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
-            {
-                content.CopyTo(entryStream);
-            }
+            using FileStream content = NativeMethodsShared.OpenReadFileThroughSymlinks(filePath);
+            using Stream entryStream = OpenArchiveEntry(filePath);
+            content.CopyTo(entryStream);
         }
 
         /// <remarks>

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -145,8 +145,11 @@ namespace Microsoft.Build.Logging
             }
 
             using FileStream content = NativeMethodsShared.OpenReadFileThroughSymlinks(filePath);
-            using Stream entryStream = OpenArchiveEntry(filePath);
-            content.CopyTo(entryStream);
+            if (content != null)
+            {
+                using Stream entryStream = OpenArchiveEntry(filePath);
+                content.CopyTo(entryStream);
+            }
         }
 
         /// <remarks>

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -131,6 +131,14 @@ namespace Microsoft.Build.Logging
             }
 
             var fileInfo = new FileInfo(filePath);
+
+#if FEATURE_SYMLINK_TARGET
+            if (fileInfo.Length == 0 && fileInfo.Exists && !string.IsNullOrEmpty(fileInfo.LinkTarget))
+            {
+                fileInfo = new FileInfo(fileInfo.LinkTarget);
+            }
+#endif
+
             if (!fileInfo.Exists || fileInfo.Length == 0)
             {
                 _processedFiles.Add(filePath);

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            if (!File.Exists(filePath))
+            if (!NativeMethodsShared.ExistAndHasContent(filePath))
             {
                 _processedFiles.Add(filePath);
                 return;
@@ -144,12 +144,9 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            using FileStream content = NativeMethodsShared.OpenReadFileThroughSymlinks(filePath);
-            if (content != null)
-            {
-                using Stream entryStream = OpenArchiveEntry(filePath);
-                content.CopyTo(entryStream);
-            }
+            using Stream entryStream = OpenArchiveEntry(filePath);
+            using FileStream content = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
+            content.CopyTo(entryStream);
         }
 
         /// <remarks>

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Text;
 using System.Threading;
 
 using Microsoft.Build.Shared;
@@ -1046,7 +1047,17 @@ internal static class NativeMethods
     {
         var fileInfo = new FileInfo(path);
 
-        return fileInfo.Exists && (fileInfo.Length > 0 || IsSymLink(fileInfo));
+        // File exist and has some content
+        return fileInfo.Exists &&
+               (fileInfo.Length > 0 ||
+                    // Or final destination of the link is nonempty file
+                    (
+                        IsSymLink(fileInfo) &&
+                        TryGetFinalLinkTarget(fileInfo, out string finalTarget, out _) &&
+                        File.Exists(finalTarget) &&
+                        new FileInfo(finalTarget).Length > 0
+                    )
+               );
     }
 
     internal static bool IsSymLink(FileInfo fileInfo)
@@ -1070,6 +1081,59 @@ internal static class NativeMethods
     internal static bool IsSymLink(string path)
     {
         return IsSymLink(new FileInfo(path));
+    }
+
+    internal static bool TryGetFinalLinkTarget(FileInfo fileInfo, out string finalTarget, out string errorMessage)
+    {
+        if (!IsWindows)
+        {
+            errorMessage = null;
+#if NET
+            while(!string.IsNullOrEmpty(fileInfo.LinkTarget))
+            {
+                fileInfo = new FileInfo(fileInfo.LinkTarget);
+            }
+            finalTarget = fileInfo.FullName;
+            return true;
+#else
+
+            finalTarget = null;
+            return false;
+#endif
+        }
+
+        using SafeFileHandle handle = OpenFileThroughSymlinks(fileInfo.FullName);
+        if (handle.IsInvalid)
+        {
+            // Link is broken.
+            errorMessage = Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()).Message;
+            finalTarget = null;
+            return false;
+        }
+
+        const int initialBufferSize = 4096;
+        char[] targetPathBuffer = new char[initialBufferSize];
+        uint result = GetFinalPathNameByHandle(handle, targetPathBuffer);
+
+        // Buffer too small
+        if (result > targetPathBuffer.Length)
+        {
+            targetPathBuffer = new char[(int)result];
+            result = GetFinalPathNameByHandle(handle, targetPathBuffer);
+        }
+
+        // Error
+        if (result == 0)
+        {
+            errorMessage = Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()).Message;
+            finalTarget = null;
+            return false;
+        }
+
+        // Normalize \\?\ and \??\ syntax.
+        finalTarget = new string(targetPathBuffer, 0, (int)result).TrimStart(new char[] { '\\', '?' });
+        errorMessage = null;
+        return true;
     }
 
     internal static bool MakeSymbolicLink(string newFileName, string exitingFileName, ref string errorMessage)
@@ -1713,6 +1777,20 @@ internal static class NativeMethods
 
     [DllImport("libc", SetLastError = true)]
     internal static extern int symlink(string oldpath, string newpath);
+
+    internal const uint FILE_NAME_NORMALIZED = 0x0;
+
+    [SupportedOSPlatform("windows")]
+    static uint GetFinalPathNameByHandle(SafeFileHandle fileHandle, char[] filePath) =>
+        GetFinalPathNameByHandle(fileHandle, filePath, (uint) filePath.Length, FILE_NAME_NORMALIZED);
+
+    [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    [SupportedOSPlatform("windows")]
+    static extern uint GetFinalPathNameByHandle(
+        SafeFileHandle hFile,
+        [Out] char[] lpszFilePath,
+        uint cchFilePath,
+        uint dwFlags);
 
     #endregion
 

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1712,7 +1712,6 @@ internal static class NativeMethods
     internal static extern bool CreateSymbolicLink(string symLinkFileName, string targetFileName, SymbolicLink dwFlags);
 
     [DllImport("libc", SetLastError = true)]
-    [SupportedOSPlatform("linux")]
     internal static extern int symlink(string oldpath, string newpath);
 
     #endregion

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Build.Tasks
             }
             else if (UseSymboliclinksIfPossible)
             {
-                TryCopyViaLink(SymbolicLinkComment, MessageImportance.Normal, sourceFileState, destinationFileState, ref destinationFileExists, out linkCreated, ref errorMessage, (source, destination, errMessage) => NativeMethods.MakeSymbolicLink(destination, source, ref errorMessage));
+                TryCopyViaLink(SymbolicLinkComment, MessageImportance.Normal, sourceFileState, destinationFileState, ref destinationFileExists, out linkCreated, ref errorMessage, (source, destination, errMessage) => NativeMethodsShared.MakeSymbolicLink(destination, source, ref errorMessage));
             }
 
             if (ErrorIfLinkFails && !linkCreated)

--- a/src/Tasks/NativeMethods.cs
+++ b/src/Tasks/NativeMethods.cs
@@ -514,13 +514,6 @@ namespace Microsoft.Build.Tasks
         public int dwThreadId;
     }
 
-    internal enum SymbolicLink
-    {
-        File = 0,
-        Directory = 1,
-        AllowUnprivilegedCreate = 2,
-    }
-
     /// <summary>
     /// Interop methods.
     /// </summary>
@@ -817,40 +810,6 @@ namespace Microsoft.Build.Tasks
             }
 
             return hardLinkCreated;
-        }
-
-        //------------------------------------------------------------------------------
-        // CreateSymbolicLink
-        //------------------------------------------------------------------------------
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        [return: MarshalAs(UnmanagedType.I1)]
-        internal static extern bool CreateSymbolicLink(string symLinkFileName, string targetFileName, SymbolicLink dwFlags);
-
-        [DllImport("libc", SetLastError = true)]
-        internal static extern int symlink(string oldpath, string newpath);
-
-        internal static bool MakeSymbolicLink(string newFileName, string exitingFileName, ref string errorMessage)
-        {
-            bool symbolicLinkCreated;
-            if (NativeMethodsShared.IsWindows)
-            {
-                Version osVersion = Environment.OSVersion.Version;
-                SymbolicLink flags = SymbolicLink.File;
-                if (osVersion.Major >= 11 || (osVersion.Major == 10 && osVersion.Build >= 14972))
-                {
-                    flags |= SymbolicLink.AllowUnprivilegedCreate;
-                }
-
-                symbolicLinkCreated = CreateSymbolicLink(newFileName, exitingFileName, flags);
-                errorMessage = symbolicLinkCreated ? null : Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()).Message;
-            }
-            else
-            {
-                symbolicLinkCreated = symlink(exitingFileName, newFileName) == 0;
-                errorMessage = symbolicLinkCreated ? null : "The link() library call failed with the following error code: " + Marshal.GetLastWin32Error();
-            }
-
-            return symbolicLinkCreated;
         }
 
         //------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6773

### Context
Symlinked files were not embedded into binlog


### Changes Made
Add detection of symlinked files and switch to their target
Support not added for full FW

### Testing
Unit test added, attempting to embed symlinked file (failing without the fix)
