### PR TITLE
fixing global properties error in Dynamic platform resolution

### DIFF
--- a/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Graph.UnitTests
     {
 
         [Fact]
-        public void ValidateSetPlatformOverride()
+        public void ValidateGlobalPropertyCopyByValueNotReference()
         {
             using (var env = TestEnvironment.Create())
             {
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Graph.UnitTests
         }
 
         [Fact]
-        public void ValidateGlobalPropertyCopyByValueNotReference()
+        public void ValidateSetPlatformOverride()
         {
             using (var env = TestEnvironment.Create())
             {

--- a/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
@@ -46,6 +46,33 @@ namespace Microsoft.Build.Graph.UnitTests
                                                                                                 <PlatformLookupTable>win32=x64</PlatformLookupTable>
                                                                                             </PropertyGroup>
                                                                                             <ItemGroup>
+                                                                                                <ProjectReference Include=""$(MSBuildThisFileDirectory)2.proj"" />
+                                                                                            </ItemGroup>");
+                var proj2 = env.CreateFile("2.proj", @"
+                                                    <Project>
+                                                        <PropertyGroup>
+                                                            <EnableDynamicPlatformResolution>true</EnableDynamicPlatformResolution>
+                                                            <Platforms>AnyCPU</Platforms>
+                                                        </PropertyGroup>
+                                                    </Project>");
+
+                ProjectGraph graph = new ProjectGraph(entryProject.Path);
+                GetFirstNodeWithProjectNumber(graph, 1).ProjectInstance.GlobalProperties.ContainsKey("Platform").ShouldBeFalse();
+            }
+        }
+
+        [Fact]
+        public void ValidateSetPlatformOverride()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+
+                TransientTestFile entryProject = CreateProjectFile(env, 1, extraContent: @"<PropertyGroup>
+                                                                                                <EnableDynamicPlatformResolution>true</EnableDynamicPlatformResolution>
+                                                                                                <Platform>x64</Platform>
+                                                                                                <PlatformLookupTable>win32=x64</PlatformLookupTable>
+                                                                                            </PropertyGroup>
+                                                                                            <ItemGroup>
                                                                                                 <ProjectReference Include=""$(MSBuildThisFileDirectory)2.proj"" >
                                                                                                     <SetPlatform>platform=x86</SetPlatform>
                                                                                                 </ProjectReference>

--- a/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Graph.UnitTests
         }
 
         [Fact]
-        public void ValidateSetPlatformOverride()
+        public void ValidateGlobalPropertyCopyByValueNotReference()
         {
             using (var env = TestEnvironment.Create())
             {

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Build.Graph
 
             var globalPropertyParts = globalPropertyModifiers?.Aggregate(defaultParts, (currentProperties, modifier) => modifier(currentProperties, projectReference)) ?? defaultParts;
 
-            if (globalPropertyParts.AllEmpty() && !DynamicPlatformEnabled)
+            if (globalPropertyParts.AllEmpty() && !dynamicPlatformEnabled)
             {
                 return requesterGlobalProperties;
             }

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Build.Graph
         private static PropertyDictionary<ProjectPropertyInstance> GetGlobalPropertiesForItem(
             ProjectItemInstance projectReference,
             PropertyDictionary<ProjectPropertyInstance> requesterGlobalProperties,
-            bool DynamicPlatformEnabled,
+            bool dynamicPlatformEnabled,
             IEnumerable<GlobalPropertiesModifier> globalPropertyModifiers = null)
         {
             ErrorUtilities.VerifyThrowInternalNull(projectReference, nameof(projectReference));

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Build.Graph
 
                 var projectReferenceFullPath = projectReferenceItem.GetMetadataValue(FullPathMetadataName);
 
-                var referenceGlobalProperties = GetGlobalPropertiesForItem(projectReferenceItem, requesterInstance.GlobalPropertiesDictionary, globalPropertiesModifiers);
+                var referenceGlobalProperties = GetGlobalPropertiesForItem(projectReferenceItem, requesterInstance.GlobalPropertiesDictionary, ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName)), globalPropertiesModifiers);
 
                 var requesterPlatform = "";
                 var requesterPlatformLookupTable = "";
@@ -310,6 +310,7 @@ namespace Microsoft.Build.Graph
         private static PropertyDictionary<ProjectPropertyInstance> GetGlobalPropertiesForItem(
             ProjectItemInstance projectReference,
             PropertyDictionary<ProjectPropertyInstance> requesterGlobalProperties,
+            Boolean DynamicPlatformEnabled,
             IEnumerable<GlobalPropertiesModifier> globalPropertyModifiers = null)
         {
             ErrorUtilities.VerifyThrowInternalNull(projectReference, nameof(projectReference));
@@ -323,7 +324,7 @@ namespace Microsoft.Build.Graph
 
             var globalPropertyParts = globalPropertyModifiers?.Aggregate(defaultParts, (currentProperties, modifier) => modifier(currentProperties, projectReference)) ?? defaultParts;
 
-            if (globalPropertyParts.AllEmpty())
+            if (globalPropertyParts.AllEmpty() && !DynamicPlatformEnabled)
             {
                 return requesterGlobalProperties;
             }


### PR DESCRIPTION
### Context
In graph projects, if project A (x86) references project B (AnyCPU), we use the same global properties dictionary in both cases. This means that project A will get Platform:AnyCPU as a global property.

Platform should be the only property that changes, so anything that prevents the parent project from getting its global properties changed by dependent projects would unblock VS.

Note that we cannot use one dictionary and change the property while building B in the above example, then revert the property because that would still affect B; anyone using the project graph object would be getting incorrect information.

From a performance perspective, there should only be ~6-7 properties in the dictionary, so copying it should not be a major hit.

### Changes Made
This change prevents the global properties dictionary from being passed directly if EnableDynamicPlatformResolution is true.

### Testing
Unit test and possibly manual tests, though I didn't ask.
