### PR TITLE
Include Microsoft.Extensions.* nuget dependencies in Bootstrap

### DIFF
--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -36,6 +36,7 @@
         <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('NuGet.'))' == 'True'" />
         <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('Newtonsoft.Json'))' == 'True'" />
         <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('NuGetSdkResolver'))' == 'True'" />
+        <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('Microsoft.Extensions.'))' == 'True'" />
 
         <!-- NuGet.targets will be in the ResolvedRuntimeTargets ItemGroup -->
         <_NuGetRuntimeDependencies Include="%(RuntimeTargetsCopyLocalItems.Identity)" Condition="'@(RuntimeTargetsCopyLocalItems->Contains('NuGet.'))' == 'True'" />
@@ -56,6 +57,7 @@
         <Reference Remove="%(Reference.Identity)" Condition="'@(Reference->Contains('NuGet.'))' == 'True'" />
         <Reference Remove="%(Reference.Identity)" Condition="'@(Reference->Contains('Newtonsoft.Json'))' == 'True'" />
         <Reference Remove="%(Reference.Identity)" Condition="'@(Reference->Contains('NuGetSdkResolver'))' == 'True'" />
+        <Reference Remove="%(Reference.Identity)" Condition="'@(Reference->Contains('Microsoft.Extensions.'))' == 'True'" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This fixes an exception when trying to use a locally built and bootstrapped msbuild, specifically in the NuGet SDK resolver:
```
System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Extensions.FileProviders.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' or one of its dependencies. The system cannot find the file specified.
File name: 'Microsoft.Extensions.FileProviders.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'
   at NuGet.Commands.ContentFileUtils.GetContentFileGroup(NuspecReader nuspec, List`1 contentFileGroups)
   at NuGet.Commands.LockFileUtils.AddContentFiles(ManagedCodeConventions managedCodeConventions, LockFileTargetLibrary lockFileLib, NuGetFramework framework, ContentItemCollection contentItems, NuspecReader nuspec)
   at NuGet.Commands.LockFileUtils.AddAssets(String aliases, LockFileLibrary library, LocalPackageInfo package, ManagedCodeConventions managedCodeConventions, LibraryIncludeFlags dependencyType, LockFileTargetLibrary lockFileLib, NuGetFramework framework, String runtimeIdentifier, ContentItemCollection contentItems, NuspecReader nuspec, IReadOnlyList`1 orderedCriteria)
   at NuGet.Commands.LockFileUtils.<>c__DisplayClass2_0.<CreateLockFileTargetLibrary>b__0()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at NuGet.Commands.LockFileBuilder.CreateLockFile(LockFile previousLockFile, PackageSpec project, IEnumerable`1 targetGraphs, IReadOnlyList`1 localRepositories, RemoteWalkContext context, LockFileBuilderCache lockFileBuilderCache)
   at NuGet.Commands.RestoreCommand.BuildAssetsFile(LockFile existingLockFile, PackageSpec project, IEnumerable`1 graphs, IReadOnlyList`1 localRepositories, RemoteWalkContext contextForProject)
   at NuGet.Commands.RestoreCommand.<ExecuteAsync>d__45.MoveNext()
   at NuGet.Commands.RestoreRunner.<ExecuteAsync>d__7.MoveNext()
   at NuGet.Commands.RestoreRunner.<CompleteTaskAsync>d__10.MoveNext()
   at NuGet.Commands.RestoreRunner.<RunWithoutCommit>d__3.MoveNext()
```

From @jeffkl :
> We used to compile the source code of these three assemblies into our assembly from a git submodule, now we're just shipping them as binaries, but they're named stuff like Microsoft..Extensions.FIleProviders.Abstractions

So this updates the bootstrap logic to include those additional assemblies for NuGet.