### PR TITLE
Update Newtonsoft.Json version

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -28,7 +28,7 @@
     <PackageReference Update="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Update="Microsoft.Win32.Registry" Condition="'$(MicrosoftWin32RegistryVersion)' != ''" Version="$(MicrosoftWin32RegistryVersion)" />
 
-    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' != ''" Version="$(NewtonsoftJsonVersion)" />
 
     <PackageReference Update="PdbGit" Version="3.0.41" />


### PR DESCRIPTION
Versions of Newtonsoft.Json <13.0.2 are flagged by compponent governance alerts as vulnerable to https://github.com/advisories/GHSA-5crp-9r3c-p9vr
Related fix: #7737. We need to update the version again. 

Fixes https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted/alert/7554893?typeId=6797870
