### PR TITLE
Update System.Security.Cryptography.Xml version

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -49,7 +49,7 @@
     <PackageReference Update="System.Security.Cryptography.Pkcs" Version="6.0.1" />
     <PackageReference Update="System.Security.Cryptography.Pkcs" Condition="'$(SystemSecurityCryptographyPkcsVersion)' != ''" Version="$(SystemSecurityCryptographyPkcsVersion)" />
 
-    <PackageReference Update="System.Security.Cryptography.Xml" Version="6.0.0" />
+    <PackageReference Update="System.Security.Cryptography.Xml" Version="6.0.1" />
     <PackageReference Update="System.Security.Cryptography.Xml" Condition="'$(SystemSecurityCryptographyXmlVersion)' != ''" Version="$(SystemSecurityCryptographyXmlVersion)" />
 
     <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.3.2" />


### PR DESCRIPTION
Versions of System.Security.Cryptography.Xml <6.0.1 are flagged by component governance alerts as vulnerable to https://github.com/dotnet/announcements/issues/232

Fixes https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted/alert/7392363?typeId=6797870