### PR TITLE
Update Newtonsoft.Json version in MSBuild.Bootstrap.csproj

### DIFF
--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -25,6 +25,10 @@
     <!-- Include NuGet build tasks -->
     <PackageReference Include="NuGet.Build.Tasks" />
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" />
+
+    <!-- As of 17.5, NuGet.Build.Tasks and Microsoft.Build.NuGetSdkResolver depends on Newtonsoft.Json version 13.0.1,
+         causing it to be downloaded and flagged by component governance -->
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MonoBuild)' == 'true'">


### PR DESCRIPTION
Versions of Newtonsoft.Json <13.0.2 are flagged by component governance alerts as vulnerable to https://github.com/advisories/GHSA-5crp-9r3c-p9vr
Related fixes: #7737, #8229. I found one more place where Newtonsoft.Json v13.0.1 is brought.

Fixes https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted/alert/7554893?typeId=6797870
