### PR TITLE
Disable MotW check on core in GenerateResource

### DIFF
--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -905,11 +905,13 @@ namespace Microsoft.Build.Tasks
             return !Log.HasLoggedErrors && outOfProcExecutionSucceeded;
         }
 
+#if FEATURE_APPDOMAIN
         private static readonly bool AllowMOTW = !NativeMethodsShared.IsWindows || (Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\SDK", "AllowProcessOfUntrustedResourceFiles", null) is string allowUntrustedFiles && allowUntrustedFiles.Equals("true", StringComparison.OrdinalIgnoreCase));
 
         private const string CLSID_InternetSecurityManager = "7b8a2d94-0ac9-11d1-896c-00c04fb6bfc4";
         private const uint ZoneInternet = 3;
         private static IInternetSecurityManager internetSecurityManager = null;
+#endif
 
         // Resources can have arbitrarily serialized objects in them which can execute arbitrary code
         // so check to see if we should trust them before analyzing them
@@ -917,8 +919,8 @@ namespace Microsoft.Build.Tasks
         {
 #if !FEATURE_APPDOMAIN
             return false;
-#endif
-
+        }
+#else
             // If they are opted out, there's no work to do
             if (AllowMOTW)
             {
@@ -992,7 +994,6 @@ namespace Microsoft.Build.Tasks
             return dangerous;
         }
 
-#if FEATURE_APPDOMAIN
         /// <summary>
         /// For setting OutputResources and ensuring it can be read after the second AppDomain has been unloaded.
         /// </summary>

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -915,14 +915,17 @@ namespace Microsoft.Build.Tasks
         // so check to see if we should trust them before analyzing them
         private bool IsDangerous(String filename)
         {
+#if !FEATURE_APPDOMAIN
+            return false;
+#endif
+
             // If they are opted out, there's no work to do
-            if (AllowMOTW || !NativeMethodsShared.IsWindows)
+            if (AllowMOTW)
             {
                 return false;
             }
 
             // First check the zone, if they are not an untrusted zone, they aren't dangerous
-
             if (internetSecurityManager == null)
             {
                 Type iismType = Type.GetTypeFromCLSID(new Guid(CLSID_InternetSecurityManager));

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -905,7 +905,7 @@ namespace Microsoft.Build.Tasks
             return !Log.HasLoggedErrors && outOfProcExecutionSucceeded;
         }
 
-#if FEATURE_APPDOMAIN
+#if FEATURE_RESXREADER_LIVEDESERIALIZATION
         private static readonly bool AllowMOTW = !NativeMethodsShared.IsWindows || (Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\SDK", "AllowProcessOfUntrustedResourceFiles", null) is string allowUntrustedFiles && allowUntrustedFiles.Equals("true", StringComparison.OrdinalIgnoreCase));
 
         private const string CLSID_InternetSecurityManager = "7b8a2d94-0ac9-11d1-896c-00c04fb6bfc4";
@@ -917,11 +917,7 @@ namespace Microsoft.Build.Tasks
         // so check to see if we should trust them before analyzing them
         private bool IsDangerous(String filename)
         {
-            // On Framework, we deserialize BinaryFormatter blobs in the main MSBuild process then serialize them again. On Core, we put them as-is into the .resources file,
-            // which eliminates the deserialization attack surface from MSBuild's perspective.
-            //
-            // Even on Framework, we only need to (dangerously) deserialize the .resx file if we think we might need a separate AppDomain, so FEATURE_APPDOMAIN makes sense here.
-#if !FEATURE_APPDOMAIN
+#if !FEATURE_RESXREADER_LIVEDESERIALIZATION
             return false;
         }
 #else

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -917,6 +917,10 @@ namespace Microsoft.Build.Tasks
         // so check to see if we should trust them before analyzing them
         private bool IsDangerous(String filename)
         {
+            // On Framework, we deserialize BinaryFormatter blobs in the main MSBuild process then serialize them again. On Core, we put them as-is into the .resources file,
+            // which eliminates the deserialization attack surface from MSBuild's perspective.
+            //
+            // Even on Framework, we only need to (dangerously) deserialize the .resx file if we think we might need a separate AppDomain, so FEATURE_APPDOMAIN makes sense here.
 #if !FEATURE_APPDOMAIN
             return false;
         }


### PR DESCRIPTION
Fixes #7946

### Context
The GenerateResource task previously would deserialize and reserialize resource files. It used BinaryFormatter, which is known to be unsafe; to mitigate that security risk, we added a check for the mark of the web on resource files; files with that mark are considered unsafe, and those without are considered safe to be deserialized. On core, we have a separate solution: don't deserialize and reserialize them.

More recently, in work to unify code paths, we effectively enabled the check on core. There remains a check that we're on windows, so it only affected windows computers, and most windows devices could accomplish that fine. Nanoservices, however, did not have the COM API that we called as part of the "IsDangerous" check. This led it to crash.

### Customer Impact
Using a (windows nanoserver) container, customers cannot build projects that include certain resource files. They instead see a confusing error about a missing COM API.

### Risk
Low

### Testing
I verified that setting the registry key resolved the issue. Though that's a different change, it leads to the same code path.

### Code Reviewers
rainersigwald

### Description of the fix
I added an early return on core to get away from the error.

### Notes
The Mark of the Web check was originally introduced as a security measure, but this code path did not initially have it and doesn't need it. This change passed a security review.

Thanks to @asalvo for finding the problematic change!