### PR TITLE
Update .vsconfig to remove .NET Core 2.1 component

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -5,7 +5,6 @@
     "Microsoft.Net.Component.4.7.2.SDK",
     "Microsoft.Net.Component.4.TargetingPack",
     "Microsoft.Net.Component.4.7.2.TargetingPack",
-    "Microsoft.Net.Core.Component.SDK.2.1",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.Net.Component.3.5.DeveloperTools",
     "Microsoft.VisualStudio.Workload.NetCoreTools"


### PR DESCRIPTION
.NET Core 2.1 is out of support and is not used in the projects in MSBuild.sln. Removing the "Microsoft.Net.Core.Component.SDK.2.1" ID from the .vsconfig file will stop Visual Studio from complaining when .NET Core 2.1 is not installed.

Fixes #8255

### Context
Developer issue while working with MSBuild.sln in Visual Studio.

### Changes Made
Remove one line from .vsconfig file

### Testing
Tested opening the solution before and after the .vsconfig change.