### PR TITLE
Exclude isolation-violating cache results from output results cache (#4386)

### DIFF
--- a/src/Build.UnitTests/BackEnd/CacheSerialization_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/CacheSerialization_Tests.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 {
     public class CacheSerialization_Tests
     {
-        public static IEnumerable<object[]> CacheData {
+        public static IEnumerable<object[]> CacheData
+        {
             get
             {
                 var configCache = new ConfigCache();
@@ -41,7 +42,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 var resultsCache = new ResultsCache();
                 var request1 = new BuildRequest(1, 0, 1, new string[] { "target1" }, null, BuildEventContext.Invalid, null);
                 var request2 = new BuildRequest(2, 0, 2, new string[] { "target2" }, null, BuildEventContext.Invalid, null);
-                var request3 = new BuildRequest(2, 0, 2, new string[] { "target2" }, null, BuildEventContext.Invalid, null);
+                var request3 = new BuildRequest(3, 0, 3, new string[] { "target3" }, null, BuildEventContext.Invalid, null);
 
                 resultsCache.AddResult(new BuildResult(request1));
                 resultsCache.AddResult(new BuildResult(request2));

--- a/src/Build.UnitTests/BackEnd/CacheSerialization_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/CacheSerialization_Tests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests.BackEnd
+{
+    public class CacheSerialization_Tests
+    {
+        public static IEnumerable<object[]> CacheData {
+            get
+            {
+                var configCache = new ConfigCache();
+                var brq1 = new BuildRequestConfiguration(
+                   1,
+                   new BuildRequestData("path1", new Dictionary<string, string> { ["a1"] = "b1" }, Constants.defaultToolsVersion, new[] { "target1" }, null),
+                   Constants.defaultToolsVersion);
+
+                var brq2 = new BuildRequestConfiguration(
+                    2,
+                    new BuildRequestData("path2", new Dictionary<string, string> { ["a2"] = "b2" }, Constants.defaultToolsVersion, new[] { "target2" }, null),
+                    Constants.defaultToolsVersion);
+                var brq3 = new BuildRequestConfiguration(
+                   3,
+                   new BuildRequestData("path3", new Dictionary<string, string> { ["a3"] = "b3" }, Constants.defaultToolsVersion, new[] { "target3" }, null),
+                   Constants.defaultToolsVersion);
+
+                configCache.AddConfiguration(brq1);
+                configCache.AddConfiguration(brq2);
+                configCache.AddConfiguration(brq3);
+
+                var resultsCache = new ResultsCache();
+                var request1 = new BuildRequest(1, 0, 1, new string[] { "target1" }, null, BuildEventContext.Invalid, null);
+                var request2 = new BuildRequest(2, 0, 2, new string[] { "target2" }, null, BuildEventContext.Invalid, null);
+                var request3 = new BuildRequest(2, 0, 2, new string[] { "target2" }, null, BuildEventContext.Invalid, null);
+
+                resultsCache.AddResult(new BuildResult(request1));
+                resultsCache.AddResult(new BuildResult(request2));
+                resultsCache.AddResult(new BuildResult(request3));
+
+                return new List<object[]>
+                {
+                    new object[] { configCache, resultsCache },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CacheData))]
+        public void OnlySerializeCacheEntryWithSmallestConfigId(object configCache, object resultsCache)
+        {
+            string cacheFile = null;
+            try
+            {
+                cacheFile = FileUtilities.GetTemporaryFile("MSBuildResultsCache");
+                Assert.Null(CacheSerialization.SerializeCaches((ConfigCache)configCache, (ResultsCache)resultsCache, cacheFile));
+
+                var result = CacheSerialization.DeserializeCaches(cacheFile);
+                Assert.True(result.ConfigCache.HasConfiguration(1));
+                Assert.False(result.ConfigCache.HasConfiguration(2));
+                Assert.False(result.ConfigCache.HasConfiguration(3));
+            }
+            finally
+            {
+                File.Delete(cacheFile);
+            }
+        }
+    }
+}

--- a/src/Build/BackEnd/Components/Caching/ConfigCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ConfigCache.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Build.Shared;
 
 #nullable disable
@@ -200,6 +201,20 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
+        /// <summary>
+        /// Gets the smallest configuration id of any configuration
+        /// in this cache.
+        /// </summary>
+        /// <returns>Gets the smallest configuration id of any
+        /// configuration in this cache.</returns>
+        public int GetSmallestConfigId()
+        {
+            lock (_lockObject)
+            {
+                return _configurations.OrderBy(kvp => kvp.Key).FirstOrDefault().Key;
+            }
+        }
+    
         /// <summary>
         /// Clears configurations from the configuration cache which have not been explicitly loaded.
         /// </summary>

--- a/src/Build/BackEnd/Components/Caching/ConfigCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ConfigCache.cs
@@ -211,7 +211,8 @@ namespace Microsoft.Build.BackEnd
         {
             lock (_lockObject)
             {
-                return _configurations.OrderBy(kvp => kvp.Key).FirstOrDefault().Key;
+                ErrorUtilities.VerifyThrow(_configurations.Count > 0, "No configurations exist from which to obtain the smallest configuration id.");
+                return _configurations.OrderBy(kvp => kvp.Key).First().Key;
             }
         }
     


### PR DESCRIPTION
Fixes #4386

### Context
Any cache entries from projects excluded from isolation constraints should be excluded from the output results cache file.

### Changes Made
Only the cache entry with the smallest configuration ID (that of the project to be built in isolation) should be serialized into the output results cache file. As described in #4386, this prevents the case where dependency projects pass down the same cache entry obtained through skipping/violating isolation constraints to a dependent project, creating duplicate input cache entries.

### Testing
Added a UT.

### Notes
Addressing this issue since it came up frequently when testing #8249.