### PR TITLE
Backport opt-prof v2 vs17.0 

### DIFF
--- a/.opt-prof.yml
+++ b/.opt-prof.yml
@@ -1,0 +1,84 @@
+# Runs OptProf for MSBuild binaries based on an insertion build
+
+trigger: none # Prevents this pipeline from triggering on check-ins
+pr: none # don't run this on PR as well, this should only trigger off on MSBuild runs
+schedules:
+  - cron: "0 9 * * Wed,Sat"
+    displayName: Weekly OptProf Run
+    branches:
+      include:
+      - main
+    always: true
+
+resources:
+  pipelines:
+  - pipeline: ComponentBuildUnderTest
+    source: MSBuild\MSBuild # The name of the pipeline that produces the artifact
+    trigger:
+      branches:
+        - vs*
+  - pipeline: DartLab
+    project: DevDiv
+    source: DartLab
+    branch: main
+  - pipeline: DartLab.OptProf
+    source: DartLab.OptProf
+    branch: main
+  repositories:
+  - repository: DartLabTemplates
+    type: git
+    name: DartLab.Templates
+    ref: refs/heads/main
+  - repository: DartLabOptProfTemplates
+    type: git
+    name: DartLab.OptProf
+    ref: refs/heads/main
+
+stages:
+- template: \templates\stages\visual-studio\single-runsettings.yml@DartLabOptProfTemplates
+  parameters:
+    ##### Required #####
+    runSettingsURI: $(Pipeline.Workspace)\ComponentBuildUnderTest\VSSetup\Insertion\OptProf\Training.runsettings
+    visualStudioBootstrapperURI: $(VisualStudio.InstallationUnderTest.BootstrapperURL)
+    ##### Optional #####
+    name: OptProfProfilingWorkflow
+    displayName: OptProf Profiling Workflow
+    optOptimizationInputsDropName: $(OptimizationInputsDropName)
+    testLabPoolName: VS-Platform # The test lab pool to run your tests in
+    testMachineImageName: Windows-10-Enterprise-20H2
+    visualStudioSigning: Test
+    variables:
+    - name: branchName # The branch in the VS repo the bootstrapper was based on
+      value: $[replace(variables['resources.pipeline.ComponentBuildUnderTest.sourceBranch'],'refs/heads/','')]
+    - name: OptimizationInputsDropName # The naming convention of the OptimizationInputsDrop
+      value: OptimizationData/DotNet-msbuild-Trusted/$(branchName)/$(resources.pipeline.ComponentBuildUnderTest.runName)/$(Build.BuildId)/$(System.StageAttempt)
+    ##### Step Hooks #####
+    preTestMachineConfigurationStepList:
+    - download: ComponentBuildUnderTest
+      artifact: MicroBuildOutputs
+      patterns: '**\BootstrapperInfo.json'
+      displayName: Download Bootstrapper Information
+    - download: ComponentBuildUnderTest
+      artifact: VSSetup
+      patterns: '**\*.runsettings'
+      displayName: Download OptProf Information
+    - powershell: |
+        try {
+          $bootstrapperInfoJson = Get-Content -Raw -Path '$(Pipeline.Workspace)\ComponentBuildUnderTest\MicroBuildOutputs\BootstrapperInfo.json' | ConvertFrom-Json
+          $vsBranch = $bootstrapperInfoJson[0].VSBranch
+          Write-Host "VSBootstrapperBranch: $vsBranch"
+          Set-AzurePipelinesVariable 'VSBootstrapperBranch' $vsBranch
+        }        
+        catch {
+          Write-Host $_
+          Write-Error "Failed to set VSBootstrapperBranch pipeline variable"
+          throw
+        }
+      displayName: Set 'VSBootstrapperBranch' variable
+    - task: PowerShell@2
+      displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL' variable
+      inputs:
+        filePath: $(DartLab.Path)\Scripts\VisualStudio\Bootstrapper\Get-BootstrapperURL.ps1
+        arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\ComponentBuildUnderTest\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBootstrapperBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
+    preDeployAndRunTestsStepList:
+    - download: ComponentBuildUnderTest

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -197,7 +197,7 @@ jobs:
 - job: CoreOnMac
   displayName: "macOS Core"
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build
@@ -233,7 +233,7 @@ jobs:
   condition: eq(1,2)
   displayName: "macOS Mono"
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   steps:
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#mono
   - bash: |

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -90,14 +90,14 @@ stages:
         signType: $(SignType)
         zipSources: false
       condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
-      
+
     - task: MicroBuildOptProfPlugin@6
       inputs:
         ProfilingInputsDropName: '$(VisualStudio.DropName)'
         ShouldSkipOptimize: true
         AccessToken: '$(System.AccessToken)'
         feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-      displayName: 'Install OptProf Plugin'      
+      displayName: 'Install OptProf Plugin'
 
     # Required by MicroBuildBuildVSBootstrapper
     - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
@@ -155,6 +155,7 @@ stages:
                   -task VisualStudio.BuildIbcTrainingSettings
                   /p:VisualStudioDropName=$(VisualStudio.DropName)
                   /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+                  /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
       displayName: 'OptProf - Build IBC training settings'
       condition: succeeded()
 

--- a/eng/config/OptProf.runsettings
+++ b/eng/config/OptProf.runsettings
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <ResultsDirectory>C:\Test\Results</ResultsDirectory>
+    <TargetPlatform>X86</TargetPlatform>
+    <MaxCpuCount>1</MaxCpuCount>
+    <BatchSize>10</BatchSize>
+    <TestSessionTimeout>21600000</TestSessionTimeout>
+    <DesignMode>False</DesignMode>
+    <InIsolation>False</InIsolation>
+    <CollectSourceInformation>False</CollectSourceInformation>
+    <DisableAppDomain>False</DisableAppDomain>
+    <DisableParallelization>False</DisableParallelization>
+    <TargetFrameworkVersion>.NETFramework,Version=v4.0</TargetFrameworkVersion>
+    <ExecutionThreadApartmentState>STA</ExecutionThreadApartmentState>
+    <TestAdaptersPaths>%SystemDrive%\Test</TestAdaptersPaths>
+    <TreatTestAdapterErrorsAsWarnings>False</TreatTestAdapterErrorsAsWarnings>
+  </RunConfiguration>
+  <SessionConfiguration>
+    <!-- Generated -->
+  </SessionConfiguration>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector uri="datacollector://microsoft/DevDiv/TestExtensions/ProcDumpCollector/v1" friendlyName="ProcDump Collector" enabled="True">
+        <Configuration>
+          <RootDumpDirectory>C:\Test\Dumps</RootDumpDirectory>
+          <Deployment PackageName = "Microsoft.DevDiv.TestExtensions.ProcDumpCollector" />
+        </Configuration>
+      </DataCollector>
+      <DataCollector uri="datacollector://microsoft/DevDiv/TestExtensions/LingeringProcessCollector/v1" friendlyName="Lingering Process Collector" enabled="True">
+        <Configuration>
+          <KillLingeringProcesses>true</KillLingeringProcesses>          
+          <ShutdownCommands>
+            <ShutdownCommand Process="VBCSCompiler" Command="%ProcessPath%" Arguments="-shutdown" Timeout="60000" />
+          </ShutdownCommands>
+          <LoggingBehavior>Warning</LoggingBehavior>
+          <Deployment PackageName = "Microsoft.DevDiv.TestExtensions.LingeringProcessCollector" />
+        </Configuration>
+      </DataCollector>
+      <DataCollector uri="datacollector://microsoft/DevDiv/VideoRecorder/2.0" friendlyName="Screen and Voice Recorder" enabled="True">
+        <Configuration>
+          <Deployment PackageName = "Microsoft.DevDiv.Validation.MediaRecorder" />
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+  <InProcDataCollectionRunSettings>
+    <InProcDataCollectors>
+      <InProcDataCollector uri="datacollector://microsoft/DevDiv/TestExtensions/OptProfDataCollector/v2" assemblyQualifiedName="Microsoft.DevDiv.TestExtensions.OptProfDataCollector, Microsoft.DevDiv.TestExtensions.OptProfDataCollector, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null" friendlyName="OptProf Data Collector" enabled="True" codebase="C:\Test\Extensions\Microsoft.DevDiv.TestExtensions.OptProfDataCollector\lib\net461\Microsoft.DevDiv.TestExtensions.OptProfDataCollector.dll">
+        <Configuration>
+          <WorkingDirectory>C:\OptProf</WorkingDirectory>
+          <ProfilesDirectory>C:\Profiles</ProfilesDirectory>
+          <IgnoreProfileNotGeneratedExceptions>true</IgnoreProfileNotGeneratedExceptions>
+          <Deployment PackageName="Microsoft.DevDiv.TestExtensions.OptProfDataCollector" />
+        </Configuration>
+      </InProcDataCollector>
+    </InProcDataCollectors>
+  </InProcDataCollectionRunSettings>
+  <TestRunParameters />
+  <LoggerRunSettings>
+    <Loggers />
+  </LoggerRunSettings>
+  <VisualStudioConfiguration>
+    <!-- MSBuild-OptProf specific VS configuration element -->
+    <InstallationUnderTest>
+      <Components All="false">
+        <Include ID="Microsoft.VisualStudio.Component.VC.CLI.Support" />
+        <Include ID="Microsoft.VisualStudio.Component.Windows81SDK" />
+        <Include ID="Microsoft.VisualStudio.ComponentGroup.UWP.VC" />
+        <Include ID="Microsoft.VisualStudio.Component.VC.ATLMFC" />
+        <Include ID="Microsoft.VisualStudio.Component.Windows10SDK.15063.Desktop" />
+        <Include ID="Microsoft.VisualStudio.Component.Windows10SDK.16299" />
+        <Include ID="Microsoft.VisualStudio.Component.Windows10SDK.16299.UWP" />
+        <Include ID="Microsoft.Net.ComponentGroup.4.7.2.DeveloperTools" />
+        <Exclude ID="Component.Incredibuild" />
+        <Exclude ID="Component.JavaJDK" />
+        <Exclude ID="Microsoft.VisualStudio.Component.AspNet45" />
+      </Components>
+      <Workloads All="false" IncludeComponents="Required,Recommended">
+        <Include ID="Microsoft.VisualStudio.Workload.CoreEditor" IncludeComponents="Required" />
+        <Include ID="Microsoft.VisualStudio.Workload.ManagedDesktop" IncludeComponents="Required" />
+        <Include ID="Microsoft.VisualStudio.Workload.NativeCrossPlat" IncludeComponents="Required" />
+        <Include ID="Microsoft.VisualStudio.Workload.NativeDesktop" IncludeComponents="Required" />
+        <Include ID="Microsoft.VisualStudio.Workload.NetWeb" IncludeComponents="Required" />
+        <Include ID="Microsoft.VisualStudio.Workload.Office" IncludeComponents="Required" />
+        <Include ID="Microsoft.VisualStudio.Workload.Universal" IncludeComponents="Required" />
+        <Include ID="Microsoft.VisualStudio.Workload.VisualStudioExtension" IncludeComponents="Required" />
+        <Include ID="Microsoft.VisualStudio.Workload.Webcrossplat" IncludeComponents="Required" />
+      </Workloads>
+    </InstallationUnderTest>
+  </VisualStudioConfiguration>
+</RunSettings>


### PR DESCRIPTION
- [vs16.11] Update dependencies from dotnet/arcade (https://github.com/dotnet/msbuild/pull/7332)
- Update dependencies from https://github.com/dotnet/arcade build 20220309.5
- Update dependencies from https://github.com/dotnet/arcade build 20220526.2
- Bump CLI version to match global.json
- Bump NuGet version to match
- Avoid AssemblyName.KeyPair on .NET (https://github.com/dotnet/msbuild/pull/7660)
- Merge remote-tracking branch 'upstream/vs16.9' into backport-keypair-elision-16.11
- Merge pull request https://github.com/dotnet/msbuild/pull/7663 from rainersigwald/backport-keypair-elision-16.11
- Configure OptProf v2 pipeline 16.11 (https://github.com/dotnet/msbuild/pull/8189)
- Updating 'Microsoft.DotNet.Arcade.Sdk': '5.0.0-beta.22276.2' => '5.0.0-beta.22526.12'
- Move BAR publish to windows-latest
- Merge pull request https://github.com/dotnet/msbuild/pull/8210 from rainersigwald/exp/16.11-build

### Testing
CI, Opt-prof CI

### Notes
Merge, do not squash.