### PR TITLE
Ensure trailing slash for string used as key in AssemblyTableInfo's cache

### DIFF
--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -3006,8 +3006,7 @@ namespace Microsoft.Build.Tasks
                     {
                         // Exactly one TargetFrameworkDirectory, so assume it's related to this
                         // InstalledAssemblyTable.
-
-                        frameworkDirectory = TargetFrameworkDirectories[0];
+                        frameworkDirectory = FileUtilities.EnsureTrailingSlash(TargetFrameworkDirectories[0]);
                     }
                 }
                 else

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2998,21 +2998,15 @@ namespace Microsoft.Build.Tasks
                 // Whidbey behavior was to accept a single TargetFrameworkDirectory, and multiple
                 // InstalledAssemblyTables, under the assumption that all of the InstalledAssemblyTables
                 // were related to the single TargetFrameworkDirectory.  If inputs look like the Whidbey
-                // case, let's make sure we behave the same way.
-
+                // case, let's make sure we behave the same way. Otherwise, use non-empty metadata.
                 if (String.IsNullOrEmpty(frameworkDirectory))
                 {
                     if (TargetFrameworkDirectories?.Length == 1)
                     {
                         // Exactly one TargetFrameworkDirectory, so assume it's related to this
                         // InstalledAssemblyTable.
-                        frameworkDirectory = FileUtilities.EnsureTrailingSlash(TargetFrameworkDirectories[0]);
+                        frameworkDirectory = TargetFrameworkDirectories[0];
                     }
-                }
-                else
-                {
-                    // The metadata on the item was non-empty, so use it.
-                    frameworkDirectory = FileUtilities.EnsureTrailingSlash(frameworkDirectory);
                 }
 
                 tableMap[installedAssemblyTable.ItemSpec] = new AssemblyTableInfo(installedAssemblyTable.ItemSpec, frameworkDirectory);

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -918,8 +918,8 @@ namespace Microsoft.Build.Tasks
 
         internal AssemblyTableInfo(string path, string frameworkDirectory)
         {
-            Path = path;
-            FrameworkDirectory = frameworkDirectory;
+            Path = FileUtilities.NormalizeForPathComparison(path);
+            FrameworkDirectory = FileUtilities.NormalizeForPathComparison(frameworkDirectory);
         }
 
         internal string Path { get; }


### PR DESCRIPTION
We do exact string comparisons with this path, and it is user-provided, so if it does not include a slash, we may do more work.
