### PR TITLE
Avoid removing outer -> inner graph edge

### DIFF
--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -585,7 +585,7 @@ namespace Microsoft.Build.Graph.UnitTests
             var graph = new ProjectGraph(_env.CreateFile("solution.sln", solutionContents).Path);
 
             var edges = graph.TestOnly_Edges.TestOnly_AsConfigurationMetadata();
-            edges.Count.ShouldBe(8);
+            edges.Count.ShouldBe(10);
 
             var node1 = GetFirstNodeWithProjectNumber(graph, 1);
             node1.ProjectReferences.Count.ShouldBe(3);

--- a/src/Build.UnitTests/Graph/GraphTestingUtilities.cs
+++ b/src/Build.UnitTests/Graph/GraphTestingUtilities.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
 using Shouldly;
@@ -36,40 +37,50 @@ namespace Microsoft.Build.Graph.UnitTests
                                                                                             <AddTransitiveProjectReferencesInStaticGraph>true</AddTransitiveProjectReferencesInStaticGraph>
                                                                                          </PropertyGroup>";
 
-        public static void AssertOuterBuildAsNonRoot(
+        public static void AssertOuterBuild(
             ProjectGraphNode outerBuild,
             ProjectGraph graph,
             Dictionary<string, string> additionalGlobalProperties = null,
             int expectedInnerBuildCount = 2)
         {
-            additionalGlobalProperties ??= new Dictionary<string, string>();
+            additionalGlobalProperties ??= new Dictionary<string, string>(0);
 
             AssertOuterBuildEvaluation(outerBuild, additionalGlobalProperties);
 
-            outerBuild.ProjectReferences.ShouldBeEmpty();
-            outerBuild.ReferencingProjects.ShouldNotBeEmpty();
+            outerBuild.ProjectReferences.Count.ShouldBe(expectedInnerBuildCount);
 
-            foreach (var outerBuildReferencer in outerBuild.ReferencingProjects)
+            // Outer -> Inner build edges
+            foreach (ProjectGraphNode innerBuild in outerBuild.ProjectReferences)
             {
-                var innerBuilds =
-                    outerBuildReferencer.ProjectReferences.Where(
-                        p =>
-                            IsInnerBuild(p) 
-                            && p.ProjectInstance.FullPath == outerBuild.ProjectInstance.FullPath).ToArray();
+                AssertInnerBuildEvaluation(innerBuild, true, additionalGlobalProperties);
+
+                ProjectItemInstance edge = graph.TestOnly_Edges[(outerBuild, innerBuild)];
+                edge.DirectMetadataCount.ShouldBe(1);
+
+                string expectedPropertiesMetadata = $"{InnerBuildPropertyName}={innerBuild.ProjectInstance.GlobalProperties[InnerBuildPropertyName]}";
+                edge.GetMetadata("Properties").EvaluatedValue.ShouldBe(expectedPropertiesMetadata);
+            }
+
+            // Ensure edges were added directly to the inner builds
+            foreach (ProjectGraphNode outerBuildReferencer in outerBuild.ReferencingProjects)
+            {
+                ProjectGraphNode[] innerBuilds = outerBuildReferencer.ProjectReferences
+                    .Where(p => IsInnerBuild(p) && p.ProjectInstance.FullPath == outerBuild.ProjectInstance.FullPath)
+                    .ToArray();
 
                 innerBuilds.Length.ShouldBe(expectedInnerBuildCount);
 
-                foreach (var innerBuild in innerBuilds)
+                foreach (ProjectGraphNode innerBuild in innerBuilds)
                 {
                     AssertInnerBuildEvaluation(innerBuild, true, additionalGlobalProperties);
 
                     innerBuild.ReferencingProjects.ShouldContain(outerBuildReferencer);
-                    innerBuild.ReferencingProjects.ShouldNotContain(outerBuild);
+                    innerBuild.ReferencingProjects.ShouldContain(outerBuild);
 
-                    graph.TestOnly_Edges.HasEdge((outerBuild, innerBuild)).ShouldBeFalse();
+                    graph.TestOnly_Edges.HasEdge((outerBuild, innerBuild)).ShouldBeTrue();
 
-                    var edgeToOuterBuild = graph.TestOnly_Edges[(outerBuildReferencer, outerBuild)];
-                    var edgeToInnerBuild = graph.TestOnly_Edges[(outerBuildReferencer, innerBuild)];
+                    ProjectItemInstance edgeToOuterBuild = graph.TestOnly_Edges[(outerBuildReferencer, outerBuild)];
+                    ProjectItemInstance edgeToInnerBuild = graph.TestOnly_Edges[(outerBuildReferencer, innerBuild)];
 
                     edgeToOuterBuild.ShouldBe(edgeToInnerBuild);
                 }

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -971,13 +971,13 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void GetTargetListsDoesNotUseTargetsMetadataOnInnerBuildsFromRootOuterBuilds()
         {
-            var projectReferenceTargetsProtocol =
+            string projectReferenceTargetsProtocol =
 $@"<ItemGroup>
      <ProjectReferenceTargets Include='A' Targets='{MSBuildConstants.ProjectReferenceTargetsOrDefaultTargetsMarker};A;AInner' />
      <ProjectReferenceTargets Include='A' Targets='{MSBuildConstants.ProjectReferenceTargetsOrDefaultTargetsMarker};A;AOuter' OuterBuild='true' />
    </ItemGroup>";
 
-            var entryProject = CreateProjectFile(
+            string entryProject = CreateProjectFile(
                 env: _env,
                 projectNumber: 1,
                 projectReferences: null,
@@ -1015,28 +1015,28 @@ $@"
 
             var dot = graph.ToDot();
 
-            var rootOuterBuild = GetOuterBuild(graph, 1);
-            var nonRootOuterBuild = GetOuterBuild(graph, 3);
+            ProjectGraphNode rootOuterBuild = GetOuterBuild(graph, 1);
+            ProjectGraphNode nonRootOuterBuild = GetOuterBuild(graph, 3);
 
-            AssertOuterBuildAsRoot(rootOuterBuild, graph);
-            AssertOuterBuildAsNonRoot(nonRootOuterBuild, graph);
+            AssertOuterBuild(rootOuterBuild, graph);
+            AssertOuterBuild(nonRootOuterBuild, graph);
 
-            var targetLists = graph.GetTargetLists(new[] {"A"});
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = graph.GetTargetLists(new[] { "A" });
 
-            targetLists[rootOuterBuild].ShouldBe(new []{"A"});
+            targetLists[rootOuterBuild].ShouldBe(new[] { "A" });
 
-            foreach (var innerBuild in GetInnerBuilds(graph, 1))
+            foreach (ProjectGraphNode innerBuild in GetInnerBuilds(graph, 1))
             {
-                targetLists[innerBuild].ShouldBe(new []{"D1", "A", "AOuter", "AInner"});
+                targetLists[innerBuild].ShouldBe(new[] { "D1", "A", "AOuter", "AInner" });
             }
 
-            targetLists[GetFirstNodeWithProjectNumber(graph, 2)].ShouldBe(new []{"T2", "A", "AOuter", "AInner"});
+            targetLists[GetFirstNodeWithProjectNumber(graph, 2)].ShouldBe(new[] { "T2", "A", "AOuter", "AInner" });
 
-            targetLists[nonRootOuterBuild].ShouldBe(new []{"T3", "A", "AOuter"});
+            targetLists[nonRootOuterBuild].ShouldBe(new[] { "T3", "A", "AOuter" });
 
-            foreach (var innerBuild in GetInnerBuilds(graph, 3))
+            foreach (ProjectGraphNode innerBuild in GetInnerBuilds(graph, 3))
             {
-                targetLists[innerBuild].ShouldBe(new []{"T3", "A", "AOuter", "AInner"});
+                targetLists[innerBuild].ShouldBe(new[] { "T3", "A", "AOuter", "AInner", "D3" });
             }
         }
 
@@ -1531,31 +1531,6 @@ $@"
             Regex.Matches(dot,"label").Count.ShouldBe(graph.ProjectNodes.Count);
         }
 
-        private static void AssertOuterBuildAsRoot(
-            ProjectGraphNode outerBuild,
-            ProjectGraph graph,
-            Dictionary<string, string> additionalGlobalProperties = null,
-            int expectedInnerBuildCount = 2)
-        {
-            additionalGlobalProperties ??= new Dictionary<string, string>();
-
-            AssertOuterBuildEvaluation(outerBuild, additionalGlobalProperties);
-
-            outerBuild.ReferencingProjects.ShouldBeEmpty();
-            outerBuild.ProjectReferences.Count.ShouldBe(expectedInnerBuildCount);
-
-            foreach (var innerBuild in outerBuild.ProjectReferences)
-            {
-                AssertInnerBuildEvaluation(innerBuild, true, additionalGlobalProperties);
-
-                var edge = graph.TestOnly_Edges[(outerBuild, innerBuild)];
-                edge.DirectMetadataCount.ShouldBe(1);
-
-                var expectedPropertiesMetadata = $"{InnerBuildPropertyName}={innerBuild.ProjectInstance.GlobalProperties[InnerBuildPropertyName]}";
-                edge.GetMetadata("Properties").EvaluatedValue.ShouldBe(expectedPropertiesMetadata);
-            }
-        }
-
         [Fact]
         public void OuterBuildAsRootShouldDirectlyReferenceInnerBuilds()
         {
@@ -1569,7 +1544,7 @@ $@"
 
             var outerBuild = graph.GraphRoots.First();
 
-            AssertOuterBuildAsRoot(outerBuild, graph);
+            AssertOuterBuild(outerBuild, graph);
         }
 
         [Fact]
@@ -1596,7 +1571,7 @@ $@"
 
             var outerBuild = GetOuterBuild(graph, 2);
 
-            AssertOuterBuildAsNonRoot(outerBuild, graph);
+            AssertOuterBuild(outerBuild, graph);
         }
 
         [Fact]
@@ -1630,7 +1605,7 @@ $@"
 
             var outerBuild = GetOuterBuild(graph, 2);
 
-            AssertOuterBuildAsNonRoot(outerBuild, graph);
+            AssertOuterBuild(outerBuild, graph);
 
             var outerBuildReferencingNode = GetFirstNodeWithProjectNumber(graph, 1);
 
@@ -1652,7 +1627,7 @@ $@"
                                                     <InnerBuildProperties>a;a</InnerBuildProperties>
                                                 </PropertyGroup>";
 
-            var root = CreateProjectFile(_env, 1, new[] {2}, null, null, multitargetingSpecification).Path;
+            var root = CreateProjectFile(_env, 1, new[] { 2 }, null, null, multitargetingSpecification).Path;
             CreateProjectFile(_env, 2, null, null, null, multitargetingSpecification);
 
             var graph = new ProjectGraph(root);
@@ -1664,8 +1639,8 @@ $@"
             var rootOuterBuild = GetOuterBuild(graph, 1);
             var nonRootOuterBuild = GetOuterBuild(graph, 2);
 
-            AssertOuterBuildAsRoot(rootOuterBuild, graph, null, 1);
-            AssertOuterBuildAsNonRoot(nonRootOuterBuild, graph, null, 1);
+            AssertOuterBuild(rootOuterBuild, graph, null, 1);
+            AssertOuterBuild(nonRootOuterBuild, graph, null, 1);
         }
 
         [Fact]
@@ -1680,7 +1655,7 @@ $@"
 
             graph.ProjectNodes.Count.ShouldBe(4);
 
-            AssertOuterBuildAsRoot(graph.GraphRoots.First(), graph);
+            AssertOuterBuild(graph.GraphRoots.First(), graph);
 
             var nonMultitargetingNode = GetFirstNodeWithProjectNumber(graph, 2);
 
@@ -1748,8 +1723,8 @@ $@"
 
             graph.ProjectNodes.Count.ShouldBe(8);
 
-            AssertOuterBuildAsRoot(graph.GraphRoots.First(), graph);
-            AssertOuterBuildAsNonRoot(GetOuterBuild(graph, 4), graph);
+            AssertOuterBuild(graph.GraphRoots.First(), graph);
+            AssertOuterBuild(GetOuterBuild(graph, 4), graph);
 
             AssertNonMultitargetingNode(GetFirstNodeWithProjectNumber(graph, 2));
             AssertNonMultitargetingNode(GetFirstNodeWithProjectNumber(graph, 3));
@@ -1775,9 +1750,9 @@ $@"
 
             graph.ProjectNodes.Count.ShouldBe(11);
 
-            AssertOuterBuildAsRoot(graph.GraphRoots.First(), graph);
-            AssertOuterBuildAsNonRoot(GetOuterBuild(graph, 2), graph);
-            AssertOuterBuildAsNonRoot(GetOuterBuild(graph, 2), graph);
+            AssertOuterBuild(graph.GraphRoots.First(), graph);
+            AssertOuterBuild(GetOuterBuild(graph, 2), graph);
+            AssertOuterBuild(GetOuterBuild(graph, 2), graph);
 
             AssertNonMultitargetingNode(GetFirstNodeWithProjectNumber(graph, 3));
             AssertNonMultitargetingNode(GetFirstNodeWithProjectNumber(graph, 5));
@@ -1817,7 +1792,7 @@ $@"
 
             var outerBuild = graph.GraphRoots.First(IsOuterBuild);
 
-            AssertOuterBuildAsRoot(outerBuild, graph, additionalGlobalProperties);
+            AssertOuterBuild(outerBuild, graph, additionalGlobalProperties);
             AssertNonMultitargetingNode(GetFirstNodeWithProjectNumber(graph, 2), additionalGlobalProperties);
 
             var referencedInnerBuild = GetNodesWithProjectNumber(graph, 1).First(n => n.ProjectInstance.GetPropertyValue(InnerBuildPropertyName) == "a");
@@ -1895,7 +1870,7 @@ $@"
 
             var outerBuild1 = GetOuterBuild(graph, 1);
 
-            AssertOuterBuildAsRoot(outerBuild1, graph, additionalGlobalProperties);
+            AssertOuterBuild(outerBuild1, graph, additionalGlobalProperties);
 
             var innerBuild1WithReferenceToInnerBuild2 = outerBuild1.ProjectReferences.FirstOrDefault(n => IsInnerBuild(n) && n.ProjectInstance.GlobalProperties[InnerBuildPropertyName] == "a");
             innerBuild1WithReferenceToInnerBuild2.ShouldNotBeNull();
@@ -2226,9 +2201,9 @@ $@"
                 innerBuild.AssertReferencesIgnoringOrder(new []{3, 4, 4, 4, 5, 6, 6, 6});
             }
 
-            GetFirstNodeWithProjectNumber(graph, 2).AssertReferencesIgnoringOrder(new []{3, 4, 4, 4, 5, 6, 6, 6});
+            GetFirstNodeWithProjectNumber(graph, 2).AssertReferencesIgnoringOrder(new[] { 3, 4, 4, 4, 5, 6, 6, 6 });
 
-            GetOuterBuild(graph, 4).AssertReferencesIgnoringOrder(Array.Empty<int>());
+            GetOuterBuild(graph, 4).AssertReferencesIgnoringOrder(new[] { 4, 4 });
 
             var innerBuilds4 = GetInnerBuilds(graph, 4);
             innerBuilds4.Count.ShouldBe(2);
@@ -2303,7 +2278,7 @@ $@"
             var outerBuild1 = GetOuterBuild(graph, 1);
             targetLists[outerBuild1].ShouldBe(new[] {"Build"});
 
-            AssertOuterBuildAsRoot(outerBuild1, graph, expectedInnerBuildCount: 2);
+            AssertOuterBuild(outerBuild1, graph, expectedInnerBuildCount: 2);
 
             var innerBuildsFor1 = GetInnerBuilds(graph, 1);
             innerBuildsFor1.Count.ShouldBe(2);
@@ -2316,7 +2291,7 @@ $@"
 
             var outerBuild2 = GetOuterBuild(graph, 2);
             targetLists[outerBuild2].ShouldBe(new[] {"BuildForOuterBuild"});
-            AssertOuterBuildAsNonRoot(outerBuild2, graph, expectedInnerBuildCount: 2);
+            AssertOuterBuild(outerBuild2, graph, expectedInnerBuildCount: 2);
 
             var innerBuildsFor2 = GetInnerBuilds(graph, 2);
             innerBuildsFor2.Count.ShouldBe(2);
@@ -2331,13 +2306,13 @@ $@"
 
             outerBuild3.ReferencingProjects.Count.ShouldBe(4);
 
-            AssertOuterBuildAsNonRoot(outerBuild3, graph, expectedInnerBuildCount: 2);
+            AssertOuterBuild(outerBuild3, graph, expectedInnerBuildCount: 2);
             var innerBuildsFor3 = GetInnerBuilds(graph, 3);
             innerBuildsFor3.Count.ShouldBe(2);
 
             foreach (var inner3 in innerBuildsFor3)
             {
-                inner3.ReferencingProjects.Count.ShouldBe(4);
+                inner3.ReferencingProjects.Count.ShouldBe(5);
 
                 // 3 does not get called with 1ATarget or 1BTarget because those apply only to direct references
                 targetLists[inner3]

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Build.Graph
 
             AddEdgesFromProjectReferenceItems(allParsedProjects, Edges);
 
-            _projectInterpretation.ReparentInnerBuilds(allParsedProjects, this);
+            _projectInterpretation.AddInnerBuildEdges(allParsedProjects, this);
 
             if (_solutionDependencies != null && _solutionDependencies.Count != 0)
             {

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -105,12 +105,12 @@ namespace Microsoft.Build.Graph
                 var requesterPlatform = "";
                 var requesterPlatformLookupTable = "";
 
-                if ( !projectReferenceItem.HasMetadata(SetPlatformMetadataName) && ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName)))
+                if (!projectReferenceItem.HasMetadata(SetPlatformMetadataName) && ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName)))
                 {
                     requesterPlatform = requesterInstance.GetPropertyValue("Platform");
                     requesterPlatformLookupTable = requesterInstance.GetPropertyValue("PlatformLookupTable");
 
-                    var  projectInstance = _projectInstanceFactory(
+                    var projectInstance = _projectInstanceFactory(
                         projectReferenceFullPath,
                         null, // Platform negotiation requires an evaluation with no global properties first
                         _projectCollection);
@@ -175,9 +175,7 @@ namespace Microsoft.Build.Graph
             {
                 ProjectGraphNode outerBuild = node.Value.GraphNode;
 
-                if (GetProjectType(outerBuild.ProjectInstance) == ProjectType.OuterBuild
-                    && outerBuild.ProjectReferences.Count != 0
-                    && outerBuild.ReferencingProjects.Count != 0)
+                if (GetProjectType(outerBuild.ProjectInstance) == ProjectType.OuterBuild && outerBuild.ReferencingProjects.Count != 0)
                 {
                     foreach (ProjectGraphNode innerBuild in outerBuild.ProjectReferences)
                     {

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -164,30 +164,30 @@ namespace Microsoft.Build.Graph
         }
 
         /// <summary>
-        /// To avoid calling nuget at graph construction time, the graph is initially constructed with outer build nodes referencing inner build nodes.
-        /// However, at build time, for non root outer builds, the inner builds are NOT referenced by the outer build, but by the nodes referencing the
-        /// outer build. Change the graph to mimic this behaviour.
-        /// Examples
-        /// OuterAsRoot -> Inner go to OuterAsRoot -> Inner. Inner builds remain the same, parented to their outer build
-        /// Node -> Outer -> Inner go to: Node -> Outer; Node->Inner; Outer -> empty. Inner builds get reparented to Node
+        /// To avoid calling nuget at graph construction time, the graph is initially constructed with nodes referencing outer build nodes which in turn
+        /// reference inner build nodes. However at build time, the inner builds are referenced directly by the nodes referencing the outer build.
+        /// Change the graph to mimic this behaviour.
+        /// Example: Node -> Outer -> Inner go to: Node -> Outer; Node->Inner; Outer -> Inner. Inner build edges get added to Node.
         /// </summary>
-        public void ReparentInnerBuilds(Dictionary<ConfigurationMetadata, ParsedProject> allNodes, GraphBuilder graphBuilder)
+        public void AddInnerBuildEdges(Dictionary<ConfigurationMetadata, ParsedProject> allNodes, GraphBuilder graphBuilder)
         {
-            foreach (var node in allNodes)
+            foreach (KeyValuePair<ConfigurationMetadata, ParsedProject> node in allNodes)
             {
-                var outerBuild = node.Value.GraphNode;
+                ProjectGraphNode outerBuild = node.Value.GraphNode;
 
-                if (GetProjectType(outerBuild.ProjectInstance) == ProjectType.OuterBuild && outerBuild.ReferencingProjects.Count != 0)
+                if (GetProjectType(outerBuild.ProjectInstance) == ProjectType.OuterBuild
+                    && outerBuild.ProjectReferences.Count != 0
+                    && outerBuild.ReferencingProjects.Count != 0)
                 {
-                    foreach (var innerBuild in outerBuild.ProjectReferences)
+                    foreach (ProjectGraphNode innerBuild in outerBuild.ProjectReferences)
                     {
-                        foreach (var outerBuildReferencingProject in outerBuild.ReferencingProjects)
+                        foreach (ProjectGraphNode outerBuildReferencingProject in outerBuild.ReferencingProjects)
                         {
                             // Which edge should be used to connect the outerBuildReferencingProject to the inner builds?
                             // Decided to use the outerBuildBuildReferencingProject -> outerBuild edge in order to preserve any extra metadata
                             // information that may be present on the edge, like the "Targets" metadata which specifies what
                             // targets to call on the references.
-                            var newInnerBuildEdge = graphBuilder.Edges[(outerBuildReferencingProject, outerBuild)];
+                            ProjectItemInstance newInnerBuildEdge = graphBuilder.Edges[(outerBuildReferencingProject, outerBuild)];
 
                             if (outerBuildReferencingProject.ProjectReferences.Contains(innerBuild))
                             {
@@ -204,8 +204,6 @@ namespace Microsoft.Build.Graph
                             outerBuildReferencingProject.AddProjectReference(innerBuild, newInnerBuildEdge, graphBuilder.Edges);
                         }
                     }
-
-                    outerBuild.RemoveReferences(graphBuilder.Edges);
                 }
             }
         }


### PR DESCRIPTION
Originally when the graph code was written, a non-top-level multitargeting project would end up never actually dispatching to the inner builds, so that edge was removed from the graph. For example if A referenced B and B was multitargeting, A would call B(outer) with `GetTargetFrameworks`, and then call B(inner) with `Build`. B(outer) never called B(inner) (again, when B wasn't an entry point). 

However, at this point `GetTargetFrameworks` on the outer build actually does call into the inner builds, specifically the `GetTargetFrameworksWithPlatformForSingleTargetFramework` target. See:

![image](https://user-images.githubusercontent.com/6445614/209861027-fb0172f7-83ae-4581-8a21-2ab4e37aaf7f.png)

Beyond the correctness issue, the practical impact of this is that this causes graph builds to potentially attempt to schedule outer builds before inner builds, which become blocked on the `GetTargetFrameworksWithPlatformForSingleTargetFramework` target. This causes MSBuild to execute that target on-demand, which in turn leads to an odd behavior where the `BuildManager` attempts to schedule the inner build, but the configuration already exists and the `CreateUniqueGlobalProperty` code path is hit, which eventually causes a double-build for the inner build down the line.

Example of bad graph execution:
1. A(outer) starts executing
2. `GetTargetFrameworksWithPlatformForSingleTargetFramework` is requested on A(inner)
3. Not in cache, so A(inner) executes
4. Some time later, A(inner) is scheduled by the graph build
5. The configuration already exists from (3), and the request already has a `ProjectInstance` from the graph. This causes `CreateUniqueGlobalProperty` to be called in `BuildManager.ResolveConfiguration`, which makes the build of A(inner) have a unique dummy global property.
6. A(inner) executes
7. Some time later, another project C starts executing
8. C depends on A, so ends up trying to build A(inner)
9. *usually* A(inner) would come from the result cache. However, it does not since the results of A(inner) have the dummy global property so it's actually a different configuration
10. A(inner) builds a second time. *Uh oh!*

This change simply removes the removal of the edges from an outer build to its inner builds. It's basically a 1 line change, but with some renames, changing to explicit types instead of `var` in places, and some minor test fixups due to the behavior change.

Unfortunately the target list for this edge isn't very accurate, but in practice the union of incoming edges into the inner build is still correct. The graph target list code and protocol probably need a bigger rewrite at some point to really dial in the correctness, as the current state isn't expressive enough to match reality.