### PR TITLE
Stop dumping stack for BadImageFormatException

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3392,6 +3392,14 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             // There should have been one warning about the exception.
             Assert.Equal(1, engine.Warnings);
+            engine.AssertLogContains("MSB3246");
+
+            // There should have been no ugly callstack dumped
+            engine.AssertLogDoesntContain("Microsoft.Build.UnitTests");
+
+            // But it should contain the message from the BadImageFormatException, something like
+            //     WARNING MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. The format of the file 'C:\WINNT\Microsoft.NET\Framework\v2.0.MyVersion\BadImage.dll' is invalid
+            engine.AssertLogContains("'C:\\WINNT\\Microsoft.NET\\Framework\\v2.0.MyVersion\\BadImage.dll'"); // just search for the un-localized part
         }
 
         /// <summary>
@@ -3429,6 +3437,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             // There should have been no warning about the exception because it's only a dependency
             Assert.Equal(0, engine.Warnings);
+        
+            // There should have been no ugly callstack dumped
+            engine.AssertLogDoesntContain("Microsoft.Build.UnitTests");
         }
 
         /// <summary>

--- a/src/Tasks/AssemblyDependency/BadImageReferenceException.cs
+++ b/src/Tasks/AssemblyDependency/BadImageReferenceException.cs
@@ -33,6 +33,6 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Gets a message that describes the exception.
         /// </summary>
-        public override string Message => (InnerException == null) ? Message : $"{Message} {InnerException.Message}";
+        public override string Message => (InnerException == null) ? base.Message : $"{base.Message} {InnerException.Message}";
     }
 }

--- a/src/Tasks/AssemblyDependency/BadImageReferenceException.cs
+++ b/src/Tasks/AssemblyDependency/BadImageReferenceException.cs
@@ -29,5 +29,10 @@ namespace Microsoft.Build.Tasks
             : base(info, context)
         {
         }
+
+        /// <summary>
+        /// Gets a message that describes the exception.
+        /// </summary>
+        public override string Message => (InnerException == null) ? Message : $"{Message} {InnerException.Message}";
     }
 }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1691,7 +1691,7 @@ namespace Microsoft.Build.Tasks
                 }
                 else if (itemError is BadImageReferenceException)
                 {
-                    message = Log.FormatResourceString("ResolveAssemblyReference.FailedWithException", itemError.InnerException?.ToString() ?? itemError.ToString());
+                    message = Log.FormatResourceString("ResolveAssemblyReference.FailedWithException", itemError.Message);
                     helpKeyword = "MSBuild.ResolveAssemblyReference.FailedWithException";
                     dependencyProblem = false;
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/6224

### Context

See issue -- a change was made to add more detail when RAR fails to resolve a reference due to encountering a BIFE. This added too much detail -- not only the message from the inner exception, but also the callstack. We should not dump callstack when there is no bug in MSBuild (or a task/logger).

Oddly enough I hit this again https://github.com/dotnet/msbuild/issues/8140 and didn't remember the original discussion, and therefore again assumed there was a bug.

### Changes Made

1. Fix BIFE to include the message from any inner exception. (There was a suggestion in the issue that it also include the exception type, but I don't know of any case where the type is necessary in order to disambiguate what happened, and we don't have precedent for doing it. It would also be ugly.)
2. Revert the original change, now unnecesssary.

### Testing

Added test that fails without the fix.

### Notes
