### PR TITLE
Make target items paths crossplatform

### DIFF
--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -700,6 +700,78 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+
+        /// <summary>
+        /// Include and Exclude items outside and inside targets should result in same behavior on
+        ///  platform specific paths.
+        /// </summary>
+        [Fact]
+        public void ItemsIncludeExcludePathsCombinations()
+        {
+            string projectFile = null;
+
+            try
+            {
+                projectFile = ObjectModelHelpers.CreateTempFileOnDisk(@"
+                    <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
+                      <ItemGroup>
+                        <iout1 Include='a/b.foo' Exclude='a\b.foo' />
+                        <iout2 Include='a\b.foo' Exclude='a/b.foo' />
+                        <iout3 Include='a/b.foo' Exclude='a/b.foo' />
+                        <iout4 Include='a\b.foo' Exclude='a\b.foo' />
+                        <iout5 Include='a/b.foo' Exclude='a\c.foo' />
+                        <iout6 Include='a\b.foo' Exclude='a\c.foo' />
+                      </ItemGroup>
+                      <Target Name='a'>
+                        <ItemGroup>
+                          <iin1 Include='a/b.foo' Exclude='a\b.foo' />
+                          <iin2 Include='a\b.foo' Exclude='a/b.foo' />
+                          <iin3 Include='a/b.foo' Exclude='a/b.foo' />
+                          <iin4 Include='a\b.foo' Exclude='a\b.foo' />
+                          <iin5 Include='a/b.foo' Exclude='a\c.foo' />
+                          <iin6 Include='a\b.foo' Exclude='a\c.foo' />
+                        </ItemGroup>
+                        <Message Text='iout1=[@(iout1)]' Importance='High' />
+                        <Message Text='iout2=[@(iout2)]' Importance='High' />
+                        <Message Text='iout3=[@(iout3)]' Importance='High' />
+                        <Message Text='iout4=[@(iout4)]' Importance='High' />
+                        <Message Text='iout5=[@(iout5)]' Importance='High' />
+                        <Message Text='iout6=[@(iout6)]' Importance='High' />
+
+                        <Message Text='iin1=[@(iin1)]' Importance='High' />
+                        <Message Text='iin2=[@(iin2)]' Importance='High' />
+                        <Message Text='iin3=[@(iin3)]' Importance='High' />
+                        <Message Text='iin4=[@(iin4)]' Importance='High' />
+                        <Message Text='iin5=[@(iin5)]' Importance='High' />
+                        <Message Text='iin6=[@(iin6)]' Importance='High' />
+                      </Target>
+                    </Project>
+                ");
+
+                MockLogger logger = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileExpectSuccess(projectFile, logger);
+
+                Console.WriteLine(logger.FullLog);
+
+                logger.AssertLogContains("iout1=[]");
+                logger.AssertLogContains("iout2=[]");
+                logger.AssertLogContains("iout3=[]");
+                logger.AssertLogContains("iout4=[]");
+                logger.AssertLogContains("iout5=[a/b.foo]");
+                logger.AssertLogContains("iout6=[a\\b.foo]");
+                logger.AssertLogContains("iin1=[]");
+                logger.AssertLogContains("iin2=[]");
+                logger.AssertLogContains("iin3=[]");
+                logger.AssertLogContains("iin4=[]");
+                logger.AssertLogContains("iin5=[a/b.foo]");
+                logger.AssertLogContains("iin6=[a\\b.foo]");
+            }
+            finally
+            {
+                File.Delete(projectFile);
+            }
+        }
+
         /// <summary>
         /// Check if passing different global properties via metadata works
         /// </summary>

--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -758,13 +758,13 @@ namespace Microsoft.Build.UnitTests
                 logger.AssertLogContains("iout3=[]");
                 logger.AssertLogContains("iout4=[]");
                 logger.AssertLogContains("iout5=[a/b.foo]");
-                logger.AssertLogContains("iout6=[a\\b.foo]");
+                logger.AssertLogContains($"iout6=[a{Path.DirectorySeparatorChar}b.foo]");
                 logger.AssertLogContains("iin1=[]");
                 logger.AssertLogContains("iin2=[]");
                 logger.AssertLogContains("iin3=[]");
                 logger.AssertLogContains("iin4=[]");
                 logger.AssertLogContains("iin5=[a/b.foo]");
-                logger.AssertLogContains("iin6=[a\\b.foo]");
+                logger.AssertLogContains($"iin6=[a{Path.DirectorySeparatorChar}b.foo]");
             }
             finally
             {

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Build.BackEnd
 
                 foreach (string excludeSplitFile in excludeSplitFiles)
                 {
-                    excludesUnescapedForComparison.Add(excludeSplitFile);
+                    excludesUnescapedForComparison.Add(excludeSplitFile.NormalizeForPathComparison());
                 }
             }
 
@@ -480,7 +480,7 @@ namespace Microsoft.Build.BackEnd
 
             for (int i = 0; i < items.Count; i++)
             {
-                if (!excludesUnescapedForComparison.Contains(((IItem)items[i]).EvaluatedInclude))
+                if (!excludesUnescapedForComparison.Contains(((IItem)items[i]).EvaluatedInclude.NormalizeForPathComparison()))
                 {
                     remainingItems.Add(items[i]);
                 }


### PR DESCRIPTION
Fixes #8188 

### Context
Items Exclusion filtering for items defined within targets is not using same filtering logic (https://github.com/dotnet/msbuild/blob/main/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs#L483-L486) as items defined outside of targets (https://github.com/dotnet/msbuild/blob/main/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs#L89-L93). There is a discrepancy in cross-platform paths mix-matchingh.


### Changes Made
Rather targeted isolated change the build time exclusion evaluation (for items defined within targets) is comparing on normalized paths.
It's a question whether we rather do not want to try to extract and unify the items expansion logic - that might however be a large spanning change with notrivial regression risk.

### Testing
Targetted unit test added ilustrating the issue.
