### PR TITLE
Allow to set empty string for ITaskItem when building tasks

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
@@ -514,7 +514,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                         infos[i].Name,
                         infos[i].PropertyType,
                         infos[i].GetCustomAttributes(typeof(OutputAttribute), false).Length > 0,
-                        infos[i].GetCustomAttributes(typeof(RequiredAttribute), false).Length > 0);
+                        infos[i].GetCustomAttributes(typeof(RequiredAttribute), false).Length > 0,
+                        infos[i].GetCustomAttributes(typeof(AllowEmptyStringAttribute), false).Length > 0);
                 }
 
                 return propertyInfos;

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -333,7 +333,8 @@ namespace Microsoft.Build.BackEnd
             // "required" so that we can keep track of whether or not they all get set.
             var setParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             IDictionary<string, string> requiredParameters = GetNamesOfPropertiesWithRequiredAttribute();
-            IDictionary<string, string> allowEmptyStringParameters = GetNamesOfPropertiesWithAllowEmptyStringAttribute();
+
+            IList<string> allowEmptyStringParameters = GetNamesOfPropertiesWithAllowEmptyStringAttribute();
 
             // look through all the attributes of the task element
             foreach (KeyValuePair<string, (string, ElementLocation)> parameter in parameters)
@@ -343,7 +344,7 @@ namespace Microsoft.Build.BackEnd
 
                 try
                 {
-                    success = SetTaskParameter(parameter.Key, parameter.Value.Item1, parameter.Value.Item2, requiredParameters.ContainsKey(parameter.Key), allowEmptyStringParameters.ContainsKey(parameter.Key), out taskParameterSet);
+                    success = SetTaskParameter(parameter.Key, parameter.Value.Item1, parameter.Value.Item2, requiredParameters.ContainsKey(parameter.Key), allowEmptyStringParameters.Contains(parameter.Key), out taskParameterSet);
                 }
                 catch (Exception e) when (!ExceptionHandling.NotExpectedReflectionException(e))
                 {
@@ -1618,13 +1619,13 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// Finds all the task properties that are allowEmptyString.
-        /// Returns them as keys in a dictionary.
+        /// Returns them in a list.
         /// </summary>
         /// <returns>Gets a list of properties which are allowEmptyString.</returns>
-        private IDictionary<string, string> GetNamesOfPropertiesWithAllowEmptyStringAttribute()
+        private IList<string> GetNamesOfPropertiesWithAllowEmptyStringAttribute()
         {
             ErrorUtilities.VerifyThrow(_taskFactoryWrapper != null, "Expected taskFactoryWrapper to not be null");
-            IDictionary<string, string> allowEmptyStringParameters = null;
+            IList<string> allowEmptyStringParameters = null;
 
             try
             {

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -781,8 +781,8 @@ namespace Microsoft.Build.Execution
             /// <summary>
             /// Creates an instance of this class given the item-spec.
             /// </summary>
-            internal TaskItem(string includeEscaped, string definingFileEscaped)
-                : this(includeEscaped, includeEscaped, null, null, null, immutable: false, definingFileEscaped)
+            internal TaskItem(string includeEscaped, string definingFileEscaped, bool allowEmptyString = false)
+                : this(includeEscaped, includeEscaped, null, null, null, immutable: false, definingFileEscaped, allowEmptyString)
             {
             }
 
@@ -797,11 +797,15 @@ namespace Microsoft.Build.Execution
                               List<ProjectItemDefinitionInstance> itemDefinitions,
                               string projectDirectory,
                               bool immutable,
-                              string definingFileEscaped // the actual project file (or import) that defines this item.
+                              string definingFileEscaped, // the actual project file (or import) that defines this item.
+                              bool allowEmptyString = false
                               )
             {
-                ErrorUtilities.VerifyThrowArgumentLength(includeEscaped, nameof(includeEscaped));
-                ErrorUtilities.VerifyThrowArgumentLength(includeBeforeWildcardExpansionEscaped, nameof(includeBeforeWildcardExpansionEscaped));
+                if (!allowEmptyString)
+                {
+                    ErrorUtilities.VerifyThrowArgumentLength(includeEscaped, nameof(includeEscaped));
+                    ErrorUtilities.VerifyThrowArgumentLength(includeBeforeWildcardExpansionEscaped, nameof(includeBeforeWildcardExpansionEscaped));
+                }
 
                 _includeEscaped = FileUtilities.FixFilePath(includeEscaped);
                 _includeBeforeWildcardExpansionEscaped = FileUtilities.FixFilePath(includeBeforeWildcardExpansionEscaped);
@@ -1137,7 +1141,7 @@ namespace Microsoft.Build.Execution
 
             IEnumerable<ProjectMetadataInstance> IItem<ProjectMetadataInstance>.Metadata => MetadataCollection;
 
-#region Operators
+            #region Operators
 
             /// <summary>
             /// This allows an explicit typecast from a "TaskItem" to a "string", returning the ItemSpec for this item.
@@ -1178,7 +1182,7 @@ namespace Microsoft.Build.Execution
                 return !(left == right);
             }
 
-#endregion
+            #endregion
 
             /// <summary>
             /// Produce a string representation.
@@ -1200,7 +1204,7 @@ namespace Microsoft.Build.Execution
             }
 #endif
 
-#region IItem and ITaskItem2 Members
+            #region IItem and ITaskItem2 Members
 
             /// <summary>
             /// Returns the metadata with the specified key.
@@ -1451,9 +1455,9 @@ namespace Microsoft.Build.Execution
                 return clonedMetadata;
             }
 
-#endregion
+            #endregion
 
-#region INodePacketTranslatable Members
+            #region INodePacketTranslatable Members
 
             /// <summary>
             /// Reads or writes the packet to the serializer.
@@ -1483,9 +1487,9 @@ namespace Microsoft.Build.Execution
                 }
             }
 
-#endregion
+            #endregion
 
-#region IEquatable<TaskItem> Members
+            #region IEquatable<TaskItem> Members
 
             /// <summary>
             /// Override of GetHashCode.
@@ -1594,7 +1598,7 @@ namespace Microsoft.Build.Execution
                 return thisNames.Count == 0;
             }
 
-#endregion
+            #endregion
 
             /// <summary>
             /// Returns true if a particular piece of metadata is defined on this item (even if
@@ -1655,7 +1659,7 @@ namespace Microsoft.Build.Execution
                 var key = interner.Intern(str);
                 translator.Writer.Write(key);
             }
-            
+
             private void ReadInternString(ITranslator translator, LookasideStringInterner interner, ref string str)
             {
                 var val = translator.Reader.ReadInt32();

--- a/src/Build/Instance/ReflectableTaskPropertyInfo.cs
+++ b/src/Build/Instance/ReflectableTaskPropertyInfo.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Build.Execution
         /// used with MetadataLoadContext, as these parameters cannot be computed for the property type passed in directly but
         /// rather the relevant base type.
         /// </summary>
-        internal ReflectableTaskPropertyInfo(PropertyInfo propertyInfo, bool output, bool required,bool allowEmptyString, bool isAssignableToITaskItemType)
+        internal ReflectableTaskPropertyInfo(PropertyInfo propertyInfo, bool output, bool required, bool allowEmptyString, bool isAssignableToITaskItemType)
             : base(
             propertyInfo.Name,
             propertyInfo.PropertyType,

--- a/src/Build/Instance/ReflectableTaskPropertyInfo.cs
+++ b/src/Build/Instance/ReflectableTaskPropertyInfo.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Execution
         /// <param name="taskPropertyInfo">The original property info that generated this instance.</param>
         /// <param name="taskType">The type to reflect over to get the reflection propertyinfo later.</param>
         internal ReflectableTaskPropertyInfo(TaskPropertyInfo taskPropertyInfo, Type taskType)
-            : base(taskPropertyInfo.Name, taskPropertyInfo.PropertyType, taskPropertyInfo.Output, taskPropertyInfo.Required)
+            : base(taskPropertyInfo.Name, taskPropertyInfo.PropertyType, taskPropertyInfo.Output, taskPropertyInfo.Required, taskPropertyInfo.AllowEmptyString)
         {
             ErrorUtilities.VerifyThrowArgumentNull(taskType, nameof(taskType));
             _taskType = taskType;
@@ -47,7 +47,8 @@ namespace Microsoft.Build.Execution
             propertyInfo.Name,
             propertyInfo.PropertyType,
             propertyInfo.GetCustomAttributes(typeof(OutputAttribute), true).Any(),
-            propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true).Any())
+            propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true).Any(),
+            propertyInfo.GetCustomAttributes(typeof(AllowEmptyStringAttribute), true).Any())
         {
             _propertyInfo = propertyInfo;
         }
@@ -57,12 +58,13 @@ namespace Microsoft.Build.Execution
         /// used with MetadataLoadContext, as these parameters cannot be computed for the property type passed in directly but
         /// rather the relevant base type.
         /// </summary>
-        internal ReflectableTaskPropertyInfo(PropertyInfo propertyInfo, bool output, bool required, bool isAssignableToITaskItemType)
+        internal ReflectableTaskPropertyInfo(PropertyInfo propertyInfo, bool output, bool required,bool allowEmptyString, bool isAssignableToITaskItemType)
             : base(
             propertyInfo.Name,
             propertyInfo.PropertyType,
             output,
-            required)
+            required,
+            allowEmptyString)
         {
             _propertyInfo = propertyInfo;
             IsAssignableToITask = isAssignableToITaskItemType;

--- a/src/Build/Instance/TaskFactoryWrapper.cs
+++ b/src/Build/Instance/TaskFactoryWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -28,11 +28,6 @@ namespace Microsoft.Build.Execution
         /// Cache of names of required properties on this type
         /// </summary>
         private IDictionary<string, string> _namesOfPropertiesWithRequiredAttribute;
-
-        /// <summary>
-        /// Cache of names of allowEmptyString properties on this type
-        /// </summary>
-        private IList<string> _namesOfPropertiesWithAllowEmptyStringAttribute;
 
         /// <summary>
         /// Cache of names of output properties on this type
@@ -151,15 +146,6 @@ namespace Microsoft.Build.Execution
             get
             {
                 return _factoryIdentityParameters;
-            }
-        }
-
-        public IList<string> GetNamesOfPropertiesWithAllowEmptyStringAttribute {
-            get
-            {
-                PopulatePropertyInfoCacheIfNecessary();
-
-                return _namesOfPropertiesWithAllowEmptyStringAttribute;
             }
         }
 
@@ -319,15 +305,6 @@ namespace Microsoft.Build.Execution
                         // we have a output attribute defined, keep a record of that
                         _namesOfPropertiesWithOutputAttribute[propertyInfo.Name] = String.Empty;
                     }
-
-                    if (propertyInfos[i].AllowEmptyString)
-                    {
-                        if (_namesOfPropertiesWithAllowEmptyStringAttribute == null)
-                        {
-                            _namesOfPropertiesWithAllowEmptyStringAttribute = new List<string>();
-                        }
-                        _namesOfPropertiesWithAllowEmptyStringAttribute.Add(propertyInfo.Name);
-                    }
                 }
 
                 _propertyInfoCache ??= ReadOnlyEmptyDictionary<string, TaskPropertyInfo>.Instance;
@@ -335,7 +312,6 @@ namespace Microsoft.Build.Execution
                 _namesOfPropertiesWithRequiredAttribute ??= ReadOnlyEmptyDictionary<string, string>.Instance;
                 _namesOfPropertiesWithOutputAttribute ??= ReadOnlyEmptyDictionary<string, string>.Instance;
                 _namesOfPropertiesWithAmbiguousMatches ??= ReadOnlyEmptyDictionary<string, string>.Instance;
-                _namesOfPropertiesWithAllowEmptyStringAttribute ??= new List<string>();
             }
         }
         #endregion

--- a/src/Build/Instance/TaskFactoryWrapper.cs
+++ b/src/Build/Instance/TaskFactoryWrapper.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Build.Execution
                             _namesOfPropertiesWithAllowEmptyStringAttribute = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                         }
 
-                        // we have a output attribute defined, keep a record of that
+                        // we have a allowEmptyString attribute defined, keep a record of that
                         _namesOfPropertiesWithAllowEmptyStringAttribute[propertyInfo.Name] = String.Empty;
                     }
                 }

--- a/src/Build/Instance/TaskFactoryWrapper.cs
+++ b/src/Build/Instance/TaskFactoryWrapper.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Build.Execution
         private IDictionary<string, string> _namesOfPropertiesWithRequiredAttribute;
 
         /// <summary>
+        /// Cache of names of allowEmptyString properties on this type
+        /// </summary>
+        private IDictionary<string, string> _namesOfPropertiesWithAllowEmptyStringAttribute;
+
+        /// <summary>
         /// Cache of names of output properties on this type
         /// </summary>
         private IDictionary<string, string> _namesOfPropertiesWithOutputAttribute;
@@ -146,6 +151,15 @@ namespace Microsoft.Build.Execution
             get
             {
                 return _factoryIdentityParameters;
+            }
+        }
+
+        public IDictionary<string, string> GetNamesOfPropertiesWithAllowEmptyStringAttribute {
+            get
+            {
+                PopulatePropertyInfoCacheIfNecessary();
+
+                return _namesOfPropertiesWithAllowEmptyStringAttribute;
             }
         }
 
@@ -305,6 +319,17 @@ namespace Microsoft.Build.Execution
                         // we have a output attribute defined, keep a record of that
                         _namesOfPropertiesWithOutputAttribute[propertyInfo.Name] = String.Empty;
                     }
+
+                    if (propertyInfos[i].AllowEmptyString)
+                    {
+                        if (_namesOfPropertiesWithAllowEmptyStringAttribute == null)
+                        {
+                            _namesOfPropertiesWithAllowEmptyStringAttribute = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        }
+
+                        // we have a output attribute defined, keep a record of that
+                        _namesOfPropertiesWithAllowEmptyStringAttribute[propertyInfo.Name] = String.Empty;
+                    }
                 }
 
                 _propertyInfoCache ??= ReadOnlyEmptyDictionary<string, TaskPropertyInfo>.Instance;
@@ -312,6 +337,7 @@ namespace Microsoft.Build.Execution
                 _namesOfPropertiesWithRequiredAttribute ??= ReadOnlyEmptyDictionary<string, string>.Instance;
                 _namesOfPropertiesWithOutputAttribute ??= ReadOnlyEmptyDictionary<string, string>.Instance;
                 _namesOfPropertiesWithAmbiguousMatches ??= ReadOnlyEmptyDictionary<string, string>.Instance;
+                _namesOfPropertiesWithAllowEmptyStringAttribute ??= ReadOnlyEmptyDictionary<string, string>.Instance;
             }
         }
         #endregion

--- a/src/Build/Instance/TaskFactoryWrapper.cs
+++ b/src/Build/Instance/TaskFactoryWrapper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Cache of names of allowEmptyString properties on this type
         /// </summary>
-        private IDictionary<string, string> _namesOfPropertiesWithAllowEmptyStringAttribute;
+        private IList<string> _namesOfPropertiesWithAllowEmptyStringAttribute;
 
         /// <summary>
         /// Cache of names of output properties on this type
@@ -154,7 +154,7 @@ namespace Microsoft.Build.Execution
             }
         }
 
-        public IDictionary<string, string> GetNamesOfPropertiesWithAllowEmptyStringAttribute {
+        public IList<string> GetNamesOfPropertiesWithAllowEmptyStringAttribute {
             get
             {
                 PopulatePropertyInfoCacheIfNecessary();
@@ -324,11 +324,9 @@ namespace Microsoft.Build.Execution
                     {
                         if (_namesOfPropertiesWithAllowEmptyStringAttribute == null)
                         {
-                            _namesOfPropertiesWithAllowEmptyStringAttribute = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                            _namesOfPropertiesWithAllowEmptyStringAttribute = new List<string>();
                         }
-
-                        // we have a allowEmptyString attribute defined, keep a record of that
-                        _namesOfPropertiesWithAllowEmptyStringAttribute[propertyInfo.Name] = String.Empty;
+                        _namesOfPropertiesWithAllowEmptyStringAttribute.Add(propertyInfo.Name);
                     }
                 }
 
@@ -337,7 +335,7 @@ namespace Microsoft.Build.Execution
                 _namesOfPropertiesWithRequiredAttribute ??= ReadOnlyEmptyDictionary<string, string>.Instance;
                 _namesOfPropertiesWithOutputAttribute ??= ReadOnlyEmptyDictionary<string, string>.Instance;
                 _namesOfPropertiesWithAmbiguousMatches ??= ReadOnlyEmptyDictionary<string, string>.Instance;
-                _namesOfPropertiesWithAllowEmptyStringAttribute ??= ReadOnlyEmptyDictionary<string, string>.Instance;
+                _namesOfPropertiesWithAllowEmptyStringAttribute ??= new List<string>();
             }
         }
         #endregion

--- a/src/Framework/AllowEmptyStringAttribute.cs
+++ b/src/Framework/AllowEmptyStringAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+#nullable disable
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// This class defines the attribute that a task writer can apply to a task's taskitem property to declare the property to be a
+    /// allowEmptyString property.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class AllowEmptyStringAttribute : Attribute
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public AllowEmptyStringAttribute()
+        {
+        }
+    }
+}

--- a/src/Framework/TaskPropertyInfo.cs
+++ b/src/Framework/TaskPropertyInfo.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Build.Framework
         /// <param name="typeOfParameter">The actual type of the parameter</param>
         /// <param name="output">True if the parameter is both an output and input parameter. False if the parameter is only an input parameter</param>
         /// <param name="required">True if the parameter must be supplied to each invocation of the task.</param>
-        public TaskPropertyInfo(string name, Type typeOfParameter, bool output, bool required)
+        /// <param name="allowEmptyString"></param>
+        public TaskPropertyInfo(string name, Type typeOfParameter, bool output, bool required, bool allowEmptyString = false)
         {
             Name = name;
             PropertyType = typeOfParameter;
@@ -30,6 +31,7 @@ namespace Microsoft.Build.Framework
             Type elementType = typeOfParameter.IsArray ? typeOfParameter.GetElementType() : typeOfParameter;
             IsValueTypeOutputParameter = elementType.GetTypeInfo().IsValueType || elementType.FullName.Equals("System.String");
             IsAssignableToITask = typeof(ITaskItem).IsAssignableFrom(elementType);
+            AllowEmptyString = allowEmptyString;
         }
 
         /// <summary>
@@ -51,6 +53,11 @@ namespace Microsoft.Build.Framework
         /// This task parameter is required (analogous to the [Required] attribute)
         /// </summary>
         public bool Required { get; private set; }
+
+        /// <summary>
+        /// This task parameter is required (analogous to the [Required] attribute)
+        /// </summary>
+        public bool AllowEmptyString { get; private set; }
 
         /// <summary>
         /// This task parameter should be logged when LogTaskInputs is set. Defaults to true.

--- a/src/Framework/TaskPropertyInfo.cs
+++ b/src/Framework/TaskPropertyInfo.cs
@@ -21,8 +21,26 @@ namespace Microsoft.Build.Framework
         /// <param name="typeOfParameter">The actual type of the parameter</param>
         /// <param name="output">True if the parameter is both an output and input parameter. False if the parameter is only an input parameter</param>
         /// <param name="required">True if the parameter must be supplied to each invocation of the task.</param>
-        /// <param name="allowEmptyString"></param>
-        public TaskPropertyInfo(string name, Type typeOfParameter, bool output, bool required, bool allowEmptyString = false)
+        public TaskPropertyInfo(string name, Type typeOfParameter, bool output, bool required)
+        {
+            Name = name;
+            PropertyType = typeOfParameter;
+            Output = output;
+            Required = required;
+            Type elementType = typeOfParameter.IsArray ? typeOfParameter.GetElementType() : typeOfParameter;
+            IsValueTypeOutputParameter = elementType.GetTypeInfo().IsValueType || elementType.FullName.Equals("System.String");
+            IsAssignableToITask = typeof(ITaskItem).IsAssignableFrom(elementType);
+        }
+
+        /// <summary>
+        /// Encapsulates a list of parameters declared in the UsingTask
+        /// </summary>
+        /// <param name="name">Name of the parameter</param>
+        /// <param name="typeOfParameter">The actual type of the parameter</param>
+        /// <param name="output">True if the parameter is both an output and input parameter. False if the parameter is only an input parameter</param>
+        /// <param name="required">True if the parameter must be supplied to each invocation of the task.</param>
+        /// <param name="allowEmptyString">True if the parameter can be empty of the task.</param>
+        public TaskPropertyInfo(string name, Type typeOfParameter, bool output, bool required, bool allowEmptyString)
         {
             Name = name;
             PropertyType = typeOfParameter;
@@ -55,7 +73,7 @@ namespace Microsoft.Build.Framework
         public bool Required { get; private set; }
 
         /// <summary>
-        /// This task parameter is required (analogous to the [Required] attribute)
+        /// This task parameter is emtpy (analogous to the [AllowEmptyString] attribute)
         /// </summary>
         public bool AllowEmptyString { get; private set; }
 

--- a/src/Shared/LoadedType.cs
+++ b/src/Shared/LoadedType.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Build.Shared
             {
                 bool outputAttribute = false;
                 bool requiredAttribute = false;
+                bool allowEmptyStringAttribute = false;
                 foreach (CustomAttributeData attr in CustomAttributeData.GetCustomAttributes(props[i]))
                 {
                     if (attr.AttributeType.Name.Equals(nameof(OutputAttribute)))
@@ -88,6 +89,10 @@ namespace Microsoft.Build.Shared
                     else if (attr.AttributeType.Name.Equals(nameof(RequiredAttribute)))
                     {
                         requiredAttribute = true;
+                    }
+                    else if (attr.AttributeType.Name.Equals(nameof(AllowEmptyStringAttribute)))
+                    {
+                        allowEmptyStringAttribute = true;
                     }
                 }
 
@@ -100,7 +105,7 @@ namespace Microsoft.Build.Shared
 
                 bool isAssignableToITask = iTaskItemType.IsAssignableFrom(pt);
 
-                Properties[i] = new ReflectableTaskPropertyInfo(props[i], outputAttribute, requiredAttribute, isAssignableToITask);
+                Properties[i] = new ReflectableTaskPropertyInfo(props[i], outputAttribute, requiredAttribute, allowEmptyStringAttribute, isAssignableToITask);
                 if (loadedViaMetadataLoadContext)
                 {
                     PropertyAssemblyQualifiedNames[i] = Properties[i].PropertyType.AssemblyQualifiedName;

--- a/src/Tasks.UnitTests/XamlDataDrivenToolTask_Tests.cs
+++ b/src/Tasks.UnitTests/XamlDataDrivenToolTask_Tests.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         {
             string projectFile = @"
                       <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory`>
-                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyName=`Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`>
+                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                           <Task>
                             <![CDATA[
                               <ProjectSchemaDefinitions xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework` xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml` xmlns:sys=`clr-namespace:System;assembly=mscorlib` xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>
@@ -309,7 +309,7 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         {
             string projectFile = @"
                       <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory`>
-                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyName=`Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`>
+                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                           <Task>
                             <![CDATA[
                               <ProjectSchemaDefinitions xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework` xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml` xmlns:sys=`clr-namespace:System;assembly=mscorlib` xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>
@@ -346,7 +346,7 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         {
             string projectFile = @"
                       <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory`>
-                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyName=`Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`>
+                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                           <Task>
                             <![CDATA[
                               <ProjectSchemaDefinitions xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework` xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml` xmlns:sys=`clr-namespace:System;assembly=mscorlib` xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>

--- a/src/Tasks.UnitTests/XamlDataDrivenToolTask_Tests.cs
+++ b/src/Tasks.UnitTests/XamlDataDrivenToolTask_Tests.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         {
             string projectFile = @"
                       <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory`>
-                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
+                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyName=`Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`>
                           <Task>
                             <![CDATA[
                               <ProjectSchemaDefinitions xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework` xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml` xmlns:sys=`clr-namespace:System;assembly=mscorlib` xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>
@@ -309,7 +309,7 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         {
             string projectFile = @"
                       <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory`>
-                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
+                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyName=`Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`>
                           <Task>
                             <![CDATA[
                               <ProjectSchemaDefinitions xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework` xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml` xmlns:sys=`clr-namespace:System;assembly=mscorlib` xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>
@@ -346,7 +346,7 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         {
             string projectFile = @"
                       <Project ToolsVersion=`msbuilddefaulttoolsversion` DefaultTargets=`XamlTaskFactory`>
-                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
+                        <UsingTask TaskName=`TestTask` TaskFactory=`XamlTaskFactory` AssemblyName=`Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`>
                           <Task>
                             <![CDATA[
                               <ProjectSchemaDefinitions xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework` xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml` xmlns:sys=`clr-namespace:System;assembly=mscorlib` xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>

--- a/src/Tasks.UnitTests/XmlPoke_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPoke_Tests.cs
@@ -86,13 +86,13 @@ namespace Microsoft.Build.UnitTests
             XmlDocument xmlDocument = ExecuteXmlPoke(query: query, value: value);
 
             List<XmlAttribute> nodes = xmlDocument.SelectNodes(query)?.Cast<XmlAttribute>().ToList();
-
+            
             nodes.ShouldNotBeNull($"There should be <class /> elements with an AccessModifier attribute {Environment.NewLine}{xmlDocument.OuterXml}");
 
             nodes.Count.ShouldBe(1, $"There should be 1 <class /> element with an AccessModifier attribute {Environment.NewLine}{xmlDocument.OuterXml}");
 
             nodes[0].Value.ShouldBe(value);
-        }
+        }   
 
         [Fact]
         public void PokeChildren()
@@ -172,6 +172,23 @@ namespace Microsoft.Build.UnitTests
                     Should.NotThrow(() => p.Execute());
                 }
             }
+        }
+
+        [Fact]
+        // https://github.com/dotnet/msbuild/issues/5814
+        public void PokeWithEmptyValue()
+        {
+            string xmlInputPath;
+            Prepare(_xmlFileNoNs, out xmlInputPath);
+            string projectContents = @"
+                <Project ToolsVersion='msbuilddefaulttoolsversion'>
+                <Target Name='Poke'>
+                    <XmlPoke Value='' Query='//class/variable/@Name' XmlInputPath='{0}'/>
+                </Target>
+                </Project>";
+            projectContents = string.Format(projectContents, xmlInputPath);
+
+            ObjectModelHelpers.BuildProjectExpectSuccess(projectContents);
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/XmlPoke_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPoke_Tests.cs
@@ -86,13 +86,13 @@ namespace Microsoft.Build.UnitTests
             XmlDocument xmlDocument = ExecuteXmlPoke(query: query, value: value);
 
             List<XmlAttribute> nodes = xmlDocument.SelectNodes(query)?.Cast<XmlAttribute>().ToList();
-            
+
             nodes.ShouldNotBeNull($"There should be <class /> elements with an AccessModifier attribute {Environment.NewLine}{xmlDocument.OuterXml}");
 
             nodes.Count.ShouldBe(1, $"There should be 1 <class /> element with an AccessModifier attribute {Environment.NewLine}{xmlDocument.OuterXml}");
 
             nodes[0].Value.ShouldBe(value);
-        }   
+        }
 
         [Fact]
         public void PokeChildren()

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -190,7 +190,8 @@ namespace Microsoft.Build.Tasks
                             i.Name,
                             i.PropertyType,
                             i.GetCustomAttribute<OutputAttribute>() != null,
-                            i.GetCustomAttribute<RequiredAttribute>() != null))
+                            i.GetCustomAttribute<RequiredAttribute>() != null,
+                            i.GetCustomAttribute<AllowEmptyStringAttribute>() != null))
                         .ToArray();
                 }
             }

--- a/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
+++ b/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
@@ -230,7 +230,8 @@ namespace Microsoft.Build.Tasks
                     infos[i].Name,
                     infos[i].PropertyType,
                     infos[i].GetCustomAttributes(typeof(OutputAttribute), false).Length > 0,
-                    infos[i].GetCustomAttributes(typeof(RequiredAttribute), false).Length > 0);
+                    infos[i].GetCustomAttributes(typeof(RequiredAttribute), false).Length > 0,
+                    infos[i].GetCustomAttributes(typeof(AllowEmptyStringAttribute), false).Length > 0);
             }
 
             return propertyInfos;

--- a/src/Tasks/XmlPoke.cs
+++ b/src/Tasks/XmlPoke.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Build.Tasks
         /// The value to be inserted into the specified location.
         /// </summary>
         [Required]
+        [AllowEmptyString]
         public ITaskItem Value
         {
             get


### PR DESCRIPTION
Fixes [#5814](https://github.com/dotnet/msbuild/issues/5814)

### Context
Can't pass empty string to XmlPoke task. 

### Changes Made
Define an attribute "AllowEmptyString" for task [ITaskItem](https://learn.microsoft.com/en-us/dotnet/api/microsoft.build.framework.itaskitem) property, just like Required attribute.  When the item value is empty, set the empty string instead of skipping setting the parameter.

### Testing


### Notes
