### PR TITLE
Fix NativeMethods.IsSymLink

### DIFF
--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1105,7 +1105,7 @@ internal static class NativeMethods
     private static bool IsSymLinkFileInternal(string path)
     {
         using SafeFileHandle handle = CreateFile(path,
-            GENERIC_READ,
+            FILE_READ_ATTRIBUTES,
             FILE_SHARE_READ,
             IntPtr.Zero,
             OPEN_EXISTING,
@@ -1800,6 +1800,7 @@ internal static class NativeMethods
     public static extern int CoWaitForMultipleHandles(COWAIT_FLAGS dwFlags, int dwTimeout, int cHandles, [MarshalAs(UnmanagedType.LPArray)] IntPtr[] pHandles, out int pdwIndex);
 
     internal const uint GENERIC_READ = 0x80000000;
+    internal const uint FILE_READ_ATTRIBUTES = 0x80;
     internal const uint FILE_SHARE_READ = 0x1;
     internal const uint FILE_ATTRIBUTE_NORMAL = 0x80;
     internal const uint FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1101,6 +1101,7 @@ internal static class NativeMethods
 #endif
     }
 
+    [SupportedOSPlatform("windows")]
     private static bool IsSymLinkFileInternal(string path)
     {
         using SafeFileHandle handle = CreateFile(path,

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -588,7 +588,7 @@ internal static class NativeMethods
     /// Use only when calling GetFileInformationByHandleEx.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    internal class FileAttributeTagInfo
+    internal struct FileAttributeTagInfo
     {
         internal int fileAttributes;
         internal int reparseTag;
@@ -1681,27 +1681,12 @@ internal static class NativeMethods
         int dwBufferSize);
 
     [SupportedOSPlatform("windows")]
-    static bool GetFileAttributeTagInfoByHandle(SafeFileHandle fileHandle, out FileAttributeTagInfo fileAttributeTagInfo)
+    static unsafe bool GetFileAttributeTagInfoByHandle(SafeFileHandle fileHandle, out FileAttributeTagInfo fileAttributeTagInfo)
     {
-        int typeSize = Marshal.SizeOf(typeof(FileAttributeTagInfo));
-        IntPtr ptr = Marshal.AllocHGlobal(typeSize);
-        try
+        fileAttributeTagInfo = new FileAttributeTagInfo();
+        fixed (FileAttributeTagInfo* ptr = &fileAttributeTagInfo)
         {
-            bool ret = GetFileInformationByHandleEx(fileHandle, FileInfoByHandleClass.FileAttributeTagInfo, ptr, typeSize);
-            if (ret)
-            {
-                fileAttributeTagInfo = (FileAttributeTagInfo)Marshal.PtrToStructure(ptr, typeof(FileAttributeTagInfo));
-            }
-            else
-            {
-                fileAttributeTagInfo = new FileAttributeTagInfo();
-            }
-
-            return ret;
-        }
-        finally
-        {
-            Marshal.FreeHGlobal(ptr);
+            return GetFileInformationByHandleEx(fileHandle, FileInfoByHandleClass.FileAttributeTagInfo, (IntPtr)ptr, sizeof(FileAttributeTagInfo));
         }
     }
         

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -45,6 +45,8 @@ internal static class NativeMethods
     internal const int FILE_ATTRIBUTE_DIRECTORY = 0x00000010;
     internal const int FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400;
 
+    internal const uint IO_REPARSE_TAG_SYMLINK = 0xA000000C;
+
     /// <summary>
     /// Default buffer size to use when dealing with the Windows API.
     /// </summary>
@@ -206,6 +208,12 @@ internal static class NativeMethods
         File = 0,
         Directory = 1,
         AllowUnprivilegedCreate = 2,
+    }
+
+    // https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ne-minwinbase-file_info_by_handle_class
+    private enum FileInfoByHandleClass : int
+    {
+        FileAttributeTagInfo = 9
     }
 
     #endregion
@@ -573,6 +581,17 @@ internal static class NativeMethods
         }
 
         return -1;
+    }
+
+    /// <summary>
+    /// Receives the requested file attribute information. Used for any handles.
+    /// Use only when calling GetFileInformationByHandleEx.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal class FileAttributeTagInfo
+    {
+        internal int fileAttributes;
+        internal int reparseTag;
     }
 
 #endregion
@@ -1072,10 +1091,36 @@ internal static class NativeMethods
 
         WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
 
-        return NativeMethods.GetFileAttributesEx(fileInfo.FullName, 0, ref data) &&
-               (data.fileAttributes & NativeMethods.FILE_ATTRIBUTE_DIRECTORY) == 0 &&
-               (data.fileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == FILE_ATTRIBUTE_REPARSE_POINT;
+        return
+            NativeMethods.GetFileAttributesEx(fileInfo.FullName, 0, ref data) &&
+            (data.fileAttributes & NativeMethods.FILE_ATTRIBUTE_DIRECTORY) == 0 &&
+            // This is fast but unspecific check - there are multiple types of reparse points.
+            (data.fileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == FILE_ATTRIBUTE_REPARSE_POINT &&
+            // Specific check for a symlink.
+            IsSymLinkFileInternal(fileInfo.FullName);
 #endif
+    }
+
+    private static bool IsSymLinkFileInternal(string path)
+    {
+        using SafeFileHandle handle = CreateFile(path,
+            GENERIC_READ,
+            FILE_SHARE_READ,
+            IntPtr.Zero,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            IntPtr.Zero);
+
+        if (handle.IsInvalid)
+        {
+            // Link is broken. Details can be obtained via GetLastError.
+            return false;
+        }
+
+        return
+            GetFileAttributeTagInfoByHandle(handle, out FileAttributeTagInfo attributes) &&
+            (attributes.fileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == FILE_ATTRIBUTE_REPARSE_POINT &&
+            (attributes.reparseTag & NativeMethods.IO_REPARSE_TAG_SYMLINK) == NativeMethods.IO_REPARSE_TAG_SYMLINK;
     }
 
     internal static bool IsSymLink(string path)
@@ -1624,6 +1669,40 @@ internal static class NativeMethods
     [return: MarshalAs(UnmanagedType.Bool)]
     [SupportedOSPlatform("windows")]
     internal static extern bool GetFileAttributesEx(String name, int fileInfoLevel, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    [SupportedOSPlatform("windows")]
+    private static extern bool GetFileInformationByHandleEx(
+        SafeFileHandle fileHandle,
+        FileInfoByHandleClass fileInfoByHandleClass,
+        [Out] IntPtr lpFileInformation,
+        int dwBufferSize);
+
+    [SupportedOSPlatform("windows")]
+    static bool GetFileAttributeTagInfoByHandle(SafeFileHandle fileHandle, out FileAttributeTagInfo fileAttributeTagInfo)
+    {
+        IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(FileAttributeTagInfo)));
+        try
+        {
+            bool ret = GetFileInformationByHandleEx(fileHandle, FileInfoByHandleClass.FileAttributeTagInfo, ptr, Marshal.SizeOf(typeof(FileAttributeTagInfo)));
+            if (ret)
+            {
+                fileAttributeTagInfo = (FileAttributeTagInfo)Marshal.PtrToStructure(ptr, typeof(FileAttributeTagInfo));
+            }
+            else
+            {
+                fileAttributeTagInfo = new FileAttributeTagInfo();
+            }
+
+            return ret;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+    }
+        
 
     [DllImport("kernel32.dll", PreserveSig = true, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1682,10 +1682,11 @@ internal static class NativeMethods
     [SupportedOSPlatform("windows")]
     static bool GetFileAttributeTagInfoByHandle(SafeFileHandle fileHandle, out FileAttributeTagInfo fileAttributeTagInfo)
     {
-        IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(FileAttributeTagInfo)));
+        int typeSize = Marshal.SizeOf(typeof(FileAttributeTagInfo));
+        IntPtr ptr = Marshal.AllocHGlobal(typeSize);
         try
         {
-            bool ret = GetFileInformationByHandleEx(fileHandle, FileInfoByHandleClass.FileAttributeTagInfo, ptr, Marshal.SizeOf(typeof(FileAttributeTagInfo)));
+            bool ret = GetFileInformationByHandleEx(fileHandle, FileInfoByHandleClass.FileAttributeTagInfo, ptr, typeSize);
             if (ret)
             {
                 fileAttributeTagInfo = (FileAttributeTagInfo)Marshal.PtrToStructure(ptr, typeof(FileAttributeTagInfo));


### PR DESCRIPTION
Fixes #6773

### Context

Original PR https://github.com/dotnet/msbuild/pull/8213 had imprecise implementation of `IsSymLink` - fixing this.
Details: https://github.com/dotnet/msbuild/pull/8213#discussion_r1061334252
Special thanks to @KalleOlaviNiemitalo for pointing out the issue and proposing remedy options.


### Changes Made

`IsSymLink` now uses `GetFileInformationByHandleEx` to obtain file attributes and detect symlink in case reparse point was detected.

### Testing

Cover by unit test added in original PR
