### PR TITLE
throw on netcoreapp5/6/7/8

### DIFF
--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Build.Evaluation
             var version = PlatformVersionProperty.GetValue(Parse(tfm)) as Version;
             if (version?.Major >= 5 && tfm.StartsWith("netcoreapp"))
             {
-                throw new InternalErrorException($"`netcoreapp` was replaced with `net` since v5: https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks. Use net{version.Major}.{version.Minor}."));
+                throw new InternalErrorException($"`netcoreapp` was replaced with `net` since v5: https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks. Use net{version.Major}.{version.Minor} instead of {tfm}."));
             }
             return GetNonZeroVersionParts(version, minVersionPartCount);
         }

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -78,6 +78,10 @@ namespace Microsoft.Build.Evaluation
         public string GetTargetPlatformVersion(string tfm, int minVersionPartCount)
         {
             var version = PlatformVersionProperty.GetValue(Parse(tfm)) as Version;
+            if (version?.Major >= 5 && tfm.StartsWith("netcoreapp"))
+            {
+                throw new InternalErrorException($"`netcoreapp` was replaced with `net` since v5: https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks. Use net{version.Major}.{version.Minor}."));
+            }
             return GetNonZeroVersionParts(version, minVersionPartCount);
         }
 

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Build.Evaluation
             var version = PlatformVersionProperty.GetValue(Parse(tfm)) as Version;
             if (version?.Major >= 5 && tfm.StartsWith("netcoreapp"))
             {
-                throw new InternalErrorException($"`netcoreapp` was replaced with `net` since v5: https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks. Use net{version.Major}.{version.Minor} instead of {tfm}."));
+                throw new InternalErrorException($"`netcoreapp` was replaced with `net` since v5: https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks. Use net{version.Major}.{version.Minor} instead of {tfm}.");
             }
             return GetNonZeroVersionParts(version, minVersionPartCount);
         }


### PR DESCRIPTION
netcoreapp was [replaced](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks) with net since v5. msbuild should stop supporting `<TargetFramework>netcoreapp7.0</TargetFramework>` etc. simply because it is wrong and easy to fix at user-end side