### PR TITLE
Update version to 17.6

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>17.6.0</VersionPrefix>
-    <PackageValidationBaselineVersion>17.4.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>17.5.0-preview-23059-01</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.5.0</VersionPrefix>
+    <VersionPrefix>17.6.0</VersionPrefix>
     <PackageValidationBaselineVersion>17.4.0</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>


### PR DESCRIPTION
Lot less to do without the build status messages!

Do you think we should update the PackageValidationBaselineVersion to 17.5.0?