### PR TITLE
Add Retries, RetryDelayMilliseconds parameters to Delete task

### DIFF
--- a/src/Tasks.UnitTests/Delete_Tests.cs
+++ b/src/Tasks.UnitTests/Delete_Tests.cs
@@ -70,10 +70,20 @@ namespace Microsoft.Build.UnitTests
 
                 // Do retries
                 ((MockEngine)t.BuildEngine).AssertLogContains("MSB3062");
+
+                File.SetAttributes(source, FileAttributes.Normal);
+                t = new Delete
+                {
+                    RetryDelayMilliseconds = 1,  // speed up tests!
+                    BuildEngine = new MockEngine(),
+                    Files = sourceFiles,
+                    Retries = 1,
+                };
+                t.Execute().ShouldBe(true);
+                ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3062");
             }
             finally
             {
-                File.SetAttributes(source, FileAttributes.Normal);
                 File.Delete(source);
             }
         }

--- a/src/Tasks.UnitTests/Delete_Tests.cs
+++ b/src/Tasks.UnitTests/Delete_Tests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Build.UnitTests
         /// Retry Delete
         /// </summary>
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void DeleteWithRetries()
         {
             string source = FileUtilities.GetTemporaryFile();

--- a/src/Tasks.UnitTests/Delete_Tests.cs
+++ b/src/Tasks.UnitTests/Delete_Tests.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 
 #nullable disable
@@ -33,6 +36,46 @@ namespace Microsoft.Build.UnitTests
 
             // Output ItemSpec should not be overwritten.
             Assert.Equal("MyFiles.nonexistent", t.DeletedFiles[0].ItemSpec);
+        }
+
+        /// <summary>
+        /// Retry Delete
+        /// </summary>
+        [Fact]
+        public void DeleteWithRetries()
+        {
+            string source = FileUtilities.GetTemporaryFile();
+            try
+            {
+                using (StreamWriter sw = FileUtilities.OpenWrite(source, true))
+                {
+                    sw.Write("This is a source file.");
+                }
+
+                File.SetAttributes(source, FileAttributes.ReadOnly);
+
+                ITaskItem sourceItem = new TaskItem(source);
+                ITaskItem[] sourceFiles = { sourceItem };
+
+                var t = new Delete
+                {
+                    RetryDelayMilliseconds = 1,  // speed up tests!
+                    BuildEngine = new MockEngine(),
+                    Files = sourceFiles,
+                    Retries = 1,
+                };
+
+                // Should fail since file is readonly
+                t.Execute().ShouldBe(false);
+
+                // Do retries
+                ((MockEngine)t.BuildEngine).AssertLogContains("MSB3062");
+            }
+            finally
+            {
+                File.SetAttributes(source, FileAttributes.Normal);
+                File.Delete(source);
+            }
         }
     }
 }

--- a/src/Tasks.UnitTests/Delete_Tests.cs
+++ b/src/Tasks.UnitTests/Delete_Tests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Retry Delete
+        /// Retry Delete. Specify windows since readonly not working on others
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
@@ -73,11 +73,12 @@ namespace Microsoft.Build.UnitTests
                 ((MockEngine)t.BuildEngine).AssertLogContains("MSB3062");
 
                 File.SetAttributes(source, FileAttributes.Normal);
+                ITaskItem[] duplicateSourceFiles = { sourceItem, sourceItem };
                 t = new Delete
                 {
                     RetryDelayMilliseconds = 1,  // speed up tests!
                     BuildEngine = new MockEngine(),
-                    Files = sourceFiles,
+                    Files = duplicateSourceFiles,
                     Retries = 1,
                 };
                 t.Execute().ShouldBe(true);

--- a/src/Tasks/Delete.cs
+++ b/src/Tasks/Delete.cs
@@ -121,6 +121,10 @@ namespace Microsoft.Build.Tasks
                             {
                                 Log.LogMessageFromResources(MessageImportance.Low, "Delete.SkippingNonexistentFile", file.ItemSpec);
                             }
+                            // keep a running list of the files that were actually deleted
+                            // note that we include in this list files that did not exist
+                            ITaskItem deletedFile = new TaskItem(file);
+                            deletedFilesList.Add(deletedFile);
                             break;
                         }
                     }
@@ -141,10 +145,6 @@ namespace Microsoft.Build.Tasks
                         }
                     }
                 }
-                // keep a running list of the files that were actually deleted
-                // note that we include in this list files that did not exist
-                ITaskItem deletedFile = new TaskItem(file);
-                deletedFilesList.Add(deletedFile);
 
                 // Add even on failure to avoid reattempting
                 deletedFilesSet.Add(file.ItemSpec);

--- a/src/Tasks/Delete.cs
+++ b/src/Tasks/Delete.cs
@@ -102,37 +102,34 @@ namespace Microsoft.Build.Tasks
 
             foreach (ITaskItem file in Files)
             {
-                // Break out of the infinite cycle in the following condition
-                // 1. succeed to delete the file
-                // 2. the file did not exist
-                // 3. deletedFilesSet contains the file
-                // 4. exceed the number of Retries
+                if (_canceling)
+                {
+                    DeletedFiles = deletedFilesList.ToArray();
+                    return false;
+                }
+
                 int retries = 0;
-                while (!_canceling)
+                while (!deletedFilesSet.Contains(file.ItemSpec))
                 {
                     try
                     {
-                        // For speed, eliminate duplicates caused by poor targets authoring
-                        if (!deletedFilesSet.Contains(file.ItemSpec))
+                        if (FileSystems.Default.FileExists(file.ItemSpec))
                         {
-                            if (FileSystems.Default.FileExists(file.ItemSpec))
-                            {
-                                // Do not log a fake command line as well, as it's superfluous, and also potentially expensive
-                                Log.LogMessageFromResources(MessageImportance.Normal, "Delete.DeletingFile", file.ItemSpec);
+                            // Do not log a fake command line as well, as it's superfluous, and also potentially expensive
+                            Log.LogMessageFromResources(MessageImportance.Normal, "Delete.DeletingFile", file.ItemSpec);
 
-                                File.Delete(file.ItemSpec);
-                            }
-                            else
-                            {
-                                Log.LogMessageFromResources(MessageImportance.Low, "Delete.SkippingNonexistentFile", file.ItemSpec);
-                            }
-                            // keep a running list of the files that were actually deleted
-                            // note that we include in this list files that did not exist
-                            ITaskItem deletedFile = new TaskItem(file);
-                            deletedFilesList.Add(deletedFile);
+                            File.Delete(file.ItemSpec);
                         }
-                        // Break when succeed to delete the file, the file did not exist or deletedFilesSet contains the file 
-                        break;
+                        else
+                        {
+                            Log.LogMessageFromResources(MessageImportance.Low, "Delete.SkippingNonexistentFile", file.ItemSpec);
+                        }
+                        // keep a running list of the files that were actually deleted
+                        // note that we include in this list files that did not exist
+                        ITaskItem deletedFile = new TaskItem(file);
+                        deletedFilesList.Add(deletedFile);
+                        // Avoid reattempting when succeed to delete and file doesn't exist.
+                        deletedFilesSet.Add(file.ItemSpec);
                     }
                     catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                     {
@@ -147,13 +144,11 @@ namespace Microsoft.Build.Tasks
                         else
                         {
                             LogError(file, e);
-                            break;
+                            // Add on failure to avoid reattempting
+                            deletedFilesSet.Add(file.ItemSpec);
                         }
                     }
                 }
-
-                // Add even on failure to avoid reattempting
-                deletedFilesSet.Add(file.ItemSpec);
             }
             // convert the list of deleted files into an array of ITaskItems
             DeletedFiles = deletedFilesList.ToArray();

--- a/src/Tasks/Delete.cs
+++ b/src/Tasks/Delete.cs
@@ -121,11 +121,7 @@ namespace Microsoft.Build.Tasks
                             {
                                 Log.LogMessageFromResources(MessageImportance.Low, "Delete.SkippingNonexistentFile", file.ItemSpec);
                             }
-
-                            // keep a running list of the files that were actually deleted
-                            // note that we include in this list files that did not exist
-                            ITaskItem deletedFile = new TaskItem(file);
-                            deletedFilesList.Add(deletedFile);
+                            break;
                         }
                     }
                     catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
@@ -144,9 +140,14 @@ namespace Microsoft.Build.Tasks
                             break;
                         }
                     }
-                    // Add even on failure to avoid reattempting
-                    deletedFilesSet.Add(file.ItemSpec);
                 }
+                // keep a running list of the files that were actually deleted
+                // note that we include in this list files that did not exist
+                ITaskItem deletedFile = new TaskItem(file);
+                deletedFilesList.Add(deletedFile);
+
+                // Add even on failure to avoid reattempting
+                deletedFilesSet.Add(file.ItemSpec);
             }
             // convert the list of deleted files into an array of ITaskItems
             DeletedFiles = deletedFilesList.ToArray();

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -369,6 +369,10 @@
   <data name="Delete.SkippingNonexistentFile">
     <value>File "{0}" doesn't exist. Skipping.</value>
   </data>
+  <data name="Delete.Retrying">
+    <value>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</value>
+    <comment>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</comment>
+  </data>
   <!--
         The Exec message bucket is: MSB3071 - MSB3080
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -373,6 +373,14 @@
     <value>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</value>
     <comment>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</comment>
   </data>
+  <data name="Delete.InvalidRetryCount">
+    <value>MSB3028: {0} is an invalid retry count. Value must not be negative.</value>
+    <comment>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</comment>
+  </data>
+  <data name="Delete.InvalidRetryDelay">
+    <value>MSB3029: {0} is an invalid retry delay. Value must not be negative.</value>
+    <comment>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</comment>
+  </data>
   <!--
         The Exec message bucket is: MSB3071 - MSB3080
 

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: Nelze odstranit soubor {0}. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Soubor {0} neexistuje. Bude vynechán.</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: Nelze odstranit soubor {0}. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: Die Datei "{0}" kann nicht gelöscht werden. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Die Datei "{0}" ist nicht vorhanden. Sie wird übersprungen.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: Die Datei "{0}" kann nicht gelöscht werden. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: No se puede eliminar el archivo "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: No se puede eliminar el archivo "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">El archivo"{0}" no existe. Se omitirá.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: Impossible de supprimer le fichier "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: Impossible de supprimer le fichier "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Le fichier "{0}" n'existe pas. Opération ignorée.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: non è possibile eliminare il file "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Il file "{0}" non esiste e verrà ignorato.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: non è possibile eliminare il file "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: ファイル "{0}" を削除できません。{1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: ファイル "{0}" を削除できません。{1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">ファイル "{0}" は存在しません。省略します。</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: "{0}" 파일을 삭제할 수 없습니다. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">"{0}" 파일이 없습니다. 건너뜁니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: "{0}" 파일을 삭제할 수 없습니다. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: Nie można usunąć pliku „{0}”. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Plik „{0}” nie istnieje. Operacja zostanie pominięta.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: Nie można usunąć pliku „{0}”. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: Não é possível excluir o arquivo "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: Não é possível excluir o arquivo "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">O arquivo "{0}" não existe. Ignorando.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: Не удается удалить файл "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Файл "{0}" не существует. Пропускается.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: Не удается удалить файл "{0}". {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: "{0}" dosyası silinemiyor. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: "{0}" dosyası silinemiyor. {1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">"{0}" dosyası yok. Atlanıyor.</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: 无法删除文件“{0}”。{1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">文件“{0}”不存在。正在跳过。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: 无法删除文件“{0}”。{1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -301,6 +301,16 @@
         <target state="translated">MSB3061: 無法刪除檔案 "{0}"。{1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Delete.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
       <trans-unit id="Delete.Retrying">
         <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
         <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -301,6 +301,11 @@
         <target state="translated">MSB3061: 無法刪除檔案 "{0}"。{1}</target>
         <note>{StrBegin="MSB3061: "}</note>
       </trans-unit>
+      <trans-unit id="Delete.Retrying">
+        <source>MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3062: Could not delete file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3062: "} LOCALIZATION: {0} are paths. {1} and {2} are numbers. {3} is an optional localized message.</note>
+      </trans-unit>
       <trans-unit id="Delete.SkippingNonexistentFile">
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">檔案 "{0}" 不存在。即將略過。</target>


### PR DESCRIPTION
Fixes [#199](https://github.com/dotnet/msbuild/issues/199)

### Changes Made
Add Retries which default value is 0 and RetryDelayMilliseconds default value is 1000ms properties. Initialize local value  retries, add while condition to reach the maximum Retries.

### Testing
Unit test DeleteWithRetries()

