### PR TITLE
Allow to set empty string for XmlPoke Value

### DIFF
--- a/src/Tasks.UnitTests/XmlPoke_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPoke_Tests.cs
@@ -174,16 +174,26 @@ namespace Microsoft.Build.UnitTests
         public void XmlPokeWithEmptyValue()
         {
             string xmlInputPath;
+            string query = "//class/variable/@Name";
             Prepare(_xmlFileNoNs, out xmlInputPath);
-            string projectContents = @"
+            string projectContents = $"""
                 <Project ToolsVersion='msbuilddefaulttoolsversion'>
                 <Target Name='Poke'>
-                    <XmlPoke Value='' Query='//class/variable/@Name' XmlInputPath='{0}'/>
+                    <XmlPoke Value='' Query='{query}' XmlInputPath='{xmlInputPath}'/>
                 </Target>
-                </Project>";
-            projectContents = string.Format(projectContents, xmlInputPath);
+                </Project>
+                """;
 
             ObjectModelHelpers.BuildProjectExpectSuccess(projectContents);
+
+            string result = File.ReadAllText(xmlInputPath);
+            XmlDocument xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml(result);
+            List<XmlAttribute> nodes = xmlDocument.SelectNodes(query)?.Cast<XmlAttribute>().ToList();
+            foreach (var node in nodes)
+            {
+                node.Value.ShouldBe(string.Empty);
+            }
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/XmlPoke_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPoke_Tests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Build.UnitTests
             string xmlInputPath;
             Prepare(_xmlFileNoNs, out xmlInputPath);
 
-            for (int i = 0; i < 8; i++)
+            for (int i = 0; i < 4; i++)
             {
                 XmlPoke p = new XmlPoke();
                 p.BuildEngine = engine;
@@ -157,13 +157,8 @@ namespace Microsoft.Build.UnitTests
                     p.Query = "//variable/@Name";
                 }
 
-                if ((i & 4) == 4)
-                {
-                    p.Value = new TaskItem("Mert");
-                }
-
-                // "Expecting argumentnullexception for the first 7 tests"
-                if (i < 7)
+                // "Expecting argumentnullexception for the first 3 tests"
+                if (i < 3)
                 {
                     Should.Throw<ArgumentNullException>(() => p.Execute());
                 }
@@ -172,6 +167,23 @@ namespace Microsoft.Build.UnitTests
                     Should.NotThrow(() => p.Execute());
                 }
             }
+        }
+
+        [Fact]
+        // https://github.com/dotnet/msbuild/issues/5814
+        public void XmlPokeWithEmptyValue()
+        {
+            string xmlInputPath;
+            Prepare(_xmlFileNoNs, out xmlInputPath);
+            string projectContents = @"
+                <Project ToolsVersion='msbuilddefaulttoolsversion'>
+                <Target Name='Poke'>
+                    <XmlPoke Value='' Query='//class/variable/@Name' XmlInputPath='{0}'/>
+                </Target>
+                </Project>";
+            projectContents = string.Format(projectContents, xmlInputPath);
+
+            ObjectModelHelpers.BuildProjectExpectSuccess(projectContents);
         }
 
         [Fact]

--- a/src/Tasks/XmlPoke.cs
+++ b/src/Tasks/XmlPoke.cs
@@ -8,6 +8,7 @@ using System.Xml.XPath;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
 
 #nullable disable
 
@@ -68,16 +69,10 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// The value to be inserted into the specified location.
-        /// </summary>
-        [Required]
+        /// </summary>        
         public ITaskItem Value
         {
-            get
-            {
-                ErrorUtilities.VerifyThrowArgumentNull(_value, nameof(Value));
-                return _value;
-            }
-
+            get => _value;
             set => _value = value;
         }
 
@@ -95,8 +90,12 @@ namespace Microsoft.Build.Tasks
         public override bool Execute()
         {
             ErrorUtilities.VerifyThrowArgumentNull(_query, "Query");
-            ErrorUtilities.VerifyThrowArgumentNull(_value, "Value");
             ErrorUtilities.VerifyThrowArgumentNull(_xmlInputPath, "XmlInputPath");
+            if (_value == null)
+            {
+                // When Value is null, it means Value is not set or empty. Here we treat them all as empty.
+                _value = new TaskItem(String.Empty);
+            }
 
             // Load the XPath Document
             XmlDocument xmlDoc = new XmlDocument();

--- a/src/Tasks/XmlPoke.cs
+++ b/src/Tasks/XmlPoke.cs
@@ -31,11 +31,6 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private string _query;
 
-        /// <summary>
-        /// The property that this task will set.
-        /// </summary>
-        private ITaskItem _value;
-
         #endregion
 
         #region Properties
@@ -70,11 +65,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The value to be inserted into the specified location.
         /// </summary>        
-        public ITaskItem Value
-        {
-            get => _value;
-            set => _value = value;
-        }
+        public ITaskItem Value { get; set; }
 
         /// <summary>
         /// The namespaces for XPath query's prefixes.
@@ -91,10 +82,10 @@ namespace Microsoft.Build.Tasks
         {
             ErrorUtilities.VerifyThrowArgumentNull(_query, "Query");
             ErrorUtilities.VerifyThrowArgumentNull(_xmlInputPath, "XmlInputPath");
-            if (_value == null)
+            if (Value == null)
             {
                 // When Value is null, it means Value is not set or empty. Here we treat them all as empty.
-                _value = new TaskItem(String.Empty);
+                Value = new TaskItem(String.Empty);
             }
 
             // Load the XPath Document
@@ -163,12 +154,12 @@ namespace Microsoft.Build.Tasks
                 try
                 {
                     count++;
-                    iter.Current.InnerXml = _value.ItemSpec;
-                    Log.LogMessageFromResources(MessageImportance.Low, "XmlPoke.Replaced", iter.Current.Name, _value.ItemSpec);
+                    iter.Current.InnerXml = Value.ItemSpec;
+                    Log.LogMessageFromResources(MessageImportance.Low, "XmlPoke.Replaced", iter.Current.Name, Value.ItemSpec);
                 }
                 catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
                 {
-                    Log.LogErrorWithCodeFromResources("XmlPoke.PokeError", _value.ItemSpec, e.Message);
+                    Log.LogErrorWithCodeFromResources("XmlPoke.PokeError", Value.ItemSpec, e.Message);
                     return false;
                 }
             }


### PR DESCRIPTION
Fixes [#5814](https://github.com/dotnet/msbuild/issues/5814)

### Context
Can't pass empty string to XmlPoke task.

### Changes Made
Remove the required attribute for Value and the exception when value is null.

### Testing
Unit test XmlPokeWithEmptyValue()
