### PR TITLE
Handle symlinks embedding into binlogs - approach #2

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Build.UnitTests
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkName));
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkLvl2Name));
-            zipArchive.Entries.ShouldNotContain(zE => zE.Name.EndsWith(emptyFileName));
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(emptyFileName));
         }
 
         [Fact]

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -213,11 +213,13 @@ namespace Microsoft.Build.UnitTests
             string testFileName = "foobar.txt";
             string symlinkName = "symlink1.txt";
             string symlinkLvl2Name = "symlink2.txt";
+            string emptyFileName = "empty.txt";
             TransientTestFolder testFolder = _env.DefaultTestDirectory.CreateDirectory("TestDir");
             TransientTestFolder testFolder2 = _env.DefaultTestDirectory.CreateDirectory("TestDir2");
             TransientTestFile testFile = testFolder.CreateFile(testFileName, string.Join(Environment.NewLine, new[] { "123", "456" }));
             string symlinkPath = Path.Combine(testFolder2.Path, symlinkName);
             string symlinkLvl2Path = Path.Combine(testFolder2.Path, symlinkLvl2Name);
+            string emptyFile = testFolder.CreateFile(emptyFileName).Path;
 
             string errorMessage = string.Empty;
             Assert.True(NativeMethodsShared.MakeSymbolicLink(symlinkPath, testFile.Path, ref errorMessage), errorMessage);
@@ -248,9 +250,12 @@ namespace Microsoft.Build.UnitTests
         <CreateItem Include=""{1}"">
             <Output TaskParameter=""Include"" ItemName=""EmbedInBinlog"" />
         </CreateItem>
+        <CreateItem Include=""{2}"">
+            <Output TaskParameter=""Include"" ItemName=""EmbedInBinlog"" />
+        </CreateItem>
     </Target>
 </Project>";
-            var testProject = string.Format(testProjectFmt, symlinkPath, symlinkLvl2Path);
+            var testProject = string.Format(testProjectFmt, symlinkPath, symlinkLvl2Path, emptyFile);
             ObjectModelHelpers.BuildProjectExpectSuccess(testProject, binaryLogger);
             var projectImportsZipPath = Path.ChangeExtension(_logFile, ".ProjectImports.zip");
             using var fileStream = new FileStream(projectImportsZipPath, FileMode.Open);
@@ -261,6 +266,7 @@ namespace Microsoft.Build.UnitTests
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkName));
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkLvl2Name));
+            zipArchive.Entries.ShouldNotContain(zE => zE.Name.EndsWith(emptyFileName));
         }
 
         [Fact]

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -145,11 +145,8 @@ namespace Microsoft.Build.Logging
             }
 
             using FileStream content = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
-            if (content.Length > 0)
-            {
-                using Stream entryStream = OpenArchiveEntry(filePath);
-                content.CopyTo(entryStream);
-            }
+            using Stream entryStream = OpenArchiveEntry(filePath);
+            content.CopyTo(entryStream);
         }
 
         /// <remarks>

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            if (!NativeMethodsShared.ExistAndHasContent(filePath))
+            if (!File.Exists(filePath))
             {
                 _processedFiles.Add(filePath);
                 return;
@@ -144,9 +144,12 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            using Stream entryStream = OpenArchiveEntry(filePath);
             using FileStream content = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
-            content.CopyTo(entryStream);
+            if (content.Length > 0)
+            {
+                using Stream entryStream = OpenArchiveEntry(filePath);
+                content.CopyTo(entryStream);
+            }
         }
 
         /// <remarks>

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1041,99 +1041,6 @@ internal static class NativeMethods
         return null;
     }
 
-    internal static bool ExistAndHasContent(string path)
-    {
-        var fileInfo = new FileInfo(path);
-
-        // File exist and has some content
-        return fileInfo.Exists &&
-               (fileInfo.Length > 0 ||
-                    // Or final destination of the link is nonempty file
-                    (
-                        IsSymLink(fileInfo) &&
-                        TryGetFinalLinkTarget(fileInfo, out string finalTarget, out _) &&
-                        File.Exists(finalTarget) &&
-                        new FileInfo(finalTarget).Length > 0
-                    )
-               );
-    }
-
-    internal static bool IsSymLink(FileInfo fileInfo)
-    {
-#if NET
-        return fileInfo.Exists && !string.IsNullOrEmpty(fileInfo.LinkTarget);
-#else
-        if (!IsWindows)
-        {
-            return false;
-        }
-
-        WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
-
-        return NativeMethods.GetFileAttributesEx(fileInfo.FullName, 0, ref data) &&
-               (data.fileAttributes & NativeMethods.FILE_ATTRIBUTE_DIRECTORY) == 0 &&
-               (data.fileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == FILE_ATTRIBUTE_REPARSE_POINT;
-#endif
-    }
-
-    internal static bool IsSymLink(string path)
-    {
-        return IsSymLink(new FileInfo(path));
-    }
-
-    internal static bool TryGetFinalLinkTarget(FileInfo fileInfo, out string finalTarget, out string errorMessage)
-    {
-        if (!IsWindows)
-        {
-            errorMessage = null;
-#if NET
-            while(!string.IsNullOrEmpty(fileInfo.LinkTarget))
-            {
-                fileInfo = new FileInfo(fileInfo.LinkTarget);
-            }
-            finalTarget = fileInfo.FullName;
-            return true;
-#else
-
-            finalTarget = null;
-            return false;
-#endif
-        }
-
-        using SafeFileHandle handle = OpenFileThroughSymlinks(fileInfo.FullName);
-        if (handle.IsInvalid)
-        {
-            // Link is broken.
-            errorMessage = Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()).Message;
-            finalTarget = null;
-            return false;
-        }
-
-        const int initialBufferSize = 4096;
-        char[] targetPathBuffer = new char[initialBufferSize];
-        uint result = GetFinalPathNameByHandle(handle, targetPathBuffer);
-
-        // Buffer too small
-        if (result > targetPathBuffer.Length)
-        {
-            targetPathBuffer = new char[(int)result];
-            result = GetFinalPathNameByHandle(handle, targetPathBuffer);
-        }
-
-        // Error
-        if (result == 0)
-        {
-            errorMessage = Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()).Message;
-            finalTarget = null;
-            return false;
-        }
-
-        // Normalize \\?\ and \??\ syntax.
-        finalTarget = new string(targetPathBuffer, 0, (int)result).TrimStart(new char[] { '\\', '?' });
-        errorMessage = null;
-        return true;
-    }
-
     internal static bool MakeSymbolicLink(string newFileName, string exitingFileName, ref string errorMessage)
     {
         bool symbolicLinkCreated;
@@ -1775,20 +1682,6 @@ internal static class NativeMethods
 
     [DllImport("libc", SetLastError = true)]
     internal static extern int symlink(string oldpath, string newpath);
-
-    internal const uint FILE_NAME_NORMALIZED = 0x0;
-
-    [SupportedOSPlatform("windows")]
-    static uint GetFinalPathNameByHandle(SafeFileHandle fileHandle, char[] filePath) =>
-        GetFinalPathNameByHandle(fileHandle, filePath, (uint) filePath.Length, FILE_NAME_NORMALIZED);
-
-    [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-    [SupportedOSPlatform("windows")]
-    static extern uint GetFinalPathNameByHandle(
-        SafeFileHandle hFile,
-        [Out] char[] lpszFilePath,
-        uint cchFilePath,
-        uint dwFlags);
 
     #endregion
 


### PR DESCRIPTION
Fixes #6773

### Context
Supersedes #8213 and  #8282
Symlinked files were not embedded into binlog - previous solution was too much focused on symlinks and hence requried nontrivial code to properly distinguish aymlinks with available contnet.

Alternate approach - proceed with adding file as soon as it has available content


### Testing
Preexisting unit test is excercising the scenario. Added a case for empty file - that still should not be added.
