### PR TITLE
Use GetTemporaryFileName over GetTemporaryFile to avoid extraneous i/o

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ProjectFormatting_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectFormatting_Tests.cs
@@ -653,7 +653,7 @@ namespace Microsoft.Build.Engine.OM.UnitTests.Construction
             content += @"<Project><Target Name=""Build""/></Project>";
             content = ObjectModelHelpers.CleanupFileContents(content);
 
-            var file = FileUtilities.GetTemporaryFile(".proj");
+            var file = FileUtilities.GetTemporaryFileName(".proj");
             try
             {
                 File.WriteAllText(file, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: byteOrderMark));

--- a/src/Build.OM.UnitTests/Construction/ProjectImportElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectImportElement_Tests.cs
@@ -163,12 +163,12 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             try
             {
-                file1 = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                file1 = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                 ProjectRootElement importProject1 = ProjectRootElement.Create();
                 importProject1.AddProperty("p", "v1");
                 importProject1.Save(file1);
 
-                file2 = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                file2 = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                 ProjectRootElement importProject2 = ProjectRootElement.Create();
                 importProject2.AddProperty("p", "v2");
                 importProject2.Save(file2);
@@ -208,7 +208,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             try
             {
-                file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                 ProjectRootElement importProject = ProjectRootElement.Create();
                 importProject.AddProperty("p", "v1");
                 importProject.Save(file);

--- a/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ConstructOverSameFileReturnsSame()
         {
             ProjectRootElement projectXml1 = ProjectRootElement.Create();
-            projectXml1.Save(FileUtilities.GetTemporaryFile());
+            projectXml1.Save(FileUtilities.GetTemporaryFileName());
 
             ProjectRootElement projectXml2 = ProjectRootElement.Open(projectXml1.FullPath);
 
@@ -429,7 +429,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 {
                     try
                     {
-                        path = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                        path = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                         File.WriteAllText(path, content);
 
                         ProjectRootElement.Open(path);
@@ -462,7 +462,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             try
             {
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
                 File.WriteAllText(path, content);
 
                 var reader1 = XmlReader.Create(path);
@@ -499,7 +499,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             try
             {
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
                 File.WriteAllText(path, content);
 
                 ProjectRootElement root1 = ProjectRootElement.Create(path);
@@ -605,7 +605,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             try
             {
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
 
                 project.Save(file);
 
@@ -730,7 +730,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         [Fact]
         public void EncodingGetterBasedOnActualEncodingWhenXmlDeclarationIsAbsent()
         {
-            string projectFullPath = FileUtilities.GetTemporaryFile();
+            string projectFullPath = FileUtilities.GetTemporaryFileName();
             try
             {
                 VerifyLoadedProjectHasEncoding(projectFullPath, Encoding.UTF8);
@@ -996,7 +996,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
                 try
                 {
-                    solutionFile = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                    solutionFile = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
 
                     // Arbitrary corrupt content
                     string content = @"Microsoft Visual Studio Solution File, Format Version 10.00

--- a/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
@@ -1064,7 +1064,7 @@ namespace Microsoft.Build.UnitTests.Construction
         private static SolutionFile ParseSolutionHelper(string solutionFileContents)
         {
             solutionFileContents = solutionFileContents.Replace('\'', '"');
-            string solutionPath = FileUtilities.GetTemporaryFile(".sln");
+            string solutionPath = FileUtilities.GetTemporaryFileName(".sln");
 
             try
             {

--- a/src/Build.OM.UnitTests/Construction/WhiteSpacePreservation_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/WhiteSpacePreservation_Tests.cs
@@ -462,7 +462,7 @@ multi-line comment here
             // Using streams can cause issues with CRLF characters being replaced by LF going in to
             // ProjectRootElement. Saving to disk mimics the real-world behavior so we can specifically
             // test issues with CRLF characters being normalized. Related issue: #1340
-            var file = FileUtilities.GetTemporaryFile();
+            var file = FileUtilities.GetTemporaryFileName();
             var expected = ObjectModelHelpers.CleanupFileContents(updatedProject);
             string actual;
 

--- a/src/Build.OM.UnitTests/Definition/ProjectCollection_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectCollection_Tests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
                 ProjectRootElement xml = ProjectRootElement.Create(path);
                 xml.Save();
 
@@ -95,7 +95,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 Project project = new Project();
                 Assert.Equal(0, ProjectCollection.GlobalProjectCollection.Count);
 
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
                 project.Save(path);
 
                 Project project2 = ProjectCollection.GlobalProjectCollection.LoadProject(path);
@@ -124,7 +124,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 ProjectCollection collection = new ProjectCollection();
                 Project project = new Project(collection);
 
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
                 project.Save(path);
 
                 Project project2 = collection.LoadProject(path);
@@ -293,7 +293,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
                 ProjectRootElement xml = ProjectRootElement.Create();
                 xml.Save(path);
                 Assert.Equal(0, ProjectCollection.GlobalProjectCollection.Count);
@@ -337,7 +337,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
                 ProjectRootElement.Create(path).Save();
 
                 ProjectCollection collection1 = new ProjectCollection();
@@ -823,8 +823,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                file1 = FileUtilities.GetTemporaryFile();
-                file2 = FileUtilities.GetTemporaryFile();
+                file1 = FileUtilities.GetTemporaryFileName();
+                file2 = FileUtilities.GetTemporaryFileName();
 
                 Project project = new Project();
                 project.Save(file1);
@@ -855,8 +855,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                file1 = FileUtilities.GetTemporaryFile();
-                file2 = FileUtilities.GetTemporaryFile();
+                file1 = FileUtilities.GetTemporaryFileName();
+                file2 = FileUtilities.GetTemporaryFileName();
 
                 var project = new Project();
                 project.Save(file1);
@@ -891,8 +891,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                file1 = FileUtilities.GetTemporaryFile();
-                file2 = FileUtilities.GetTemporaryFile();
+                file1 = FileUtilities.GetTemporaryFileName();
+                file2 = FileUtilities.GetTemporaryFileName();
 
                 var project = new Project();
                 project.Save(file1);
@@ -1433,7 +1433,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         private static string CreateProjectFile()
         {
             ProjectRootElement xml = ProjectRootElement.Create();
-            string path = FileUtilities.GetTemporaryFile();
+            string path = FileUtilities.GetTemporaryFileName();
             xml.Save(path);
             return path;
         }

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                path = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                path = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                 File.WriteAllText(path, String.Empty);
                 FileInfo info = new FileInfo(path);
 
@@ -2063,7 +2063,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 try
                 {
-                    file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                    file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                     Project import = new Project();
                     import.AddItem("i", "i1");
                     import.Save(file);
@@ -2095,7 +2095,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 try
                 {
-                    file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                    file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                     Project import = new Project();
                     import.AddItem("i", "i1");
                     import.Save(file);
@@ -2127,7 +2127,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 try
                 {
-                    file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                    file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                     Project import = new Project();
                     ProjectItem item = import.AddItem("i", "i1")[0];
                     item.SetMetadataValue("m", "m0");

--- a/src/Build.OM.UnitTests/Definition/ProjectProperty_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectProperty_Tests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 try
                 {
-                    file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                    file = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                     Project import = new Project();
                     import.SetProperty("p", "v0");
                     import.Save(file);

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
 
                 string content = GetSampleProjectContent();
                 File.WriteAllText(file, content);
@@ -413,7 +413,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 Project project = new Project(collection);
                 project.Xml.AddImport("$(MSBuildProjectFullPath)");
 
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
                 project.Save(file);
                 project.ReevaluateIfNecessary();
 
@@ -440,8 +440,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 MockLogger logger = new MockLogger();
                 collection.RegisterLogger(logger);
 
-                file = FileUtilities.GetTemporaryFile();
-                file2 = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
+                file2 = FileUtilities.GetTemporaryFileName();
                 Project project = new Project(collection);
                 project.Xml.AddImport(file2);
                 project.Save(file);
@@ -476,8 +476,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 MockLogger logger = new MockLogger();
                 collection.RegisterLogger(logger);
 
-                file = FileUtilities.GetTemporaryFile();
-                file2 = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
+                file2 = FileUtilities.GetTemporaryFileName();
                 Project project = new Project(collection);
                 project.Xml.AddImport(file2);
                 project.Xml.AddImport(file2);
@@ -513,9 +513,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 MockLogger logger = new MockLogger();
                 collection.RegisterLogger(logger);
 
-                file = FileUtilities.GetTemporaryFile();
-                file2 = FileUtilities.GetTemporaryFile();
-                file3 = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
+                file2 = FileUtilities.GetTemporaryFileName();
+                file3 = FileUtilities.GetTemporaryFileName();
 
                 Project project = new Project(collection);
                 project.Xml.AddImport(file2);
@@ -649,7 +649,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
                 project.Save(file);
                 project.ReevaluateIfNecessary();
 
@@ -1359,7 +1359,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
                 ProjectRootElement.Create().Save(path);
 
                 Project project = new Project(path);
@@ -1387,7 +1387,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             try
             {
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
                 ProjectRootElement import = ProjectRootElement.Create(path);
                 import.Save();
 
@@ -2080,7 +2080,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 ObjectModelHelpers.CleanupFileContents(@"<Project xmlns='msbuildnamespace'>
                 </Project>");
 
-            string importFileName = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile() + ".proj";
+            string importFileName = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName() + ".proj";
             File.WriteAllText(importFileName, importProjectContent);
 
             string projectContent =
@@ -2180,7 +2180,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             string file = null;
             try
             {
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
                 project.Save(file);
             }
             finally

--- a/src/Build.OM.UnitTests/Definition/ProtectImports_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProtectImports_Tests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 </Project>";
 
             importContents = Expand(importContents);
-            _importFilename = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile() + ".targets";
+            _importFilename = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName() + ".targets";
             File.WriteAllText(_importFilename, importContents);
         }
 

--- a/src/Build.OM.UnitTests/Instance/ProjectTargetInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectTargetInstance_Tests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
             try
             {
-                path = Microsoft.Build.Shared.FileUtilities.GetTemporaryFile();
+                path = Microsoft.Build.Shared.FileUtilities.GetTemporaryFileName();
                 ProjectRootElement projectXml = ProjectRootElement.Create(path);
                 projectXml.Save();
 

--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -3325,7 +3325,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             try
             {
-                importedFile = FileUtilities.GetTemporaryFile();
+                importedFile = FileUtilities.GetTemporaryFileName();
                 File.WriteAllText(importedFile, ObjectModelHelpers.CleanupFileContents(@"
                 <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
                   <ItemGroup>
@@ -3363,7 +3363,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             try
             {
-                importedFile = FileUtilities.GetTemporaryFile();
+                importedFile = FileUtilities.GetTemporaryFileName();
                 File.WriteAllText(importedFile, ObjectModelHelpers.CleanupFileContents(@"
                 <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
                   <ItemGroup>

--- a/src/Build.UnitTests/BackEnd/TargetUpToDateChecker_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetUpToDateChecker_Tests.cs
@@ -872,28 +872,28 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 if (input1Time != null)
                 {
-                    input1 = FileUtilities.GetTemporaryFile();
+                    input1 = FileUtilities.GetTemporaryFileName();
                     File.WriteAllText(input1, String.Empty);
                     File.SetLastWriteTime(input1, (DateTime)input1Time);
                 }
 
                 if (input2Time != null)
                 {
-                    input2 = FileUtilities.GetTemporaryFile();
+                    input2 = FileUtilities.GetTemporaryFileName();
                     File.WriteAllText(input2, String.Empty);
                     File.SetLastWriteTime(input2, (DateTime)input2Time);
                 }
 
                 if (output1Time != null)
                 {
-                    output1 = FileUtilities.GetTemporaryFile();
+                    output1 = FileUtilities.GetTemporaryFileName();
                     File.WriteAllText(output1, String.Empty);
                     File.SetLastWriteTime(output1, (DateTime)output1Time);
                 }
 
                 if (output2Time != null)
                 {
-                    output2 = FileUtilities.GetTemporaryFile();
+                    output2 = FileUtilities.GetTemporaryFileName();
                     File.WriteAllText(output2, String.Empty);
                     File.SetLastWriteTime(output2, (DateTime)output2Time);
                 }

--- a/src/Build.UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/Build.UnitTests/Construction/ElementLocation_Tests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Build.UnitTests.Construction
             var doc = new XmlDocumentWithLocation(loadAsReadOnly: true);
             doc.Load(_pathToCommonTargets);
             Assert.True(doc.IsReadOnly);
-            using (XmlWriter wr = XmlWriter.Create(new FileStream(FileUtilities.GetTemporaryFile(), FileMode.Create)))
+            using (XmlWriter wr = XmlWriter.Create(new FileStream(FileUtilities.GetTemporaryFileName(), FileMode.Create)))
             {
                 Assert.Throws<InvalidOperationException>(() =>
                 {
@@ -421,7 +421,7 @@ namespace Microsoft.Build.UnitTests.Construction
 
             try
             {
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
                 File.WriteAllText(file, content);
                 var doc = new XmlDocumentWithLocation(loadAsReadOnly: readOnly);
                 doc.Load(file);

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -1947,8 +1947,7 @@ EndGlobal
         [Trait("Category", "mono-osx-failing")]
         public void TestSkipInvalidConfigurationsCase()
         {
-            string tmpFileName = FileUtilities.GetTemporaryFile();
-            File.Delete(tmpFileName);
+            string tmpFileName = FileUtilities.GetTemporaryFileName();
             string projectFilePath = tmpFileName + ".sln";
 
             string solutionContents =
@@ -2024,8 +2023,7 @@ EndGlobal
         [Fact(Skip = "https://github.com/dotnet/msbuild/issues/515")]
         public void BadFrameworkMonkierExpectBuildToFail()
         {
-            string tmpFileName = FileUtilities.GetTemporaryFile();
-            File.Delete(tmpFileName);
+            string tmpFileName = FileUtilities.GetTemporaryFileName();
             string projectFilePath = tmpFileName + ".sln";
 
             string solutionFileContents =
@@ -2112,8 +2110,7 @@ EndGlobal
         [Fact(Skip = "https://github.com/dotnet/msbuild/issues/515")]
         public void BadFrameworkMonkierExpectBuildToFail2()
         {
-            string tmpFileName = FileUtilities.GetTemporaryFile();
-            File.Delete(tmpFileName);
+            string tmpFileName = FileUtilities.GetTemporaryFileName();
             string projectFilePath = tmpFileName + ".sln";
 
             string solutionFileContents =
@@ -2200,8 +2197,7 @@ EndGlobal
         [Fact]
         public void TestTargetFrameworkVersionGreaterThan4()
         {
-            string tmpFileName = FileUtilities.GetTemporaryFile();
-            File.Delete(tmpFileName);
+            string tmpFileName = FileUtilities.GetTemporaryFileName();
             string projectFilePath = tmpFileName + ".sln";
 
             string solutionFileContents =

--- a/src/Build.UnitTests/Definition/ItemDefinitionGroup_Tests.cs
+++ b/src/Build.UnitTests/Definition/ItemDefinitionGroup_Tests.cs
@@ -1188,7 +1188,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
             try
             {
-                importedFile = FileUtilities.GetTemporaryFile();
+                importedFile = FileUtilities.GetTemporaryFileName();
                 File.WriteAllText(importedFile, @"
                 <Project ToolsVersion='msbuilddefaulttoolsversion'>
                   <ItemDefinitionGroup>
@@ -1710,7 +1710,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
             try
             {
-                otherProject = FileUtilities.GetTemporaryFile();
+                otherProject = FileUtilities.GetTemporaryFileName();
                 string otherProjectContent = @"<Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'/>
@@ -1766,7 +1766,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
             try
             {
-                otherProject = FileUtilities.GetTemporaryFile();
+                otherProject = FileUtilities.GetTemporaryFileName();
                 string otherProjectContent = @"<Project ToolsVersion=""msbuilddefaulttoolsversion"">
                   <ItemGroup>
                     <i Include='i1'>

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -788,7 +788,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             try
             {
-                importPath = FileUtilities.GetTemporaryFile();
+                importPath = FileUtilities.GetTemporaryFileName();
 
                 string import = ObjectModelHelpers.CleanupFileContents(@"
                     <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns='msbuildnamespace' >
@@ -850,9 +850,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             try
             {
-                importPath = FileUtilities.GetTemporaryFile();
-                importPath2 = FileUtilities.GetTemporaryFile();
-                importPath3 = FileUtilities.GetTemporaryFile();
+                importPath = FileUtilities.GetTemporaryFileName();
+                importPath2 = FileUtilities.GetTemporaryFileName();
+                importPath3 = FileUtilities.GetTemporaryFileName();
 
                 string import = ObjectModelHelpers.CleanupFileContents(@"
                     <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns='msbuildnamespace' >
@@ -926,8 +926,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             try
             {
-                importPath1 = FileUtilities.GetTemporaryFile();
-                importPath2 = FileUtilities.GetTemporaryFile();
+                importPath1 = FileUtilities.GetTemporaryFileName();
+                importPath2 = FileUtilities.GetTemporaryFileName();
 
                 // "import1" imports "import2" and vice versa.
                 string import1 = ObjectModelHelpers.CleanupFileContents(@"
@@ -986,8 +986,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 try
                 {
-                    importPath1 = FileUtilities.GetTemporaryFile();
-                    importPath2 = FileUtilities.GetTemporaryFile();
+                    importPath1 = FileUtilities.GetTemporaryFileName();
+                    importPath2 = FileUtilities.GetTemporaryFileName();
 
                     // "import1" imports "import2" and vice versa.
                     string import1 = ObjectModelHelpers.CleanupFileContents(@"
@@ -1761,7 +1761,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 ProjectRootElement import = ProjectRootElement.Create();
                 import.AddItemDefinition("i").AddMetadata("m", "%(m);m1");
 
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
                 import.Save(file);
 
                 string content = ObjectModelHelpers.CleanupFileContents(@"
@@ -1907,7 +1907,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             try
             {
                 // Should include imported items
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
                 ProjectRootElement import = ProjectRootElement.Create(file);
                 import.AddItem("i", "i10");
                 import.Save();
@@ -1991,7 +1991,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             try
             {
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
                 ProjectRootElement import = ProjectRootElement.Create(file);
                 import.AddProperty("p", "0").Condition = "false";
                 import.AddProperty("p", "1");

--- a/src/Build.UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             {
                 ProjectRootElementCache cache = new ProjectRootElementCache(true /* auto reload from disk */);
 
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
 
                 ProjectRootElement xml0 = ProjectRootElement.Create(path);
                 xml0.Save();
@@ -151,7 +151,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
             {
                 ProjectRootElementCache cache = new ProjectRootElementCache(false /* do not auto reload from disk */);
 
-                path = FileUtilities.GetTemporaryFile();
+                path = FileUtilities.GetTemporaryFileName();
 
                 ProjectRootElement xml0 = ProjectRootElement.Create(path);
                 xml0.Save();

--- a/src/Build.UnitTests/Evaluation/ProjectStringCache_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectStringCache_Tests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
                     </Project>
                     ");
 
-                string path = FileUtilities.GetTemporaryFile();
+                string path = FileUtilities.GetTemporaryFileName();
 
                 try
                 {
@@ -100,7 +100,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
                     </Project>
                     ");
 
-                string path = FileUtilities.GetTemporaryFile();
+                string path = FileUtilities.GetTemporaryFileName();
 
                 try
                 {
@@ -176,7 +176,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
                     </Project>
                     ");
 
-                string path = FileUtilities.GetTemporaryFile();
+                string path = FileUtilities.GetTemporaryFileName();
 
                 try
                 {

--- a/src/Build.UnitTests/ExpressionTree_Tests.cs
+++ b/src/Build.UnitTests/ExpressionTree_Tests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Build.UnitTests
             expander.Metadata = new StringMetadataTable(null);
             bool value;
 
-            string fileThatMustAlwaysExist = FileUtilities.GetTemporaryFile();
+            string fileThatMustAlwaysExist = FileUtilities.GetTemporaryFileName();
             File.WriteAllText(fileThatMustAlwaysExist, "foo");
             string command = "Exists('" + fileThatMustAlwaysExist + "')";
             tree = p.Parse(command, ParserOptions.AllowAll, ElementLocation.EmptyLocation);

--- a/src/Build.UnitTests/FileLogger_Tests.cs
+++ b/src/Build.UnitTests/FileLogger_Tests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                log = GetTempFilename();
+                log = FileUtilities.GetTemporaryFileName();
                 SetUpFileLoggerAndLogMessage("logfile=" + log, new BuildMessageEventArgs("message here", null, null, MessageImportance.High));
                 VerifyFileContent(log, "message here");
 
@@ -105,7 +105,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                log = GetTempFilename();
+                log = FileUtilities.GetTemporaryFileName();
                 FileLogger fl = new FileLogger();
                 EventSourceSink es = new EventSourceSink();
                 fl.Parameters = "verbosity=diagnostic;logfile=" + log;  // diagnostic specific setting
@@ -184,7 +184,7 @@ namespace Microsoft.Build.UnitTests
 
                 try
                 {
-                    log = GetTempFilename();
+                    log = FileUtilities.GetTemporaryFileName();
                     FileLogger fl = new FileLogger();
                     EventSourceSink es = new EventSourceSink();
                     fl.Parameters = "encoding=foo;logfile=" + log;
@@ -208,7 +208,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                log = GetTempFilename();
+                log = FileUtilities.GetTemporaryFileName();
                 SetUpFileLoggerAndLogMessage("encoding=utf-16;logfile=" + log, new BuildMessageEventArgs("message here", null, null, MessageImportance.High));
                 byte[] content = ReadRawBytes(log);
 
@@ -232,7 +232,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                log = GetTempFilename();
+                log = FileUtilities.GetTemporaryFileName();
                 SetUpFileLoggerAndLogMessage("encoding=utf-8;logfile=" + log, new BuildMessageEventArgs("message here", null, null, MessageImportance.High));
                 byte[] content = ReadRawBytes(log);
 
@@ -278,7 +278,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                log = GetTempFilename();
+                log = FileUtilities.GetTemporaryFileName();
                 WriteContentToFile(log);
                 SetUpFileLoggerAndLogMessage("logfile=" + log, new BuildMessageEventArgs("message here", null, null, MessageImportance.High));
                 VerifyFileContent(log, "message here");
@@ -299,7 +299,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                log = GetTempFilename();
+                log = FileUtilities.GetTemporaryFileName();
                 WriteContentToFile(log);
                 SetUpFileLoggerAndLogMessage("append;logfile=" + log, new BuildMessageEventArgs("message here", null, null, MessageImportance.High));
                 VerifyFileContent(log, "existing content\nmessage here");
@@ -404,17 +404,6 @@ namespace Microsoft.Build.UnitTests
                     Assert.DoesNotContain(message, log);
                 }
             }
-        }
-
-        /// <summary>
-        /// Gets a filename for a nonexistent temporary file.
-        /// </summary>
-        /// <returns></returns>
-        private string GetTempFilename()
-        {
-            string path = FileUtilities.GetTemporaryFile();
-            File.Delete(path);
-            return path;
         }
 
         /// <summary>

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -990,7 +990,7 @@ namespace Microsoft.Build.UnitTests
                 string filename = null;
                 try
                 {
-                    filename = FileUtilities.GetTemporaryFile();
+                    filename = FileUtilities.GetTemporaryFileName();
                     ProjectRootElement project = ProjectRootElement.Create();
                     project.Save(filename);
                     MSBuildApp.BuildProject(

--- a/src/MSBuild.UnitTests/ProjectSchemaValidationHandler_Tests.cs
+++ b/src/MSBuild.UnitTests/ProjectSchemaValidationHandler_Tests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Build.UnitTests
                 Environment.SetEnvironmentVariable("MSBuildOldOM", "");
 
                 // Create schema files in the temp folder
-                invalidSchemaFile = FileUtilities.GetTemporaryFile();
+                invalidSchemaFile = FileUtilities.GetTemporaryFileName();
 
                 File.WriteAllText(invalidSchemaFile, "<this_is_invalid_schema_content/>");
 
@@ -120,7 +120,7 @@ namespace Microsoft.Build.UnitTests
                 Environment.SetEnvironmentVariable("MSBuildOldOM", "");
 
                 // Create schema files in the temp folder
-                invalidSchemaFile = FileUtilities.GetTemporaryFile();
+                invalidSchemaFile = FileUtilities.GetTemporaryFileName();
 
                 File.WriteAllText(invalidSchemaFile, @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <xs:schema targetNamespace=""http://schemas.microsoft.com/developer/msbuild/2003"" xmlns:msb=""http://schemas.microsoft.com/developer/msbuild/2003"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" elementFormDefault=""qualified"">
@@ -342,7 +342,7 @@ namespace Microsoft.Build.UnitTests
         /// this project everything that ObjectModelHelpers depends on</remarks>
         static internal string CreateTempFileOnDiskNoFormat(string fileContents)
         {
-            string projectFilePath = FileUtilities.GetTemporaryFile();
+            string projectFilePath = FileUtilities.GetTemporaryFileName();
 
             File.WriteAllText(projectFilePath, CleanupFileContents(fileContents));
 

--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -92,6 +92,18 @@ namespace Microsoft.Build.Shared
         /// File will NOT be created.
         /// May throw IOException.
         /// </summary>
+        internal static string GetTemporaryFileName()
+        {
+            return GetTemporaryFileName(".tmp");
+        }
+
+        /// <summary>
+        /// Generates a unique temporary file name with a given extension in the temporary folder.
+        /// File is guaranteed to be unique.
+        /// Extension may have an initial period.
+        /// File will NOT be created.
+        /// May throw IOException.
+        /// </summary>
         internal static string GetTemporaryFileName(string extension)
         {
             return GetTemporaryFile(null, null, extension, false);

--- a/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
+++ b/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
@@ -77,9 +77,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void GetLastWriteFileUtcTimeReturnsMinValueForMissingFile()
         {
-            string nonexistentFile = FileUtilities.GetTemporaryFile();
-            // Make sure that the file does not, in fact, exist.
-            File.Delete(nonexistentFile);
+            string nonexistentFile = FileUtilities.GetTemporaryFileName();
 
             DateTime nonexistentFileTime = NativeMethodsShared.GetLastWriteFileUtcTime(nonexistentFile);
             Assert.Equal(DateTime.MinValue, nonexistentFileTime);

--- a/src/Tasks.UnitTests/AssemblyDependency/FilePrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/FilePrimary.cs
@@ -210,8 +210,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
                 "<File AssemblyName='Microsoft.Build.Engine' Version='2.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='true' />" +
                 "</FileList >";
 
-            string redistListPath = FileUtilities.GetTemporaryFile();
-            string subsetListPath = FileUtilities.GetTemporaryFile();
+            string redistListPath = FileUtilities.GetTemporaryFileName();
+            string subsetListPath = FileUtilities.GetTemporaryFileName();
             string appConfigFile = null;
             try
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -2538,7 +2538,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                   "<File AssemblyName='Microsoft.BuildEngine' Version='3.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='false' />" +
               "</FileList >";
 
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText(redistFile, fullRedistListContentsDuplicates);
@@ -2691,7 +2691,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// </summary>
         private static List<AssemblyEntry> ExpectRedistEntries(string fullRedistListContentsDuplicates, int numberOfExpectedEntries, int numberofExpectedRemapEntries)
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             List<AssemblyEntry> assembliesReadIn = new List<AssemblyEntry>();
             List<AssemblyRemapping> remapEntries = new List<AssemblyRemapping>();
             try
@@ -5303,10 +5303,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 @"c:\Regress407623"                    // Assembly is here.
             };
 
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,
@@ -5389,12 +5388,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             };
             t.TargetFrameworkDirectories = new string[] { @"r:\WINDOWS\Microsoft.NET\Framework\v2.0.myfx" };
 
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
 
             try
             {
-                File.Delete(redistFile);
-
                 File.WriteAllText
                 (
                     redistFile,
@@ -5422,12 +5419,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void PartialNameMatchingFromRedist()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
 
             try
             {
-                File.Delete(redistFile);
-
                 File.WriteAllText
                 (
                     redistFile,
@@ -5570,7 +5565,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                          "<File AssemblyName='C' Version='2.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='true' />" +
                     "</FileList >";
 
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             File.WriteAllText(redistFile, redistListContents);
 
             bool success = false;
@@ -5637,7 +5632,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                         "<File AssemblyName='Microsoft.Build.Engine' Version='2.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='true' />" +
                     "</FileList >";
 
-            string tempFile = FileUtilities.GetTemporaryFile();
+            string tempFile = FileUtilities.GetTemporaryFileName();
             File.WriteAllText(tempFile, redistListContents);
             return tempFile;
         }
@@ -5743,7 +5738,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void RedistListGenerateBlackListGarbageSubsetListFiles()
         {
             string redistFile = CreateGenericRedistList();
-            string garbageSubsetFile = FileUtilities.GetTemporaryFile();
+            string garbageSubsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText
@@ -5787,7 +5782,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void RedistListNoSubsetListName()
         {
             string redistFile = CreateGenericRedistList();
-            string subsetFile = FileUtilities.GetTemporaryFile();
+            string subsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 string subsetListContents =
@@ -5832,8 +5827,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void RedistListNullkRedistListName()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
-            string subsetFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
+            string subsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 string subsetListContents =
@@ -5885,7 +5880,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void RedistListDifferentNameToSubSet()
         {
             string redistFile = CreateGenericRedistList();
-            string subsetFile = FileUtilities.GetTemporaryFile();
+            string subsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 string subsetListContents =
@@ -5922,7 +5917,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void RedistListEmptySubsetMatchingName()
         {
             string redistFile = CreateGenericRedistList();
-            string subsetFile = FileUtilities.GetTemporaryFile();
+            string subsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 string subsetListContents =
@@ -5979,8 +5974,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 @"{TargetFrameworkDirectory}"
             };
 
-            string redistListPath = FileUtilities.GetTemporaryFile();
-            string subsetListPath = FileUtilities.GetTemporaryFile();
+            string redistListPath = FileUtilities.GetTemporaryFileName();
+            string subsetListPath = FileUtilities.GetTemporaryFileName();
             File.WriteAllText(subsetListPath, _xmlOnlySubset);
             try
             {
@@ -6013,7 +6008,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void RedistListGenerateBlackListGoodListsSubsetIsSubsetOfRedist()
         {
             string redistFile = CreateGenericRedistList();
-            string goodSubsetFile = FileUtilities.GetTemporaryFile();
+            string goodSubsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText(goodSubsetFile, _engineOnlySubset);
@@ -6046,7 +6041,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void RedistListGenerateBlackListVerifyBlackListCache()
         {
             string redistFile = CreateGenericRedistList();
-            string goodSubsetFile = FileUtilities.GetTemporaryFile();
+            string goodSubsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText(goodSubsetFile, _engineOnlySubset);
@@ -6087,8 +6082,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void RedistListGenerateBlackListGoodListsSubsetIsSameAsRedistList()
         {
             string redistFile = CreateGenericRedistList();
-            string goodSubsetFile = FileUtilities.GetTemporaryFile();
-            string goodSubsetFile2 = FileUtilities.GetTemporaryFile();
+            string goodSubsetFile = FileUtilities.GetTemporaryFileName();
+            string goodSubsetFile2 = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText(goodSubsetFile, _engineOnlySubset);
@@ -6124,7 +6119,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void RedistListGenerateBlackListGoodListsSubsetIsSuperSet()
         {
             string redistFile = CreateGenericRedistList();
-            string goodSubsetFile = FileUtilities.GetTemporaryFile();
+            string goodSubsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText
@@ -6164,7 +6159,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void RedistListGenerateBlackListGoodListsCheckCaseInsensitive()
         {
             string redistFile = CreateGenericRedistList();
-            string goodSubsetFile = FileUtilities.GetTemporaryFile();
+            string goodSubsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText(goodSubsetFile, _engineAndXmlSubset.ToUpperInvariant());
@@ -6195,8 +6190,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void RedistListGenerateBlackListGoodListsMultipleIdenticalAssembliesInRedistList()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
-            string goodSubsetFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
+            string goodSubsetFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 // Create a redist list which will contains both of the assemblies to search for
@@ -7982,13 +7977,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 @"c:\MyRedist"
             };
 
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
 
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
-(
+                (
                     redistFile,
                     "<FileList Redist='Microsoft-Windows-CLRCoreComp' >" +
                         "<File IsRedistRoot='true' AssemblyName='MyRedistRootAssembly' Version='0.0.0.0' PublicKeyToken='null' Culture='Neutral' FileVersion='2.0.40824.0' InGAC='true'/>" +
@@ -8114,10 +8108,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void VerifyGetSimpleNamesIsSorted()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,
@@ -8162,10 +8155,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void VerifyAssemblyInRedistListNonWindowsRedistName()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,
@@ -8193,10 +8185,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void VerifyAssemblyInRedistListWindowsRedistName()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,
@@ -8224,10 +8215,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void VerifyAssemblyInRedistListPartialMatches()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,
@@ -8267,10 +8257,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void VerifyAssemblyInRedistListDiffVersion()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,
@@ -8299,10 +8288,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void VerifyAssemblyInRedistListDiffPublicKey()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,
@@ -8331,10 +8319,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void VerifyAssemblyInRedistListDiffCulture()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,
@@ -8363,10 +8350,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void VerifyAssemblyInRedistListDiffSimpleName()
         {
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -2936,7 +2936,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             "    </runtime>\n" +
             "</configuration>";
 
-            string appConfigFile = FileUtilities.GetTemporaryFile();
+            string appConfigFile = FileUtilities.GetTemporaryFileName();
             File.WriteAllText(appConfigFile, appConfigContents);
             return appConfigFile;
         }
@@ -3150,10 +3150,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.Assemblies = items;
             t.SearchPaths = searchPaths.ToArray();
-            string redistFile = FileUtilities.GetTemporaryFile();
+            string redistFile = FileUtilities.GetTemporaryFileName();
             try
             {
-                File.Delete(redistFile);
                 File.WriteAllText
                 (
                     redistFile,

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
@@ -109,8 +109,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
                 "<File AssemblyName='UniFYme' Version='2.0.0.0' Culture='neutral' PublicKeyToken='b77a5c561934e089' InGAC='false' />" +
                 "</FileList >";
 
-            string redistListPath = FileUtilities.GetTemporaryFile();
-            string subsetListPath = FileUtilities.GetTemporaryFile();
+            string redistListPath = FileUtilities.GetTemporaryFileName();
+            string subsetListPath = FileUtilities.GetTemporaryFileName();
             string appConfigFile = null;
             try
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAutoUnify.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAutoUnify.cs
@@ -121,8 +121,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
                 "<File AssemblyName='Microsoft.Build.Engine' Version='2.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='true' />" +
                 "</FileList >";
 
-            string redistListPath = FileUtilities.GetTemporaryFile();
-            string subsetListPath = FileUtilities.GetTemporaryFile();
+            string redistListPath = FileUtilities.GetTemporaryFileName();
+            string subsetListPath = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText(redistListPath, implicitRedistListContents);
@@ -204,8 +204,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
                 "<File AssemblyName='Microsoft.Build.Engine' Version='2.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='true' />" +
                 "</FileList >";
 
-            string redistListPath = FileUtilities.GetTemporaryFile();
-            string subsetListPath = FileUtilities.GetTemporaryFile();
+            string redistListPath = FileUtilities.GetTemporaryFileName();
+            string subsetListPath = FileUtilities.GetTemporaryFileName();
             string appConfigFile = null;
             try
             {
@@ -286,8 +286,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
                 "<File AssemblyName='Microsoft.Build.Engine' Version='2.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='true' />" +
                 "</FileList >";
 
-            string redistListPath = FileUtilities.GetTemporaryFile();
-            string subsetListPath = FileUtilities.GetTemporaryFile();
+            string redistListPath = FileUtilities.GetTemporaryFileName();
+            string subsetListPath = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText(redistListPath, implicitRedistListContents);
@@ -362,8 +362,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
                 "<File AssemblyName='Microsoft.Build.Engine' Version='2.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='true' />" +
                 "</FileList >";
 
-            string redistListPath = FileUtilities.GetTemporaryFile();
-            string subsetListPath = FileUtilities.GetTemporaryFile();
+            string redistListPath = FileUtilities.GetTemporaryFileName();
+            string subsetListPath = FileUtilities.GetTemporaryFileName();
             File.WriteAllText(redistListPath, implicitRedistListContents);
             File.WriteAllText(subsetListPath, engineOnlySubset);
 

--- a/src/Tasks.UnitTests/Move_Tests.cs
+++ b/src/Tasks.UnitTests/Move_Tests.cs
@@ -467,7 +467,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
                 bool result;
                 Move move = null;
 

--- a/src/Tasks.UnitTests/ReadLinesFromFile_Tests.cs
+++ b/src/Tasks.UnitTests/ReadLinesFromFile_Tests.cs
@@ -24,12 +24,10 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void Basic()
         {
-            var file = FileUtilities.GetTemporaryFile();
+            // Start with a missing file.
+            var file = FileUtilities.GetTemporaryFileName();
             try
             {
-                // Start with a missing file.
-                File.Delete(file);
-
                 // Append one line to the file.
                 var a = new WriteLinesToFile
                 {
@@ -73,12 +71,10 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void Escaping()
         {
-            var file = FileUtilities.GetTemporaryFile();
+            // Start with a missing file.
+            var file = FileUtilities.GetTemporaryFileName();
             try
             {
-                // Start with a missing file.
-                File.Delete(file);
-
                 // Append one line to the file.
                 var a = new WriteLinesToFile
                 {
@@ -120,12 +116,10 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ANSINonASCII()
         {
-            var file = FileUtilities.GetTemporaryFile();
+            // Start with a missing file.
+            var file = FileUtilities.GetTemporaryFileName();
             try
             {
-                // Start with a missing file.
-                File.Delete(file);
-
                 // Append one line to the file.
                 var a = new WriteLinesToFile
                 {
@@ -156,8 +150,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ReadMissing()
         {
-            var file = FileUtilities.GetTemporaryFile();
-            File.Delete(file);
+            var file = FileUtilities.GetTemporaryFileName();
 
             // Read the line from the file.
             var r = new ReadLinesFromFile
@@ -175,12 +168,10 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void IgnoreBlankLines()
         {
-            var file = FileUtilities.GetTemporaryFile();
+            // Start with a missing file.
+            var file = FileUtilities.GetTemporaryFileName();
             try
             {
-                // Start with a missing file.
-                File.Delete(file);
-
                 // Append one line to the file.
                 var a = new WriteLinesToFile
                 {
@@ -227,12 +218,10 @@ namespace Microsoft.Build.UnitTests
                 return; // "The security API is not the same under Unix"
             }
 
-            var file = FileUtilities.GetTemporaryFile();
+            // Start with a missing file.
+            var file = FileUtilities.GetTemporaryFileName();
             try
             {
-                // Start with a missing file.
-                File.Delete(file);
-
                 // Append one line to the file.
                 var a = new WriteLinesToFile
                 {

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -3826,9 +3826,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests
         /// </summary>
         public static string GetTempFileName(string extension)
         {
-            string f = FileUtilities.GetTemporaryFile();
+            string f = FileUtilities.GetTemporaryFileName();
             string filename = Path.ChangeExtension(f, extension);
-            File.Delete(f);
             // Make sure that the new file doesn't already exist, since the test is probably
             // expecting it not to
             File.Delete(filename);

--- a/src/Tasks.UnitTests/ResourceHandling/ResGenDependencies_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/ResGenDependencies_Tests.cs
@@ -92,8 +92,7 @@ namespace Microsoft.Build.UnitTests
         /// <returns></returns>
         private string CreateSampleResx()
         {
-            string resx = FileUtilities.GetTemporaryFile();
-            File.Delete(resx);
+            string resx = FileUtilities.GetTemporaryFileName();
             Stream fileToSend = Assembly.GetExecutingAssembly().GetManifestResourceStream("Microsoft.Build.Tasks.UnitTests.SampleResx");
             using (FileStream f = new FileStream(resx, FileMode.CreateNew))
             {

--- a/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
                                        <StringProperty Name=`TargetAssembly` Switch=`/target:&quot;[value]&quot;` />
                                      </Rule>
                                    </ProjectSchemaDefinitions>";
-            string tmpXamlFile = FileUtilities.GetTemporaryFile();
+            string tmpXamlFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.WriteAllText(tmpXamlFile, xmlContents.Replace("`", "\""));

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Build.Tasks
             var encoding = EncodingUtilities.BatchFileEncoding(Command + WorkingDirectory, UseUtf8Encoding);
 
             // Temporary file with the extension .Exec.bat
-            _batchFile = FileUtilities.GetTemporaryFile(".exec.cmd");
+            _batchFile = FileUtilities.GetTemporaryFileName(".exec.cmd");
 
             // UNICODE Batch files are not allowed as of WinXP. We can't use normal ANSI code pages either,
             // since console-related apps use OEM code pages "for historical reasons". Sigh.

--- a/src/Tasks/ManifestUtil/ManifestWriter.cs
+++ b/src/Tasks/ManifestUtil/ManifestWriter.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 else
                 {
                     // May throw IO-related exceptions
-                    string temp = FileUtilities.GetTemporaryFile();
+                    string temp = FileUtilities.GetTemporaryFileName();
 
                     am.TrustInfo.Write(temp);
                     if (Util.logging)

--- a/src/Tasks/ManifestUtil/Util.cs
+++ b/src/Tasks/ManifestUtil/Util.cs
@@ -510,7 +510,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public static string WriteTempFile(Stream s)
         {
             // May throw IO-related exceptions
-            string path = FileUtilities.GetTemporaryFile();
+            string path = FileUtilities.GetTemporaryFileName();
 
             WriteFile(path, s);
             return path;
@@ -519,7 +519,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public static string WriteTempFile(string s)
         {
             // May throw IO-related exceptions
-            string path = FileUtilities.GetTemporaryFile();
+            string path = FileUtilities.GetTemporaryFileName();
 
             WriteFile(path, s);
             return path;

--- a/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
+++ b/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                file = FileUtilities.GetTemporaryFile();
+                file = FileUtilities.GetTemporaryFileName();
 
                 string contents = @"a message here
                     error abcd12345: hey jude.

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void OverrideStdOutImportanceToLow()
         {
-            string tempFile = FileUtilities.GetTemporaryFile();
+            string tempFile = FileUtilities.GetTemporaryFileName();
             File.WriteAllText(tempFile, @"hello world");
 
             using (MyTool t = new MyTool())
@@ -444,7 +444,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void OverrideStdOutImportanceToHigh()
         {
-            string tempFile = FileUtilities.GetTemporaryFile();
+            string tempFile = FileUtilities.GetTemporaryFileName();
             File.WriteAllText(tempFile, @"hello world");
 
             using (MyTool t = new MyTool())
@@ -475,7 +475,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ToolTaskCanChangeCanonicalErrorFormat()
         {
-            string tempFile = FileUtilities.GetTemporaryFile();
+            string tempFile = FileUtilities.GetTemporaryFileName();
             File.WriteAllText(tempFile, @"
                 Main.cs(17,20): warning CS0168: The variable 'foo' is declared but never used.
                 BADTHINGHAPPENED: This is my custom error format that's not in canonical error format.

--- a/src/Utilities.UnitTests/TrackedDependencies/FileTrackerTests.cs
+++ b/src/Utilities.UnitTests/TrackedDependencies/FileTrackerTests.cs
@@ -314,7 +314,7 @@ namespace ConsoleApplication4
 
             try
             {
-                codeFile = FileUtilities.GetTemporaryFile();
+                codeFile = FileUtilities.GetTemporaryFileName();
                 File.WriteAllText(codeFile, codeContent);
                 Csc csc = new Csc();
                 csc.BuildEngine = new MockEngine();
@@ -418,7 +418,7 @@ namespace ConsoleApplication4
             try
             {
                 string inputPath = Path.GetFullPath("test.in");
-                codeFile = FileUtilities.GetTemporaryFile();
+                codeFile = FileUtilities.GetTemporaryFileName();
                 string codeContent = @"using System.IO; class X { static void Main() { File.ReadAllText(@""" + inputPath + @"""); File.ReadAllText(@""" + inputPath + @"""); }}";
                 File.WriteAllText(codeFile, codeContent);
                 Csc csc = new Csc();

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -545,7 +545,7 @@ namespace Microsoft.Build.Utilities
                 // have to worry about how long the command-line is going to be
 
                 // May throw IO-related exceptions
-                responseFile = FileUtilities.GetTemporaryFile(".rsp");
+                responseFile = FileUtilities.GetTemporaryFileName(".rsp");
 
                 // Use the encoding specified by the overridable ResponseFileEncoding property
                 using (StreamWriter responseFileStream = FileUtilities.OpenWrite(responseFile, false, ResponseFileEncoding))

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Build.Utilities
         /// <returns>The response file path.</returns>
         public static string CreateRootingMarkerResponseFile(string rootMarker)
         {
-            string trackerResponseFile = FileUtilities.GetTemporaryFile(".rsp");
+            string trackerResponseFile = FileUtilities.GetTemporaryFileName(".rsp");
             File.WriteAllText(trackerResponseFile, "/r \"" + rootMarker + "\"", Encoding.Unicode);
 
             return trackerResponseFile;


### PR DESCRIPTION
Use GetTemporaryFileName over GetTemporaryFile to avoid extraneous i/o

`GetTemporaryFile` creates an empty file while `GetTemporaryFileName` does not. However, most existing callers override the file. This change replaces various locations where `GetTemporaryFile` is used with `GetTemporaryFileName`.