### PR TITLE
Sort paths descendingly by depth

### DIFF
--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1817,10 +1817,9 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         internal static void DeleteFiles(params string[] paths)
         {
-            // When we delete the file which has the sub folder/file firstly, it will be not delected since not empty.
-            // So sort paths descendingly by depth, it will delete sub folder/file at first.
-            var pathsSortedByDepth = paths.OrderByDescending(x =>
-                                       x.NormalizeForPathComparison().Split(Path.DirectorySeparatorChar).Length);
+            // When we delete the file which has the sub folder/file firstly, it will be not deleted since not empty.
+            // So sort paths descendingly by file directory length, it will delete sub folder/file at first.
+            var pathsSortedByDepth = paths.OrderByDescending(x => Path.GetDirectoryName(x).Length);
 
             foreach (string path in pathsSortedByDepth)
             {

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1817,7 +1817,12 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         internal static void DeleteFiles(params string[] paths)
         {
-            foreach (string path in paths)
+            // When we delete the file which has the sub folder/file firstly, it will be not delected since not empty.
+            // So sort paths descendingly by depth, it will delete sub folder/file at first.
+            var pathsSortedByDepth = paths.OrderByDescending(x =>
+                                       x.NormalizeForPathComparison().Split(Path.DirectorySeparatorChar).Length);
+
+            foreach (string path in pathsSortedByDepth)
             {
                 if (FileSystems.Default.FileExists(path))
                 {

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1819,7 +1819,7 @@ namespace Microsoft.Build.UnitTests
         {
             // When we delete the file directory which has the sub folder/file firstly, it will not be deleted since not empty.
             // So sort paths descendingly by file directory length, it will delete sub folder/file at first.
-            var pathsSortedByDepth = paths.OrderByDescending(x => Path.GetDirectoryName(x).Length);
+            var pathsSortedByDepth = paths.OrderByDescending(x => Path.GetDirectoryName(Path.GetFullPath(x)).Length);
 
             foreach (string path in pathsSortedByDepth)
             {


### PR DESCRIPTION
Fixes [#8288](https://github.com/dotnet/msbuild/issues/8228)

### Context
There's a bug in the cleanup logic here. Specifically, it creates the source and dest files, and at the end of the test, it calls Helpers.DeleteFiles(sourceFile, destFile); That method loops through each file and deletes it if it exists, then deletes the directory containing it if it's empty...but when we delete the source file, the directory isn't empty; it has the destination folder/file. When we delete the destination file, its folder just contains the destination file, so we delete that. Afterwards, the source folder never gets deleted. That means we can't write to it. Mentioned in https://github.com/dotnet/msbuild/pull/8211#discussion_r1040269656

### Changes Made
Sort paths descendingly by depth, it will delete sub folder/file at first.

Test locally