### PR TITLE
FancyLogger: Hide cursor on alternate buffer

### DIFF
--- a/src/Build/Logging/FancyLogger/ANSIBuilder.cs
+++ b/src/Build/Logging/FancyLogger/ANSIBuilder.cs
@@ -235,6 +235,16 @@ namespace Microsoft.Build.Logging.FancyLogger
             public static string RestorePosition() {
                 return String.Format("\x1b[u");
             }
+
+            public static string Invisible()
+            {
+                return "\x1b[?25l";
+            }
+
+            public static string Visible()
+            {
+                return "\x1b[?25h";
+            }
         }
 
         public static class Tabulator

--- a/src/Build/Logging/FancyLogger/FancyLoggerBuffer.cs
+++ b/src/Build/Logging/FancyLogger/FancyLoggerBuffer.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Build.Logging.FancyLogger
             Console.Write(ANSIBuilder.Buffer.UseMainBuffer());
             Console.Write(ANSIBuilder.Buffer.UseAlternateBuffer());
 
+            Console.Write(ANSIBuilder.Cursor.Invisible());
+
             Task.Run(async () => {
                 while (true)
                 {
@@ -73,6 +75,9 @@ namespace Microsoft.Build.Logging.FancyLogger
             // TODO: Remove. Tries to solve a bug when switching from and to the alternate buffer
             Console.Write(ANSIBuilder.Buffer.UseMainBuffer());
             Console.Write(ANSIBuilder.Eraser.Display());
+
+            Console.Write(ANSIBuilder.Cursor.Visible());
+
             Lines = new();
         }
 


### PR DESCRIPTION
Tweak to FancyLogger: hide the cursor so it's less obvious what part of the screen is being written at any given time, and it doesn't jump around visibly.