### PR TITLE
[FancyLogger] Clear screen on ctrl-c

### DIFF
--- a/src/Build/Logging/FancyLogger/FancyLogger.cs
+++ b/src/Build/Logging/FancyLogger/FancyLogger.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Build.Logging.FancyLogger
             eventSource.MessageRaised += new BuildMessageEventHandler(eventSource_MessageRaised);
             eventSource.WarningRaised += new BuildWarningEventHandler(eventSource_WarningRaised);
             eventSource.ErrorRaised += new BuildErrorEventHandler(eventSource_ErrorRaised);
+            // Cancelled
+            Console.CancelKeyPress += new ConsoleCancelEventHandler(console_CancelKeyPressed);
             // Initialize FancyLoggerBuffer
             FancyLoggerBuffer.Initialize();
         }
@@ -145,6 +147,13 @@ namespace Microsoft.Build.Logging.FancyLogger
             node.Log();
         }
 
+        void console_CancelKeyPressed(object? sender, ConsoleCancelEventArgs eventArgs)
+        {
+            // Clear screen
+            FancyLoggerBuffer.Terminate();
+            // TODO: Remove. There is a bug that causes switching to main buffer without deleting the contents of the alternate buffer
+            Console.Clear();
+        }
 
         public void Shutdown()
         {

--- a/src/Build/Logging/FancyLogger/FancyLogger.cs
+++ b/src/Build/Logging/FancyLogger/FancyLogger.cs
@@ -149,10 +149,8 @@ namespace Microsoft.Build.Logging.FancyLogger
 
         void console_CancelKeyPressed(object? sender, ConsoleCancelEventArgs eventArgs)
         {
-            // Clear screen
-            FancyLoggerBuffer.Terminate();
-            // TODO: Remove. There is a bug that causes switching to main buffer without deleting the contents of the alternate buffer
-            Console.Clear();
+            // Shutdown logger
+            Shutdown();
         }
 
         public void Shutdown()


### PR DESCRIPTION
Fixes #

### Context
Previously, when using <kbd>Ctrl</kbd><kbd>C</kbd> with the FancyLogger, the process would end abruptly, causing unexpected behavior such as rendered elements not erasing.

### Changes Made
Added new `Console.CancelKeyPress` event handler

### Testing


### Notes
Waiting for https://github.com/dotnet/msbuild/pull/8284 to show summary at the end