### PR TITLE
Sync ProcessorArchitectures with those known by runtime.

### DIFF
--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -450,7 +450,9 @@ internal static class NativeMethods
             else
             {
                 ProcessorArchitectures processorArchitecture = ProcessorArchitectures.Unknown;
+
 #if !NET35
+                // .NET Core 1.0+
                 // Get the architecture from the runtime.
                 processorArchitecture = RuntimeInformation.OSArchitecture switch
                 {
@@ -471,78 +473,62 @@ internal static class NativeMethods
 #endif
                     _ => ProcessorArchitectures.Unknown,
                 };
-#endif
-                // Fall back to 'uname -m' to get the architecture.
-                if (processorArchitecture == ProcessorArchitectures.Unknown)
-                {
-                    try
-                    {
-                        // On Unix run 'uname -m' to get the architecture. It's common for Linux and Mac
-                        using (
-                            var proc =
-                                Process.Start(
-                                    new ProcessStartInfo("uname")
-                                    {
-                                        Arguments = "-m",
-                                        UseShellExecute = false,
-                                        RedirectStandardOutput = true,
-                                        CreateNoWindow = true
-                                    }))
-                        {
-                            string arch = null;
-                            if (proc != null)
-                            {
-                                arch = proc.StandardOutput.ReadLine();
-                                proc.WaitForExit();
-                            }
 
-                            if (!string.IsNullOrEmpty(arch))
+#else
+                // Mono
+                // Use 'uname -m' to get the architecture.
+                try
+                {
+                    // On Unix run 'uname -m' to get the architecture. It's common for Linux and Mac
+                    using (
+                        var proc =
+                            Process.Start(
+                                new ProcessStartInfo("uname")
+                                {
+                                    Arguments = "-m",
+                                    UseShellExecute = false,
+                                    RedirectStandardOutput = true,
+                                    CreateNoWindow = true
+                                }))
+                    {
+                        string arch = null;
+                        if (proc != null)
+                        {
+                            arch = proc.StandardOutput.ReadLine();
+                            proc.WaitForExit();
+                        }
+
+                        if (!string.IsNullOrEmpty(arch))
+                        {
+                            if (arch.StartsWith("x86_64", StringComparison.OrdinalIgnoreCase))
                             {
-                                if (arch.StartsWith("x86_64", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    ProcessorArchitectureType = ProcessorArchitectures.X64;
-                                }
-                                else if (arch.StartsWith("ia64", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    ProcessorArchitectureType = ProcessorArchitectures.IA64;
-                                }
-                                else if (arch.StartsWith("arm", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    ProcessorArchitectureType = ProcessorArchitectures.ARM;
-                                }
-                                else if (arch.StartsWith("aarch64", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    ProcessorArchitectureType = ProcessorArchitectures.ARM64;
-                                }
-                                else if (arch.StartsWith("s390x", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    ProcessorArchitectureType = ProcessorArchitectures.S390X;
-                                }
-                                else if (arch.StartsWith("ppc64le", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    ProcessorArchitectureType = ProcessorArchitectures.PPC64LE;
-                                }
-                                else if (arch.StartsWith("armv6l", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    ProcessorArchitectureType = ProcessorArchitectures.ARMV6;
-                                }
-                                else if (arch.StartsWith("loongarch64", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    ProcessorArchitectureType = ProcessorArchitectures.LOONGARCH64;
-                                }
-                                else if (arch.StartsWith("i", StringComparison.OrdinalIgnoreCase)
-                                        && arch.EndsWith("86", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    ProcessorArchitectureType = ProcessorArchitectures.X86;
-                                }
+                                processorArchitecture = ProcessorArchitectures.X64;
+                            }
+                            else if (arch.StartsWith("ia64", StringComparison.OrdinalIgnoreCase))
+                            {
+                                processorArchitecture = ProcessorArchitectures.IA64;
+                            }
+                            else if (arch.StartsWith("arm", StringComparison.OrdinalIgnoreCase))
+                            {
+                                processorArchitecture = ProcessorArchitectures.ARM;
+                            }
+                            else if (arch.StartsWith("aarch64", StringComparison.OrdinalIgnoreCase))
+                            {
+                                processorArchitecture = ProcessorArchitectures.ARM64;
+                            }
+                            else if (arch.StartsWith("i", StringComparison.OrdinalIgnoreCase)
+                                    && arch.EndsWith("86", StringComparison.OrdinalIgnoreCase))
+                            {
+                                processorArchitecture = ProcessorArchitectures.X86;
                             }
                         }
                     }
-                    catch
-                    {
-                        // Best effort: fall back to Unknown
-                    }
                 }
+                catch
+                {
+                    // Best effort: fall back to Unknown
+                }
+#endif
 
                 ProcessorArchitectureTypeNative = ProcessorArchitectureType = processorArchitecture;
             }

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -451,8 +451,7 @@ internal static class NativeMethods
             {
                 ProcessorArchitectures processorArchitecture = ProcessorArchitectures.Unknown;
 
-#if !NET35
-                // .NET Core 1.0+
+#if NETCOREAPP || NETSTANDARD1_1_OR_GREATER
                 // Get the architecture from the runtime.
                 processorArchitecture = RuntimeInformation.OSArchitecture switch
                 {
@@ -474,60 +473,6 @@ internal static class NativeMethods
                     _ => ProcessorArchitectures.Unknown,
                 };
 
-#else
-                // Mono
-                // Use 'uname -m' to get the architecture.
-                try
-                {
-                    // On Unix run 'uname -m' to get the architecture. It's common for Linux and Mac
-                    using (
-                        var proc =
-                            Process.Start(
-                                new ProcessStartInfo("uname")
-                                {
-                                    Arguments = "-m",
-                                    UseShellExecute = false,
-                                    RedirectStandardOutput = true,
-                                    CreateNoWindow = true
-                                }))
-                    {
-                        string arch = null;
-                        if (proc != null)
-                        {
-                            arch = proc.StandardOutput.ReadLine();
-                            proc.WaitForExit();
-                        }
-
-                        if (!string.IsNullOrEmpty(arch))
-                        {
-                            if (arch.StartsWith("x86_64", StringComparison.OrdinalIgnoreCase))
-                            {
-                                processorArchitecture = ProcessorArchitectures.X64;
-                            }
-                            else if (arch.StartsWith("ia64", StringComparison.OrdinalIgnoreCase))
-                            {
-                                processorArchitecture = ProcessorArchitectures.IA64;
-                            }
-                            else if (arch.StartsWith("arm", StringComparison.OrdinalIgnoreCase))
-                            {
-                                processorArchitecture = ProcessorArchitectures.ARM;
-                            }
-                            else if (arch.StartsWith("aarch64", StringComparison.OrdinalIgnoreCase))
-                            {
-                                processorArchitecture = ProcessorArchitectures.ARM64;
-                            }
-                            else if (arch.StartsWith("i", StringComparison.OrdinalIgnoreCase)
-                                    && arch.EndsWith("86", StringComparison.OrdinalIgnoreCase))
-                            {
-                                processorArchitecture = ProcessorArchitectures.X86;
-                            }
-                        }
-                    }
-                }
-                catch
-                {
-                    // Best effort: fall back to Unknown
-                }
 #endif
 
                 ProcessorArchitectureTypeNative = ProcessorArchitectureType = processorArchitecture;

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -195,6 +195,21 @@ internal static class NativeMethods
         // ARM64
         ARM64,
 
+        // WebAssembly
+        WASM,
+
+        // S390x
+        S390X,
+
+        // LongAarch64
+        LOONGARCH64,
+
+        // 32-bit ARMv6
+        ARMV6,
+
+        // PowerPC 64-bit (little-endian) 
+        PPC64LE,
+
         // Who knows
         Unknown
     }
@@ -443,6 +458,17 @@ internal static class NativeMethods
                     Architecture.Arm64 => ProcessorArchitectures.ARM64,
                     Architecture.X64 => ProcessorArchitectures.X64,
                     Architecture.X86 => ProcessorArchitectures.X86,
+#if NET5_0_OR_GREATER
+                    Architecture.Wasm => ProcessorArchitectures.WASM,
+#endif
+#if NET6_0_OR_GREATER
+                    Architecture.S390x => ProcessorArchitectures.S390X,
+#endif
+#if NET7_0_OR_GREATER
+                    Architecture.LoongArch64 => ProcessorArchitectures.LOONGARCH64,
+                    Architecture.Armv6 => ProcessorArchitectures.ARMV6,
+                    Architecture.Ppc64le => ProcessorArchitectures.PPC64LE,
+#endif
                     _ => ProcessorArchitectures.Unknown,
                 };
 #endif
@@ -487,6 +513,22 @@ internal static class NativeMethods
                                 else if (arch.StartsWith("aarch64", StringComparison.OrdinalIgnoreCase))
                                 {
                                     ProcessorArchitectureType = ProcessorArchitectures.ARM64;
+                                }
+                                else if (arch.StartsWith("s390x", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    ProcessorArchitectureType = ProcessorArchitectures.S390X;
+                                }
+                                else if (arch.StartsWith("ppc64le", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    ProcessorArchitectureType = ProcessorArchitectures.PPC64LE;
+                                }
+                                else if (arch.StartsWith("armv6l", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    ProcessorArchitectureType = ProcessorArchitectures.ARMV6;
+                                }
+                                else if (arch.StartsWith("loongarch64", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    ProcessorArchitectureType = ProcessorArchitectures.LOONGARCH64;
                                 }
                                 else if (arch.StartsWith("i", StringComparison.OrdinalIgnoreCase)
                                         && arch.EndsWith("86", StringComparison.OrdinalIgnoreCase))

--- a/src/Utilities.UnitTests/ProcessorArchitecture_Tests.cs
+++ b/src/Utilities.UnitTests/ProcessorArchitecture_Tests.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Build.UnitTests
                 NativeMethodsShared.ProcessorArchitectures.IA64 => ProcessorArchitecture.IA64,
                 NativeMethodsShared.ProcessorArchitectures.ARM => ProcessorArchitecture.ARM,
                 NativeMethodsShared.ProcessorArchitectures.ARM64 => ProcessorArchitecture.ARM64,
+                NativeMethodsShared.ProcessorArchitectures.WASM => ProcessorArchitecture.WASM,
+                NativeMethodsShared.ProcessorArchitectures.S390X => ProcessorArchitecture.S390X,
+                NativeMethodsShared.ProcessorArchitectures.LOONGARCH64 => ProcessorArchitecture.LOONGARCH64,
+                NativeMethodsShared.ProcessorArchitectures.ARMV6 => ProcessorArchitecture.ARMV6,
+                NativeMethodsShared.ProcessorArchitectures.PPC64LE => ProcessorArchitecture.PPC64LE,
                 // unknown architecture? return null
                 _ => null,
             };
@@ -37,6 +42,11 @@ namespace Microsoft.Build.UnitTests
             ProcessorArchitecture.MSIL.ShouldBe("MSIL"); // "MSIL ProcessorArchitecture isn't correct"
             ProcessorArchitecture.ARM.ShouldBe("ARM"); // "ARM ProcessorArchitecture isn't correct"
             ProcessorArchitecture.ARM64.ShouldBe("ARM64"); // "ARM ProcessorArchitecture isn't correct"
+            ProcessorArchitecture.WASM.ShouldBe("WASM"); // "WASM ProcessorArchitecture isn't correct"
+            ProcessorArchitecture.S390X.ShouldBe("S390X"); // "S390X ProcessorArchitecture isn't correct"
+            ProcessorArchitecture.LOONGARCH64.ShouldBe("LOONGARCH64"); // "LOONGARCH64 ProcessorArchitecture isn't correct"
+            ProcessorArchitecture.ARMV6.ShouldBe("ARMV6"); // "ARMV6 ProcessorArchitecture isn't correct"
+            ProcessorArchitecture.PPC64LE.ShouldBe("PPC64LE"); // "PPC64LE ProcessorArchitecture isn't correct"
         }
 
         [Fact]

--- a/src/Utilities/ProcessorArchitecture.cs
+++ b/src/Utilities/ProcessorArchitecture.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Utilities
         public const string S390X = nameof(S390X);
 
         /// <summary>
-        /// Represents the LongAarch64 processor architecture.
+        /// Represents the LoongAarch64 processor architecture.
         /// </summary>
         public const string LOONGARCH64 = nameof(LOONGARCH64);
 

--- a/src/Utilities/ProcessorArchitecture.cs
+++ b/src/Utilities/ProcessorArchitecture.cs
@@ -46,6 +46,31 @@ namespace Microsoft.Build.Utilities
         public const string ARM64 = nameof(ARM64);
 
         /// <summary>
+        /// Represents the WebAssembly platform.
+        /// </summary>
+        public const string WASM = nameof(WASM);
+
+        /// <summary>
+        /// Represents the S390x processor architecture.
+        /// </summary>
+        public const string S390X = nameof(S390X);
+
+        /// <summary>
+        /// Represents the LongAarch64 processor architecture.
+        /// </summary>
+        public const string LOONGARCH64 = nameof(LOONGARCH64);
+
+        /// <summary>
+        /// Represents the 32-bit ARMv6 processor architecture.
+        /// </summary>
+        public const string ARMV6 = nameof(ARMV6);
+
+        /// <summary>
+        /// Represents the PowerPC 64-bit (little-endian) processor architecture.
+        /// </summary>
+        public const string PPC64LE = nameof(PPC64LE);
+
+        /// <summary>
         /// Lazy-initted property for getting the architecture of the currently running process
         /// </summary>
         public static string CurrentProcessArchitecture => GetCurrentProcessArchitecture();
@@ -63,6 +88,11 @@ namespace Microsoft.Build.Utilities
                 NativeMethodsShared.ProcessorArchitectures.IA64 => IA64,
                 NativeMethodsShared.ProcessorArchitectures.ARM => ARM,
                 NativeMethodsShared.ProcessorArchitectures.ARM64 => ARM64,
+                NativeMethodsShared.ProcessorArchitectures.WASM => WASM,
+                NativeMethodsShared.ProcessorArchitectures.S390X => S390X,
+                NativeMethodsShared.ProcessorArchitectures.LOONGARCH64 => LOONGARCH64,
+                NativeMethodsShared.ProcessorArchitectures.ARMV6 => ARMV6,
+                NativeMethodsShared.ProcessorArchitectures.PPC64LE => PPC64LE,
                 // unknown architecture? return null
                 _ => null,
             };


### PR DESCRIPTION
This makes architectures added in .NET 5, 6, and 7 known to MSBuild.

By using the architecture returned by the runtime, we eliminate the 'uname' processes started on these platform to try determine the processor architecture.

@Forgind @rainersigwald ptal.

cc @omajid @uweigand @janani66