### PR TITLE
Infer dotnet host to run integration scenarios

### DIFF
--- a/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -79,6 +79,7 @@
       <Link>TestData\GlobbingTestData.cs</Link>
     </Compile>
     <Compile Include="..\Shared\ProcessExtensions.cs" />
+    <Compile Include="..\UnitTests.Shared\EnvironmentProvider.cs" />
     <Compile Include="..\UnitTests.Shared\RunnerUtilities.cs" />
     <None Include="..\Shared\UnitTests\App.config">
       <Link>App.config</Link>

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="..\Shared\UnitTests\ResourceUtilities_Tests.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\UnitTests.Shared\EnvironmentProvider.cs" />
     <Compile Include="..\UnitTests.Shared\RunnerUtilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
+++ b/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\Shared\UnitTests\MockEngine.cs" />
     <Compile Include="..\Shared\UnitTests\MockLogger.cs" />
     <Compile Include="..\Shared\UnitTests\ObjectModelHelpers.cs" />
+    <Compile Include="..\UnitTests.Shared\EnvironmentProvider.cs" />
     <Compile Include="..\UnitTests.Shared\RunnerUtilities.cs" />
 
     <EmbeddedResource Include="..\MSBuild\MSBuild\Microsoft.Build.Core.xsd">

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -57,6 +57,7 @@
       <Link>TestEnvironment.cs</Link>
     </Compile>
     <Compile Include="..\Shared\ProcessExtensions.cs" />
+    <Compile Include="..\UnitTests.Shared\EnvironmentProvider.cs" />
     <Compile Include="..\UnitTests.Shared\RunnerUtilities.cs" />
 
     <EmbeddedResource Include="SampleResx" />

--- a/src/UnitTests.Shared/EnvironmentProvider.cs
+++ b/src/UnitTests.Shared/EnvironmentProvider.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Collections.Generic;
+#if !NET6_0_OR_GREATER
+using System.Diagnostics;
+#endif
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Build.UnitTests.Shared
+{
+    public class EnvironmentProvider
+    {
+        private static class Constants
+        {
+            public const string DotNet = "dotnet";
+            public const string Path = "PATH";
+            public const string DotnetMsbuildSdkResolverCliDir = "DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR";
+            public static readonly bool RunningOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            public static readonly string ExeSuffix = RunningOnWindows ? ".exe" : string.Empty;
+        }
+
+        private IEnumerable<string>? _searchPaths;
+
+        private readonly Func<string, string?> _getEnvironmentVariable;
+        private readonly Func<string?> _getCurrentProcessPath;
+
+        public EnvironmentProvider(Func<string, string?> getEnvironmentVariable)
+            : this(getEnvironmentVariable, GetCurrentProcessPath)
+        { }
+
+        public EnvironmentProvider(Func<string, string?> getEnvironmentVariable, Func<string?> getCurrentProcessPath)
+        {
+            _getEnvironmentVariable = getEnvironmentVariable;
+            _getCurrentProcessPath = getCurrentProcessPath;
+        }
+
+        private IEnumerable<string> SearchPaths
+        {
+            get
+            {
+                if (_searchPaths == null)
+                {
+                    var searchPaths = new List<string>();
+
+                    searchPaths.AddRange(
+                        (_getEnvironmentVariable(Constants.Path) ?? string.Empty)
+                        .Split(new char[] { Path.PathSeparator }, options: StringSplitOptions.RemoveEmptyEntries)
+                        .Select(p => p.Trim('"')));
+
+                    _searchPaths = searchPaths;
+                }
+
+                return _searchPaths;
+            }
+        }
+
+        public string? GetCommandPath(string commandName)
+        {
+            var commandNameWithExtension = commandName + Constants.ExeSuffix;
+            var commandPath = SearchPaths
+                .Where(p => !Path.GetInvalidPathChars().Any(p.Contains))
+                .Select(p => Path.Combine(p, commandNameWithExtension))
+                .FirstOrDefault(File.Exists);
+
+            return commandPath;
+        }
+
+        public string? GetDotnetExePath()
+        {
+            string? environmentOverride = _getEnvironmentVariable(Constants.DotnetMsbuildSdkResolverCliDir);
+            if (!string.IsNullOrEmpty(environmentOverride))
+            {
+                return Path.Combine(environmentOverride, Constants.DotNet + Constants.ExeSuffix);
+            }
+
+            string? dotnetExe = _getCurrentProcessPath();
+
+            if (string.IsNullOrEmpty(dotnetExe) || !Path.GetFileNameWithoutExtension(dotnetExe)
+                    .Equals(Constants.DotNet, StringComparison.InvariantCultureIgnoreCase))
+            {
+                string? dotnetExeFromPath = GetCommandPath(Constants.DotNet);
+#if NET
+                if (dotnetExeFromPath != null && !Constants.RunningOnWindows)
+                {
+                    // on Linux the 'dotnet' command from PATH is a symlink so we need to
+                    // resolve it to get the actual path to the binary
+                    FileInfo fi = new FileInfo(dotnetExeFromPath);
+                    while (fi.LinkTarget != null)
+                    {
+                        dotnetExeFromPath = fi.LinkTarget;
+                        fi = new FileInfo(dotnetExeFromPath);
+                    }
+                }
+#endif
+                if (!string.IsNullOrWhiteSpace(dotnetExeFromPath))
+                {
+                    dotnetExe = dotnetExeFromPath;
+                }
+            }
+
+            return dotnetExe;
+        }
+
+        public static string? GetDotnetExePath(Func<string, string?>? getEnvironmentVariable = null)
+        {
+            if (getEnvironmentVariable == null)
+            {
+                getEnvironmentVariable = Environment.GetEnvironmentVariable;
+            }
+            var environmentProvider = new EnvironmentProvider(getEnvironmentVariable);
+            return environmentProvider.GetDotnetExePath();
+        }
+
+        public static string? GetDotnetExePath(Func<string, string?> getEnvironmentVariable, Func<string?> getCurrentProcessPath)
+        {
+            getEnvironmentVariable ??= Environment.GetEnvironmentVariable;
+            getCurrentProcessPath ??= GetCurrentProcessPath;
+            var environmentProvider = new EnvironmentProvider(getEnvironmentVariable, getCurrentProcessPath);
+            return environmentProvider.GetDotnetExePath();
+        }
+
+        private static string? GetCurrentProcessPath()
+        {
+            string? currentProcessPath;
+#if NET6_0_OR_GREATER
+            currentProcessPath = Environment.ProcessPath;
+#else
+            currentProcessPath = Process.GetCurrentProcess().MainModule.FileName;
+#endif
+            return currentProcessPath;
+        }
+    }
+}

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Build.UnitTests.Shared
     public static class RunnerUtilities
     {
         public static string PathToCurrentlyRunningMsBuildExe => BuildEnvironmentHelper.Instance.CurrentMSBuildExePath;
+#if !FEATURE_RUN_EXE_IN_TESTS
+        private static readonly string s_dotnetExePath = EnvironmentProvider.GetDotnetExePath();
+#endif
 
         /// <summary>
         /// Invoke the currently running msbuild and return the stdout, stderr, and process exit status.
@@ -29,7 +32,7 @@ namespace Microsoft.Build.UnitTests.Shared
 #if FEATURE_RUN_EXE_IN_TESTS
             var pathToExecutable = pathToMsBuildExe;
 #else
-            var pathToExecutable = ResolveRuntimeExecutableName();
+            var pathToExecutable = s_dotnetExePath;
             msbuildParameters = FileUtilities.EnsureDoubleQuotes(pathToMsBuildExe) + " " + msbuildParameters;
 #endif
 
@@ -51,20 +54,6 @@ namespace Microsoft.Build.UnitTests.Shared
                 throw new NotImplementedException();
             }
         }
-
-#if !FEATURE_RUN_EXE_IN_TESTS
-        /// <summary>
-        /// Resolve the platform specific path to the runtime executable that msbuild.exe needs to be run in (unix-mono, {unix, windows}-corerun).
-        /// </summary>
-        private static string ResolveRuntimeExecutableName()
-        {
-            // Run the child process with the same host as the currently-running process.
-            using (Process currentProcess = Process.GetCurrentProcess())
-            {
-                return currentProcess.MainModule.FileName;
-            }
-        }
-#endif
 
         /// <summary>
         /// Run the process and get stdout and stderr


### PR DESCRIPTION
Fixes #8313

### Context
Some of the unit tests are failing when run from VS - caused by the fact that those tests are supposed to execute msbuild and fail to do so due to attempts to interpret the test runner as the dotnet host process

### Changes Made
Added helper to infer the proper host to run the msbuild in core
Logic adopted from [SDK](https://github.com/dotnet/sdk/blob/main/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs#L65-L94), with some alternations (removed unnecessary interop, added nullables, some styling fixes)

