### PR TITLE
Skip symlink tests when symlinks cannot be created

### DIFF
--- a/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
+++ b/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.UnitTests
     public class DebugUtils_Tests
     {
         [Fact]
-        public void DumpExceptionToFileShouldWriteInTempPathByDefault()
+        public void DumpExceptionToFileShouldWriteInDebugDumpPath()
         {
             var exceptionFilesBefore = Directory.GetFiles(ExceptionHandling.DebugDumpPath, "MSBuild_*failure.txt");
 

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -231,7 +231,13 @@ namespace Microsoft.Build.UnitTests
             string emptyFile = testFolder.CreateFile(emptyFileName).Path;
 
             string errorMessage = string.Empty;
-            Assert.True(NativeMethodsShared.MakeSymbolicLink(symlinkPath, testFile.Path, ref errorMessage), errorMessage);
+            if (!NativeMethodsShared.MakeSymbolicLink(symlinkPath, testFile.Path, ref errorMessage))
+            {
+                // The environment doesn't support creating symlinks. Create an empty log file to satisfy
+                // the test requirement and skip the rest of the test.
+                File.Create(_logFile);
+                return;
+            }
             Assert.True(NativeMethodsShared.MakeSymbolicLink(symlinkLvl2Path, symlinkPath, ref errorMessage), errorMessage);
 
             using var buildManager = new BuildManager();

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Build.UnitTests
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
         }
 
-        [Fact]
+        [RequiresSymbolicLinksFact]
         public void BinaryLoggerShouldEmbedSymlinkFilesViaTaskOutput()
         {
             string testFileName = "foobar.txt";
@@ -231,13 +231,7 @@ namespace Microsoft.Build.UnitTests
             string emptyFile = testFolder.CreateFile(emptyFileName).Path;
 
             string errorMessage = string.Empty;
-            if (!NativeMethodsShared.MakeSymbolicLink(symlinkPath, testFile.Path, ref errorMessage))
-            {
-                // The environment doesn't support creating symlinks. Create an empty log file to satisfy
-                // the test requirement and skip the rest of the test.
-                File.Create(_logFile);
-                return;
-            }
+            Assert.True(NativeMethodsShared.MakeSymbolicLink(symlinkPath, testFile.Path, ref errorMessage), errorMessage);
             Assert.True(NativeMethodsShared.MakeSymbolicLink(symlinkLvl2Path, symlinkPath, ref errorMessage), errorMessage);
 
             using var buildManager = new BuildManager();

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -122,6 +122,9 @@
     <Compile Include="..\Shared\UnitTests\LongPathSupportDisabledFactAttribute.cs">
       <Link>Shared\LongPathSupportDisabledFactAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\UnitTests.Shared\RequiresSymbolicLinksFactAttribute.cs">
+      <Link>RequiresSymbolicLinksFactAttribute.cs</Link>
+    </Compile>
 
     <None Include="..\Shared\UnitTests\App.config">
       <Link>App.config</Link>

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1017,7 +1017,7 @@ internal static class NativeMethods
         return null;
     }
 
-    internal static bool MakeSymbolicLink(string newFileName, string exitingFileName, ref string errorMessage)
+    internal static bool MakeSymbolicLink(string newFileName, string existingFileName, ref string errorMessage)
     {
         bool symbolicLinkCreated;
         if (IsWindows)
@@ -1029,12 +1029,12 @@ internal static class NativeMethods
                 flags |= SymbolicLink.AllowUnprivilegedCreate;
             }
 
-            symbolicLinkCreated = CreateSymbolicLink(newFileName, exitingFileName, flags);
+            symbolicLinkCreated = CreateSymbolicLink(newFileName, existingFileName, flags);
             errorMessage = symbolicLinkCreated ? null : Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()).Message;
         }
         else
         {
-            symbolicLinkCreated = symlink(exitingFileName, newFileName) == 0;
+            symbolicLinkCreated = symlink(existingFileName, newFileName) == 0;
             errorMessage = symbolicLinkCreated ? null : Marshal.GetLastWin32Error().ToString();
         }
 

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Build.UnitTests
         }
 
 #if FEATURE_SYMLINK_TARGET
-        [Fact]
+        [RequiresSymbolicLinksFact]
         public void DoNotFollowRecursiveSymlinks()
         {
             TransientTestFolder testFolder = _env.CreateFolder();

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2380,7 +2380,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// DestinationFolder should work.
         /// </summary>
-        [Fact]
+        [RequiresSymbolicLinksFact]
         public void CopyToDestinationFolderWithSymbolicLinkCheck()
         {
             string sourceFile = FileUtilities.GetTemporaryFile();
@@ -2390,12 +2390,6 @@ namespace Microsoft.Build.UnitTests
             try
             {
                 File.WriteAllText(sourceFile, "This is a source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
-
-                if (!IsSymlinkingSupported(sourceFile))
-                {
-                    // The environment doesn't support creating symlinks, skip the test.
-                    return;
-                }
 
                 // Don't create the dest folder, let task do that
                 ITaskItem[] sourceFiles = { new TaskItem(sourceFile) };
@@ -2443,11 +2437,8 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                File.Delete(sourceFile);
-                if (Directory.Exists(destFolder))
-                {
-                    FileUtilities.DeleteWithoutTrailingBackslash(destFolder, true);
-                }
+                File.Delete(destFile);
+                FileUtilities.DeleteWithoutTrailingBackslash(destFolder, true);
             }
         }
 
@@ -2455,23 +2446,6 @@ namespace Microsoft.Build.UnitTests
         internal override void ErrorIfLinkFailedCheck()
         {
             base.ErrorIfLinkFailedCheck();
-        }
-
-        private bool IsSymlinkingSupported(string sourceFile)
-        {
-            if (!NativeMethodsShared.IsWindows)
-            {
-                return true;
-            }
-
-            string symlinkFile = FileUtilities.GetTemporaryFile();
-            string errorMessage = null;
-            if (NativeMethodsShared.MakeSymbolicLink(symlinkFile, sourceFile, ref errorMessage))
-            {
-                File.Delete(symlinkFile);
-                return true;
-            }
-            return false;
         }
     }
 }

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2437,6 +2437,7 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
+                File.Delete(sourceFile);
                 File.Delete(destFile);
                 FileUtilities.DeleteWithoutTrailingBackslash(destFolder, true);
             }

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -59,10 +59,10 @@
     <Compile Include="..\Shared\ProcessExtensions.cs" />
     <Compile Include="..\UnitTests.Shared\EnvironmentProvider.cs" />
     <Compile Include="..\UnitTests.Shared\RunnerUtilities.cs" />
-    
     <Compile Include="..\Shared\UnitTests\LongPathSupportDisabledFactAttribute.cs">
       <Link>Shared\LongPathSupportDisabledFactAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\UnitTests.Shared\RequiresSymbolicLinksFactAttribute.cs" />
 
     <EmbeddedResource Include="SampleResx" />
     <EmbeddedResource Include="AssemblyDependency\CacheFileSamples\Microsoft.VisualStudio.LanguageServices.Implementation.csprojAssemblyReference.cache" />

--- a/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
+++ b/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Build.UnitTests
                 string? errorMessage = null;
                 if (!NativeMethodsShared.MakeSymbolicLink(destinationFile, sourceFile, ref errorMessage))
                 {
-                    Skip = "This test requires symbolic link support to run.";
+                    Skip = "Requires permission to create symbolic links. Need to be run elevated or under development mode " +
+                        "(https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development).";
                 }
             }
             finally

--- a/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
+++ b/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 
 using Microsoft.Build.Shared;
@@ -14,9 +15,12 @@ namespace Microsoft.Build.UnitTests
     /// </summary>
     public sealed class RequiresSymbolicLinksFactAttribute : FactAttribute
     {
+        private static readonly bool s_runningInAzurePipeline =
+            bool.TryParse(Environment.GetEnvironmentVariable("TF_BUILD"), out bool value) && value;
+
         public RequiresSymbolicLinksFactAttribute()
         {
-            if (!NativeMethodsShared.IsWindows)
+            if (s_runningInAzurePipeline || !NativeMethodsShared.IsWindows)
             {
                 return;
             }

--- a/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
+++ b/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
@@ -9,6 +9,9 @@ using Xunit;
 
 namespace Microsoft.Build.UnitTests
 {
+    /// <summary>
+    /// A custom <see cref="FactAttribute"/> that skips the test if the OS doesn't support creating symlinks.
+    /// </summary>
     public sealed class RequiresSymbolicLinksFactAttribute : FactAttribute
     {
         public RequiresSymbolicLinksFactAttribute()
@@ -18,6 +21,8 @@ namespace Microsoft.Build.UnitTests
                 return;
             }
 
+            // In Windows, a process can create symlinks only if it has sufficient permissions.
+            // We simply try to create one and if it fails we skip the test.
             string sourceFile = FileUtilities.GetTemporaryFile();
             string destinationFile = FileUtilities.GetTemporaryFile();
             try

--- a/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
+++ b/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+using Microsoft.Build.Shared;
+using Xunit;
+
+
+namespace Microsoft.Build.UnitTests
+{
+    public sealed class RequiresSymbolicLinksFactAttribute : FactAttribute
+    {
+        public RequiresSymbolicLinksFactAttribute()
+        {
+            if (!NativeMethodsShared.IsWindows)
+            {
+                return;
+            }
+
+            string sourceFile = FileUtilities.GetTemporaryFile();
+            string destinationFile = FileUtilities.GetTemporaryFile();
+            try
+            {
+                File.Create(sourceFile).Dispose();
+
+                string? errorMessage = null;
+                if (!NativeMethodsShared.MakeSymbolicLink(destinationFile, sourceFile, ref errorMessage))
+                {
+                    Skip = "This test requires symbolic link support to run.";
+                }
+            }
+            finally
+            {
+                if (File.Exists(sourceFile))
+                {
+                    File.Delete(sourceFile);
+                }
+                if (File.Exists(destinationFile))
+                {
+                    File.Delete(destinationFile);
+                }
+            }
+        }
+    }
+}

--- a/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
+++ b/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
@@ -1,12 +1,11 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;
 
 using Microsoft.Build.Shared;
 using Xunit;
-
 
 namespace Microsoft.Build.UnitTests
 {


### PR DESCRIPTION
### Context

Tests currently don't pass on a clean Windows machine in a non-admin command prompt. Even on Win11 with developer mode enabled (and on a Microsoft DevBox VM, no less), the OS refuses to create symlinks unless the process runs elevated.

### Changes Made

Made the affected tests detect the ability to create symlinks and skip if the `kernel32!CreateSymbolicLink` call is failing.

### Testing

Unit tests in admin and non-admin command prompts.

### Notes

As much as I would like to have maximum possible coverage by running the tests unconditionally, I believe that a good developer experience is more important here. Specifically I do not want to require contributors to run elevated or jump through hoops to make the OS cooperate. This is a niche functionality anyway.