### PR TITLE
[FancyLogger] Improve render performance

### DIFF
--- a/src/Build/Logging/FancyLogger/FancyLogger.cs
+++ b/src/Build/Logging/FancyLogger/FancyLogger.cs
@@ -48,11 +48,11 @@ namespace Microsoft.Build.Logging.FancyLogger
             
             Task.Run(() =>
             {
-                task_Render();
+                Render();
             });
         }
 
-        void task_Render()
+        void Render()
         {
             // Initialize FancyLoggerBuffer
             FancyLoggerBuffer.Initialize();
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Logging.FancyLogger
                 Task.Delay((i / 60) * 1_000).ContinueWith((t) =>
                 {
                     // Rerender projects only when needed
-                    foreach (var project in projects) project.Value.Render();
+                    foreach (var project in projects) project.Value.Log();
                     // Rerender buffer
                     FancyLoggerBuffer.Render();
                 });

--- a/src/Build/Logging/FancyLogger/FancyLogger.cs
+++ b/src/Build/Logging/FancyLogger/FancyLogger.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             {
                 i++;
                 // Delay by 1/60 seconds
+                // Use task delay to avoid blocking the task, so that keyboard input is listened continously
                 Task.Delay((i / 60) * 1_000).ContinueWith((t) =>
                 {
                     // Rerender projects only when needed

--- a/src/Build/Logging/FancyLogger/FancyLogger.cs
+++ b/src/Build/Logging/FancyLogger/FancyLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Logging.FancyLogger
@@ -44,11 +45,48 @@ namespace Microsoft.Build.Logging.FancyLogger
             eventSource.ErrorRaised += new BuildErrorEventHandler(eventSource_ErrorRaised);
             // Cancelled
             Console.CancelKeyPress += new ConsoleCancelEventHandler(console_CancelKeyPressed);
-            // Initialize FancyLoggerBuffer
-            FancyLoggerBuffer.Initialize();
-            // TODO: Fix. First line does not appear at top. Leaving empty line for now
-            FancyLoggerBuffer.WriteNewLine(string.Empty);
-            FancyLoggerBuffer.Render();
+            
+            Task.Run(() =>
+            {
+                // Initialize FancyLoggerBuffer
+                FancyLoggerBuffer.Initialize();
+                // TODO: Fix. First line does not appear at top. Leaving empty line for now
+                FancyLoggerBuffer.WriteNewLine(string.Empty);
+                // First render
+                FancyLoggerBuffer.Render();
+                int i = 0;
+                // Rerender periodically
+                while (!FancyLoggerBuffer.IsTerminated)
+                {
+                    i++;
+                    // Delay by 1/60 seconds
+                    Task.Delay((i / 60) * 1_000).ContinueWith((t) =>
+                    {
+                        // Rerender projects only when needed
+                        foreach (var project in projects) project.Value.Render();
+                        // Rerender buffer
+                        FancyLoggerBuffer.Render();
+                    });
+                    // Handle keyboard input
+                    if (Console.KeyAvailable)
+                    {
+                        ConsoleKey key = Console.ReadKey().Key;
+                        switch (key)
+                        {
+                            case ConsoleKey.UpArrow:
+                                if (FancyLoggerBuffer.TopLineIndex > 0) FancyLoggerBuffer.TopLineIndex--;
+                                FancyLoggerBuffer.ShouldRerender = true;
+                                break;
+                            case ConsoleKey.DownArrow:
+                                FancyLoggerBuffer.TopLineIndex++;
+                                FancyLoggerBuffer.ShouldRerender = true;
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+            });
         }
 
         // Build
@@ -72,7 +110,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             FancyLoggerProjectNode node = new FancyLoggerProjectNode(e);
             projects[id] = node;
             // Log
-            node.Log();
+            node.ShouldRerender = true;
         }
 
         void eventSource_ProjectFinished(object sender, ProjectFinishedEventArgs e)
@@ -83,7 +121,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             // Update line
             node.Finished = true;
             // Log
-            node.Log();
+            node.ShouldRerender = true;
         }
 
         // Target
@@ -95,7 +133,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             // Update
             node.AddTarget(e);
             // Log
-            node.Log();
+            node.ShouldRerender = true;
         }
 
         void eventSource_TargetFinished(object sender, TargetFinishedEventArgs e)
@@ -106,7 +144,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             // Update
             node.FinishedTargets++;
             // Log
-            node.Log();
+            node.ShouldRerender = true;
         }
 
         // Task
@@ -119,7 +157,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             node.AddTask(e);
             existingTasks++;
             // Log
-            node.Log();
+            node.ShouldRerender = true;
         }
 
         void eventSource_TaskFinished(object sender, TaskFinishedEventArgs e)
@@ -137,7 +175,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             // Update
             node.AddMessage(e);
             // Log
-            node.Log();
+            node.ShouldRerender = true;
         }
 
         void eventSource_WarningRaised(object sender, BuildWarningEventArgs e)
@@ -148,7 +186,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             // Update
             node.AddWarning(e);
             // Log
-            node.Log();
+            node.ShouldRerender = true;
         }
         void eventSource_ErrorRaised(object sender, BuildErrorEventArgs e)
         {
@@ -158,7 +196,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             // Update
             node.AddError(e);
             // Log
-            node.Log();
+            node.ShouldRerender = true;
         }
 
         void console_CancelKeyPressed(object? sender, ConsoleCancelEventArgs eventArgs)

--- a/src/Build/Logging/FancyLogger/FancyLoggerBuffer.cs
+++ b/src/Build/Logging/FancyLogger/FancyLoggerBuffer.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Build.Logging.FancyLogger
                 }
             }
             // Iterate for the rest of the screen
-            for (int i = lineIndex; i < ScrollableAreaHeight; i++)
+            for (int i = lineIndex + 1; i < ScrollableAreaHeight; i++)
             {
                 contents += ANSIBuilder.Cursor.Position(i + 2, 0) + ANSIBuilder.Eraser.LineCursorToEnd();
             }

--- a/src/Build/Logging/FancyLogger/FancyLoggerMessageNode.cs
+++ b/src/Build/Logging/FancyLogger/FancyLoggerMessageNode.cs
@@ -70,10 +70,10 @@ namespace Microsoft.Build.Logging.FancyLogger
             }
         }
 
-        public void Log()
+        public void Render()
         {
             if (Line == null) return;
-            FancyLoggerBuffer.UpdateLine(Line.Id, $"    └── {ToANSIString()}");
+            Line.Text = $"    └── {ToANSIString()}";
         }
     }
 }

--- a/src/Build/Logging/FancyLogger/FancyLoggerMessageNode.cs
+++ b/src/Build/Logging/FancyLogger/FancyLoggerMessageNode.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Build.Logging.FancyLogger
             }
         }
 
-        public void Render()
+        // TODO: Rename to Log after FancyLogger's API becomes internal
+        public void Log()
         {
             if (Line == null) return;
             Line.Text = $"    └── {ToANSIString()}";

--- a/src/Build/Logging/FancyLogger/FancyLoggerProjectNode.cs
+++ b/src/Build/Logging/FancyLogger/FancyLoggerProjectNode.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Build.Logging.FancyLogger
             }
         }
 
-        public void Render()
+        // TODO: Rename to Render() after FancyLogger's API becomes internal
+        public void Log()
         {
             if (!ShouldRerender) return;
             ShouldRerender = false;
@@ -98,7 +99,7 @@ namespace Microsoft.Build.Logging.FancyLogger
             {
                 if (Finished && node.Type == FancyLoggerMessageNode.MessageType.HighPriorityMessage) continue;
                 if (node.Line is null) node.Line = FancyLoggerBuffer.WriteNewLineAfter(Line!.Id, "Message");
-                node.Render();
+                node.Log();
             }
         }
 

--- a/src/Build/Logging/FancyLogger/FancyLoggerProjectNode.cs
+++ b/src/Build/Logging/FancyLogger/FancyLoggerProjectNode.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Build.Logging.FancyLogger
         public int MessageCount = 0;
         public int WarningCount = 0;
         public int ErrorCount = 0;
+        // Bool if node should rerender
+        internal bool ShouldRerender = true;
         public FancyLoggerProjectNode(ProjectStartedEventArgs args)
         {
             Id = args.ProjectId;
@@ -54,8 +56,10 @@ namespace Microsoft.Build.Logging.FancyLogger
             }
         }
 
-        public void Log()
+        public void Render()
         {
+            if (!ShouldRerender) return;
+            ShouldRerender = false;
             // Project details
             string lineContents = ANSIBuilder.Alignment.SpaceBetween(
                 // Show indicator
@@ -68,34 +72,33 @@ namespace Microsoft.Build.Logging.FancyLogger
                 Console.WindowWidth
             );
             // Create or update line
-            if (Line == null) Line = FancyLoggerBuffer.WriteNewLine(lineContents, false);
-            else FancyLoggerBuffer.UpdateLine(Line.Id, lineContents);
+            if (Line is null) Line = FancyLoggerBuffer.WriteNewLine(lineContents, false);
+            else Line.Text = lineContents;
 
             // For finished projects
             if (Finished)
             {
-                if (CurrentTargetLine != null) FancyLoggerBuffer.DeleteLine(CurrentTargetLine.Id);
+                if (CurrentTargetLine is not null) FancyLoggerBuffer.DeleteLine(CurrentTargetLine.Id);
                 foreach (FancyLoggerMessageNode node in AdditionalDetails.ToList())
                 {
                     // Only delete high priority messages
                     if (node.Type != FancyLoggerMessageNode.MessageType.HighPriorityMessage) continue;
-                    if (node.Line != null) FancyLoggerBuffer.DeleteLine(node.Line.Id);
-                    // AdditionalDetails.Remove(node);
+                    if (node.Line is not null) FancyLoggerBuffer.DeleteLine(node.Line.Id);
                 }
             }
 
             // Current target details
-            if (CurrentTargetNode == null) return;
+            if (CurrentTargetNode is null) return;
             string currentTargetLineContents = $"    └── {CurrentTargetNode.TargetName} : {CurrentTargetNode.CurrentTaskNode?.TaskName ?? String.Empty}";
-            if (CurrentTargetLine == null) CurrentTargetLine = FancyLoggerBuffer.WriteNewLineAfter(Line!.Id, currentTargetLineContents);
-            else FancyLoggerBuffer.UpdateLine(CurrentTargetLine.Id, currentTargetLineContents);
+            if (CurrentTargetLine is null) CurrentTargetLine = FancyLoggerBuffer.WriteNewLineAfter(Line!.Id, currentTargetLineContents);
+            else CurrentTargetLine.Text = currentTargetLineContents;
 
             // Messages, warnings and errors
             foreach (FancyLoggerMessageNode node in AdditionalDetails)
             {
                 if (Finished && node.Type == FancyLoggerMessageNode.MessageType.HighPriorityMessage) continue;
-                if (node.Line == null) node.Line = FancyLoggerBuffer.WriteNewLineAfter(Line!.Id, "Message");
-                node.Log();
+                if (node.Line is null) node.Line = FancyLoggerBuffer.WriteNewLineAfter(Line!.Id, "Message");
+                node.Render();
             }
         }
 


### PR DESCRIPTION
Fixes #

### Context
A design goal for the FancyLogger is not to have too big of an impact on performance, especially considering all the formatting, layout and constant updating on the buffer. This PR reduces render and build time when using the logger by half.

### Changes Made
- Rendering now occurs in a completely separate project to the build, meaning it doesn't block
- Added indicators to both `FancyLoggerProjectNode` and `FancyLoggerBuffer` to avoid re-rendering when no changes occured
- Delimited for loop in `FancyLoggerBuffer.Render()` to only perform operations on the lines that are visible on the screen
- In `FancyLoggerBuffer.Render()` text is stored in a string and then logged to the console all at once to avoid laggy behavior
- Improved performance for finding lines by Id
- Code refactoring

### Testing


### Notes
