### PR TITLE
Improve PFX error message

### DIFF
--- a/src/Tasks/ResolveKeySource.cs
+++ b/src/Tasks/ResolveKeySource.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Build.Tasks
                             fs?.Close();
                         }
 #else
-                        Log.LogError("PFX signing not supported on .NET Core");
+                        Log.LogErrorWithCodeFromResources("ResolveKeySource.PfxUnsupported");
                         pfxSuccess = false;
 #endif
                     }
@@ -266,7 +266,7 @@ namespace Microsoft.Build.Tasks
                     }
                 }
 #else
-                Log.LogError("PFX signing not supported on .NET Core");
+                Log.LogErrorWithCodeFromResources("ResolveKeySource.PfxUnsupported");
 #endif
             }
             else if (!certInStore && !string.IsNullOrEmpty(CertificateFile) && !string.IsNullOrEmpty(CertificateThumbprint))

--- a/src/Tasks/ResolveKeySource.cs
+++ b/src/Tasks/ResolveKeySource.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Build.Tasks
                     }
                 }
 #else
-                Log.LogError("Certificate signing not supported on .NET Core");
+                Log.LogError("PFX signing not supported on .NET Core");
 #endif
             }
             else if (!certInStore && !string.IsNullOrEmpty(CertificateFile) && !string.IsNullOrEmpty(CertificateThumbprint))

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2960,6 +2960,9 @@
   <data name="GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform">
     <value>Platform property of referenced project '{0}' matches current project's platform: '{1}'. Referenced project will be built without a global Platform property.</value>
   </data>
+  <data name="ResolveKeySource.PfxUnsupported" xml:space="preserve">
+    <value>PFX signing not supported on .NET Core.</value>
+  </data>
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: Následující soubor klíčů nelze importovat: {0}. Soubor klíčů může být chráněn heslem. Chcete-li problém vyřešit, naimportujte certifikát znovu nebo certifikát naimportujte ručně do osobního úložiště certifikátů aktuálního uživatele.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: V úložišti certifikátů Windows aktuálního uživatele se nedá najít certifikát pro podpis kódu. Pokud chcete tento problém opravit, zakažte podepisování manifestu ClickOnce, nebo do úložiště certifikátů nainstalujte certifikát.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: Die folgende Schlüsseldatei kann nicht importiert werden: {0}. Die Schlüsseldatei ist möglicherweise kennwortgeschützt. Importieren Sie das Zertifikat erneut, oder importieren Sie das Zertifikat manuell in den persönlichen Zertifikatspeicher des aktuellen Benutzers, um das Problem zu beheben.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: Das Codesignaturzertifikat wurde im Windows-Zertifikatspeicher des aktuellen Benutzers nicht gefunden. Deaktivieren Sie entweder das Signieren des ClickOnce-Manifests, oder installieren Sie das Zertifikat im Zertifikatspeicher, um das Problem zu beheben.</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: No se puede importar el archivo de clave siguiente: {0}. Puede que esté protegido mediante contraseña. Para solucionar este problema, intente importar de nuevo el certificado o impórtelo manualmente en el almacén de certificados personales del usuario.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: No se puede encontrar el certificado de firma de código en el almacén de certificados de Windows del usuario actual. Para solucionarlo, deshabilite la firma del manifiesto de ClickOnce o instale el certificado en el almacén de certificados.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: Impossible d'importer le fichier de clé suivant : {0}. Le fichier de clé est peut-être protégé par mot de passe. Pour corriger ce problème, essayez de réimporter le certificat, ou importez manuellement le certificat dans le magasin de certificats personnel de l'utilisateur actuel.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: Le certificat de signature de code est introuvable dans le magasin de certificats Windows de l'utilisateur actuel. Pour corriger ce problème, désactivez la signature du manifeste ClickOnce ou installez le certificat dans le magasin de certificats.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: non è possibile importare il seguente file di chiave: {0}. Il file di chiave potrebbe essere protetto da password. Per risolvere il problema, provare a importare di nuovo il certificato oppure importarlo manualmente nell'archivio certificati personale dell'utente corrente.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: il certificato di firma del codice non è stato trovato nell'archivio certificati Windows dell'utente corrente. Per risolvere il problema, disabilitare la firma del manifesto ClickOnce o installare il certificato nell'archivio certificati.</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: 次のキー ファイルをインポートできません: {0}。キー ファイルはパスワードで保護されている可能性があります。この状況を解決するには、証明書をもう一度インポートするか、現在のユーザーの個人証明書ストアに証明書を手動でインポートしてください。</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: 現在のユーザーの Windows 証明書ストアにコード署名証明書が見つかりません。これを修正するには、ClickOnce マニフェストの署名を無効にするか、証明書ストアに証明書をインストールしてください。</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: 키 파일 {0}을(를) 가져올 수 없습니다. 해당 키 파일이 암호로 보호되어 있을 수 있습니다. 이 문제를 해결하려면 인증서를 다시 가져오거나 현재 사용자의 개인 인증서 저장소로 인증서를 직접 가져오세요.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: 현재 사용자의 Windows 인증서 저장소에서 코드 서명 인증서를 찾을 수 없습니다. 이 문제를 해결하려면 ClickOnce 매니페스트를 사용하지 않도록 설정하거나 인증서를 인증서 저장소에 설치하세요.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: Nie można zaimportować następującego pliku klucza: {0}. Plik klucza może być chroniony hasłem. Aby rozwiązać ten problem, spróbuj ponownie zaimportować certyfikat lub zaimportuj certyfikat ręcznie do osobistego magazynu certyfikatów bieżącego użytkownika.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: Nie można znaleźć certyfikatu podpisywania kodu w magazynie certyfikatów bieżącego użytkownika systemu Windows. Aby naprawić ten błąd, wyłącz podpisywanie manifestu ClickOnce lub zainstaluj certyfikat w magazynie certyfikatów.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: Não é possível importar o seguinte arquivo de chave: {0}. Talvez esse arquivo de chave esteja protegido por senha. Para corrigir isso, tente importar o certificado de novo ou importe-o manualmente para o repositório de certificados pessoal do usuário atual.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: Não foi possível encontrar o certificado de assinatura de código no repositório de certificados do Windows do usuário atual. Para corrigir isso, desabilite a assinatura do manifesto ClickOnce ou instale o certificado no repositório de certificados.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: невозможно импортировать следующий файл ключа: {0}. Возможно, файл ключа защищен паролем. Чтобы устранить эту ошибку, повторите попытку импорта сертификата или вручную импортируйте сертификат в личное хранилище сертификатов текущего пользователя.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: не удается найти сертификат подписи кода в хранилище сертификатов Windows текущего пользователя. Чтобы исправить это, отключите подписывание манифеста ClickOnce или установите сертификат в хранилище сертификатов.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: Şu anahtar dosyası içeri aktarılamıyor: {0}. Anahtar dosyası parola korumalı olabilir. Bunu düzeltmek için, sertifikayı yeniden içeri aktarmayı deneyin veya sertifikayı el ile geçerli kullanıcının kişisel sertifika deposuna aktarın.</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: Geçerli kullanıcının Windows sertifika deposunda kod imzalama sertifikası bulunamadı. Bunu düzeltmek için, ClickOnce bildiriminin imzalanmasını devre dışı bırakın veya sertifikayı sertifika deposuna yükleyin.</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: 无法导入以下密钥文件: {0}。该密钥文件可能受密码保护。若要更正此问题，请尝试再次导入证书，或手动将证书导入当前用户的个人证书存储中。</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: 无法在当前用户的 Windows 证书存储中找到代码签名证书。若要更正此问题，请禁用 ClickOnce 清单的签名或将证书安装到证书存储中。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -2353,6 +2353,11 @@
         <target state="translated">MSB3326: 無法匯入下列金鑰檔: {0}。此金鑰檔可能有密碼保護。若要改正這種情況，請嘗試再次匯入憑證，或手動將憑證匯入到目前使用者的個人憑證存放區。</target>
         <note>{StrBegin="MSB3326: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveKeySource.PfxUnsupported">
+        <source>PFX signing not supported on .NET Core.</source>
+        <target state="new">PFX signing not supported on .NET Core.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
         <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
         <target state="translated">MSB3327: 在目前使用者的 Windows 憑證存放區中，找不到程式碼簽署憑證。若要更正此問題，請停用 ClickOnce 資訊清單的簽署，或將憑證安裝到憑證存放區。</target>


### PR DESCRIPTION


### Context
The error message "Certificate signing not supported on .NET Core" is logged in ResolveManifestKey because signing from a PFX file is not enabled. `FEATURE_PFX_SIGNING`. In other places, like in `ResolveAssemblyKey()` just above, it will give the error message "PFX signing not supported on .NET Core" which is a lot less confusing.

### Changes Made
Changed the error message logged.

### Testing


### Notes
