### PR TITLE
Enable temporary comm logging for CanShutdownServerProcess test

### DIFF
--- a/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
+++ b/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
@@ -15,13 +15,6 @@ namespace Microsoft.Build.UnitTests
 {
     public class DebugUtils_Tests
     {
-        private readonly ITestOutputHelper _testOutput;
-
-        public DebugUtils_Tests(ITestOutputHelper testOutput)
-        {
-            _testOutput = testOutput;
-        }
-
         [Fact]
         public void DumpExceptionToFileShouldWriteInTempPathByDefault()
         {

--- a/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
+++ b/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
@@ -1,18 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Shared;
-using Microsoft.Build.Shared.Debugging;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+
+#nullable disable
+
 namespace Microsoft.Build.UnitTests
 {
     public class DebugUtils_Tests

--- a/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
+++ b/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
@@ -1,23 +1,33 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+
+
+#nullable disable
+
 using System;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.Debugging;
 using Shouldly;
 using Xunit;
-
-#nullable disable
-
+using Xunit.Abstractions;
 namespace Microsoft.Build.UnitTests
 {
     public class DebugUtils_Tests
     {
+        private readonly ITestOutputHelper _testOutput;
+
+        public DebugUtils_Tests(ITestOutputHelper testOutput)
+        {
+            _testOutput = testOutput;
+        }
+
         [Fact]
         public void DumpExceptionToFileShouldWriteInTempPathByDefault()
         {
-            Directory.GetFiles(Path.GetTempPath(), "MSBuild_*failure.txt").ShouldBeEmpty();
+            var exceptionFilesBefore = Directory.GetFiles(FileUtilities.TempFileDirectory, "MSBuild_*failure.txt");
 
             string[] exceptionFiles = null;
 
@@ -28,10 +38,14 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                exceptionFiles.ShouldNotBeNull();
-                exceptionFiles.ShouldHaveSingleItem();
+                _testOutput.WriteLine($"DebugUtils.DebugPath: {DebugUtils.DebugPath}");
+                _testOutput.WriteLine($"Environment.GetEnvironmentVariable(\"MSBUILDDEBUGPATH\"): {Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH")}");
 
-                var exceptionFile = exceptionFiles.First();
+                exceptionFilesBefore.ShouldNotBeNull();
+                exceptionFiles.ShouldNotBeNull();
+                (exceptionFiles.Length - exceptionFilesBefore.Length).ShouldBe(1);
+
+                var exceptionFile = exceptionFiles.Except(exceptionFilesBefore).Single();
                 File.ReadAllText(exceptionFile).ShouldContain("hello world");
                 File.Delete(exceptionFile);
             }

--- a/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
+++ b/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
@@ -27,20 +27,17 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void DumpExceptionToFileShouldWriteInTempPathByDefault()
         {
-            var exceptionFilesBefore = Directory.GetFiles(FileUtilities.TempFileDirectory, "MSBuild_*failure.txt");
+            var exceptionFilesBefore = Directory.GetFiles(ExceptionHandling.DebugDumpPath, "MSBuild_*failure.txt");
 
             string[] exceptionFiles = null;
 
             try
             {
                 ExceptionHandling.DumpExceptionToFile(new Exception("hello world"));
-                exceptionFiles = Directory.GetFiles(FileUtilities.TempFileDirectory, "MSBuild_*failure.txt");
+                exceptionFiles = Directory.GetFiles(ExceptionHandling.DebugDumpPath, "MSBuild_*failure.txt");
             }
             finally
             {
-                _testOutput.WriteLine($"DebugUtils.DebugPath: {DebugUtils.DebugPath}");
-                _testOutput.WriteLine($"Environment.GetEnvironmentVariable(\"MSBUILDDEBUGPATH\"): {Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH")}");
-
                 exceptionFilesBefore.ShouldNotBeNull();
                 exceptionFiles.ShouldNotBeNull();
                 (exceptionFiles.Length - exceptionFilesBefore.Length).ShouldBe(1);

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -17,7 +17,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Build.Graph.UnitTests
 {
-    public class IsolateProjectsTests : IDisposable
+    public class IsolateProjectsTests : IDisposable, IClassFixture<IsolateProjectsTests.IsolateProjectsClassFixture>
     {
         private readonly string _project = @"
                 <Project DefaultTargets='BuildSelf'>
@@ -132,16 +132,6 @@ BuildEngine5.BuildProjectFilesInParallel(
         {
             _testOutput = testOutput;
             _env = TestEnvironment.Create(_testOutput, ignoreBuildErrorFiles: true);
-
-            if (NativeMethodsShared.IsOSX)
-            {
-                // OSX links /var into /private, which makes Path.GetTempPath() to return "/var..." but Directory.GetCurrentDirectory to return "/private/var..."
-                // this discrepancy fails the msbuild undeclared reference enforcements due to failed path equality checks
-                var tempFolder = _env.CreateFolder(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")));
-                _env.SetTempPath(tempFolder.Path);
-            }
-
-            _env.WithInvariant(new BuildFailureLogInvariant());
 
             // todo investigate why out of proc builds fail on macos https://github.com/dotnet/msbuild/issues/3915
             var disableInProcNode = !NativeMethodsShared.IsOSX;
@@ -492,6 +482,28 @@ BuildEngine5.BuildProjectFilesInParallel(
                 buildManagerSession.Logger.ErrorCount.ShouldBe(0);
                 // twice for the initial target, once for A, once for DefaultTarget
                 buildManagerSession.Logger.AssertMessageCount("Previously built successfully", 4);
+            }
+        }
+
+        internal class IsolateProjectsClassFixture : IDisposable
+        {
+            private readonly TestEnvironment _classFixtureEnv;
+
+            public IsolateProjectsClassFixture()
+            {
+                _classFixtureEnv = TestEnvironment.Create(output: null, ignoreBuildErrorFiles: true);
+                if (NativeMethodsShared.IsOSX)
+                {
+                    // OSX links /var into /private, which makes Path.GetTempPath() to return "/var..." but Directory.GetCurrentDirectory to return "/private/var..."
+                    // this discrepancy fails the msbuild undeclared reference enforcements due to failed path equality checks
+                    var tempFolder = _classFixtureEnv.CreateFolder(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")));
+                    _classFixtureEnv.SetTempPath(tempFolder.Path);
+                }
+            }
+
+            public void Dispose()
+            {
+                _classFixtureEnv.Dispose();
             }
         }
     }

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -17,7 +17,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Build.Graph.UnitTests
 {
-    public class IsolateProjectsTests : IDisposable, IClassFixture<IsolateProjectsTests.IsolateProjectsClassFixture>
+    public class IsolateProjectsTests : IDisposable
     {
         private readonly string _project = @"
                 <Project DefaultTargets='BuildSelf'>
@@ -133,6 +133,13 @@ BuildEngine5.BuildProjectFilesInParallel(
             _testOutput = testOutput;
             _env = TestEnvironment.Create(_testOutput, ignoreBuildErrorFiles: true);
 
+            if (NativeMethodsShared.IsOSX)
+            {
+                // OSX links /var into /private, which makes Path.GetTempPath() to return "/var..." but Directory.GetCurrentDirectory to return "/private/var..."
+                // this discrepancy fails the msbuild undeclared reference enforcements due to failed path equality checks
+                _env.SetTempPath(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")), deleteTempDirectory: true);
+            }
+
             // todo investigate why out of proc builds fail on macos https://github.com/dotnet/msbuild/issues/3915
             var disableInProcNode = !NativeMethodsShared.IsOSX;
 
@@ -148,8 +155,6 @@ BuildEngine5.BuildProjectFilesInParallel(
         {
             _env.Dispose();
         }
-
-
 
         [Theory]
         [InlineData(BuildResultCode.Success, new string[] { })]
@@ -482,28 +487,6 @@ BuildEngine5.BuildProjectFilesInParallel(
                 buildManagerSession.Logger.ErrorCount.ShouldBe(0);
                 // twice for the initial target, once for A, once for DefaultTarget
                 buildManagerSession.Logger.AssertMessageCount("Previously built successfully", 4);
-            }
-        }
-
-        internal class IsolateProjectsClassFixture : IDisposable
-        {
-            private readonly TestEnvironment _classFixtureEnv;
-
-            public IsolateProjectsClassFixture()
-            {
-                _classFixtureEnv = TestEnvironment.Create(output: null, ignoreBuildErrorFiles: true);
-                if (NativeMethodsShared.IsOSX)
-                {
-                    // OSX links /var into /private, which makes Path.GetTempPath() to return "/var..." but Directory.GetCurrentDirectory to return "/private/var..."
-                    // this discrepancy fails the msbuild undeclared reference enforcements due to failed path equality checks
-                    var tempFolder = _classFixtureEnv.CreateFolder(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")));
-                    _classFixtureEnv.SetTempPath(tempFolder.Path);
-                }
-            }
-
-            public void Dispose()
-            {
-                _classFixtureEnv.Dispose();
             }
         }
     }

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -131,7 +131,7 @@ BuildEngine5.BuildProjectFilesInParallel(
         public IsolateProjectsTests(ITestOutputHelper testOutput)
         {
             _testOutput = testOutput;
-            _env = TestEnvironment.Create(_testOutput);
+            _env = TestEnvironment.Create(_testOutput, ignoreBuildErrorFiles: false);
 
             if (NativeMethodsShared.IsOSX)
             {
@@ -139,6 +139,8 @@ BuildEngine5.BuildProjectFilesInParallel(
                 // this discrepancy fails the msbuild undeclared reference enforcements due to failed path equality checks
                 _env.SetTempPath(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")), deleteTempDirectory: true);
             }
+
+            _env.WithInvariant(new BuildFailureLogInvariant());
 
             // todo investigate why out of proc builds fail on macos https://github.com/dotnet/msbuild/issues/3915
             var disableInProcNode = !NativeMethodsShared.IsOSX;

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -131,7 +131,7 @@ BuildEngine5.BuildProjectFilesInParallel(
         public IsolateProjectsTests(ITestOutputHelper testOutput)
         {
             _testOutput = testOutput;
-            _env = TestEnvironment.Create(_testOutput, ignoreBuildErrorFiles: false);
+            _env = TestEnvironment.Create(_testOutput, ignoreBuildErrorFiles: true);
 
             if (NativeMethodsShared.IsOSX)
             {

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -137,7 +137,8 @@ BuildEngine5.BuildProjectFilesInParallel(
             {
                 // OSX links /var into /private, which makes Path.GetTempPath() to return "/var..." but Directory.GetCurrentDirectory to return "/private/var..."
                 // this discrepancy fails the msbuild undeclared reference enforcements due to failed path equality checks
-                _env.SetTempPath(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")), deleteTempDirectory: true);
+                var tempFolder = _env.CreateFolder(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")));
+                _env.SetTempPath(tempFolder.Path);
             }
 
             _env.WithInvariant(new BuildFailureLogInvariant());

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -531,6 +531,7 @@ namespace Microsoft.Build.Experimental
 
         private bool TrySendShutdownCommand()
         {
+            CommunicationsUtilities.Trace("Sending shutdown command to server.");
             _packetPump.ServerWillDisconnect();
             return TrySendPacket(() => new NodeBuildComplete(false /* no node reuse */));
         }

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Build.Engine.UnitTests
             else
             {
                 bool serverIsDown = MSBuildClient.ShutdownServer(CancellationToken.None);
-                //serverIsDown.ShouldBeTrue();
+                // serverIsDown.ShouldBeTrue();
                 // TODO: uncomment line above and delete line bellow, once tested if logging is sufficient
                 serverIsDown.ShouldBeFalse();
             }

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -218,6 +218,10 @@ namespace Microsoft.Build.Engine.UnitTests
         [InlineData(false)]
         public void CanShutdownServerProcess(bool byBuildManager)
         {
+            // this log seems to be flaky, lets enable better logging to investigate it next time
+            // TODO: delete after investigated its flakiness
+            _env.SetEnvironmentVariable("MSBuildDebugEngine", "1");
+
             _env.SetEnvironmentVariable("MSBUILDUSESERVER", "1");
 
             TransientTestFile project = _env.CreateFile("testProject.proj", printPidContents);
@@ -239,7 +243,9 @@ namespace Microsoft.Build.Engine.UnitTests
             else
             {
                 bool serverIsDown = MSBuildClient.ShutdownServer(CancellationToken.None);
-                serverIsDown.ShouldBeTrue();
+                //serverIsDown.ShouldBeTrue();
+                // TODO: uncomment line above and delete line bellow, once tested if logging is sufficient
+                serverIsDown.ShouldBeFalse();
             }
 
             serverProcess.WaitForExit(10_000);

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -289,6 +289,10 @@ namespace Microsoft.Build.Engine.UnitTests
         [Fact]
         public void PropertyMSBuildStartupDirectoryOnServer()
         {
+            // This test seems to be flaky, lets enable better logging to investigate it next time
+            // TODO: delete after investigated its flakiness
+            _env.WithTransientDebugEngineForNewProcesses(true);
+
             string reportMSBuildStartupDirectoryProperty = @$"
 <Project>
     <UsingTask TaskName=""ProcessIdTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -11,6 +11,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Experimental;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.Debugging;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.Shared;
 #if NETFRAMEWORK
@@ -218,11 +219,11 @@ namespace Microsoft.Build.Engine.UnitTests
         [InlineData(false)]
         public void CanShutdownServerProcess(bool byBuildManager)
         {
+            _env.SetEnvironmentVariable("MSBUILDUSESERVER", "1");
+
             // this log seems to be flaky, lets enable better logging to investigate it next time
             // TODO: delete after investigated its flakiness
-            _env.SetEnvironmentVariable("MSBuildDebugEngine", "1");
-
-            _env.SetEnvironmentVariable("MSBUILDUSESERVER", "1");
+            _env.WithTransientDebugEngineForNewProcesses(true);
 
             TransientTestFile project = _env.CreateFile("testProject.proj", printPidContents);
 
@@ -243,9 +244,7 @@ namespace Microsoft.Build.Engine.UnitTests
             else
             {
                 bool serverIsDown = MSBuildClient.ShutdownServer(CancellationToken.None);
-                // serverIsDown.ShouldBeTrue();
-                // TODO: uncomment line above and delete line bellow, once tested if logging is sufficient
-                serverIsDown.ShouldBeFalse();
+                serverIsDown.ShouldBeTrue();
             }
 
             serverProcess.WaitForExit(10_000);

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             _env.SetEnvironmentVariable("MSBUILDUSESERVER", "1");
 
-            // this log seems to be flaky, lets enable better logging to investigate it next time
+            // This test seems to be flaky, lets enable better logging to investigate it next time
             // TODO: delete after investigated its flakiness
             _env.WithTransientDebugEngineForNewProcesses(true);
 

--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -64,9 +64,7 @@ namespace Microsoft.Build.Shared
                 Directory.CreateDirectory(basePath);
             }
 
-            basePath = FileUtilities.EnsureTrailingSlash(basePath);
-
-            return basePath;
+            return FileUtilities.EnsureTrailingSlash(basePath);
         }
 
         /// <summary>

--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -4,6 +4,8 @@
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using Microsoft.Build.Shared.FileSystem;
 
 #nullable disable
@@ -62,6 +64,10 @@ namespace Microsoft.Build.Shared
             else
             {
                 Directory.CreateDirectory(basePath);
+                DirectoryInfo dInfo = new DirectoryInfo(basePath);
+                DirectorySecurity dSecurity = dInfo.GetAccessControl();
+                dSecurity.AddAccessRule(new FileSystemAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null), FileSystemRights.FullControl, InheritanceFlags.ObjectInherit | InheritanceFlags.ContainerInherit, PropagationFlags.NoPropagateInherit, AccessControlType.Allow));
+                dInfo.SetAccessControl(dSecurity);
             }
 
             basePath = FileUtilities.EnsureTrailingSlash(basePath);

--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -64,10 +64,6 @@ namespace Microsoft.Build.Shared
             else
             {
                 Directory.CreateDirectory(basePath);
-                DirectoryInfo dInfo = new DirectoryInfo(basePath);
-                DirectorySecurity dSecurity = dInfo.GetAccessControl();
-                dSecurity.AddAccessRule(new FileSystemAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null), FileSystemRights.FullControl, InheritanceFlags.ObjectInherit | InheritanceFlags.ContainerInherit, PropagationFlags.NoPropagateInherit, AccessControlType.Allow));
-                dInfo.SetAccessControl(dSecurity);
             }
 
             basePath = FileUtilities.EnsureTrailingSlash(basePath);

--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -38,6 +38,9 @@ namespace Microsoft.Build.Shared
         {
             string basePath = Path.Combine(Path.GetTempPath(), $"MSBuildTemp{Environment.UserName}");
 
+            if (basePath.StartsWith("/Users"))
+                throw new InvalidOperationException($"Weird OSX error 1: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
+
             if (NativeMethodsShared.IsLinux && NativeMethodsShared.mkdir(basePath, userRWX) != 0)
             {
                 if (NativeMethodsShared.chmod(basePath, userRWX) == 0)
@@ -58,13 +61,26 @@ namespace Microsoft.Build.Shared
 
                     basePath = pathToCheck;
                 }
+
+                if (basePath.StartsWith("/Users"))
+                    throw new InvalidOperationException($"Weird OSX error 2a: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
             }
             else
             {
                 Directory.CreateDirectory(basePath);
+                if (basePath.StartsWith("/Users"))
+                    throw new InvalidOperationException($"Weird OSX error 2b: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
             }
 
-            return FileUtilities.EnsureTrailingSlash(basePath);
+            if (basePath.StartsWith("/Users"))
+                throw new InvalidOperationException($"Weird OSX error 3: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
+
+            basePath = FileUtilities.EnsureTrailingSlash(basePath);
+
+            if (basePath.StartsWith("/Users"))
+                throw new InvalidOperationException($"Weird OSX error 3: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
+
+            return basePath;
         }
 
         /// <summary>

--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -38,9 +38,6 @@ namespace Microsoft.Build.Shared
         {
             string basePath = Path.Combine(Path.GetTempPath(), $"MSBuildTemp{Environment.UserName}");
 
-            if (basePath.StartsWith("/Users"))
-                throw new InvalidOperationException($"Weird OSX error 1: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
-
             if (NativeMethodsShared.IsLinux && NativeMethodsShared.mkdir(basePath, userRWX) != 0)
             {
                 if (NativeMethodsShared.chmod(basePath, userRWX) == 0)
@@ -61,24 +58,13 @@ namespace Microsoft.Build.Shared
 
                     basePath = pathToCheck;
                 }
-
-                if (basePath.StartsWith("/Users"))
-                    throw new InvalidOperationException($"Weird OSX error 2a: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
             }
             else
             {
                 Directory.CreateDirectory(basePath);
-                if (basePath.StartsWith("/Users"))
-                    throw new InvalidOperationException($"Weird OSX error 2b: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
             }
 
-            if (basePath.StartsWith("/Users"))
-                throw new InvalidOperationException($"Weird OSX error 3: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
-
             basePath = FileUtilities.EnsureTrailingSlash(basePath);
-
-            if (basePath.StartsWith("/Users"))
-                throw new InvalidOperationException($"Weird OSX error 3: basePath: {basePath}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}");
 
             return basePath;
         }

--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -4,8 +4,6 @@
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Security.AccessControl;
-using System.Security.Principal;
 using Microsoft.Build.Shared.FileSystem;
 
 #nullable disable

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Build.UnitTests
             var assemblyTempFolder = _testEnvironment.CreateFolder(newTempPath);
 
             _testEnvironment.SetTempPath(assemblyTempFolder.Path);
+
+            // Lets clear FileUtilities.TempFileDirectory in case it was already initialized by other code, so it picks up new TempPath
             FileUtilities.ClearTempFileDirectory();
 
             _testEnvironment.CreateFile(

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Build.UnitTests
             var runningTestsField = testInfoType.GetField("s_runningTests", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
             runningTestsField.SetValue(null, true);
 
-            _testEnvironment = TestEnvironment.Create();
+            // Note: build error files will be initialized in test environments for particular tests, also we don't have output to report error files into anyway...
+            _testEnvironment = TestEnvironment.Create(output: null, ignoreBuildErrorFiles: true);
 
             _testEnvironment.DoNotLaunchDebugger();
 

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Xml.Linq;
+using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.UnitTests;
 using Xunit;
@@ -63,6 +64,7 @@ namespace Microsoft.Build.UnitTests
             var assemblyTempFolder = _testEnvironment.CreateFolder(newTempPath);
 
             _testEnvironment.SetTempPath(assemblyTempFolder.Path);
+            FileUtilities.ClearTempFileDirectory();
 
             _testEnvironment.CreateFile(
                 transientTestFolder: assemblyTempFolder,

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Build.UnitTests
                 // Temp folder might have been deleted by other TestEnvironment logic
             }
 
-            return files.ToArray();
+            return files.Distinct(StringComparer.InvariantCultureIgnoreCase).ToArray();
         }
 
         public override void AssertInvariant(ITestOutputHelper output)
@@ -629,12 +629,12 @@ namespace Microsoft.Build.UnitTests
         private readonly string _previousDebugEngineEnv;
         private readonly string _previousDebugPath;
 
-        public TransientDebugEngine(bool state)
+        public TransientDebugEngine(bool enabled)
         {
             _previousDebugEngineEnv = Environment.GetEnvironmentVariable("MSBuildDebugEngine");
             _previousDebugPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
 
-            if (state)
+            if (enabled)
             {
                 Environment.SetEnvironmentVariable("MSBuildDebugEngine", "1");
                 Environment.SetEnvironmentVariable("MSBUILDDEBUGPATH", FileUtilities.TempFileDirectory);

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -452,15 +452,25 @@ namespace Microsoft.Build.UnitTests
 
         private string[] GetMSBuildLogFiles()
         {
-            List<string> files = new();
-            string debugPath = FileUtilities.TempFileDirectory;
-            if (debugPath != null)
+            try
             {
-                files.AddRange(Directory.GetFiles(debugPath, MSBuildLogFiles));
-            }
-            files.AddRange(Directory.GetFiles(Path.GetTempPath(), MSBuildLogFiles));
+                List<string> files = new();
+                string debugPath = FileUtilities.TempFileDirectory;
+                if (debugPath != null)
+                {
+                    files.AddRange(Directory.GetFiles(debugPath, MSBuildLogFiles));
+                }
 
-            return files.ToArray();
+                files.AddRange(Directory.GetFiles(Path.GetTempPath(), MSBuildLogFiles));
+                return files.ToArray();
+            }
+            catch (Exception ex)
+            {
+                throw new AggregateException(
+                    ex,
+                    new InvalidOperationException($"Weird OSX error: debugPath: {FileUtilities.TempFileDirectory}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}")
+                );
+            }
         }
 
         public override void AssertInvariant(ITestOutputHelper output)

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-
-#nullable disable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -13,7 +9,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.Debugging;
 using Microsoft.Build.Shared.FileSystem;
@@ -23,6 +18,9 @@ using Xunit.Abstractions;
 
 using TempPaths = System.Collections.Generic.Dictionary<string, string>;
 using CommonWriterType = System.Action<string, string, System.Collections.Generic.IEnumerable<string>>;
+
+#nullable disable
+
 namespace Microsoft.Build.UnitTests
 {
     public partial class TestEnvironment : IDisposable

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -452,25 +452,15 @@ namespace Microsoft.Build.UnitTests
 
         private string[] GetMSBuildLogFiles()
         {
-            try
+            List<string> files = new();
+            string debugPath = FileUtilities.TempFileDirectory;
+            if (debugPath != null)
             {
-                List<string> files = new();
-                string debugPath = FileUtilities.TempFileDirectory;
-                if (debugPath != null)
-                {
-                    files.AddRange(Directory.GetFiles(debugPath, MSBuildLogFiles));
-                }
+                files.AddRange(Directory.GetFiles(debugPath, MSBuildLogFiles));
+            }
 
-                files.AddRange(Directory.GetFiles(Path.GetTempPath(), MSBuildLogFiles));
-                return files.ToArray();
-            }
-            catch (Exception ex)
-            {
-                throw new AggregateException(
-                    ex,
-                    new InvalidOperationException($"Weird OSX error: debugPath: {FileUtilities.TempFileDirectory}, Path.GetTempPath(): {Path.GetTempPath()}, [TMP]: {Environment.GetEnvironmentVariable("TMP")}, [TMPDIR]: {Environment.GetEnvironmentVariable("TMPDIR")}")
-                );
-            }
+            files.AddRange(Directory.GetFiles(Path.GetTempPath(), MSBuildLogFiles));
+            return files.ToArray();
         }
 
         public override void AssertInvariant(ITestOutputHelper output)

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -454,10 +454,25 @@ namespace Microsoft.Build.UnitTests
             string debugPath = FileUtilities.TempFileDirectory;
             if (debugPath != null)
             {
-                files.AddRange(Directory.GetFiles(debugPath, MSBuildLogFiles));
+                try
+                {
+                    files.AddRange(Directory.GetFiles(debugPath, MSBuildLogFiles));
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    // Temp folder might have been deleted by other TestEnvironment logic
+                }
             }
 
-            files.AddRange(Directory.GetFiles(Path.GetTempPath(), MSBuildLogFiles));
+            try
+            {
+                files.AddRange(Directory.GetFiles(Path.GetTempPath(), MSBuildLogFiles));
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Temp folder might have been deleted by other TestEnvironment logic
+            }
+
             return files.ToArray();
         }
 


### PR DESCRIPTION
### Context
CanShutdownServerProcess  seems to be flaky. We need more logs to find out why...

### Changes Made
Enable comm logs

### Notes
Sorry for all those commits. Was debugging macos tests...

!!! PLEASE SQUASH !!!
