### PR TITLE
Fix .NET 3.5 InternableString.GetHashCode to match the full implementation

### DIFF
--- a/src/MSBuildTaskHost/OutOfProcTaskHost.cs
+++ b/src/MSBuildTaskHost/OutOfProcTaskHost.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Build.CommandLine
         [MTAThread]
         public static int Main()
         {
+            while (true)
+            {
+                Microsoft.NET.StringTools.Strings.WeakIntern("hello");
+            }
+
             int exitCode = Execute() == ExitType.Success ? 0 : 1;
             return exitCode;
         }

--- a/src/MSBuildTaskHost/OutOfProcTaskHost.cs
+++ b/src/MSBuildTaskHost/OutOfProcTaskHost.cs
@@ -68,11 +68,6 @@ namespace Microsoft.Build.CommandLine
         [MTAThread]
         public static int Main()
         {
-            while (true)
-            {
-                Microsoft.NET.StringTools.Strings.WeakIntern("hello");
-            }
-
             int exitCode = Execute() == ExitType.Success ? 0 : 1;
             return exitCode;
         }

--- a/src/StringTools/InternableString.Simple.cs
+++ b/src/StringTools/InternableString.Simple.cs
@@ -237,9 +237,7 @@ namespace Microsoft.NET.StringTools
                 return hash ^ ((uint)ch << 16);
             }
 
-            // The JIT recognized the pattern and generates efficient code, e.g. the rol instruction on x86/x64.
             uint rotatedHash = (hash << 5) | (hash >> (32 - 5));
-
             return (rotatedHash + hash) ^ ch;
         }
     }

--- a/src/StringTools/InternableString.Simple.cs
+++ b/src/StringTools/InternableString.Simple.cs
@@ -200,29 +200,47 @@ namespace Microsoft.NET.StringTools
         /// <returns>A stable hashcode of the string represented by this instance.</returns>
         public override int GetHashCode()
         {
-            int hashCode = 5381;
+            uint hash = (5381 << 16) + 5381;
+            bool isOddIndex = false;
 
             if (_firstString != null)
             {
                 foreach (char ch in _firstString)
                 {
-                    unchecked
-                    {
-                        hashCode = hashCode * 33 ^ ch;
-                    }
+                    hash = HashOneCharacter(hash, ch, isOddIndex);
+                    isOddIndex = !isOddIndex;
                 }
             }
             else if (_builder != null)
             {
                 for (int i = 0; i < _builder.Length; i++)
                 {
-                    unchecked
-                    {
-                        hashCode = hashCode * 33 ^ _builder[i];
-                    }
+                    hash = HashOneCharacter(hash, _builder[i], isOddIndex);
+                    isOddIndex = !isOddIndex;
                 }
             }
-            return hashCode;
+            return (int)hash;
+        }
+
+        /// <summary>
+        /// A helper to hash one character.
+        /// </summary>
+        /// <param name="hash">The running hash code.</param>
+        /// <param name="ch">The character to hash.</param>
+        /// <param name="isOddIndex">True if the index of the character in the string is odd.</param>
+        /// <returns></returns>
+        private static uint HashOneCharacter(uint hash, char ch, bool isOddIndex)
+        {
+            if (isOddIndex)
+            {
+                // The hash code was rotated for the previous character, just xor.
+                return hash ^ ((uint)ch << 16);
+            }
+
+            // The JIT recognized the pattern and generates efficient code, e.g. the rol instruction on x86/x64.
+            uint rotatedHash = (hash << 5) | (hash >> (32 - 5));
+
+            return (rotatedHash + hash) ^ ch;
         }
     }
 }


### PR DESCRIPTION
Fixes part of 8329

### Context

The 3.5 version of `InternableString` uses a simpler hash code calculation, the results of which were not matching the 4.72/Core version. This manifested as a failing unit test `RetainsLastStringWithGivenHashCode` in VS.

### Changes Made

Made the routine return the same numbers as the other implementation. It fixed the UT and also made the hash code "better" as previously we were shifting instead of rotating bits.

### Testing

Existing unit tests (previously failing).

### Notes

It would be nice to figure out how to run 3.5 tests in CI.
