### PR TITLE
XSD: InternalsVisibleTo uses Key

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -6157,10 +6157,10 @@ elementFormDefault="qualified">
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="PublicKey" type="xs:string" use="optional">
+          <xs:attribute name="Key" type="xs:string" use="optional">
             <xs:annotation>
               <xs:documentation>
-                <!-- _locID_text="InternalsVisibleTo_PublicKey" _locComment="" -->Optional public key associated with the strong name signature of the friend assembly.
+                <!-- _locID_text="InternalsVisibleTo_Key" _locComment="" -->Optional public key associated with the strong name signature of the friend assembly.
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>


### PR DESCRIPTION
It respects PublicKey as a property in the current project
but not metadata: https://github.com/dotnet/sdk/blob/f31b16f8a6a05a600f277975a329399b44b85e9b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets#L114-L118

Fixes an issue reported over email.