### PR TITLE
Introduce intrinsic to 'intersect' target frameworks

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4303,12 +4303,9 @@ $(
         [InlineData("netstandard2.0;net6.0-windows", "net6.0", "net6.0-windows")]
         [InlineData("netstandard2.0;net6.0-windows", "net6.0;netstandard2.0;net472", "netstandard2.0;net6.0-windows")]
         [InlineData("netstandard2.0;net472", "net6.0;netstandard2.0;net472", "netstandard2.0;net472")]
-        public void PropertyFunctionFilterTargetFrameworks(string left, string right, string expected)
+        public void PropertyFunctionFilterTargetFrameworks(string incoming, string filter, string expected)
         {
-            var pg = new PropertyDictionary<ProjectPropertyInstance>();
-            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
-
-            AssertSuccess(expander, $"$([MSBuild]::FilterTargetFrameworks('{left}', '{right}'))", expected);
+            TestPropertyFunction($"$([MSBuild]::FilterTargetFrameworks('{incoming}', '{filter}'))", "_", "_", expected);
         }
 
         [Fact]

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4295,6 +4295,23 @@ $(
             result.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData("net6.0", "netstandard2.0", "")]
+        [InlineData("net6.0-windows", "netstandard2.0", "")]
+        [InlineData("net6.0-windows", "net6.0", "net6.0-windows")]
+        [InlineData("netstandard2.0;net6.0", "net6.0", "net6.0")]
+        [InlineData("netstandard2.0;net6.0-windows", "net6.0", "net6.0-windows")]
+        [InlineData("netstandard2.0;net6.0-windows", "net6.0;netstandard2.0;net472", "netstandard2.0;net6.0-windows")]
+        [InlineData("netstandard2.0;net472", "net6.0;netstandard2.0;net472", "netstandard2.0;net472")]
+        [InlineData("netstandard2.0;net472", "net6.0;netstandard2.0;net472", "netstandard2.0;net472")]
+        public void PropertyFunctionIntersectTargetFrameworks(string left, string right, string expected)
+        {
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+
+            AssertSuccess(expander, $"$([MSBuild]::FilterTargetFrameworks('{left}', '{right}'))", expected);
+        }
+
         [Fact]
         public void ExpandItemVectorFunctions_GetPathsOfAllDirectoriesAbove()
         {

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4303,8 +4303,7 @@ $(
         [InlineData("netstandard2.0;net6.0-windows", "net6.0", "net6.0-windows")]
         [InlineData("netstandard2.0;net6.0-windows", "net6.0;netstandard2.0;net472", "netstandard2.0;net6.0-windows")]
         [InlineData("netstandard2.0;net472", "net6.0;netstandard2.0;net472", "netstandard2.0;net472")]
-        [InlineData("netstandard2.0;net472", "net6.0;netstandard2.0;net472", "netstandard2.0;net472")]
-        public void PropertyFunctionIntersectTargetFrameworks(string left, string right, string expected)
+        public void PropertyFunctionFilterTargetFrameworks(string left, string right, string expected)
         {
             var pg = new PropertyDictionary<ProjectPropertyInstance>();
             var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4301,8 +4301,8 @@ $(
         [InlineData("net6.0-windows", "net6.0", "net6.0-windows")]
         [InlineData("netstandard2.0;net6.0", "net6.0", "net6.0")]
         [InlineData("netstandard2.0;net6.0-windows", "net6.0", "net6.0-windows")]
-        [InlineData("netstandard2.0;net6.0-windows", "net6.0;netstandard2.0;net472", "netstandard2.0;net6.0-windows")]
-        [InlineData("netstandard2.0;net472", "net6.0;netstandard2.0;net472", "netstandard2.0;net472")]
+        [InlineData("netstandard2.0;net6.0-windows", "net6.0;netstandard2.0;net472", "netstandard2.0%3bnet6.0-windows")]
+        [InlineData("netstandard2.0;net472", "net6.0;netstandard2.0;net472", "netstandard2.0%3bnet472")]
         public void PropertyFunctionFilterTargetFrameworks(string incoming, string filter, string expected)
         {
             TestPropertyFunction($"$([MSBuild]::FilterTargetFrameworks('{incoming}', '{filter}'))", "_", "_", expected);

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -549,6 +549,11 @@ namespace Microsoft.Build.Evaluation
             return NuGetFramework.Value.GetTargetPlatformVersion(tfm, versionPartCount);
         }
 
+        internal static string IntersectTargetFrameworks(string left, string right)
+        {
+            return NuGetFramework.Value.IntersectTargetFrameworks(left, right);
+        }
+
         internal static bool AreFeaturesEnabled(Version wave)
         {
             return ChangeWaves.AreFeaturesEnabled(wave);

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -549,9 +549,9 @@ namespace Microsoft.Build.Evaluation
             return NuGetFramework.Value.GetTargetPlatformVersion(tfm, versionPartCount);
         }
 
-        internal static string IntersectTargetFrameworks(string left, string right)
+        internal static string FilterTargetFrameworks(string incoming, string filter)
         {
-            return NuGetFramework.Value.IntersectTargetFrameworks(left, right);
+            return NuGetFramework.Value.FilterTargetFrameworks(incoming, filter);
         }
 
         internal static bool AreFeaturesEnabled(Version wave)

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -96,27 +96,27 @@ namespace Microsoft.Build.Evaluation
             return version.ToString(Math.Max(nonZeroVersionParts, minVersionPartCount));
         }
 
-        public string IntersectTargetFrameworks(string left, string right)
+        public string FilterTargetFrameworks(string incoming, string filter)
         {
-            IEnumerable<(string originalTfm, object parsedTfm)> leftFrameworks = ParseTfms(left);
-            IEnumerable<(string originalTfm, object parsedTfm)> rightFrameworks = ParseTfms(right);
-            string tfmList = "";
+            IEnumerable<(string originalTfm, object parsedTfm)> incomingFrameworks = ParseTfms(incoming);
+            IEnumerable<(string originalTfm, object parsedTfm)> filterFrameworks = ParseTfms(filter);
+            StringBuilder tfmList = new StringBuilder();
 
-            // An incoming target framework from 'left' is kept if it is compatible with any of the desired target frameworks on 'right'
-            foreach (var l in leftFrameworks)
+            // An incoming target framework from 'incoming' is kept if it is compatible with any of the desired target frameworks on 'filter'
+            foreach (var l in incomingFrameworks)
             {
-                if (rightFrameworks.Any(r =>
+                if (filterFrameworks.Any(r =>
                         (FrameworkProperty.GetValue(l.parsedTfm) as string).Equals(FrameworkProperty.GetValue(r.parsedTfm) as string, StringComparison.OrdinalIgnoreCase) &&
                         (((Convert.ToBoolean(AllFrameworkVersionsProperty.GetValue(l.parsedTfm))) && (Convert.ToBoolean(AllFrameworkVersionsProperty.GetValue(r.parsedTfm)))) ||
                          ((VersionProperty.GetValue(l.parsedTfm) as Version) == (VersionProperty.GetValue(r.parsedTfm) as Version)))))
                 {
                     if (string.IsNullOrEmpty(tfmList))
                     {
-                        tfmList = l.originalTfm;
+                        tfmList.Append(l.originalTfm);
                     }
                     else
                     {
-                        tfmList += $";{l.originalTfm}";
+                        tfmList.Append($";{l.originalTfm}");
                     }
                 }
             }

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -4,6 +4,8 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Linq;
+using System.Collections.Generic;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -27,6 +29,7 @@ namespace Microsoft.Build.Evaluation
         private static PropertyInfo VersionProperty;
         private static PropertyInfo PlatformProperty;
         private static PropertyInfo PlatformVersionProperty;
+        private static PropertyInfo AllFrameworkVersionsProperty;
 
         public NuGetFrameworkWrapper()
         {
@@ -47,6 +50,7 @@ namespace Microsoft.Build.Evaluation
                 VersionProperty = NuGetFramework.GetProperty("Version");
                 PlatformProperty = NuGetFramework.GetProperty("Platform");
                 PlatformVersionProperty = NuGetFramework.GetProperty("PlatformVersion");
+                AllFrameworkVersionsProperty = NuGetFramework.GetProperty("AllFrameworkVersions");
             }
             catch
             {
@@ -90,6 +94,43 @@ namespace Microsoft.Build.Evaluation
         {
             var nonZeroVersionParts = version.Revision == 0 ? version.Build == 0 ? version.Minor == 0 ? 1 : 2 : 3 : 4;
             return version.ToString(Math.Max(nonZeroVersionParts, minVersionPartCount));
+        }
+
+        public string IntersectTargetFrameworks(string left, string right)
+        {
+            IEnumerable<(string originalTfm, object parsedTfm)> leftFrameworks = ParseTfms(left);
+            IEnumerable<(string originalTfm, object parsedTfm)> rightFrameworks = ParseTfms(right);
+            string tfmList = "";
+
+            // An incoming target framework from 'left' is kept if it is compatible with any of the desired target frameworks on 'right'
+            foreach (var l in leftFrameworks)
+            {
+                if (rightFrameworks.Any(r =>
+                        (FrameworkProperty.GetValue(l.parsedTfm) as string).Equals(FrameworkProperty.GetValue(r.parsedTfm) as string, StringComparison.OrdinalIgnoreCase) &&
+                        (((Convert.ToBoolean(AllFrameworkVersionsProperty.GetValue(l.parsedTfm))) && (Convert.ToBoolean(AllFrameworkVersionsProperty.GetValue(r.parsedTfm)))) ||
+                         ((VersionProperty.GetValue(l.parsedTfm) as Version) == (VersionProperty.GetValue(r.parsedTfm) as Version)))))
+                {
+                    if (string.IsNullOrEmpty(tfmList))
+                    {
+                        tfmList = l.originalTfm;
+                    }
+                    else
+                    {
+                        tfmList += $";{l.originalTfm}";
+                    }
+                }
+            }
+
+            return tfmList;
+
+            IEnumerable<(string originalTfm, object parsedTfm)> ParseTfms(string desiredTargetFrameworks)
+            {
+                return desiredTargetFrameworks.Split(new char[] {';'}, StringSplitOptions.RemoveEmptyEntries).Select(tfm =>
+                {
+                    (string originalTfm, object parsedTfm) parsed = (tfm, Parse(tfm));
+                    return parsed;
+                });
+            }
         }
     }
 }

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Build.Evaluation
                         (((Convert.ToBoolean(AllFrameworkVersionsProperty.GetValue(l.parsedTfm))) && (Convert.ToBoolean(AllFrameworkVersionsProperty.GetValue(r.parsedTfm)))) ||
                          ((VersionProperty.GetValue(l.parsedTfm) as Version) == (VersionProperty.GetValue(r.parsedTfm) as Version)))))
                 {
-                    if (string.IsNullOrEmpty(tfmList))
+                    if (tfmList.Length == 0)
                     {
                         tfmList.Append(l.originalTfm);
                     }

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
-using System.Reflection;
-using System.Linq;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            return tfmList;
+            return tfmList.ToString();
 
             IEnumerable<(string originalTfm, object parsedTfm)> ParseTfms(string desiredTargetFrameworks)
             {


### PR DESCRIPTION
This is the initial implementation of an experimental intrinsic designed to support the ability to build subsets of a repo/solution/project. This ability can reduce build time and support the ability to build projects based on available target resources per-platforms.

The idea is that this intrinsic would be used in a set of targets that are imported early, before standard .NET SDK targets, and could be used to filter the target frameworks that a project is going to build for. .NET's arcade will contain an initial implementation of those targets, looking something like this:

```
<PropertyGroup Condition="$(_EnableTargetFrameworkFiltering)">
  <_OriginalTargetFrameworks Condition="'$(TargetFrameworks)' != ''">$(TargetFrameworks)</_OriginalTargetFrameworks>
  <_OriginalTargetFrameworks Condition="'$(TargetFramework)' != ''">$(TargetFramework)</_OriginalTargetFrameworks>
  <_FilteredTargetFrameworks>$([MSBuild]::Unescape($([MSBuild]::IntersectTargetFrameworks('$(_OriginalTargetFrameworks)', '$(DotNetTargetFrameworkFilter)'))))</_FilteredTargetFrameworks>
  <!-- Maintain usage of the original property,  -->
  <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$(_FilteredTargetFrameworks)</TargetFrameworks>
  <TargetFramework Condition="'$(TargetFramework)' != ''">$(_FilteredTargetFrameworks)</TargetFramework>
  <ExcludeFromBuild Condition="'$(_FilteredTargetFrameworks)' == ''">true</ExcludeFromBuild>
</PropertyGroup>
```

Initially, the intrinsic is implemented as follows:
- A framework is maintained if the Framework name (Framework property of parsed nuget property) exists in both lists AND
- The version matches, if specified.

Thus, if a TFM list is: `net6.0-windows;netstandard2.0;net472` and the intersect list is `net6.0;netstandard2.0`, the result would be net6.0;netstandard2.0.

It's possible that before this MSBuild version goes out of preview. There are two other options:
- **An implementation that selects based on compatibilty**. The inherent problem with a compatibility check (based on NuGet's notion) is that some TFMs are compatible with TFMs you may want to remove. For instance, you may want to keep netstandard2.0, but not net472. However, since net472 is compatible with netstandard2.0, it would not be eliminated.
- **Strict intersection based on all TFM properties**. This is simpler and more straightforward, but requires a more verbose input list. For instance, if you wanted to preserve net6 targets, especially in cross-targeting situations, you may have list many TFMs (e.g. specific OS versions like net6.0-windows).

Of these alternate approaches, I think strict is the most likely to be usable and understandable.

Fixes #

### Context


### Changes Made


### Testing


### Notes
