### PR TITLE
Fix temp file filtering in FileTracker

### DIFF
--- a/src/Utilities.UnitTests/TrackedDependencies/FileTrackerTests.cs
+++ b/src/Utilities.UnitTests/TrackedDependencies/FileTrackerTests.cs
@@ -68,11 +68,13 @@ namespace Microsoft.Build.UnitTests.FileTracking
                     Environment.ExpandEnvironmentVariables("%windir%\\system32;%windir%"));
             }
 
+#if ENABLE_TRACKER_TESTS // https://github.com/dotnet/msbuild/issues/649
             // Call StopTrackingAndCleanup here, just in case one of the unit tests failed before it called it
             // In real code StopTrackingAndCleanup(); would always be in a finally {} block.
             FileTracker.StopTrackingAndCleanup();
             FileTrackerTestHelper.CleanTlogs();
             FileTracker.SetThreadCount(1);
+#endif
         }
 
         public void Dispose()
@@ -83,7 +85,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
                 Environment.SetEnvironmentVariable("PATH", s_oldPath);
                 s_oldPath = null;
             }
-
             FileTrackerTestHelper.CleanTlogs();
         }
 
@@ -837,11 +838,9 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), tlogFiles[0]);
         }
 
-        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/dotnet/msbuild/issues/649")]
+        [Fact]
         public void FileTrackerFileIsUnderPath()
         {
-            Console.WriteLine("Test: FileTrackerFileIsUnderPath");
-
             // YES: Both refer to something under baz, so yes this is on the path
             Assert.True(FileTracker.FileIsUnderPath(@"c:\foo\bar\baz\", @"c:\foo\bar\baz\"));
 
@@ -883,11 +882,9 @@ class X
             Assert.False(FileTracker.FileIsUnderPath(@"c:\foo\rumble.cpp", @"c:\foo\rumble\"));
         }
 
-        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/dotnet/msbuild/issues/649")]
+        [Fact]
         public void FileTrackerFileIsExcludedFromDependencies()
         {
-            Console.WriteLine("Test: FileTrackerFileIsExcludedFromDependencies");
-
             string applicationDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             string localApplicationDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             string localLowApplicationDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData\\LocalLow");

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -72,8 +72,14 @@ namespace Microsoft.Build.Utilities
     {
 #region Static Member Data
 
-        // The default path to temp, used to create explicitly short and long paths
-        private static readonly string s_tempPath = FileUtilities.TempFileDirectory;
+        /// <summary>
+        /// The default path to temp, used to create explicitly short and long paths.
+        /// </summary>
+        /// <remarks>
+        /// This must be the base system-wide temp path because we use it to filter out I/O of tools outside of our control.
+        /// Tools running under the tracker may put temp files in the temp base or in a sub-directory of their choosing.
+        /// </remarks>
+        private static readonly string s_tempPath = Path.GetTempPath();
 
         // The short path to temp
         private static readonly string s_tempShortPath = FileUtilities.EnsureTrailingSlash(NativeMethodsShared.GetShortFilePath(s_tempPath).ToUpperInvariant());


### PR DESCRIPTION
Fixes [AB#1678521](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1678521)

### Context
#8049 broke the temp filtering logic by using the MSBuild-specific temp path instead of the true base temp path. This manifests as an overbuild of some C++ projects.

### Changes Made
Reverted the change. Enabled relevant unit tests.

### Testing
Existing unit tests and a C++ end-to-end repro.

### Notes
The rest of FileTracker tests cannot be enabled without significant work (related to #649).