### PR TITLE
reordered import in Samples `Directory.Build.props`

### DIFF
--- a/src/Samples/Directory.Build.props
+++ b/src/Samples/Directory.Build.props
@@ -1,9 +1,15 @@
 ﻿<Project>
 
+  <!--This should be before importing parent properties, as it affects the output directory (defined in arcade SDK) -->
   <PropertyGroup>
     <!-- Use Samples subdirectory for samples in output folder -->
     <OutDirName>Samples\$(MSBuildProjectName)</OutDirName>
+  </PropertyGroup>
 
+  <!-- Import parent props -->
+  <Import Project="..\Directory.Build.props"/>
+
+  <PropertyGroup>
     <!-- Don't regulate package versions for samples -->
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
@@ -11,8 +17,5 @@
     <IsShipping>false</IsShipping>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
-
-  <!-- Import parent props -->
-  <Import Project="..\Directory.Build.props"/>
 
 </Project>


### PR DESCRIPTION
### Context
https://github.com/dotnet/msbuild/pull/8317 causes a lot of red NU1008 on restore in VS

### Changes Made
Reordered import in Samples `Directory.Build.props`

It seems order of import affects value of `ManagePackageVersionsCentrally` for sample projects: when import happens before the values of properties in `src/Samples/Directory.Build.props` takes precedence; otherwise root Directory.Build.props overwrites the value with `true`.

### Testing


### Notes
