### PR TITLE
Introduce backport GHA

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,19 @@
+name: Backport PR to branch
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  backport:
+    uses: dotnet/arcade/.github/workflows/backport-base.yml@main
+    with:
+        pr_description_template: |
+          Backport of #%source_pr_number% to %target_branch%
+
+          /cc %cc_users%


### PR DESCRIPTION
### Context

Introduces backport GitHub action for automation-aided propagation of changes between branches.

**usage:**
comment
`/backport to <target bracnh>`
on PR that needs to be backported (ideally after merging). New PR will be created backporting to the requested branch.