### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,6 @@ stage1/
 
 # ETL traces
 *.etl.zip
+
+# .DS_Store for MacOS
+**/.DS_Store


### PR DESCRIPTION
Fixes #

### Context
DS_Store files are automatically created by MacOS Finder on any directory to include metadata about it. These information however, is useless to the repo. Hence should not be included in commits

### Changes Made
Updated .gitignore to include .DS_Store in all subdirectories.

### Testing


### Notes
