### PR TITLE
Enable temporary comm logging for CanShutdownServerProcess test

### DIFF
--- a/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
+++ b/src/Build.UnitTests/BackEnd/DebugUtils_tests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.Build.Shared;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 #nullable disable
 
@@ -17,21 +18,22 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void DumpExceptionToFileShouldWriteInTempPathByDefault()
         {
-            Directory.GetFiles(Path.GetTempPath(), "MSBuild_*failure.txt").ShouldBeEmpty();
+            var exceptionFilesBefore = Directory.GetFiles(ExceptionHandling.DebugDumpPath, "MSBuild_*failure.txt");
 
             string[] exceptionFiles = null;
 
             try
             {
                 ExceptionHandling.DumpExceptionToFile(new Exception("hello world"));
-                exceptionFiles = Directory.GetFiles(FileUtilities.TempFileDirectory, "MSBuild_*failure.txt");
+                exceptionFiles = Directory.GetFiles(ExceptionHandling.DebugDumpPath, "MSBuild_*failure.txt");
             }
             finally
             {
+                exceptionFilesBefore.ShouldNotBeNull();
                 exceptionFiles.ShouldNotBeNull();
-                exceptionFiles.ShouldHaveSingleItem();
+                (exceptionFiles.Length - exceptionFilesBefore.Length).ShouldBe(1);
 
-                var exceptionFile = exceptionFiles.First();
+                var exceptionFile = exceptionFiles.Except(exceptionFilesBefore).Single();
                 File.ReadAllText(exceptionFile).ShouldContain("hello world");
                 File.Delete(exceptionFile);
             }

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -131,7 +131,7 @@ BuildEngine5.BuildProjectFilesInParallel(
         public IsolateProjectsTests(ITestOutputHelper testOutput)
         {
             _testOutput = testOutput;
-            _env = TestEnvironment.Create(_testOutput);
+            _env = TestEnvironment.Create(_testOutput, ignoreBuildErrorFiles: true);
 
             if (NativeMethodsShared.IsOSX)
             {
@@ -155,8 +155,6 @@ BuildEngine5.BuildProjectFilesInParallel(
         {
             _env.Dispose();
         }
-
-
 
         [Theory]
         [InlineData(BuildResultCode.Success, new string[] { })]

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -531,6 +531,7 @@ namespace Microsoft.Build.Experimental
 
         private bool TrySendShutdownCommand()
         {
+            CommunicationsUtilities.Trace("Sending shutdown command to server.");
             _packetPump.ServerWillDisconnect();
             return TrySendPacket(() => new NodeBuildComplete(false /* no node reuse */));
         }

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -11,6 +11,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Experimental;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.Debugging;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.Shared;
 #if NETFRAMEWORK
@@ -220,6 +221,10 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             _env.SetEnvironmentVariable("MSBUILDUSESERVER", "1");
 
+            // This test seems to be flaky, lets enable better logging to investigate it next time
+            // TODO: delete after investigated its flakiness
+            _env.WithTransientDebugEngineForNewProcesses(true);
+
             TransientTestFile project = _env.CreateFile("testProject.proj", printPidContents);
 
             // Start a server node and find its PID.
@@ -284,6 +289,10 @@ namespace Microsoft.Build.Engine.UnitTests
         [Fact]
         public void PropertyMSBuildStartupDirectoryOnServer()
         {
+            // This test seems to be flaky, lets enable better logging to investigate it next time
+            // TODO: delete after investigated its flakiness
+            _env.WithTransientDebugEngineForNewProcesses(true);
+
             string reportMSBuildStartupDirectoryProperty = @$"
 <Project>
     <UsingTask TaskName=""ProcessIdTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Xml.Linq;
+using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.UnitTests;
 using Xunit;
@@ -39,7 +40,8 @@ namespace Microsoft.Build.UnitTests
             var runningTestsField = testInfoType.GetField("s_runningTests", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
             runningTestsField.SetValue(null, true);
 
-            _testEnvironment = TestEnvironment.Create();
+            // Note: build error files will be initialized in test environments for particular tests, also we don't have output to report error files into anyway...
+            _testEnvironment = TestEnvironment.Create(output: null, ignoreBuildErrorFiles: true);
 
             _testEnvironment.DoNotLaunchDebugger();
 
@@ -62,6 +64,9 @@ namespace Microsoft.Build.UnitTests
             var assemblyTempFolder = _testEnvironment.CreateFolder(newTempPath);
 
             _testEnvironment.SetTempPath(assemblyTempFolder.Path);
+
+            // Lets clear FileUtilities.TempFileDirectory in case it was already initialized by other code, so it picks up new TempPath
+            FileUtilities.ClearTempFileDirectory();
 
             _testEnvironment.CreateFile(
                 transientTestFolder: assemblyTempFolder,

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -331,6 +331,16 @@ namespace Microsoft.Build.UnitTests
             return WithTransientTestState(transientTestProcess);
         }
 
+        /// <summary>
+        /// Register transient debug engine.
+        /// Usable for tests which investigating might need msbuild debug logs.
+        /// </summary>
+        public TransientDebugEngine WithTransientDebugEngineForNewProcesses(bool state)
+        {
+            TransientDebugEngine transient = new(state);
+            return WithTransientTestState(transient);
+        }
+
         #endregion
 
         private class DefaultOutput : ITestOutputHelper
@@ -430,46 +440,72 @@ namespace Microsoft.Build.UnitTests
 
     public class BuildFailureLogInvariant : TestInvariant
     {
+        private const string MSBuildLogFiles = "MSBuild_*.txt";
         private readonly string[] _originalFiles;
 
         public BuildFailureLogInvariant()
         {
-            _originalFiles = Directory.GetFiles(Path.GetTempPath(), "MSBuild_*.txt");
+            _originalFiles = GetMSBuildLogFiles();
+        }
+
+        private string[] GetMSBuildLogFiles()
+        {
+            List<string> files = new();
+            string debugPath = FileUtilities.TempFileDirectory;
+            if (debugPath != null)
+            {
+                try
+                {
+                    files.AddRange(Directory.GetFiles(debugPath, MSBuildLogFiles));
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    // Temp folder might have been deleted by other TestEnvironment logic
+                }
+            }
+
+            try
+            {
+                files.AddRange(Directory.GetFiles(Path.GetTempPath(), MSBuildLogFiles));
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Temp folder might have been deleted by other TestEnvironment logic
+            }
+
+            return files.Distinct(StringComparer.InvariantCultureIgnoreCase).ToArray();
         }
 
         public override void AssertInvariant(ITestOutputHelper output)
         {
-            var newFiles = Directory.GetFiles(Path.GetTempPath(), "MSBuild_*.txt");
+            var newFiles = GetMSBuildLogFiles();
 
             int newFilesCount = newFiles.Length;
-            if (newFilesCount > _originalFiles.Length)
+            foreach (FileInfo file in newFiles.Except(_originalFiles).Select(f => new FileInfo(f)))
             {
-                foreach (FileInfo file in newFiles.Except(_originalFiles).Select(f => new FileInfo(f)))
+                string contents = File.ReadAllText(file.FullName);
+
+                // Delete the file so we don't pollute the build machine
+                FileUtilities.DeleteNoThrow(file.FullName);
+
+                // Ignore clean shutdown trace logs.
+                if (Regex.IsMatch(file.Name, @"MSBuild_NodeShutdown_\d+\.txt") &&
+                    Regex.IsMatch(contents, @"Node shutting down with reason BuildComplete and exception:\s*"))
                 {
-                    string contents = File.ReadAllText(file.FullName);
-
-                    // Delete the file so we don't pollute the build machine
-                    FileUtilities.DeleteNoThrow(file.FullName);
-
-                    // Ignore clean shutdown trace logs.
-                    if (Regex.IsMatch(file.Name, @"MSBuild_NodeShutdown_\d+\.txt") &&
-                        Regex.IsMatch(contents, @"Node shutting down with reason BuildComplete and exception:\s*"))
-                    {
-                        newFilesCount--;
-                        continue;
-                    }
-
-                    // Com trace file. This is probably fine, but output it as it was likely turned on
-                    // for a reason.
-                    if (Regex.IsMatch(file.Name, @"MSBuild_CommTrace_PID_\d+\.txt"))
-                    {
-                        output.WriteLine($"{file.Name}: {contents}");
-                        newFilesCount--;
-                        continue;
-                    }
-
-                    output.WriteLine($"Build Error File {file.Name}: {contents}");
+                    newFilesCount--;
+                    continue;
                 }
+
+                // Com trace file. This is probably fine, but output it as it was likely turned on
+                // for a reason.
+                if (Regex.IsMatch(file.Name, @"MSBuild_CommTrace_PID_\d+\.txt"))
+                {
+                    output.WriteLine($"{file.Name}: {contents}");
+                    newFilesCount--;
+                    continue;
+                }
+
+                output.WriteLine($"Build Error File {file.Name}: {contents}");
             }
 
             // Assert file count is equal minus any files that were OK
@@ -588,6 +624,34 @@ namespace Microsoft.Build.UnitTests
         }
     }
 
+    public class TransientDebugEngine : TransientTestState
+    {
+        private readonly string _previousDebugEngineEnv;
+        private readonly string _previousDebugPath;
+
+        public TransientDebugEngine(bool enabled)
+        {
+            _previousDebugEngineEnv = Environment.GetEnvironmentVariable("MSBuildDebugEngine");
+            _previousDebugPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+
+            if (enabled)
+            {
+                Environment.SetEnvironmentVariable("MSBuildDebugEngine", "1");
+                Environment.SetEnvironmentVariable("MSBUILDDEBUGPATH", FileUtilities.TempFileDirectory);
+            }
+            else
+            {
+                Environment.SetEnvironmentVariable("MSBuildDebugEngine", null);
+                Environment.SetEnvironmentVariable("MSBUILDDEBUGPATH", null);
+            }
+        }
+
+        public override void Revert()
+        {
+            Environment.SetEnvironmentVariable("MSBuildDebugEngine", _previousDebugEngineEnv);
+            Environment.SetEnvironmentVariable("MSBUILDDEBUGPATH", _previousDebugPath);
+        }
+    }
 
     public class TransientTestFile : TransientTestState
     {


### PR DESCRIPTION
Context
CanShutdownServerProcess seems to be flaky. We need more logs to find out why...

Changes Made
- Add support for enabling DebugEngine in integration tests
- Use it in CanShutdownServerProcess  and other flaky test