### PR TITLE
Set an environment variable indicating that the binary logger is enabled

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Build.Logging
         private ProjectImportsCollector projectImportsCollector;
         private string _initialTargetOutputLogging;
         private bool _initialLogImports;
+        private string _initialIsBinaryLoggerEnabled;
 
         /// <summary>
         /// Describes whether to collect the project files (including imported project files) used during the build.
@@ -114,9 +115,12 @@ namespace Microsoft.Build.Logging
         {
             _initialTargetOutputLogging = Environment.GetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING");
             _initialLogImports = Traits.Instance.EscapeHatches.LogProjectImports;
+            _initialIsBinaryLoggerEnabled = Environment.GetEnvironmentVariable("MSBUILDBINARYLOGGERENABLED");
 
             Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", "true");
             Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", "1");
+            Environment.SetEnvironmentVariable("MSBUILDBINARYLOGGERENABLED", bool.TrueString);
+
             Traits.Instance.EscapeHatches.LogProjectImports = true;
             bool logPropertiesAndItemsAfterEvaluation = Traits.Instance.EscapeHatches.LogPropertiesAndItemsAfterEvaluation ?? true;
 
@@ -214,6 +218,8 @@ namespace Microsoft.Build.Logging
         {
             Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", _initialTargetOutputLogging);
             Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", _initialLogImports ? "1" : "");
+            Environment.SetEnvironmentVariable("MSBUILDBINARYLOGGERENABLED", _initialIsBinaryLoggerEnabled);
+
             Traits.Instance.EscapeHatches.LogProjectImports = _initialLogImports;
 
             if (projectImportsCollector != null)


### PR DESCRIPTION


Fixes #8394 

### Context
This is mainly so that the static graph-based restore can detect that the user enabled the binary logger so it can automatically provide a binary log for restore which is run out-of-proc so it has to be another file.

### Changes Made
This sets `MSBUILDBINARYLOGGERENABLED=true` when the binary logger is enabled.  I originally tried to have a new property on the `EngineServices` but that doesn't work for out-of-proc nodes.  To make that work, each out-of-proc node would need to be told if the binary logger is in use for that particular build which seems like a lot overhead compared to just setting an environment variable.

### Testing
Built locally and ran the bootstrap MSBuild to verify the environment variable is set.

### Notes
