### PR TITLE
[LiveLogger] Add code to high priority messages

### DIFF
--- a/src/MSBuild/LiveLogger/MessageNode.cs
+++ b/src/MSBuild/LiveLogger/MessageNode.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Logging.LiveLogger
                         ANSIBuilder.Formatting.ForegroundColor.Red)}";
                 case MessageType.HighPriorityMessage:
                 default:
-                    return $"ℹ️ {(Code != null ? Code + ": " : string.Empty)} {ANSIBuilder.Formatting.Italic(Message)}";
+                    return $"ℹ️ {Code}{(Code is not null ? ": " : string.Empty)} {ANSIBuilder.Formatting.Italic(Message)}";
             }
         }
 

--- a/src/MSBuild/LiveLogger/MessageNode.cs
+++ b/src/MSBuild/LiveLogger/MessageNode.cs
@@ -34,8 +34,9 @@ namespace Microsoft.Build.Logging.LiveLogger
             // Get type
             switch (args)
             {
-                case BuildMessageEventArgs:
+                case BuildMessageEventArgs message:
                     Type = MessageType.HighPriorityMessage;
+                    Code = message.Code;
                     break;
                 case BuildWarningEventArgs warning:
                     Type = MessageType.Warning;
@@ -68,7 +69,7 @@ namespace Microsoft.Build.Logging.LiveLogger
                         ANSIBuilder.Formatting.ForegroundColor.Red)}";
                 case MessageType.HighPriorityMessage:
                 default:
-                    return $"ℹ️ {ANSIBuilder.Formatting.Italic(Message)}";
+                    return $"ℹ️ Message {Code}: {ANSIBuilder.Formatting.Italic(Message)}";
             }
         }
 

--- a/src/MSBuild/LiveLogger/MessageNode.cs
+++ b/src/MSBuild/LiveLogger/MessageNode.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.Logging.LiveLogger
             {
                 case BuildMessageEventArgs message:
                     Type = MessageType.HighPriorityMessage;
-                    Code = message.Code;
+                    Code = message.Subcategory;
                     break;
                 case BuildWarningEventArgs warning:
                     Type = MessageType.Warning;
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Logging.LiveLogger
                         ANSIBuilder.Formatting.ForegroundColor.Red)}";
                 case MessageType.HighPriorityMessage:
                 default:
-                    return $"ℹ️ Message {Code}: {ANSIBuilder.Formatting.Italic(Message)}";
+                    return $"ℹ️ {(Code != null ? Code + ": " : string.Empty)} {ANSIBuilder.Formatting.Italic(Message)}";
             }
         }
 


### PR DESCRIPTION
Fixes #8393 

### Context
Currently the live logger does not log the message id's. Including the message ID is useful when searching for messages from customer reports.

### Changes Made
When receiving `BuildMessageEventArgs`, the `Code` is now also passed to `MessageNode` and printed on the display. 

### Testing


### Notes
