### PR TITLE
Added support for logging interpolated strings in tasks.

### DIFF
--- a/src/Framework/LogInterpolatedStringHandler.cs
+++ b/src/Framework/LogInterpolatedStringHandler.cs
@@ -19,18 +19,9 @@ namespace Microsoft.Build.Framework
 
         public LogInterpolatedStringHandler(int literalLength, int formattedCount)
         {
-            int bufferSize;
-
             // Buffer size is computed with reserved space for "{x..x}" placeholders
-            if (formattedCount < 10)
-            {
-                bufferSize = literalLength + (3 * formattedCount);
-            }
-            else
-            {
-                int maxNumberOfDigits = (int)(Math.Log10(formattedCount) + 1);
-                bufferSize = literalLength + (formattedCount * (maxNumberOfDigits + 2));
-            }
+            int maxNumberOfDigits = GetNumberOfDigits(formattedCount);
+            int bufferSize = literalLength + (formattedCount * (maxNumberOfDigits + 2));
 
             buffer = new char[bufferSize];
 
@@ -69,6 +60,21 @@ namespace Microsoft.Build.Framework
         internal string GetFormat()
         {
             string result = new string(buffer, 0, position);
+
+            return result;
+        }
+
+        private int GetNumberOfDigits(int value)
+        {
+            // It's OK to return 0 if the value is 0, because we don't need to reserve
+            // extra space in that case
+            int result = 0;
+
+            while (value > 0)
+            {
+                result++;
+                value /= 10;
+            }
 
             return result;
         }

--- a/src/Framework/LogInterpolatedStringHandler.cs
+++ b/src/Framework/LogInterpolatedStringHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Framework
         private int position = 0;
         private int argPosition = 0;
 
-        public object[] Arguments { get; } = Array.Empty<object>();
+        public object?[] Arguments { get; } = Array.Empty<object?>();
 
         public LogInterpolatedStringHandler(int literalLength, int formattedCount)
         {

--- a/src/Framework/LogInterpolatedStringHandler.cs
+++ b/src/Framework/LogInterpolatedStringHandler.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Build.Framework
     [InterpolatedStringHandler]
     public ref struct LogInterpolatedStringHandler
     {
-        private char[] buffer;
+        private readonly char[] buffer;
         private int position = 0;
         private int argPosition = 0;
 
@@ -24,8 +24,12 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentOutOfRangeException("Number of formatted arguments must be less than 100.");
             }
 
-            // Length is computed with reserved space for "{x}" and "{xx}" placeholders 
-            buffer = new char[literalLength + (4 * formattedCount)];
+            // Buffer size is computed with reserved space for "{x}" and "{xx}" placeholders
+            int bufferSize = formattedCount < 10 ?
+                literalLength + (3 * formattedCount) :
+                literalLength + 3 * (formattedCount % 10) + 4 * (formattedCount - (formattedCount % 10));
+
+            buffer = new char[bufferSize];
 
             if (formattedCount > 0)
             {

--- a/src/Framework/LogInterpolatedStringHandler.cs
+++ b/src/Framework/LogInterpolatedStringHandler.cs
@@ -8,6 +8,10 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Build.Framework
 {
+    /// <summary>
+    /// Represents interpolation string handler which allows to get string format and parameters
+    /// such like <see cref="FormattableString"/>.
+    /// </summary>
     [InterpolatedStringHandler]
     public ref struct LogInterpolatedStringHandler
     {
@@ -64,7 +68,7 @@ namespace Microsoft.Build.Framework
             return result;
         }
 
-        private int GetNumberOfDigits(int value)
+        private static int GetNumberOfDigits(int value)
         {
             // It's OK to return 0 if the value is 0, because we don't need to reserve
             // extra space in that case

--- a/src/Framework/LogInterpolatingHandler.cs
+++ b/src/Framework/LogInterpolatingHandler.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Build.Framework
+{
+    [InterpolatedStringHandler]
+    public ref struct LogInterpolatedStringHandler
+    {
+        private char[] buffer;
+        private int position = 0;
+        private int argPosition = 0;
+
+        public object[] Arguments { get; } = Array.Empty<object>();
+
+        public LogInterpolatedStringHandler(int literalLength, int formattedCount)
+        {
+            if (formattedCount > 99)
+            {
+                throw new ArgumentOutOfRangeException("Number of formatted arguments must be less than 100.");
+            }
+
+            // Length is computed with reserved space for "{x}" and "{xx}" placeholders 
+            buffer = new char[literalLength + (4 * formattedCount)];
+
+            if (formattedCount > 0)
+            {
+                Arguments = new object[formattedCount];
+            }
+        }
+
+        public void AppendLiteral(string s)
+        {
+            s.AsSpan().CopyTo(buffer.AsSpan().Slice(position));
+            position += s.Length;
+        }
+
+        public void AppendFormatted<T>(T t)
+        {
+            string indexString = argPosition.ToString();
+            buffer[position++] = '{';
+            indexString.AsSpan().CopyTo(buffer.AsSpan().Slice(position));
+            position += indexString.Length;
+            buffer[position++] = '}';
+
+            Arguments[argPosition++] = t;
+        }
+
+        internal string GetFormat()
+        {
+            string result = new string(buffer, 0, position);
+
+            return result;
+        }
+    }
+}
+
+#endif

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Build.Utilities
         }
         #endregion
 
-        #region Message logging methods
+        #region Message logging method
 
         /// <summary>
         /// Returns <see langword="true"/> if the build is configured to log all task inputs.
@@ -257,6 +257,33 @@ namespace Microsoft.Build.Utilities
             return BuildEngine is not IBuildEngine10 buildEngine10
                 || buildEngine10.EngineServices.LogsMessagesOfImportance(importance);
         }
+
+#if NET6_0_OR_GREATER
+
+        /// <summary>
+        /// Logs a message using the specified interpolated string.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="stringHandler">The message interpolated string.</param>
+        public void LogMessage(LogInterpolatedStringHandler stringHandler)
+        {
+            LogMessage(MessageImportance.Normal, stringHandler);
+        }
+
+        /// <summary>
+        /// Logs a message using the specified interpolated string.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="importance">The importance level of the message.</param>
+        /// <param name="stringHandler">The message interpolated string.</param>
+        public void LogMessage(MessageImportance importance, LogInterpolatedStringHandler stringHandler)
+        {
+            if (LogsMessagesOfImportance(importance))
+            {
+                LogMessage(importance, stringHandler.GetFormat(), stringHandler.Arguments);
+            }
+        }
+#endif
 
         /// <summary>
         /// Logs a message using the specified string.
@@ -592,6 +619,19 @@ namespace Microsoft.Build.Utilities
         #endregion
 
         #region Error logging methods
+
+#if NET6_0_OR_GREATER
+
+        /// <summary>
+        /// Logs an error message using the specified interpolated string.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="stringHandler">The message interpolated string.</param>
+        public void LogError(LogInterpolatedStringHandler stringHandler)
+        {
+            LogError(stringHandler.GetFormat(), stringHandler.Arguments);
+        }
+#endif
 
         /// <summary>
         /// Logs an error using the specified string.
@@ -943,6 +983,19 @@ namespace Microsoft.Build.Utilities
         #endregion
 
         #region Warning logging methods
+
+#if NET6_0_OR_GREATER
+
+        /// <summary>
+        /// Logs a warning message using the specified interpolated string.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="stringHandler">The message interpolated string.</param>
+        public void LogWarning(LogInterpolatedStringHandler stringHandler)
+        {
+            LogWarning(stringHandler.GetFormat(), stringHandler.Arguments);
+        }
+#endif
 
         /// <summary>
         /// Logs a warning using the specified string.

--- a/src/Utilities.UnitTests/MockEngine.cs
+++ b/src/Utilities.UnitTests/MockEngine.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Build.UnitTests
     {
         private StringBuilder _log = new StringBuilder();
 
+        public List<LazyFormattedBuildEventArgs> BuildEventArgs { get; } = new List<LazyFormattedBuildEventArgs>();
+
         public MessageImportance MinimumMessageImportance { get; set; } = MessageImportance.Low;
 
         internal int Messages { set; get; }
@@ -43,6 +45,8 @@ namespace Microsoft.Build.UnitTests
 
         public void LogErrorEvent(BuildErrorEventArgs eventArgs)
         {
+            BuildEventArgs.Add(eventArgs);
+
             Console.WriteLine(EventArgsFormatting.FormatEventMessage(eventArgs));
             _log.AppendLine(EventArgsFormatting.FormatEventMessage(eventArgs));
             ++Errors;
@@ -50,6 +54,8 @@ namespace Microsoft.Build.UnitTests
 
         public void LogWarningEvent(BuildWarningEventArgs eventArgs)
         {
+            BuildEventArgs.Add(eventArgs);
+
             Console.WriteLine(EventArgsFormatting.FormatEventMessage(eventArgs));
             _log.AppendLine(EventArgsFormatting.FormatEventMessage(eventArgs));
             ++Warnings;
@@ -66,6 +72,8 @@ namespace Microsoft.Build.UnitTests
             // Only if the message is above the minimum importance should we record the log message
             if (eventArgs.Importance <= MinimumMessageImportance)
             {
+                BuildEventArgs.Add(eventArgs);
+
                 Console.WriteLine(eventArgs.Message);
                 _log.AppendLine(eventArgs.Message);
                 ++Messages;

--- a/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
+++ b/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
@@ -310,5 +310,63 @@ namespace Microsoft.Build.UnitTests
             engine.AssertLogContains("The operation was invalid");
             engine.AssertLogContains("An I/O error occurred");
         }
+
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void LogMessageWithInterpolatedString()
+        {
+            MockEngine mockEngine = new MockEngine();
+            Task t = new MockTask();
+            t.BuildEngine = mockEngine;
+
+            t.Log.LogMessage($"echo {0} and {"1"}");
+
+            mockEngine.BuildEventArgs.Count.ShouldBe(1);
+            mockEngine.BuildEventArgs[0].ShouldBeOfType<BuildMessageEventArgs>();
+            mockEngine.BuildEventArgs[0].Message.ShouldBe("echo 0 and 1");
+        }
+
+        [Fact]
+        public void LogMessageWithInterpolatedString_RespectsImportanceLevel()
+        {
+            MockEngine mockEngine = new MockEngine();
+            Task t = new MockTask();
+            t.BuildEngine = mockEngine;
+
+            mockEngine.MinimumMessageImportance = MessageImportance.High;
+            t.Log.LogMessage(MessageImportance.Low, $"echo {0} and {"1"}");
+
+            mockEngine.BuildEventArgs.Count.ShouldBe(0);
+        }
+
+        [Fact]
+        public void LogWarningWithInterpolatedString()
+        {
+            MockEngine mockEngine = new MockEngine();
+            Task t = new MockTask();
+            t.BuildEngine = mockEngine;
+
+            t.Log.LogWarning($"echo {0} and {"1"}");
+
+            mockEngine.BuildEventArgs.Count.ShouldBe(1);
+            mockEngine.BuildEventArgs[0].ShouldBeOfType<BuildWarningEventArgs>();
+            mockEngine.BuildEventArgs[0].Message.ShouldBe("echo 0 and 1");
+        }
+
+        [Fact]
+        public void LogErrorWithInterpolatedString()
+        {
+            MockEngine mockEngine = new MockEngine();
+            Task t = new MockTask();
+            t.BuildEngine = mockEngine;
+
+            t.Log.LogError($"echo {0} and {"1"}");
+
+            mockEngine.BuildEventArgs.Count.ShouldBe(1);
+            mockEngine.BuildEventArgs[0].ShouldBeOfType<BuildErrorEventArgs>();
+            mockEngine.BuildEventArgs[0].Message.ShouldBe("echo 0 and 1");
+        }
+#endif
+
     }
 }

--- a/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
+++ b/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
@@ -319,11 +319,11 @@ namespace Microsoft.Build.UnitTests
             Task t = new MockTask();
             t.BuildEngine = mockEngine;
 
-            t.Log.LogMessage($"echo {0} and {"1"}");
+            t.Log.LogMessage($"echo {0} and {"1"} {2} {3} {4} {5} {6} {7} {8} {9} {10}");
 
             mockEngine.BuildEventArgs.Count.ShouldBe(1);
             mockEngine.BuildEventArgs[0].ShouldBeOfType<BuildMessageEventArgs>();
-            mockEngine.BuildEventArgs[0].Message.ShouldBe("echo 0 and 1");
+            mockEngine.BuildEventArgs[0].Message.ShouldBe("echo 0 and 1 2 3 4 5 6 7 8 9 10");
         }
 
         [Fact]

--- a/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
+++ b/src/Utilities.UnitTests/TaskLoggingHelper_Tests.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -312,18 +316,40 @@ namespace Microsoft.Build.UnitTests
         }
 
 #if NET6_0_OR_GREATER
-        [Fact]
-        public void LogMessageWithInterpolatedString()
+
+        public static IEnumerable<object[]> InterpolatedLogTestData()
+        {
+            Action<Task> logMessage = t => t.Log.LogMessage($"echo {0} and {"1"} {2} {3} {4} {5} {6} {7} {8} {9} {10}");
+            Action<Task> logWarning = t => t.Log.LogWarning($"echo {0} and {"1"}");
+            Action<Task> logError = t => t.Log.LogError($"echo {0} and {"1"}");
+
+            yield return new object[] { logMessage, "echo 0 and 1 2 3 4 5 6 7 8 9 10", typeof(BuildMessageEventArgs) };
+            yield return new object[] { logWarning, "echo 0 and 1", typeof(BuildWarningEventArgs) };
+            yield return new object[] { logError, "echo 0 and 1", typeof(BuildErrorEventArgs) };
+        }
+
+        [Theory]
+        [MemberData(nameof(InterpolatedLogTestData))]
+        public void LogWithInterpolatedString(Action<Task> logAction, string expectedResult, Type expectedEventType)
         {
             MockEngine mockEngine = new MockEngine();
             Task t = new MockTask();
             t.BuildEngine = mockEngine;
 
-            t.Log.LogMessage($"echo {0} and {"1"} {2} {3} {4} {5} {6} {7} {8} {9} {10}");
+            logAction(t);
 
             mockEngine.BuildEventArgs.Count.ShouldBe(1);
-            mockEngine.BuildEventArgs[0].ShouldBeOfType<BuildMessageEventArgs>();
-            mockEngine.BuildEventArgs[0].Message.ShouldBe("echo 0 and 1 2 3 4 5 6 7 8 9 10");
+            mockEngine.BuildEventArgs[0].ShouldBeOfType(expectedEventType);
+            mockEngine.BuildEventArgs[0].Message.ShouldBe(expectedResult);
+
+            MethodBody logActionBody = logAction
+                .GetMethodInfo()
+                .GetMethodBody();
+
+            logActionBody
+                .LocalVariables
+                .Select(lvi => lvi.LocalType)
+                .ShouldContain(typeof(LogInterpolatedStringHandler), "Wrong logging method was bound");
         }
 
         [Fact]
@@ -337,34 +363,6 @@ namespace Microsoft.Build.UnitTests
             t.Log.LogMessage(MessageImportance.Low, $"echo {0} and {"1"}");
 
             mockEngine.BuildEventArgs.Count.ShouldBe(0);
-        }
-
-        [Fact]
-        public void LogWarningWithInterpolatedString()
-        {
-            MockEngine mockEngine = new MockEngine();
-            Task t = new MockTask();
-            t.BuildEngine = mockEngine;
-
-            t.Log.LogWarning($"echo {0} and {"1"}");
-
-            mockEngine.BuildEventArgs.Count.ShouldBe(1);
-            mockEngine.BuildEventArgs[0].ShouldBeOfType<BuildWarningEventArgs>();
-            mockEngine.BuildEventArgs[0].Message.ShouldBe("echo 0 and 1");
-        }
-
-        [Fact]
-        public void LogErrorWithInterpolatedString()
-        {
-            MockEngine mockEngine = new MockEngine();
-            Task t = new MockTask();
-            t.BuildEngine = mockEngine;
-
-            t.Log.LogError($"echo {0} and {"1"}");
-
-            mockEngine.BuildEventArgs.Count.ShouldBe(1);
-            mockEngine.BuildEventArgs[0].ShouldBeOfType<BuildErrorEventArgs>();
-            mockEngine.BuildEventArgs[0].Message.ShouldBe("echo 0 and 1");
         }
 #endif
 


### PR DESCRIPTION
Fixes #7875

This PR replaces #8410

### Context
Enables to log interpolated strings from tasks.

### Changes Made
Added new interpolated string handler with overloads in TaskLoggingHelper.

### Testing
New unit tests added.

### Notes
I tried to use ```FormattableString```, but old overload had precedence.
Handler is mutable value type, but mutating methods should be invoked by compiler generated code. If you are not comfortable with it, we can change it to reference type with heap allocation.