### PR TITLE
[LiveLogger] Advertise during preview

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3249,17 +3249,20 @@ namespace Microsoft.Build.CommandLine
             // Add any loggers which have been specified on the commandline
             distributedLoggerRecords = ProcessDistributedLoggerSwitch(distributedLoggerSwitchParameters, verbosity);
 
+            // See if live logger is supported
+            bool liveLoggerSupported = DoesEnvironmentSupportLiveLogger();
+
             // Choose default console logger
             if (
                 (liveLoggerCommandLineOptIn || Environment.GetEnvironmentVariable("MSBUILDFANCYLOGGER") == "true" || Environment.GetEnvironmentVariable("MSBUILDLIVELOGGER") == "true")
-                && DoesEnvironmentSupportLiveLogger())
+                && liveLoggerSupported)
             {
                 ProcessLiveLogger(noConsoleLogger, loggers);
             }
             else
             {
                 // If supported, advertise livelogger
-                if (DoesEnvironmentSupportLiveLogger())
+                if (liveLoggerSupported)
                 {
                     messagesToLogInBuildLoggers.Add(
                         new BuildManager.DeferredBuildMessage("Try out the new LiveLogger using the switch -livelogger or -ll", MessageImportance.High));

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3258,6 +3258,12 @@ namespace Microsoft.Build.CommandLine
             }
             else
             {
+                // If supported, advertise livelogger
+                if (DoesEnvironmentSupportLiveLogger())
+                {
+                    messagesToLogInBuildLoggers.Add(
+                        new BuildManager.DeferredBuildMessage("Try out the new LiveLogger using the switch -livelogger or -ll", MessageImportance.High));
+                }
                 ProcessConsoleLoggerSwitch(noConsoleLogger, consoleLoggerParameters, distributedLoggerRecords, verbosity, cpuCount, loggers);
             }
 


### PR DESCRIPTION
Fixes #8428 

### Context
As LiveLogger enters preview we are interested in users using it and receiving feedback. As this is an opt-in behavior, the new feature needs to be advertised.

### Changes Made
A `DeferredBuildMessage` with the legend "Try out the new LiveLogger using the switch -livelogger or -ll" is displayed whenever the LiveLogger is supported but not used. 

<img width="614" alt="image" src="https://user-images.githubusercontent.com/5952839/217938619-91b20180-0772-45d3-86fa-eeab2667f0f3.png">


### Testing
Manual testing.

### Notes
