### PR TITLE
Improve VS binlogs providing info

### DIFF
--- a/documentation/wiki/Binary-Log.md
+++ b/documentation/wiki/Binary-Log.md
@@ -66,12 +66,7 @@ https://msbuildlog.com/
 
 # Collecting binary logs from Visual Studio builds
 
-If you need to capture a binary log in Visual Studio, instead of the command line, you'll need a Visual Studio plugin:
-
-- https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.ProjectSystemTools for VS 2017 & 2019
-- https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.ProjectSystemTools2022 for VS 2022
-
-After installing that, enable logging and run your build ([more details](https://github.com/dotnet/project-system-tools)).
+[see more details](Providing-Binary-Logs.md#capturing-binary-logs-through-visual-studio)
 
 # Binary log file format
 

--- a/documentation/wiki/Providing-Binary-Logs.md
+++ b/documentation/wiki/Providing-Binary-Logs.md
@@ -6,7 +6,7 @@ However, you should be aware what type of information is captured in the binary 
 
 ⚠ NOTE: some build environments make secrets available using environment variables. Before sharing a binary log, make sure it does not expose API tokens or other important secrets.
 
-You can create a binary log by passing the `-bl` parameter to MSBuild. You can explore the contents of the generated .binlog file using [MSBuild Structured Log Viewer](http://msbuildlog.com/) or in your browser using [Live Structured Log Viewer](https://live.msbuildlog.com). Note: We don't capture any data from binary logs viewed on your browser.
+You can create a binary log by passing the `-bl` parameter to MSBuild (`MSBuild.exe` or `dotnet build`). You can explore the contents of the generated .binlog file using [MSBuild Structured Log Viewer](http://msbuildlog.com/) or in your browser using [Live Structured Log Viewer](https://live.msbuildlog.com). Note: We don't capture any data from binary logs viewed on your browser.
 
 [More details about binary logs](Binary-Log.md)
 
@@ -19,6 +19,8 @@ Via setting `MSBUILDDEBUGENGINE` environment variable to `'1'`:
 ```
 
 MSBuild binary logs are then captured to `MSBuild_Logs` subfolder of a current folder.
+
+⚠ NOTE: logs are being recorded for each MSBuild invocation (including design time builds) and kept in the folder without removing older ones - so the number of log files can grow quickly. It is recommended to set the opt-in environment variable only for the short duration of reproducing the issue to be investigated (though it is understandable that some nondeterministic issues might need multiple reproduction attempts)
 
 [More technical info](Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md#logs)
 

--- a/documentation/wiki/Providing-Binary-Logs.md
+++ b/documentation/wiki/Providing-Binary-Logs.md
@@ -18,11 +18,13 @@ Via setting `MSBUILDDEBUGENGINE` environment variable to `'1'`:
 > devenv.exe MySolution.sln
 ```
 
-MSBuild binary logs are then captured to `MSBuild_Logs` subfolder of a current folder.
+MSBuild binary logs are then captured to a location specified via `MSBUILDDEBUGPATH` environment variable (or defaults to `MSBuild_Logs` subfolder of a current folder or `%temp%`, based on access rights).
 
 ⚠ NOTE: logs are being recorded for each MSBuild invocation (including design time builds) and kept in the folder without removing older ones - so the number of log files can grow quickly. It is recommended to set the opt-in environment variable only for the short duration of reproducing the issue to be investigated (though it is understandable that some nondeterministic issues might need multiple reproduction attempts)
 
-[More technical info](Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md#logs)
+Further reading:
+* [More technical info](Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md#logs)
+* [Design time builds logs](https://github.com/dotnet/project-system/blob/main/docs/repo/debugging/design-time-builds.md#gathering-full-fidelity-binlogs)
 
 ### Capturing specific logs for chosen build invocations
 See [this guide](https://github.com/dotnet/project-system-tools) in the Project System Tools repo for capturing binlogs through Visual Studio.

--- a/documentation/wiki/Providing-Binary-Logs.md
+++ b/documentation/wiki/Providing-Binary-Logs.md
@@ -11,4 +11,16 @@ You can create a binary log by passing the `-bl` parameter to MSBuild. You can e
 [More details about binary logs](Binary-Log.md)
 
 ## Capturing Binary Logs Through Visual Studio
+### (Preferred way) Capturing logs for all MSBuild invocations
+Via setting `MSBUILDDEBUGENGINE` environment variable to `'1'`:
+```
+> SET MSBUILDDEBUGENGINE=1
+> devenv.exe MySolution.sln
+```
+
+MSBuild binary logs are then captured to `MSBuild_Logs` subfolder of a current folder.
+
+[More technical info](Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md#logs)
+
+### Capturing specific logs for chosen build invocations
 See [this guide](https://github.com/dotnet/project-system-tools) in the Project System Tools repo for capturing binlogs through Visual Studio.

--- a/documentation/wiki/Providing-Binary-Logs.md
+++ b/documentation/wiki/Providing-Binary-Logs.md
@@ -12,7 +12,7 @@ You can create a binary log by passing the `-bl` parameter to MSBuild (`MSBuild.
 
 ## Capturing Binary Logs Through Visual Studio
 ### (Preferred way) Capturing logs for all MSBuild invocations
-Via setting `MSBUILDDEBUGENGINE` environment variable to `'1'` and (optionaly) `MSBUILDDEBUGPATH` to an existing destination folder to store the captured logs and starting the Visual Studio from the same shell to inherit the environment:
+Set `MSBUILDDEBUGENGINE` environment variable to `'1'` and (optionally) set `MSBUILDDEBUGPATH` to an existing destination folder to store the captured logs. Then start Visual Studio from the same shell to inherit the environment:
 
 `cmd:`
 ```

--- a/documentation/wiki/Providing-Binary-Logs.md
+++ b/documentation/wiki/Providing-Binary-Logs.md
@@ -12,10 +12,20 @@ You can create a binary log by passing the `-bl` parameter to MSBuild (`MSBuild.
 
 ## Capturing Binary Logs Through Visual Studio
 ### (Preferred way) Capturing logs for all MSBuild invocations
-Via setting `MSBUILDDEBUGENGINE` environment variable to `'1'`:
+Via setting `MSBUILDDEBUGENGINE` environment variable to `'1'` and (optionaly) `MSBUILDDEBUGPATH` to an existing destination folder to store the captured logs and starting the Visual Studio from the same shell to inherit the environment:
+
+`cmd:`
 ```
 > SET MSBUILDDEBUGENGINE=1
+> SET MSBUILDDEBUGPATH=C:\MSBuildReproLogs
 > devenv.exe MySolution.sln
+```
+
+`PowerShell:`
+```
+> $env:MSBUILDDEBUGENGINE = 1
+> $env:MSBUILDDEBUGPATH= C:\MSBuildReproLogs
+> & "devenv.exe" MySolution.sln
 ```
 
 MSBuild binary logs are then captured to a location specified via `MSBUILDDEBUGPATH` environment variable (or defaults to `MSBuild_Logs` subfolder of a current folder or `%temp%`, based on access rights).


### PR DESCRIPTION
### Context
As discussed on triage - binlogs captured through VS project system extension tooling are less preferrable to logs captured via environment opt-in. Let's make it more explicit in our docs that we are often linking externally to our customers.
