### PR TITLE
[LiveLogger] Report build time

### DIFF
--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Build.Logging.LiveLogger
         private int finishedProjects = 0;
         private Dictionary<string, int> blockedProjects = new();
 
+        private DateTime startTime;
+        private DateTime endTime;
+
         public LoggerVerbosity Verbosity { get; set; }
         public string Parameters { get; set; }
 
@@ -119,10 +122,12 @@ namespace Microsoft.Build.Logging.LiveLogger
         // Build
         private void eventSource_BuildStarted(object sender, BuildStartedEventArgs e)
         {
+            startTime = DateTime.Now;
         }
 
         private void eventSource_BuildFinished(object sender, BuildFinishedEventArgs e)
         {
+            endTime = DateTime.Now;
             succeeded = e.Succeeded;
         }
 
@@ -286,6 +291,7 @@ namespace Microsoft.Build.Logging.LiveLogger
 
         public void Shutdown()
         {
+            TimeSpan buildDuration = endTime - startTime;
             TerminalBuffer.Terminate();
             int errorCount = 0;
             int warningCount = 0;
@@ -311,15 +317,15 @@ namespace Microsoft.Build.Logging.LiveLogger
             if (succeeded)
             {
                 Console.WriteLine(ANSIBuilder.Formatting.Color("Build succeeded.", ANSIBuilder.Formatting.ForegroundColor.Green));
-                Console.WriteLine($"\t{warningCount} Warning(s)");
-                Console.WriteLine($"\t{errorCount} Error(s)");
             }
             else
             {
                 Console.WriteLine(ANSIBuilder.Formatting.Color("Build failed.", ANSIBuilder.Formatting.ForegroundColor.Red));
-                Console.WriteLine($"\t{warningCount} Warnings(s)");
-                Console.WriteLine($"\t{errorCount} Errors(s)");
             }
+            Console.WriteLine($"\t{warningCount} Warnings(s)");
+            Console.WriteLine($"\t{errorCount} Errors(s)");
+            Console.WriteLine();
+            Console.WriteLine($"Time elapsed {buildDuration.ToString()}");
         }
     }
 }

--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -150,7 +150,6 @@ namespace Microsoft.Build.Logging.LiveLogger
 
         private void eventSource_BuildFinished(object sender, BuildFinishedEventArgs e)
         {
-            endTime = DateTime.Now;
             succeeded = e.Succeeded;
         }
 
@@ -323,7 +322,7 @@ namespace Microsoft.Build.Logging.LiveLogger
             Console.WriteLine();
 
             Debug.Assert(_stopwatch is not null, $"Expected {nameof(_stopwatch)} to be initialized long before Shutdown()");
-            TimeSpan buildDuration = _stopwatch.Elapsed;
+            TimeSpan buildDuration = _stopwatch!.Elapsed;
 
             string prettyDuration = buildDuration.TotalHours > 1.0 ?
                 buildDuration.ToString(@"h\:mm\:ss") :

--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -314,18 +314,19 @@ namespace Microsoft.Build.Logging.LiveLogger
 
             // Emmpty line
             Console.WriteLine();
-            if (succeeded)
-            {
-                Console.WriteLine(ANSIBuilder.Formatting.Color("Build succeeded.", ANSIBuilder.Formatting.ForegroundColor.Green));
-            }
-            else
-            {
-                Console.WriteLine(ANSIBuilder.Formatting.Color("Build failed.", ANSIBuilder.Formatting.ForegroundColor.Red));
-            }
+
+            string prettyDuration = buildDuration.TotalHours > 1.0 ?
+                buildDuration.ToString(@"h\:mm\:ss") :
+                buildDuration.ToString(@"m\:ss");
+
+            string status = succeeded ?
+                ANSIBuilder.Formatting.Color("succeeded", ANSIBuilder.Formatting.ForegroundColor.Green) :
+                ANSIBuilder.Formatting.Color("failed", ANSIBuilder.Formatting.ForegroundColor.Red);
+
+            Console.WriteLine($"Build {status} in {prettyDuration}");
             Console.WriteLine($"\t{warningCount} Warnings(s)");
             Console.WriteLine($"\t{errorCount} Errors(s)");
             Console.WriteLine();
-            Console.WriteLine($"Time elapsed {buildDuration.ToString()}");
         }
     }
 }


### PR DESCRIPTION
Fixes #8450

### Context
The console logger shows the total time elapsed for the build in the summary. It should also be shown on the summary for the LiveLogger

### Changes Made
The difference between the time at build start and build end is displayed in the summary at the end of the build.

### Testing
Manual testing

### Notes
