### PR TITLE
[LiveLogger] Fix for conhost.exe

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3444,7 +3444,7 @@ namespace Microsoft.Build.CommandLine
             }
             // If terminal is dumb
             if (
-                (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && (Environment.GetEnvironmentVariable("WT_SESSION") == "" || Environment.GetEnvironmentVariable("WT_SESSION") == null))
+                (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WT_SESSION")))
                 || Environment.GetEnvironmentVariable("TERM") == "dumb")
             {
                 messagesToLogInBuildLoggers.Add(

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3444,7 +3444,7 @@ namespace Microsoft.Build.CommandLine
             }
             // If terminal is dumb
             if (
-                (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.GetEnvironmentVariable("WT_SESSION") == "")
+                (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && (Environment.GetEnvironmentVariable("WT_SESSION") == "" || Environment.GetEnvironmentVariable("WT_SESSION") == null))
                 || Environment.GetEnvironmentVariable("TERM") == "dumb")
             {
                 messagesToLogInBuildLoggers.Add(


### PR DESCRIPTION
Fixes #8455

### Context
LiveLogger is only enabled for terminal emulators that support VT100/ANSI escape sequences. On Windows, these are supported by default on Windows Terminal, but Console Host (the old terminal emulator) does not support all of them. Hence LiveLogger checks if the code is run on Windows Terminal via the `WT_SESSION` environment variable. 

### Changes Made
Added check for when `Environment.GetEnvironmentVariable("WT_SESSION") == null`

### Testing


### Notes
