### PR TITLE
Fix graph p2p protocol when using DeployOnBuild=true

### DIFF
--- a/src/Tasks/Microsoft.Managed.After.targets
+++ b/src/Tasks/Microsoft.Managed.After.targets
@@ -52,6 +52,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_MainReferenceTargetForPublish Condition="'$(NoBuild)' != 'true'">$(_MainReferenceTargetForBuild)</_MainReferenceTargetForPublish>
     <ProjectReferenceTargetsForPublish>GetTargetFrameworks;$(_MainReferenceTargetForPublish);GetNativeManifest;GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForPublish)</ProjectReferenceTargetsForPublish>
 
+    <!-- When DeployOnBuild=true, the Publish target is hooked to the Build target -->
+    <ProjectReferenceTargetsForBuild Condition="'$(DeployOnBuild)' == 'true'">$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForPublish)</ProjectReferenceTargetsForBuild>
+    <ProjectReferenceTargetsForRebuild Condition="'$(DeployOnBuild)' == 'true'">$(ProjectReferenceTargetsForRebuild);$(ProjectReferenceTargetsForPublish)</ProjectReferenceTargetsForRebuild>
+
     <ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)</ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>
   </PropertyGroup>
 
@@ -59,7 +63,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true" />
     <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" />
     <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
-    
+
     <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true" />
     <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" />
     <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />


### PR DESCRIPTION
When using `DeployOnBuild=true`, the `Publish` target is hooked to the `Build` target. This change reflects that in the graph p2p protocol by appending the publish targets to the build (and rebuild) targets.