### PR TITLE
LiveLogger: ConcurrentDictionary for projects

### DIFF
--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
@@ -10,12 +11,12 @@ namespace Microsoft.Build.Logging.LiveLogger
 {
     internal class LiveLogger : ILogger
     {
-        private Dictionary<int, ProjectNode> projects = new Dictionary<int, ProjectNode>();
+        private ConcurrentDictionary<int, ProjectNode> projects = new();
 
         private bool succeeded;
         private int startedProjects = 0;
         private int finishedProjects = 0;
-        private Dictionary<string, int> blockedProjects = new();
+        private ConcurrentDictionary<string, int> blockedProjects = new();
 
         public LoggerVerbosity Verbosity { get; set; }
         public string Parameters { get; set; }
@@ -135,16 +136,17 @@ namespace Microsoft.Build.Logging.LiveLogger
             int id = e.BuildEventContext!.ProjectInstanceId;
 
             // If id does not exist...
-            if (!projects.ContainsKey(id))
+            projects.GetOrAdd(id, (_) =>
             {
                 // Add project
                 ProjectNode node = new(e)
                 {
                     ShouldRerender = true,
                 };
-                projects[id] = node;
                 UpdateFooter();
-            }
+
+                return node;
+            });
         }
 
         private void eventSource_ProjectFinished(object sender, ProjectFinishedEventArgs e)


### PR DESCRIPTION
This should avoid some exceptions observed caused by races between modifying and accessing the dictionary, part of #8458.
