### PR TITLE
net35 task host properly handle isolated AppDomain tasks

### DIFF
--- a/src/Shared/LoadedType.cs
+++ b/src/Shared/LoadedType.cs
@@ -42,8 +42,10 @@ namespace Microsoft.Build.Shared
             LoadedAssembly = loadedAssembly;
 
 #if !NET35
-            // Properties set in this block aren't used by TaskHosts. Properties below are only used on the NodeProvider side to get information about the
+            // This block is reflection only loaded type implementation. Net35 does not support it, and fall backs to former implementation in #else
+            // Property `Properties` set in this block aren't used by TaskHosts. Properties below are only used on the NodeProvider side to get information about the
             // properties and reflect over them without needing them to be fully loaded, so it also isn't need for TaskHosts.
+
             // MetadataLoadContext-loaded Type objects don't support testing for inherited attributes, so we manually walk the BaseType chain.
             Type t = type;
             while (t is not null)

--- a/src/Shared/LoadedType.cs
+++ b/src/Shared/LoadedType.cs
@@ -104,6 +104,11 @@ namespace Microsoft.Build.Shared
                     PropertyAssemblyQualifiedNames[i] = Properties[i].PropertyType.AssemblyQualifiedName;
                 }
             }
+#else
+            // For v3.5 fallback to old full type approach, as oppose to reflection only
+            HasLoadInSeparateAppDomainAttribute = this.Type.GetTypeInfo().IsDefined(typeof(LoadInSeparateAppDomainAttribute), true /* inherited */);
+            HasSTAThreadAttribute = this.Type.GetTypeInfo().IsDefined(typeof(RunInSTAAttribute), true /* inherited */);
+            IsMarshalByRef = this.Type.IsMarshalByRef;
 #endif
         }
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1729428

### Context
Change https://github.com/dotnet/msbuild/pull/7387/files#diff-2295212a8e8b80807c0594f9e600d287e5a813c10326d71b4ac5ce907f0ecc42R45 have caused regression of not running specific net35 task in isolated AppDomain.

In our particular case of customer feedback issue, `UnregisterAssembly` task have kept some assemblies locked, because it need to load assemblies in order to unregister them, while prior this changes assembly files were released when `AppDomain` which loaded them have been deleted.

### Changes Made
Fallback to old behavior handling detecting attributes from full types as oppose to reflection only types.
Changes was based on changes of related PR ^.

### Testing
I have created repro. After fixes it no longer repros.

### Notes
Consequences of this error might be serious. Everyone with VS 17.3+ compiling and registering COM objects in net35 will experience it while rebuilding. We do not have multiple reports of this issue, AFAIK, but people might hesitate to report it, as obvious workarounds  exists (rebuild again, or use older VS 2019-).

@rainersigwald  we still might consider to backport it and/or servicing it in VS 17.5
