### PR TITLE
Fix static graph restore functionality for the bootstrap

### DIFF
--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -38,8 +38,11 @@
         <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('NuGetSdkResolver'))' == 'True'" />
         <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('Microsoft.Extensions.'))' == 'True'" />
 
-        <!-- NuGet.targets will be in the ResolvedRuntimeTargets ItemGroup -->
+        <!-- NuGet.targets and NuGet.RestoreEx.targets will be in the RuntimeTargetsCopyLocalItems ItemGroup -->
         <_NuGetRuntimeDependencies Include="%(RuntimeTargetsCopyLocalItems.Identity)" Condition="'@(RuntimeTargetsCopyLocalItems->Contains('NuGet.'))' == 'True'" />
+
+        <!-- NuGet.Build.Tasks.Console.exe will be in the None ItemGroup -->
+        <_NuGetRuntimeDependencies Include="%(None.Identity)" Condition="'@(None->Contains('NuGet.'))' == 'True'" />
 
         <_NuGetRuntimeDependencies Include="$(DOTNET_INSTALL_DIR)\sdk\$(DotNetCliVersion)\RuntimeIdentifierGraph.json" />
     </ItemGroup>
@@ -155,11 +158,11 @@
           SkipUnchangedFiles="true" />
     <Copy Condition="'$(MonoBuild)' == 'true'"
           SourceFiles="@(_NuGetRuntimeDependencies)"
-          DestinationFolder="$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin" 
+          DestinationFolder="$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin"
           SkipUnchangedFiles="true" />
 
     <Copy SourceFiles="@(NuGetSdkResolverManifest)"
-          DestinationFolder="$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\SdkResolvers\Microsoft.Build.NuGetSdkResolver" 
+          DestinationFolder="$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\SdkResolvers\Microsoft.Build.NuGetSdkResolver"
           SkipUnchangedFiles="true" />
 
     <!-- Delete shim projects, because they point where we can't follow. -->
@@ -168,35 +171,35 @@
 
     <!-- Copy our binaries -->
     <Copy SourceFiles="@(FreshlyBuiltBinaries)"
-          DestinationFiles="@(FreshlyBuiltBinaries -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\%(RecursiveDir)%(Filename)%(Extension)')" 
+          DestinationFiles="@(FreshlyBuiltBinaries -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
 
     <Copy SourceFiles="@(RoslynBinaries)"
-          DestinationFiles="@(RoslynBinaries -> '$(BootstrapDestination)15.0\Bin\Roslyn\%(RecursiveDir)%(Filename)%(Extension)')" 
+          DestinationFiles="@(RoslynBinaries -> '$(BootstrapDestination)15.0\Bin\Roslyn\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
 
     <!-- Copy our binaries to the x64 location. -->
     <Copy SourceFiles="@(FreshlyBuiltBinariesx64)"
-          DestinationFiles="@(FreshlyBuiltBinariesx64 -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\amd64\%(RecursiveDir)%(Filename)%(Extension)')" 
+          DestinationFiles="@(FreshlyBuiltBinariesx64 -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\amd64\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
 
     <!-- Copy our binaries to the arm64 location. -->
     <Copy SourceFiles="@(FreshlyBuiltBinariesArm64)"
-          DestinationFiles="@(FreshlyBuiltBinariesArm64 -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\arm64\%(RecursiveDir)%(Filename)%(Extension)')" 
+          DestinationFiles="@(FreshlyBuiltBinariesArm64 -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\arm64\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
 
     <!-- Copy our freshly-built props and targets, overwriting anything we copied from the machine -->
     <Copy SourceFiles="@(FreshlyBuiltRootProjects)"
-          DestinationFiles="@(FreshlyBuiltRootProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\%(Filename)%(Extension)')" 
+          DestinationFiles="@(FreshlyBuiltRootProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(FreshlyBuiltProjects)"
-          DestinationFiles="@(FreshlyBuiltProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\%(RecursiveDir)%(Filename)%(Extension)')" 
+          DestinationFiles="@(FreshlyBuiltProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(FreshlyBuiltProjects)"
-          DestinationFiles="@(FreshlyBuiltProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\amd64\%(RecursiveDir)%(Filename)%(Extension)')" 
+          DestinationFiles="@(FreshlyBuiltProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\amd64\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(FreshlyBuiltProjects)"
-          DestinationFiles="@(FreshlyBuiltProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\arm64\%(RecursiveDir)%(Filename)%(Extension)')" 
+          DestinationFiles="@(FreshlyBuiltProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\arm64\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
 
   </Target>
@@ -239,6 +242,9 @@
 
     <Copy SourceFiles="@(_NuGetRuntimeDependencies)"
           DestinationFolder="$(BootstrapDestination)" />
+
+    <Copy SourceFiles="$(RepoRoot)src\MSBuild.Bootstrap\RedirectNuGetConsoleProcess.After.Microsoft.Common.targets"
+          DestinationFolder="$(BootstrapDestination)\Current\Microsoft.Common.targets\ImportAfter" />
 
     <!-- Disable workload resolver until we can figure out whether it can work in the bootstrap
          https://github.com/dotnet/msbuild/issues/6566 -->

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistVersion)" />
     <PackageVersion Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksVersion)" />
+    <PackageVersion Include="NuGet.Build.Tasks.Console" Version="$(NuGetBuildTasksVersion)" />
     <PackageVersion Include="NuGet.Frameworks" Version="$(NuGetBuildTasksVersion)" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -24,6 +24,7 @@
 
     <!-- Include NuGet build tasks -->
     <PackageReference Include="NuGet.Build.Tasks" />
+    <PackageReference Include="NuGet.Build.Tasks.Console" />
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" />
 
     <!-- As of 17.5, NuGet.Build.Tasks and Microsoft.Build.NuGetSdkResolver depends on Newtonsoft.Json version 13.0.1,

--- a/src/MSBuild.Bootstrap/RedirectNuGetConsoleProcess.After.Microsoft.Common.targets
+++ b/src/MSBuild.Bootstrap/RedirectNuGetConsoleProcess.After.Microsoft.Common.targets
@@ -1,0 +1,24 @@
+<Project>
+  <!-- The CoreCLR flavor of NuGet.Build.Tasks.Console.exe looks for dotnet under "..\..\dotnet", so we need to redirect it for the bootstrap to the currently executing dotnet.exe.
+       See: https://github.com/NuGet/NuGet.Client/blob/91f6fdb26b09e16c4520b1d13ee30bb38172a7bd/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs#L240-L252 -->
+  <UsingTask
+    TaskName="GetCurrentProcessFileName"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    <ParameterGroup>
+      <CurrentProcessFileName ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.Diagnostics" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+      CurrentProcessFileName = Process.GetCurrentProcess().MainModule.FileName;
+      ]]></Code>
+    </Task>
+  </UsingTask>
+  <Target Name="RedirectNuGetConsoleProcess" BeforeTargets="Restore">
+    <GetCurrentProcessFileName>
+      <Output TaskParameter="CurrentProcessFileName" PropertyName="NuGetConsoleProcessFileName" />
+    </GetCurrentProcessFileName>
+    <Message Text="NuGetConsoleProcessFileName=$(NuGetConsoleProcessFileName)" Importance="High" />
+  </Target>
+</Project>

--- a/src/MSBuild.Bootstrap/RedirectNuGetConsoleProcess.After.Microsoft.Common.targets
+++ b/src/MSBuild.Bootstrap/RedirectNuGetConsoleProcess.After.Microsoft.Common.targets
@@ -19,6 +19,5 @@
     <GetCurrentProcessFileName>
       <Output TaskParameter="CurrentProcessFileName" PropertyName="NuGetConsoleProcessFileName" />
     </GetCurrentProcessFileName>
-    <Message Text="NuGetConsoleProcessFileName=$(NuGetConsoleProcessFileName)" Importance="High" />
   </Target>
 </Project>


### PR DESCRIPTION
Today the bootstrap doesn't have `NuGet.RestoreEx.targets` (or `NuGet.Build.Tasks.Console.exe` even), so it falls back to the "regular" restore. This change brings in those bits via the `NuGet.Build.Tasks.Console` package.