### PR TITLE
Fix logging of node reuse

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -287,7 +287,10 @@ namespace Microsoft.Build.BackEnd
                         // Connection successful, use this node.
                         CommunicationsUtilities.Trace("Successfully connected to existed node {0} which is PID {1}", nodeId, nodeToReuse.Id);
                         string msg = ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("NodeReused", nodeId, nodeToReuse.Id);
-                        _componentHost.LoggingService.LogBuildEvent(new BuildMessageEventArgs(msg, null, null, MessageImportance.Low));
+                        _componentHost.LoggingService.LogBuildEvent(new BuildMessageEventArgs(msg, null, null, MessageImportance.Low)
+                        {
+                            BuildEventContext = new BuildEventContext(nodeId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId)
+                        });
 
                         CreateNodeContext(nodeId, nodeToReuse, nodeStream);
                         return true;


### PR DESCRIPTION
FYI @JaynieBai 

Fixes issue causing failing insertion https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/454231

### Context
Setting verbose logging and rebuilding twice was leading to build errors.
This was caused by the fact that low-pri node reuse log event didn't have BuildContext set and ParallelConsoleLogger was choking on it (null ref).

### Fix
Setting BuildEventContext on the node reuse log event
