### PR TITLE
Move ResolveSdkStop event to finally

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -317,13 +317,12 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
                 SdkResultFactory resultFactory = new SdkResultFactory(sdk);
 
-                SdkResult result;
+                SdkResult result = null;
 
                 try
                 {
                     MSBuildEventSource.Log.SdkResolverResolveSdkStart();
                     result = (SdkResult)sdkResolver.Resolve(sdk, context, resultFactory);
-                    MSBuildEventSource.Log.SdkResolverResolveSdkStop(sdkResolver.Name, sdk.Name, solutionPath, projectPath, result?.Path, result?.Success ?? false);
                 }
                 catch (Exception e) when ((e is FileNotFoundException || e is FileLoadException) && sdkResolver.GetType().GetTypeInfo().Name.Equals("NuGetSdkResolver", StringComparison.Ordinal))
                 {
@@ -338,6 +337,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 {
                     // The SDK resolver "{0}" failed while attempting to resolve the SDK "{1}": {2}
                     throw new SdkResolverException("SDKResolverFailed", sdkResolver, sdk, e, sdkResolver.Name, sdk.ToString(), e.ToString());
+                }
+                finally
+                {
+                    MSBuildEventSource.Log.SdkResolverResolveSdkStop(sdkResolver.Name, sdk.Name, solutionPath, projectPath, result?.Path, result?.Success ?? false);
                 }
 
                 SetResolverState(submissionId, sdkResolver, context.State);


### PR DESCRIPTION
May fix #8519

### Context
Some SdkResolverResolveSdkStop events aren't being picked up. This is especially problematic, since those hold most of the interesting information. This tries to ensure that they are logged even if we throw.

### Changes Made
Move stop event to finally block

### Testing
None

### Notes
