### PR TITLE
Add ProjectOptions.Interactive so that callers can specify that project evaluation can be interactive

### DIFF
--- a/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
+++ b/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
@@ -5,7 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Shouldly;
 using Xunit;
@@ -252,6 +255,93 @@ namespace Microsoft.Build.UnitTests.Definition
                 {
                     var c = project.ItemsIgnoringCondition;
                 });
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when calling <see cref="Project.FromFile(string, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ProjectFromFileInteractive(bool interactive)
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                ProjectCollection projectCollection = testEnvironment.CreateProjectCollection().Collection;
+
+                ProjectRootElement projectRootElement = ProjectRootElement.Create(projectCollection);
+
+                projectRootElement.Save(testEnvironment.CreateFile().Path);
+
+                Project project = Project.FromFile(
+                    projectRootElement.FullPath,
+                    new ProjectOptions
+                    {
+                        Interactive = interactive,
+                        ProjectCollection = projectCollection,
+                    });
+
+                project.GetPropertyValue(ReservedPropertyNames.interactive).ShouldBe(interactive ? bool.TrueString : string.Empty, StringCompareShould.IgnoreCase);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when calling <see cref="Project.FromProjectRootElement(ProjectRootElement, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ProjectFromProjectRootElementInteractive(bool interactive)
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                ProjectCollection projectCollection = testEnvironment.CreateProjectCollection().Collection;
+
+                ProjectRootElement projectRootElement = ProjectRootElement.Create(projectCollection);
+
+                projectRootElement.Save(testEnvironment.CreateFile().Path);
+
+                Project project = Project.FromProjectRootElement(
+                    projectRootElement,
+                    new ProjectOptions
+                    {
+                        Interactive = interactive,
+                        ProjectCollection = projectCollection,
+                    });
+
+                project.GetPropertyValue(ReservedPropertyNames.interactive).ShouldBe(interactive ? bool.TrueString : string.Empty, StringCompareShould.IgnoreCase);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when calling <see cref="Project.FromXmlReader(XmlReader, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ProjectFromXmlReaderInteractive(bool interactive)
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                ProjectCollection projectCollection = testEnvironment.CreateProjectCollection().Collection;
+
+                ProjectRootElement projectRootElement = ProjectRootElement.Create(projectCollection);
+
+                projectRootElement.Save(testEnvironment.CreateFile().Path);
+
+                using (XmlReader xmlReader = XmlReader.Create(projectRootElement.FullPath))
+                {
+                    Project project = Project.FromXmlReader(
+                        xmlReader,
+                        new ProjectOptions
+                        {
+                            Interactive = interactive,
+                            ProjectCollection = projectCollection,
+                        });
+
+                    project.GetPropertyValue(ReservedPropertyNames.interactive).ShouldBe(interactive ? bool.TrueString : string.Empty, StringCompareShould.IgnoreCase);
+                }
             }
         }
     }

--- a/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
+++ b/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 
         /// <summary>
-        /// Verifies that when calling <see cref="Project.FromFile(string, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// Verifies that when calling <see cref="Project.FromFile(string, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <see langword="true" />, the built-in &quot;MSBuildInteractive&quot; property is set to <see langword="true" />, otherwise the property is <see cref="string.Empty" />.
         /// </summary>
         [Theory]
         [InlineData(true)]
@@ -287,7 +287,7 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 
         /// <summary>
-        /// Verifies that when calling <see cref="Project.FromProjectRootElement(ProjectRootElement, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// Verifies that when calling <see cref="Project.FromProjectRootElement(ProjectRootElement, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <see langword="true" />, the built-in &quot;MSBuildInteractive&quot; property is set to <see langword="true" />, otherwise the property is <see cref="string.Empty" />.
         /// </summary>
         [Theory]
         [InlineData(true)]
@@ -315,7 +315,7 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 
         /// <summary>
-        /// Verifies that when calling <see cref="Project.FromXmlReader(XmlReader, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// Verifies that when calling <see cref="Project.FromXmlReader(XmlReader, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <see langword="true" />, the built-in &quot;MSBuildInteractive&quot; property is set to <see langword="true" />, otherwise the property is <see cref="string.Empty" />.
         /// </summary>
         [Theory]
         [InlineData(true)]

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -69,11 +69,11 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
                 ProjectInstance project = new Project(ProjectRootElement.Create(XmlReader.Create(new StringReader(projectFileContent)))).CreateProjectInstance();
 
-                Assert.Equal(3, project.TaskRegistry.TaskRegistrations.Count);
-                Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), "af0"), project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t0", null)][0].TaskFactoryAssemblyLoadInfo.AssemblyFile);
-                Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), "af1a"), project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t1", null)][0].TaskFactoryAssemblyLoadInfo.AssemblyFile);
-                Assert.Equal("an1", project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t1", null)][1].TaskFactoryAssemblyLoadInfo.AssemblyName);
-                Assert.Equal("an2", project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t2", null)][0].TaskFactoryAssemblyLoadInfo.AssemblyName);
+                project.TaskRegistry.TaskRegistrations.Count.ShouldBe(3);
+                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t0", null)][0].TaskFactoryAssemblyLoadInfo.AssemblyFile.ShouldBe(Path.Combine(Directory.GetCurrentDirectory(), "af0"));
+                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t1", null)][0].TaskFactoryAssemblyLoadInfo.AssemblyFile.ShouldBe(Path.Combine(Directory.GetCurrentDirectory(), "af1a"));
+                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t1", null)][1].TaskFactoryAssemblyLoadInfo.AssemblyName.ShouldBe("an1");
+                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t2", null)][0].TaskFactoryAssemblyLoadInfo.AssemblyName.ShouldBe("an2");
             }
             finally
             {
@@ -116,8 +116,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
                 ProjectInstance project = new Project(ProjectRootElement.Create(XmlReader.Create(new StringReader(projectFileContent)))).CreateProjectInstance();
 
-                Helpers.AssertListsValueEqual(new string[] { "d0a", "d0b" }, project.DefaultTargets);
-                Helpers.AssertListsValueEqual(new string[] { "i0a", "i0b", "i1a", "i1b", "i3a", "i3b", "i2a", "i2b" }, project.InitialTargets);
+                project.DefaultTargets.ShouldBe(new string[] { "d0a", "d0b" });
+                project.InitialTargets.ShouldBe(new string[] { "i0a", "i0b", "i1a", "i1b", "i3a", "i3b", "i2a", "i2b" });
             }
             finally
             {
@@ -141,8 +141,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
                 ProjectInstance project = new Project(ProjectRootElement.Create(XmlReader.Create(new StringReader(projectFileContent)))).CreateProjectInstance();
 
-                Helpers.AssertListsValueEqual(new string[] { "d0a;d0b" }, project.DefaultTargets);
-                Helpers.AssertListsValueEqual(new string[] { "i0a;i0b" }, project.InitialTargets);
+                project.DefaultTargets.ShouldBe(new string[] { "d0a;d0b" });
+                project.InitialTargets.ShouldBe(new string[] { "i0a;i0b" });
             }
             finally
             {
@@ -170,16 +170,16 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance p = GetProjectInstance(content);
             ProjectPropertyGroupTaskInstance propertyGroup = (ProjectPropertyGroupTaskInstance)(p.Targets["t"].Children[0]);
 
-            Assert.Equal("c1", propertyGroup.Condition);
+            propertyGroup.Condition.ShouldBe("c1");
 
             List<ProjectPropertyGroupTaskPropertyInstance> properties = Helpers.MakeList(propertyGroup.Properties);
-            Assert.Equal(2, properties.Count);
+            properties.Count.ShouldBe(2);
 
-            Assert.Equal("c2", properties[0].Condition);
-            Assert.Equal("v1", properties[0].Value);
+            properties[0].Condition.ShouldBe("c2");
+            properties[0].Value.ShouldBe("v1");
 
-            Assert.Equal(String.Empty, properties[1].Condition);
-            Assert.Equal(String.Empty, properties[1].Value);
+            properties[1].Condition.ShouldBe(String.Empty);
+            properties[1].Value.ShouldBe(String.Empty);
         }
 
         /// <summary>
@@ -208,41 +208,41 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance p = GetProjectInstance(content);
             ProjectItemGroupTaskInstance itemGroup = (ProjectItemGroupTaskInstance)(p.Targets["t"].Children[0]);
 
-            Assert.Equal("c1", itemGroup.Condition);
+            itemGroup.Condition.ShouldBe("c1");
 
             List<ProjectItemGroupTaskItemInstance> items = Helpers.MakeList(itemGroup.Items);
-            Assert.Equal(3, items.Count);
+            items.Count.ShouldBe(3);
 
-            Assert.Equal("i1", items[0].Include);
-            Assert.Equal("e1", items[0].Exclude);
-            Assert.Equal(String.Empty, items[0].Remove);
-            Assert.Equal("c2", items[0].Condition);
+            items[0].Include.ShouldBe("i1");
+            items[0].Exclude.ShouldBe("e1");
+            items[0].Remove.ShouldBe(String.Empty);
+            items[0].Condition.ShouldBe("c2");
 
-            Assert.Equal(String.Empty, items[1].Include);
-            Assert.Equal(String.Empty, items[1].Exclude);
-            Assert.Equal("r1", items[1].Remove);
-            Assert.Equal(String.Empty, items[1].Condition);
+            items[1].Include.ShouldBe(String.Empty);
+            items[1].Exclude.ShouldBe(String.Empty);
+            items[1].Remove.ShouldBe("r1");
+            items[1].Condition.ShouldBe(String.Empty);
 
-            Assert.Equal(String.Empty, items[2].Include);
-            Assert.Equal(String.Empty, items[2].Exclude);
-            Assert.Equal(String.Empty, items[2].Remove);
-            Assert.Equal(String.Empty, items[2].Condition);
+            items[2].Include.ShouldBe(String.Empty);
+            items[2].Exclude.ShouldBe(String.Empty);
+            items[2].Remove.ShouldBe(String.Empty);
+            items[2].Condition.ShouldBe(String.Empty);
 
             List<ProjectItemGroupTaskMetadataInstance> metadata1 = Helpers.MakeList(items[0].Metadata);
             List<ProjectItemGroupTaskMetadataInstance> metadata2 = Helpers.MakeList(items[1].Metadata);
             List<ProjectItemGroupTaskMetadataInstance> metadata3 = Helpers.MakeList(items[2].Metadata);
 
-            Assert.Equal(2, metadata1.Count);
-            Assert.Empty(metadata2);
-            Assert.Single(metadata3);
+            metadata1.Count.ShouldBe(2);
+            metadata2.ShouldBeEmpty();
+            metadata3.ShouldHaveSingleItem();
 
-            Assert.Equal("c3", metadata1[0].Condition);
-            Assert.Equal("m1", metadata1[0].Value);
-            Assert.Equal(String.Empty, metadata1[1].Condition);
-            Assert.Equal("n1", metadata1[1].Value);
+            metadata1[0].Condition.ShouldBe("c3");
+            metadata1[0].Value.ShouldBe("m1");
+            metadata1[1].Condition.ShouldBe(String.Empty);
+            metadata1[1].Value.ShouldBe("n1");
 
-            Assert.Equal(String.Empty, metadata3[0].Condition);
-            Assert.Equal("o1", metadata3[0].Value);
+            metadata3[0].Condition.ShouldBe(String.Empty);
+            metadata3[0].Value.ShouldBe("o1");
         }
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         {
             ProjectInstance p = GetSampleProjectInstance();
 
-            Assert.True(p.TaskRegistry != null);
+            p.TaskRegistry.ShouldNotBeNull();
         }
 
         /// <summary>
@@ -264,8 +264,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         {
             ProjectInstance p = GetSampleProjectInstance();
 
-            Assert.Equal("v1", p.GlobalPropertiesDictionary["g1"].EvaluatedValue);
-            Assert.Equal("v2", p.GlobalPropertiesDictionary["g2"].EvaluatedValue);
+            p.GlobalPropertiesDictionary["g1"].EvaluatedValue.ShouldBe("v1");
+            p.GlobalPropertiesDictionary["g2"].EvaluatedValue.ShouldBe("v2");
         }
 
         /// <summary>
@@ -276,7 +276,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         {
             ProjectInstance p = GetSampleProjectInstance();
 
-            Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, p.Toolset.ToolsVersion);
+            p.Toolset.ToolsVersion.ShouldBe(ObjectModelHelpers.MSBuildDefaultToolsVersion);
         }
 
         [Fact]
@@ -299,9 +299,9 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             CreateMockToolsetIfNotExists("TESTTV", projectCollection);
             ProjectInstance first = GetSampleProjectInstance(null, null, projectCollection, toolsVersion: "TESTTV");
             ProjectInstance second = first.DeepCopy();
-            Assert.Equal(first.ToolsVersion, second.ToolsVersion);
-            Assert.Equal(first.ExplicitToolsVersion, second.ExplicitToolsVersion);
-            Assert.Equal(first.ExplicitToolsVersionSpecified, second.ExplicitToolsVersionSpecified);
+            second.ToolsVersion.ShouldBe(first.ToolsVersion);
+            second.ExplicitToolsVersion.ShouldBe(first.ExplicitToolsVersion);
+            second.ExplicitToolsVersionSpecified.ShouldBe(first.ExplicitToolsVersionSpecified);
         }
 
         /// <summary>
@@ -318,16 +318,16 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
                 ProjectInstance p = GetSampleProjectInstance(null, null, new ProjectCollection());
 
-                Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, p.Toolset.ToolsVersion);
-                Assert.Equal(p.Toolset.DefaultSubToolsetVersion, p.SubToolsetVersion);
+                p.Toolset.ToolsVersion.ShouldBe(ObjectModelHelpers.MSBuildDefaultToolsVersion);
+                p.SubToolsetVersion.ShouldBe(p.Toolset.DefaultSubToolsetVersion);
 
                 if (p.Toolset.DefaultSubToolsetVersion == null)
                 {
-                    Assert.Equal(MSBuildConstants.CurrentVisualStudioVersion, p.GetPropertyValue("VisualStudioVersion"));
+                    p.GetPropertyValue("VisualStudioVersion").ShouldBe(MSBuildConstants.CurrentVisualStudioVersion);
                 }
                 else
                 {
-                    Assert.Equal(p.Toolset.DefaultSubToolsetVersion, p.GetPropertyValue("VisualStudioVersion"));
+                    p.GetPropertyValue("VisualStudioVersion").ShouldBe(p.Toolset.DefaultSubToolsetVersion);
                 }
             }
             finally
@@ -351,9 +351,9 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
                 ProjectInstance p = GetSampleProjectInstance(null, null, new ProjectCollection());
 
-                Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, p.Toolset.ToolsVersion);
-                Assert.Equal("ABCD", p.SubToolsetVersion);
-                Assert.Equal("ABCD", p.GetPropertyValue("VisualStudioVersion"));
+                p.Toolset.ToolsVersion.ShouldBe(ObjectModelHelpers.MSBuildDefaultToolsVersion);
+                p.SubToolsetVersion.ShouldBe("ABCD");
+                p.GetPropertyValue("VisualStudioVersion").ShouldBe("ABCD");
             }
             finally
             {
@@ -378,9 +378,9 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
                 ProjectInstance p = GetSampleProjectInstance(null, globalProperties, new ProjectCollection());
 
-                Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, p.Toolset.ToolsVersion);
-                Assert.Equal("ABCDE", p.SubToolsetVersion);
-                Assert.Equal("ABCDE", p.GetPropertyValue("VisualStudioVersion"));
+                p.Toolset.ToolsVersion.ShouldBe(ObjectModelHelpers.MSBuildDefaultToolsVersion);
+                p.SubToolsetVersion.ShouldBe("ABCDE");
+                p.GetPropertyValue("VisualStudioVersion").ShouldBe("ABCDE");
             }
             finally
             {
@@ -417,9 +417,9 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
                 ProjectInstance p = new ProjectInstance(xml, globalProperties, ObjectModelHelpers.MSBuildDefaultToolsVersion, "ABCDEF", new ProjectCollection(projectCollectionGlobalProperties));
 
-                Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, p.Toolset.ToolsVersion);
-                Assert.Equal("ABCDEF", p.SubToolsetVersion);
-                Assert.Equal("ABCDEF", p.GetPropertyValue("VisualStudioVersion"));
+                p.Toolset.ToolsVersion.ShouldBe(ObjectModelHelpers.MSBuildDefaultToolsVersion);
+                p.SubToolsetVersion.ShouldBe("ABCDEF");
+                p.GetPropertyValue("VisualStudioVersion").ShouldBe("ABCDEF");
             }
             finally
             {
@@ -435,7 +435,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         {
             ProjectInstance p = GetSampleProjectInstance();
 
-            Helpers.AssertListsValueEqual(new string[] { "dt" }, p.DefaultTargets);
+            p.DefaultTargets.ShouldBe(new string[] { "dt" });
         }
 
         /// <summary>
@@ -446,7 +446,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         {
             ProjectInstance p = GetSampleProjectInstance();
 
-            Helpers.AssertListsValueEqual(new string[] { "it" }, p.InitialTargets);
+            p.InitialTargets.ShouldBe(new string[] { "it" });
         }
 
         /// <summary>
@@ -461,13 +461,14 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance second = first.DeepCopy();
 
             // Targets, tasks are immutable so we can expect the same objects
-            Assert.True(Object.ReferenceEquals(first.Targets, second.Targets));
-            Assert.True(Object.ReferenceEquals(first.Targets["t"], second.Targets["t"]));
+            first.Targets.ShouldBeSameAs(second.Targets);
+
+            first.Targets["t"].ShouldBeSameAs(second.Targets["t"]);
 
             var firstTasks = first.Targets["t"];
             var secondTasks = second.Targets["t"];
 
-            Assert.True(Object.ReferenceEquals(firstTasks.Children[0], secondTasks.Children[0]));
+            firstTasks.Children[0].ShouldBeSameAs(secondTasks.Children[0]);
         }
 
         /// <summary>
@@ -480,7 +481,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance second = first.DeepCopy();
 
             // Task registry object should be immutable
-            Assert.Same(first.TaskRegistry, second.TaskRegistry);
+            first.TaskRegistry.ShouldBeSameAs(second.TaskRegistry);
         }
 
         /// <summary>
@@ -492,8 +493,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance first = GetSampleProjectInstance();
             ProjectInstance second = first.DeepCopy();
 
-            Assert.Equal("v1", second.GlobalPropertiesDictionary["g1"].EvaluatedValue);
-            Assert.Equal("v2", second.GlobalPropertiesDictionary["g2"].EvaluatedValue);
+            second.GlobalPropertiesDictionary["g1"].EvaluatedValue.ShouldBe("v1");
+            second.GlobalPropertiesDictionary["g2"].EvaluatedValue.ShouldBe("v2");
         }
 
         /// <summary>
@@ -505,7 +506,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance first = GetSampleProjectInstance();
             ProjectInstance second = first.DeepCopy();
 
-            Helpers.AssertListsValueEqual(new string[] { "dt" }, second.DefaultTargets);
+            second.DefaultTargets.ShouldBe(new string[] { "dt" });
         }
 
         /// <summary>
@@ -517,7 +518,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance first = GetSampleProjectInstance();
             ProjectInstance second = first.DeepCopy();
 
-            Helpers.AssertListsValueEqual(new string[] { "it" }, second.InitialTargets);
+            second.InitialTargets.ShouldBe(new string[] { "it" });
         }
 
         /// <summary>
@@ -529,7 +530,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance first = GetSampleProjectInstance();
             ProjectInstance second = first.DeepCopy();
 
-            Assert.Equal(first.Toolset, second.Toolset);
+            second.Toolset.ShouldBe(first.Toolset);
         }
 
         /// <summary>
@@ -543,7 +544,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
             ProjectInstance second = first.DeepCopy();
 
-            Assert.True(second.TranslateEntireState);
+            second.TranslateEntireState.ShouldBeTrue();
         }
 
         /// <summary>
@@ -575,7 +576,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             loggers.Add(mockLogger);
             bool success = projectInstance.Build("Build", loggers);
 
-            Assert.True(success);
+            success.ShouldBeTrue();
             mockLogger.AssertLogContains(new string[] { "Building...", "Completed!" });
         }
 
@@ -685,7 +686,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ((ITranslatable)original).Translate(TranslationHelpers.GetWriteTranslator());
             var copy = ProjectInstance.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
 
-            Assert.Equal(original, copy, new ProjectInstanceComparer());
+            new ProjectInstanceComparer().Equals(original, copy).ShouldBeTrue($"{nameof(copy)} and {original} should be equal according to the {nameof(ProjectInstanceComparer)}");
         }
 
         public delegate ProjectInstance ProjectInstanceFactory(string file, ProjectRootElement xml, ProjectCollection collection);
@@ -758,7 +759,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                 xml.Save(file);
 
                 var projectInstance = projectInstanceFactory.Invoke(file, xml, projectCollection);
-                Assert.NotEqual(BuildEventContext.InvalidEvaluationId, projectInstance.EvaluationId);
+                projectInstance.EvaluationId.ShouldNotBe(BuildEventContext.InvalidEvaluationId);
             }
         }
 
@@ -774,27 +775,27 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
             ProjectTargetInstance targetInstance = projectInstance.AddTarget("b", "1==1", "inputs", "outputs", "returns", "keepDuplicateOutputs", "dependsOnTargets", "beforeTargets", "afterTargets", true);
 
-            Assert.Equal(2, projectInstance.Targets.Count);
-            Assert.Equal(targetInstance, projectInstance.Targets["b"]);
-            Assert.Equal("b", targetInstance.Name);
-            Assert.Equal("1==1", targetInstance.Condition);
-            Assert.Equal("inputs", targetInstance.Inputs);
-            Assert.Equal("outputs", targetInstance.Outputs);
-            Assert.Equal("returns", targetInstance.Returns);
-            Assert.Equal("keepDuplicateOutputs", targetInstance.KeepDuplicateOutputs);
-            Assert.Equal("dependsOnTargets", targetInstance.DependsOnTargets);
-            Assert.Equal("beforeTargets", targetInstance.BeforeTargets);
-            Assert.Equal("afterTargets", targetInstance.AfterTargets);
-            Assert.Equal(projectInstance.ProjectFileLocation, targetInstance.Location);
-            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.ConditionLocation);
-            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.InputsLocation);
-            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.OutputsLocation);
-            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.ReturnsLocation);
-            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.KeepDuplicateOutputsLocation);
-            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.DependsOnTargetsLocation);
-            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.BeforeTargetsLocation);
-            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.AfterTargetsLocation);
-            Assert.True(targetInstance.ParentProjectSupportsReturnsAttribute);
+            projectInstance.Targets.Count.ShouldBe(2);
+            projectInstance.Targets["b"].ShouldBe(targetInstance);
+            targetInstance.Name.ShouldBe("b");
+            targetInstance.Condition.ShouldBe("1==1");
+            targetInstance.Inputs.ShouldBe("inputs");
+            targetInstance.Outputs.ShouldBe("outputs");
+            targetInstance.Returns.ShouldBe("returns");
+            targetInstance.KeepDuplicateOutputs.ShouldBe("keepDuplicateOutputs");
+            targetInstance.DependsOnTargets.ShouldBe("dependsOnTargets");
+            targetInstance.BeforeTargets.ShouldBe("beforeTargets");
+            targetInstance.AfterTargets.ShouldBe("afterTargets");
+            targetInstance.Location.ShouldBe(projectInstance.ProjectFileLocation);
+            targetInstance.ConditionLocation.ShouldBe(ElementLocation.EmptyLocation);
+            targetInstance.InputsLocation.ShouldBe(ElementLocation.EmptyLocation);
+            targetInstance.OutputsLocation.ShouldBe(ElementLocation.EmptyLocation);
+            targetInstance.ReturnsLocation.ShouldBe(ElementLocation.EmptyLocation);
+            targetInstance.KeepDuplicateOutputsLocation.ShouldBe(ElementLocation.EmptyLocation);
+            targetInstance.DependsOnTargetsLocation.ShouldBe(ElementLocation.EmptyLocation);
+            targetInstance.BeforeTargetsLocation.ShouldBe(ElementLocation.EmptyLocation);
+            targetInstance.AfterTargetsLocation.ShouldBe(ElementLocation.EmptyLocation);
+            targetInstance.ParentProjectSupportsReturnsAttribute.ShouldBeTrue();
         }
 
         [Fact]
@@ -807,7 +808,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectRootElement rootElement = ProjectRootElement.Create(XmlReader.Create(new StringReader(projectFileContent)));
             ProjectInstance projectInstance = new ProjectInstance(rootElement);
 
-            Assert.Throws<InternalErrorException>(() => projectInstance.AddTarget("a", "1==1", "inputs", "outputs", "returns", "keepDuplicateOutputs", "dependsOnTargets", "beforeTargets", "afterTargets", true));
+            Should.Throw<InternalErrorException>(() => projectInstance.AddTarget("a", "1==1", "inputs", "outputs", "returns", "keepDuplicateOutputs", "dependsOnTargets", "beforeTargets", "afterTargets", true));
         }
 
         [Theory]
@@ -857,8 +858,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                     ? new string[] { import1Path, import2Path, import3Path, import2Path, import1Path }
                     : expectedImportPaths;
 
-                Helpers.AssertListsValueEqual(expectedImportPaths, projectInstance.ImportPaths.ToList());
-                Helpers.AssertListsValueEqual(expectedImportPathsIncludingDuplicates, projectInstance.ImportPathsIncludingDuplicates.ToList());
+                projectInstance.ImportPaths.ToList().ShouldBe(expectedImportPaths);
+                projectInstance.ImportPathsIncludingDuplicates.ToList().ShouldBe(expectedImportPathsIncludingDuplicates);
             }
             finally
             {
@@ -890,7 +891,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                         ProjectCollection = projectCollection,
                     });
 
-                Assert.Equal(interactive ? bool.TrueString : string.Empty, projectInstance.GetPropertyValue(ReservedPropertyNames.interactive), ignoreCase: true);
+                projectInstance.GetPropertyValue(ReservedPropertyNames.interactive).ShouldBe(interactive ? bool.TrueString : string.Empty, StringCompareShould.IgnoreCase);
             }
         }
 
@@ -918,7 +919,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                         ProjectCollection = projectCollection,
                     });
 
-                Assert.Equal(interactive ? bool.TrueString : string.Empty, projectInstance.GetPropertyValue(ReservedPropertyNames.interactive), ignoreCase: true);
+                projectInstance.GetPropertyValue(ReservedPropertyNames.interactive).ShouldBe(interactive ? bool.TrueString : string.Empty, StringCompareShould.IgnoreCase);
             }
         }
 

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -12,6 +12,7 @@ using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests.BackEnd;
 using Shouldly;
@@ -862,6 +863,62 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             finally
             {
                 ObjectModelHelpers.DeleteTempProjectDirectory();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when calling <see cref="ProjectInstance.FromFile(string, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ProjectInstanceFromFileInteractive(bool interactive)
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                ProjectCollection projectCollection = testEnvironment.CreateProjectCollection().Collection;
+
+                ProjectRootElement projectRootElement = ProjectRootElement.Create(projectCollection);
+
+                projectRootElement.Save(testEnvironment.CreateFile().Path);
+
+                ProjectInstance projectInstance = ProjectInstance.FromFile(
+                    projectRootElement.FullPath,
+                    new ProjectOptions
+                    {
+                        Interactive = interactive,
+                        ProjectCollection = projectCollection,
+                    });
+
+                Assert.Equal(interactive ? bool.TrueString : string.Empty, projectInstance.GetPropertyValue(ReservedPropertyNames.interactive), ignoreCase: true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when calling <see cref="ProjectInstance.FromProjectRootElement(ProjectRootElement, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ProjectInstanceFromProjectRootElementInteractive(bool interactive)
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                ProjectCollection projectCollection = testEnvironment.CreateProjectCollection().Collection;
+
+                ProjectRootElement projectRootElement = ProjectRootElement.Create(projectCollection);
+
+                projectRootElement.Save(testEnvironment.CreateFile().Path);
+
+                ProjectInstance projectInstance = ProjectInstance.FromProjectRootElement(
+                    projectRootElement,
+                    new ProjectOptions
+                    {
+                        Interactive = interactive,
+                        ProjectCollection = projectCollection,
+                    });
+
+                Assert.Equal(interactive ? bool.TrueString : string.Empty, projectInstance.GetPropertyValue(ReservedPropertyNames.interactive), ignoreCase: true);
             }
         }
 

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -868,7 +868,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
-        /// Verifies that when calling <see cref="ProjectInstance.FromFile(string, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// Verifies that when calling <see cref="ProjectInstance.FromFile(string, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <see langword="true" />, the built-in &quot;MSBuildInteractive&quot; property is set to <see langword="true" />, otherwise the property is <see cref="string.Empty" />.
         /// </summary>
         [Theory]
         [InlineData(true)]
@@ -896,7 +896,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
-        /// Verifies that when calling <see cref="ProjectInstance.FromProjectRootElement(ProjectRootElement, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <c>true</c>, the built-in &quot;MSBuildInteractive&quot; property is set to <c>true</c>, otherwise the property is <see cref="string.Empty" />.
+        /// Verifies that when calling <see cref="ProjectInstance.FromProjectRootElement(ProjectRootElement, ProjectOptions)" /> with <see cref="ProjectOptions.Interactive" /> <see langword="true" />, the built-in &quot;MSBuildInteractive&quot; property is set to <see langword="true" />, otherwise the property is <see cref="string.Empty" />.
         /// </summary>
         [Theory]
         [InlineData(true)]

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -257,12 +257,12 @@ namespace Microsoft.Build.Evaluation
         /// <param name="projectCollection">The <see cref="ProjectCollection"/> the project is added to.</param>
         /// <param name="loadSettings">The <see cref="ProjectLoadSettings"/> to use for evaluation.</param>
         public Project(ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings)
-            : this(xml, globalProperties, toolsVersion, subToolsetVersion, projectCollection, loadSettings, null, null)
+            : this(xml, globalProperties, toolsVersion, subToolsetVersion, projectCollection, loadSettings, evaluationContext: null, directoryCacheFactory: null, interactive: false)
         {
         }
 
         private Project(ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
-            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory)
+            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
             ErrorUtilities.VerifyThrowArgumentNull(xml, nameof(xml));
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -273,7 +273,7 @@ namespace Microsoft.Build.Evaluation
             implementation = defaultImplementation;
 
             _directoryCacheFactory = directoryCacheFactory;
-            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext);
+            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive);
         }
 
         /// <summary>
@@ -351,12 +351,12 @@ namespace Microsoft.Build.Evaluation
         /// <param name="projectCollection">The collection with which this project should be associated. May not be null.</param>
         /// <param name="loadSettings">The load settings for this project.</param>
         public Project(XmlReader xmlReader, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings)
-            : this(xmlReader, globalProperties, toolsVersion, subToolsetVersion, projectCollection, loadSettings, null, null)
+            : this(xmlReader, globalProperties, toolsVersion, subToolsetVersion, projectCollection, loadSettings, evaluationContext: null, directoryCacheFactory: null, interactive: false)
         {
         }
 
         private Project(XmlReader xmlReader, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
-            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory)
+            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
             ErrorUtilities.VerifyThrowArgumentNull(xmlReader, nameof(xmlReader));
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -367,7 +367,7 @@ namespace Microsoft.Build.Evaluation
             implementation = defaultImplementation;
 
             _directoryCacheFactory = directoryCacheFactory;
-            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext);
+            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive);
         }
 
         /// <summary>
@@ -447,12 +447,12 @@ namespace Microsoft.Build.Evaluation
         /// <param name="projectCollection">The collection with which this project should be associated. May not be null.</param>
         /// <param name="loadSettings">The load settings for this project.</param>
         public Project(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings)
-            : this(projectFile, globalProperties, toolsVersion, subToolsetVersion, projectCollection, loadSettings, null, null)
+            : this(projectFile, globalProperties, toolsVersion, subToolsetVersion, projectCollection, loadSettings, evaluationContext: null, directoryCacheFactory: null, interactive: false)
         {
         }
 
         private Project(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
-            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory)
+            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
             ErrorUtilities.VerifyThrowArgumentNull(projectFile, nameof(projectFile));
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -469,7 +469,7 @@ namespace Microsoft.Build.Evaluation
             // seems the XmlReader based one should also clean the same way.
             try
             {
-                defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext);
+                defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive);
             }
             catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
             {
@@ -500,7 +500,8 @@ namespace Microsoft.Build.Evaluation
                 options.ProjectCollection ?? ProjectCollection.GlobalProjectCollection,
                 options.LoadSettings,
                 options.EvaluationContext,
-                options.DirectoryCacheFactory);
+                options.DirectoryCacheFactory,
+                options.Interactive);
         }
 
         /// <summary>
@@ -518,7 +519,8 @@ namespace Microsoft.Build.Evaluation
                 options.ProjectCollection ?? ProjectCollection.GlobalProjectCollection,
                 options.LoadSettings,
                 options.EvaluationContext,
-                options.DirectoryCacheFactory);
+                options.DirectoryCacheFactory,
+                options.Interactive);
         }
 
         /// <summary>
@@ -536,7 +538,8 @@ namespace Microsoft.Build.Evaluation
                 options.ProjectCollection ?? ProjectCollection.GlobalProjectCollection,
                 options.LoadSettings,
                 options.EvaluationContext,
-                options.DirectoryCacheFactory);
+                options.DirectoryCacheFactory,
+                options.Interactive);
         }
 
         /// <summary>
@@ -1870,6 +1873,11 @@ namespace Microsoft.Build.Evaluation
             /// If it has been set to null, the project has been unloaded from its collection.
             /// </summary>
             private RenameHandlerDelegate _renameHandler;
+
+            /// <summary>
+            /// Indicates if the process of loading the project is allowed to interact with the user.
+            /// </summary>
+            private bool _interactive = false;
 
             /// <summary>
             ///
@@ -3733,7 +3741,8 @@ namespace Microsoft.Build.Evaluation
                     s_buildEventContext,
                     evaluationContext.SdkResolverService,
                     BuildEventContext.InvalidSubmissionId,
-                    evaluationContext);
+                    evaluationContext,
+                    _interactive);
 
                 ErrorUtilities.VerifyThrow(LastEvaluationId != BuildEventContext.InvalidEvaluationId, "Evaluation should produce an evaluation ID");
 
@@ -3766,7 +3775,7 @@ namespace Microsoft.Build.Evaluation
             /// Global properties may be null.
             /// Tools version may be null.
             /// </summary>
-            internal void Initialize(IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext)
+            internal void Initialize(IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext, bool interactive)
             {
                 Xml.MarkAsExplicitlyLoaded();
 
@@ -3801,6 +3810,7 @@ namespace Microsoft.Build.Evaluation
                 _data = new Data(Owner, globalPropertiesCollection, toolsVersion, subToolsetVersion, canEvaluateElementsWithFalseConditions);
 
                 _loadSettings = loadSettings;
+                _interactive = interactive;
 
                 ErrorUtilities.VerifyThrow(LastEvaluationId == BuildEventContext.InvalidEvaluationId, "This is the first evaluation therefore the last evaluation id is invalid");
 

--- a/src/Build/Definition/ProjectOptions.cs
+++ b/src/Build/Definition/ProjectOptions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Definition
         public string SubToolsetVersion { get; set; }
 
         /// <summary>
-        /// The <see cref="ProjectCollection"/> the project is added to. Default is <see cref="ProjectCollection.GlobalProjectCollection"/>/>
+        /// The <see cref="ProjectCollection"/> the project is added to. Default is <see cref="ProjectCollection.GlobalProjectCollection"/>.
         /// </summary>
         public ProjectCollection ProjectCollection { get; set; }
 
@@ -49,5 +49,10 @@ namespace Microsoft.Build.Definition
         /// Provides <see cref="IDirectoryCache"/> to be used for evaluation.
         /// </summary>
         public IDirectoryCacheFactory DirectoryCacheFactory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating if loading the project is allowed to interact with the user.
+        /// </summary>
+        public bool Interactive { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #8523

### Context
When a build happens the `BuildParameters` object passes along the `Interactive` property when creating `ProjectInstance` objects.  During evaluation, the `Evaluator` then sets the built-in `MSBuildInteractive` property to true and the SDK resolver context is also set.  

However, when you create an instance of a `ProjectInstance` object via the `ProjectInstance.FromFile(string, ProjectOptions)` method, there is no way to indicate that the evaluation should be interactive.  

### Changes Made
This change adds a new `Interactive` property to the `ProjectOptions` object.  The value is passed to the evaluator and the `MSBuildInteractive` MSBuild property is now set.

I implemented this for:
* `ProjectInstance.FromFile(string, ProjectOptions)`
* `ProjectInstance.FromProjectRootElement(ProjectRootElement, ProjectOptions)`
* `Project.FromFile(string, ProjectOptions)`
* `Project.FromProjectRootElement(ProjectRootElement, ProjectOptions)`
* `Project.FromXmlReader(XmlReader, ProjectOptions)`

### Testing
I added unit tests for all affected methods by testing what happens when `Interactive` is set to `true` or `false`.  When the value is `true`, it is expected that the `MSBuildInteractive` MSBuild property is set, otherwise the property value should be an empty string.

### Notes
* I broke up the commits separately in case we don't want to touch `Project` (although it was trivial to implement).
* The last commit migrates `ProjectInstance_Internal_Tests` to Shouldly, commit [ff9398d46008b1e2389dafb083cf6b86fb40eedb](https://github.com/dotnet/msbuild/commit/ff9398d46008b1e2389dafb083cf6b86fb40eedb) has a simpler diff showing the added tests.