### PR TITLE
ProjectRootElementCache.Clear do not clear immutable files

### DIFF
--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
@@ -441,6 +442,14 @@ namespace Microsoft.Build.Evaluation
 
                         listNode = nextNode;
                     }
+
+                    // From weak list remove all which is not in strong list anymore
+                    IList<string> toBeRemovedFromWeakRefs = _weakCache.Keys.Except(_strongCache.Select(i => i.FullPath)).ToList();
+                    foreach (string victim in toBeRemovedFromWeakRefs)
+                    {
+                        _weakCache.Remove(victim);
+                    }
+                    _weakCache.Scavenge();
                 }
             }
         }


### PR DESCRIPTION
### Context
For `msbuild -restore` scenarios `ProjectRootElementCache` cache used to be cleared for restore could have modified or added some project files (like *.directory.props etc...). 
We can optimize it by keeping ProjectRootElements from immutable locations (like SDK) in that cache as those will be used by build following that restore.

### Changes Made
`Clear()` does not remove immutable files from cache.

### Testing
Locally
