### PR TITLE
Reset internal terminated flag in ToolTask (#8541)

### DIFF
--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Build.UnitTests
                 StartInfo = GetProcessStartInfo(GenerateFullPathToTool(), NativeMethodsShared.IsWindows ? "/x" : string.Empty, null);
                 return result;
             }
-        };
+        }
 
         [Fact]
         public void Regress_Mutation_UserSuppliedToolPathIsLogged()
@@ -823,6 +823,132 @@ namespace Microsoft.Build.UnitTests
             protected override string GenerateCommandLineCommands()
             {
                 return $"echo łoł > {OutputPath}";
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a ToolTask instance can return correct results when executed multiple times with timeout.
+        /// </summary>
+        /// <param name="repeats">Specifies the number of repeats for external command execution.</param>
+        /// <param name="initialDelay">Delay to generate on the first execution in milliseconds.</param>
+        /// <param name="followupDelay">Delay to generate on follow-up execution in milliseconds.</param>
+        /// <param name="timeout">Task timeout in milliseconds.</param>
+        /// <remarks>
+        /// These tests execute the same task instance multiple times, which will in turn run  a PowerShell command to
+        /// sleep predefined amount of time. The first execution may time out, but all following ones won't. It is
+        /// expected that all following executions return success.
+        /// </remarks>
+        [Theory]
+        [InlineData(1, 1, 1, -1)] // Normal case, no repeat.
+        [InlineData(3, 1, 1, -1)] // Repeat without timeout.
+        [InlineData(3, 10000, 1, 1000)] // Repeat with timeout.
+        public void ToolTaskThatTimeoutAndRetry(int repeats, int initialDelay, int followupDelay, int timeout)
+        {
+            using var env = TestEnvironment.Create(_output);
+
+            // Task under test:
+            var task = new ToolTaskThatRetry
+            {
+                BuildEngine = new MockEngine(),
+                InitialDelay = initialDelay,
+                FollowupDelay = followupDelay,
+                Timeout = timeout
+            };
+
+            // Execute the same task instance multiple times. The index is one-based.
+            bool result;
+            for (int i = 1; i <= repeats; i++)
+            {
+                // Execute the task:
+                result = task.Execute();
+                task.RepeatCount.ShouldBe(i);
+
+                // The first execution may fail (timeout), but all following ones should succeed:
+                if (i > 1)
+                {
+                    result.ShouldBeTrue();
+                    task.ExitCode.ShouldBe(0);
+                }
+            }
+        }
+
+        /// <summary>
+        /// A simple implementation of <see cref="ToolTask"/> to run PowerShell to generate programmable delay.
+        /// </summary>
+        /// <remarks>
+        /// This task to run PowerShell "Start-Sleep" command to delay for predefined, variable amount of time based on
+        /// how many times the instance has been executed.
+        /// </remarks>
+        private sealed class ToolTaskThatRetry : ToolTask
+        {
+            // Test with PowerShell to generate a programmable delay:
+            private readonly string _powerShell = "PowerShell.exe";
+
+            // PowerShell command to sleep:
+            private readonly string _sleepCommand = "-ExecutionPolicy RemoteSigned -Command \"Start-Sleep -Milliseconds {0}\"";
+
+            public ToolTaskThatRetry()
+                : base()
+            {
+            }
+
+            /// <summary>
+            /// Gets or sets the delay for the first execution.
+            /// </summary>
+            /// <remarks>
+            /// Defaults to 10 seconds.
+            /// </remarks>
+            public Int32 InitialDelay { get; set; } = 10000;
+
+            /// <summary>
+            /// Gets or sets the delay for the follow-up executions.
+            /// </summary>
+            /// <remarks>
+            /// Defaults to 1 milliseconds.
+            /// </remarks>
+            public Int32 FollowupDelay { get; set; } = 1;
+
+            /// <summary>
+            /// Int32 output parameter for the execution repeat counter for test purpose.
+            /// </summary>
+            [Output]
+            public Int32 RepeatCount { get; private set; } = 0;
+
+            /// <summary>
+            /// Gets the tool name (PowerShell).
+            /// </summary>
+            protected override string ToolName => _powerShell;
+
+            /// <summary>
+            /// Search path for PowerShell.
+            /// </summary>
+            /// <remarks>
+            /// This only works on Windows.
+            /// </remarks>
+            protected override string GenerateFullPathToTool() => FindOnPath(_powerShell);
+
+            /// <summary>
+            /// Generate a PowerShell command to sleep different amount of time based on execution counter.
+            /// </summary>
+            protected override string GenerateCommandLineCommands() =>
+                string.Format(_sleepCommand, RepeatCount < 2 ? InitialDelay : FollowupDelay);
+
+            /// <summary>
+            /// Ensures that test parameters make sense.
+            /// </summary>
+            protected internal override bool ValidateParameters() =>
+                (InitialDelay > 0) && (FollowupDelay > 0) && base.ValidateParameters();
+
+            /// <summary>
+            /// Runs external command (PowerShell) to generate programmable delay.
+            /// </summary>
+            /// <returns>
+            /// true if the task runs successfully; false otherwise.
+            /// </returns>
+            public override bool Execute()
+            {
+                RepeatCount++;
+                return base.Execute();
             }
         }
     }

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -834,9 +834,9 @@ namespace Microsoft.Build.UnitTests
         /// <param name="followupDelay">Delay to generate on follow-up execution in milliseconds.</param>
         /// <param name="timeout">Task timeout in milliseconds.</param>
         /// <remarks>
-        /// These tests execute the same task instance multiple times, which will in turn run  a PowerShell command to
-        /// sleep predefined amount of time. The first execution may time out, but all following ones won't. It is
-        /// expected that all following executions return success.
+        /// These tests execute the same task instance multiple times, which will in turn run a shell command to sleep
+        /// predefined amount of time. The first execution may time out, but all following ones won't. It is expected
+        /// that all following executions return success.
         /// </remarks>
         [Theory]
         [InlineData(1, 1, 1, -1)] // Normal case, no repeat.
@@ -847,7 +847,7 @@ namespace Microsoft.Build.UnitTests
             using var env = TestEnvironment.Create(_output);
 
             // Task under test:
-            var task = new ToolTaskThatRetry
+            var task = new ToolTaskThatSleeps
             {
                 BuildEngine = new MockEngine(),
                 InitialDelay = initialDelay,
@@ -873,23 +873,28 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// A simple implementation of <see cref="ToolTask"/> to run PowerShell to generate programmable delay.
+        /// A simple implementation of <see cref="ToolTask"/> to sleep for a while.
         /// </summary>
         /// <remarks>
-        /// This task to run PowerShell "Start-Sleep" command to delay for predefined, variable amount of time based on
-        /// how many times the instance has been executed.
+        /// This task runs shell command to sleep for predefined, variable amount of time based on how many times the
+        /// instance has been executed.
         /// </remarks>
-        private sealed class ToolTaskThatRetry : ToolTask
+        private sealed class ToolTaskThatSleeps : ToolTask
         {
-            // Test with PowerShell to generate a programmable delay:
-            private readonly string _powerShell = "PowerShell.exe";
-
             // PowerShell command to sleep:
-            private readonly string _sleepCommand = "-ExecutionPolicy RemoteSigned -Command \"Start-Sleep -Milliseconds {0}\"";
+            private readonly string _powerShellSleep = "-ExecutionPolicy RemoteSigned -Command \"Start-Sleep -Milliseconds {0}\"";
 
-            public ToolTaskThatRetry()
+            // UNIX command to sleep:
+            private readonly string _unixSleep = "-c \"sleep {0}\"";
+
+            // Full path to shell:
+            private readonly string _pathToShell;
+
+            public ToolTaskThatSleeps()
                 : base()
             {
+                // Determines shell to use: PowerShell for Windows, sh for UNIX-like systems:
+                _pathToShell = NativeMethodsShared.IsUnixLike ? "/bin/sh" : FindOnPath("PowerShell.exe");
             }
 
             /// <summary>
@@ -909,29 +914,28 @@ namespace Microsoft.Build.UnitTests
             public Int32 FollowupDelay { get; set; } = 1;
 
             /// <summary>
-            /// Int32 output parameter for the execution repeat counter for test purpose.
+            /// Int32 output parameter for the repeat counter for test purpose.
             /// </summary>
             [Output]
             public Int32 RepeatCount { get; private set; } = 0;
 
             /// <summary>
-            /// Gets the tool name (PowerShell).
+            /// Gets the tool name (shell).
             /// </summary>
-            protected override string ToolName => _powerShell;
+            protected override string ToolName => Path.GetFileName(_pathToShell);
 
             /// <summary>
-            /// Search path for PowerShell.
+            /// Gets the full path to shell.
             /// </summary>
-            /// <remarks>
-            /// This only works on Windows.
-            /// </remarks>
-            protected override string GenerateFullPathToTool() => FindOnPath(_powerShell);
+            protected override string GenerateFullPathToTool() => _pathToShell;
 
             /// <summary>
-            /// Generate a PowerShell command to sleep different amount of time based on execution counter.
+            /// Generates a shell command to sleep different amount of time based on repeat counter.
             /// </summary>
             protected override string GenerateCommandLineCommands() =>
-                string.Format(_sleepCommand, RepeatCount < 2 ? InitialDelay : FollowupDelay);
+                NativeMethodsShared.IsUnixLike ?
+                string.Format(_unixSleep, RepeatCount < 2 ? InitialDelay / 1000.0 : FollowupDelay / 1000.0) :
+                string.Format(_powerShellSleep, RepeatCount < 2 ? InitialDelay : FollowupDelay);
 
             /// <summary>
             /// Ensures that test parameters make sense.
@@ -940,7 +944,7 @@ namespace Microsoft.Build.UnitTests
                 (InitialDelay > 0) && (FollowupDelay > 0) && base.ValidateParameters();
 
             /// <summary>
-            /// Runs external command (PowerShell) to generate programmable delay.
+            /// Runs shell command to sleep for a while.
             /// </summary>
             /// <returns>
             /// true if the task runs successfully; false otherwise.

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -670,6 +670,7 @@ namespace Microsoft.Build.Utilities
             _standardOutputDataAvailable = new ManualResetEvent(false);
 
             _toolExited = new ManualResetEvent(false);
+            _terminatedTool = false;
             _toolTimeoutExpired = new ManualResetEvent(false);
 
             _eventsDisposed = false;


### PR DESCRIPTION
ToolTask uses a private flag `_terminatedTool` to indicate the task execution timed out or cancelled. That flag should be reset on each execution, otherwise the return value of all following executions could be changed.

Fixes https://github.com/dotnet/msbuild/issues/8541

### Context

When the same ToolTask instance being executed multiple times (by derived classes, for example), the return status of all following executions might be wrong (`false`) if the first execution timed-out or cancelled. Such case may arise if user try to run an external tool with retry and timeout. The problem is the internal `_terminatedTool` flag has not been reset on each execution. Reset that flag on each execution solved the problem.

### Changes Made

Resets the internal flag `ToolTask._terminatedTool` on each task execution.

### Testing

The following unit test has been added: `Microsoft.Build.UnitTests.ToolTaskThatTimeoutAndRetry`. It has 3 cases that verify no repeated execution, repeated execution with or without timeout. It's the last case that has been fixed, the rest is for regression.

All ToolTask unit tests passed.

### Notes

- The `Timeout` setting in the unit test might be tricky. On slow hardware you may want to set that to a larger value;
- The unit test needs PowerShell to run, only Windows platform considered.