### PR TITLE
Use ToolTask.TaskProcessTerminationTimeout correctly

### DIFF
--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -827,6 +827,41 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// Verifies the validation of the <see cref="ToolTask.TaskProcessTerminationTimeout" />.
+        /// </summary>
+        /// <param name="timeout">New value for <see cref="ToolTask.TaskProcessTerminationTimeout" />.</param>
+        /// <param name="expectException">Is an exception expected or not.</param>
+        [Theory]
+        [InlineData(int.MaxValue, false)]
+        [InlineData(97, false)]
+        [InlineData(0, false)]
+        [InlineData(-1, false)]
+        [InlineData(-2, true)]
+        [InlineData(-101, true)]
+        [InlineData(int.MinValue, true)]
+        public void SetsTerminationTimeoutCorrectly(int timeout, bool expectException)
+        {
+            using var env = TestEnvironment.Create(_output);
+
+            // Task under test:
+            var task = new ToolTaskSetsTerminationTimeout
+            {
+                BuildEngine = new MockEngine()
+            };
+
+            if (expectException)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => task.TerminationTimeout = timeout);
+                task.TerminationTimeout.ShouldBe(5000);
+            }
+            else
+            {
+                task.TerminationTimeout = timeout;
+                task.TerminationTimeout.ShouldBe(timeout);
+            }
+        }
+		
+		/// <summary>
         /// Verifies that a ToolTask instance can return correct results when executed multiple times with timeout.
         /// </summary>
         /// <param name="repeats">Specifies the number of repeats for external command execution.</param>
@@ -959,6 +994,50 @@ namespace Microsoft.Build.UnitTests
                 RepeatCount++;
                 return base.Execute();
             }
+        }
+
+        /// <summary>
+        /// A simple implementation of <see cref="ToolTask"/> to excercise <see cref="ToolTask.TaskProcessTerminationTimeout" />.
+        /// </summary>
+        private sealed class ToolTaskSetsTerminationTimeout : ToolTask
+        {
+            public ToolTaskSetsTerminationTimeout()
+                : base()
+            {
+            }
+
+            /// <summary>
+            /// Gets or sets <see cref="ToolTask.TaskProcessTerminationTimeout" />.
+            /// </summary>
+            /// <remarks>
+            /// This is just a proxy property to access <see cref="ToolTask.TaskProcessTerminationTimeout" />.
+            /// </remarks>
+            public int TerminationTimeout
+            {
+                get => TaskProcessTerminationTimeout;
+                set => TaskProcessTerminationTimeout = value;
+            }
+
+            /// <summary>
+            /// Gets the tool name (dummy).
+            /// </summary>
+            protected override string ToolName => string.Empty;
+
+            /// <summary>
+            /// Gets the full path to tool (dummy).
+            /// </summary>
+            protected override string GenerateFullPathToTool() => string.Empty;
+
+            /// <summary>
+            /// Does nothing.
+            /// </summary>
+            /// <returns>
+            /// Always returns true.
+            /// </returns>
+            /// <remarks>
+            /// This dummy tool task is not meant to run anything.
+            /// </remarks>
+            public override bool Execute() => true;
         }
     }
 }

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -830,7 +830,7 @@ namespace Microsoft.Build.UnitTests
         /// Verifies the validation of the <see cref="ToolTask.TaskProcessTerminationTimeout" />.
         /// </summary>
         /// <param name="timeout">New value for <see cref="ToolTask.TaskProcessTerminationTimeout" />.</param>
-        /// <param name="expectException">Is an exception expected or not.</param>
+        /// <param name="isInvalidValid">Is a task expected to be valid or not.</param>
         [Theory]
         [InlineData(int.MaxValue, false)]
         [InlineData(97, false)]
@@ -839,7 +839,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData(-2, true)]
         [InlineData(-101, true)]
         [InlineData(int.MinValue, true)]
-        public void SetsTerminationTimeoutCorrectly(int timeout, bool expectException)
+        public void SetsTerminationTimeoutCorrectly(int timeout, bool isInvalidValid)
         {
             using var env = TestEnvironment.Create(_output);
 
@@ -849,16 +849,9 @@ namespace Microsoft.Build.UnitTests
                 BuildEngine = new MockEngine()
             };
 
-            if (expectException)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => task.TerminationTimeout = timeout);
-                task.TerminationTimeout.ShouldBe(5000);
-            }
-            else
-            {
-                task.TerminationTimeout = timeout;
-                task.TerminationTimeout.ShouldBe(timeout);
-            }
+            task.TerminationTimeout = timeout;
+            task.ValidateParameters().ShouldBe(!isInvalidValid);
+            task.TerminationTimeout.ShouldBe(timeout);
         }
 		
 		/// <summary>
@@ -1004,6 +997,7 @@ namespace Microsoft.Build.UnitTests
             public ToolTaskSetsTerminationTimeout()
                 : base()
             {
+                base.TaskResources = AssemblyResources.PrimaryResources;
             }
 
             /// <summary>

--- a/src/Utilities/Resources/Strings.resx
+++ b/src/Utilities/Resources/Strings.resx
@@ -290,6 +290,9 @@
     <value>MSB6012: The path "{0}" used for debug logs is too long. Set it to a shorter value using the MSBUILDDEBUGPATH environment variable or change your system configuration to allow long paths.</value>
     <comment>{StrBegin="MSB6012: "}</comment>
   </data>
+  <data name="ToolTask.InvalidTerminationTimeout" xml:space="preserve">
+    <value>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</value>
+  </data>
   <!--
         The Utilities message bucket is: MSB6001 - MSB6200
 

--- a/src/Utilities/Resources/xlf/Strings.cs.xlf
+++ b/src/Utilities/Resources/xlf/Strings.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: Nepodařilo se spustit spustitelný soubor zadané úlohy {0}. {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">Úlohu nelze přeskočit, protože není aktuální.</target>

--- a/src/Utilities/Resources/xlf/Strings.de.xlf
+++ b/src/Utilities/Resources/xlf/Strings.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: Die angegebene ausführbare Datei der Aufgabe "{0}" konnte nicht ausgeführt werden. {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">Die Aufgabe kann nicht übersprungen werden, da sie nicht auf dem neuesten Stand ist.</target>

--- a/src/Utilities/Resources/xlf/Strings.es.xlf
+++ b/src/Utilities/Resources/xlf/Strings.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: No se pudo ejecutar la tarea ejecutable especificada "{0}". {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">No se puede omitir la tarea porque no está actualizada.</target>

--- a/src/Utilities/Resources/xlf/Strings.fr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: Impossible d'exécuter la tâche exécutable spécifiée "{0}". {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">Nous n’avons pas pu ignorer la tâche, car elle n’est pas à jour.</target>

--- a/src/Utilities/Resources/xlf/Strings.it.xlf
+++ b/src/Utilities/Resources/xlf/Strings.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: non è stato possibile eseguire il file eseguibile "{0}" dell'attività. {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">Non è possibile ignorare l'attività perché non è aggiornata.</target>

--- a/src/Utilities/Resources/xlf/Strings.ja.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: 指定されたタスク実行可能ファイル "{0}" を実行できませんでした。{1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">タスクは最新ではないため、スキップできません。</target>

--- a/src/Utilities/Resources/xlf/Strings.ko.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: 지정한 작업 실행 파일 "{0}"을(를) 실행할 수 없습니다. {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">작업이 최신 상태가 아니므로 건너뛸 수 없습니다.</target>

--- a/src/Utilities/Resources/xlf/Strings.pl.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: Nie można uruchomić określonego pliku wykonywalnego zadania „{0}”. {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">Nie można pominąć zadania, ponieważ nie jest ono aktualne.</target>

--- a/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: Não foi possível executar a tarefa executável "{0}" especificada. {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">Não foi possível ignorar a tarefa porque ela não está atualizada.</target>

--- a/src/Utilities/Resources/xlf/Strings.ru.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: Не удалось запустить указанный исполняемый файл задачи "{0}". {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">Невозможно пропустить задачу, поскольку она не обновлена.</target>

--- a/src/Utilities/Resources/xlf/Strings.tr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: Belirtilen "{0}" görev yürütülebilir dosyası çalıştırılamadı. {1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">Güncel olmadığı için görev atlanamıyor.</target>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: 指定的任务可执行文件“{0}”未能运行。{1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">无法跳过任务，因为它不是最新的。</target>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">MSB6003: 無法執行指定的工作可執行檔 "{0}"。{1}</target>
         <note>{StrBegin="MSB6003: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.InvalidTerminationTimeout">
+        <source>Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</source>
+        <target state="new">Specified termination timeout ({0}) is invalid - expecting value greater or equal to -1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.NotUpToDate">
         <source>Unable to skip task because it is not up-to-date.</source>
         <target state="translated">無法略過工作，因為它不是最新的。</target>

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -135,14 +135,8 @@ namespace Microsoft.Build.Utilities
         public bool EchoOff { get; set; }
 
         /// <summary>
-        /// This is the backing field for property <see cref="TaskProcessTerminationTimeout" />.
-        /// </summary>
-        private int _taskProcessTerminationTimeout;
-
-        /// <summary>
         /// A timeout to wait for a task to terminate before killing it.  In milliseconds.
         /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if the property is set to a negative value other than -1.</exception>
         protected int TaskProcessTerminationTimeout { get; set; }
 
         /// <summary>

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -135,9 +135,29 @@ namespace Microsoft.Build.Utilities
         public bool EchoOff { get; set; }
 
         /// <summary>
+        /// This is the backing field for property <see cref="TaskProcessTerminationTimeout" />.
+        /// </summary>
+        private int _taskProcessTerminationTimeout;
+
+        /// <summary>
         /// A timeout to wait for a task to terminate before killing it.  In milliseconds.
         /// </summary>
-        protected int TaskProcessTerminationTimeout { get; set; }
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the property is set to a negative value other than -1.</exception>
+        protected int TaskProcessTerminationTimeout
+        {
+            get => _taskProcessTerminationTimeout;
+            set
+            {
+                if (value < -1)
+                {
+                    ErrorUtilities.ThrowArgumentOutOfRange(nameof(TaskProcessTerminationTimeout));
+                }
+                else
+                {
+                    _taskProcessTerminationTimeout = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Used to signal when a tool has been cancelled.

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -945,7 +945,7 @@ namespace Microsoft.Build.Utilities
                     LogShared.LogWarningWithCodeFromResources("Shared.KillingProcessByCancellation", processName);
                 }
 
-                int timeout = 5000;
+                int timeout = TaskProcessTerminationTimeout;
                 string timeoutFromEnvironment = Environment.GetEnvironmentVariable("MSBUILDTOOLTASKCANCELPROCESSWAITTIMEOUT");
                 if (timeoutFromEnvironment != null)
                 {


### PR DESCRIPTION
Use `ToolTask.TaskProcessTerminationTimeout` as termination time-out to kill external tool when it was cancelled or timed out.

Fixes #8545 

### Context

The protected property `ToolTask.TaskProcessTerminationTimeout` has been initialized but never used. Looks like it should be used as `timeout` on the following line when killing external tool on time-out or cancellation:
https://github.com/dotnet/msbuild/blob/main/src/Utilities/ToolTask.cs#L940

### Changes Made

Use `ToolTask.TaskProcessTerminationTimeout` as termination time-out to kill external tool when it was cancelled or timed out.

### Testing

All `ToolTask` unit test passed.

### Notes

No new unit test created.