### PR TITLE
[Bugfix] Do not read Location of dynamic assemblies

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Build.BackEnd.Components.RequestBuilder
         private void CurrentDomainOnAssemblyLoad(object? sender, AssemblyLoadEventArgs args)
         {
             string? assemblyName = args.LoadedAssembly.FullName;
-            string assemblyPath = args.LoadedAssembly.Location;
+            string assemblyPath = args.LoadedAssembly.IsDynamic ? string.Empty : args.LoadedAssembly.Location;
             Guid mvid = args.LoadedAssembly.ManifestModule.ModuleVersionId;
             string? appDomainDescriptor = _appDomain.IsDefaultAppDomain()
                 ? null


### PR DESCRIPTION
Fixes [AB#1761147](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1761147)

### Context
`Assembly.Location` throws in fullFW (https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location?source=recommendations&view=net-7.0#exceptions)
It returns empty fron net5.0 up


### Changes Made
Altering the code to uniformly return empty path for dynamic assemblies (and prevent exceptions)

### Experimental Insertion Build
[Internal] https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/456834