### PR TITLE
Log DownloadFile error stack trace to low priority message

### DIFF
--- a/src/Tasks/DownloadFile.cs
+++ b/src/Tasks/DownloadFile.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
@@ -125,7 +126,15 @@ namespace Microsoft.Build.Tasks
                     }
                     else
                     {
-                        Log.LogErrorWithCodeFromResources("DownloadFile.ErrorDownloading", SourceUrl, actualException.ToString());
+                        StringBuilder flattenedMessage = new StringBuilder(actualException.Message);
+                        Exception excep = actualException;
+                        while (excep.InnerException != null)
+                        {
+                            excep = excep.InnerException;
+                            flattenedMessage.Append("--->").Append(excep.Message);
+                        }
+                        Log.LogErrorWithCodeFromResources("DownloadFile.ErrorDownloading", SourceUrl, flattenedMessage.ToString());
+                        Log.LogMessage(MessageImportance.Low, actualException.ToString());
                         break;
                     }
                 }

--- a/src/Tasks/DownloadFile.cs
+++ b/src/Tasks/DownloadFile.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Build.Tasks
                         while (excep.InnerException != null)
                         {
                             excep = excep.InnerException;
-                            flattenedMessage.Append("--->").Append(excep.Message);
+                            flattenedMessage.Append(" ---> ").Append(excep.Message);
                         }
                         Log.LogErrorWithCodeFromResources("DownloadFile.ErrorDownloading", SourceUrl, flattenedMessage.ToString());
                         Log.LogMessage(MessageImportance.Low, actualException.ToString());


### PR DESCRIPTION
Fixes [#8538](https://github.com/dotnet/msbuild/issues/8538)

### Context
With https://github.com/dotnet/msbuild/pull/8440 MSBuild is now logging callstacks for scenarios in which neither MSBuild, nor a logger, nor a task has any bug.
Assertion: a callstack should indicate someone should make a bug report.

### Changes Made
Concatenate the exception message and that of any inner exceptions, and display that. Log the ex.ToString() in the low-prio message.

### Testing
Local Testing. build with -verbosity:diag
![image](https://user-images.githubusercontent.com/26814373/224595360-b7651958-d668-4c06-a15c-99f193ab4d9d.png)