### PR TITLE
Change WriteCodeFragment task to create directory

### DIFF
--- a/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
+++ b/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
@@ -100,12 +100,12 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CombineFileDirectoryAndDirectoryDoesNotExist()
         {
-            TaskItem folder;
-            do
-            {
-                folder = new TaskItem(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.DirectorySeparatorChar));
-            } while (Directory.Exists(folder.ItemSpec));
+            using TestEnvironment env = TestEnvironment.Create();
+
+            TaskItem folder = new TaskItem(env.CreateFolder(folderPath: null, createFolder: false).Path);
+
             TaskItem file = new TaskItem("CombineFileDirectory.tmp");
+
             string expectedFile = Path.Combine(folder.ItemSpec, file.ItemSpec);
             WriteCodeFragment task = CreateTask("c#", folder, file, new TaskItem[] { new TaskItem("aa") });
             MockEngine engine = new MockEngine(true);
@@ -115,8 +115,6 @@ namespace Microsoft.Build.UnitTests
             Assert.True(result);
             Assert.Equal(expectedFile, task.OutputFile.ItemSpec);
             Assert.True(File.Exists(expectedFile));
-
-            FileUtilities.DeleteWithoutTrailingBackslash(folder.ItemSpec, true);
         }
 
         /// <summary>
@@ -350,11 +348,10 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ToDirectoryAndDirectoryDoesNotExist()
         {
-            TaskItem folder;
-            do
-            {
-                folder = new TaskItem(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.DirectorySeparatorChar));
-            } while (Directory.Exists(folder.ItemSpec));
+            using TestEnvironment env = TestEnvironment.Create();
+
+            TaskItem folder = new TaskItem(env.CreateFolder(folderPath: null, createFolder: false).Path);
+
             WriteCodeFragment task = CreateTask("c#", folder, null, new TaskItem[] { new TaskItem("System.AssemblyTrademarkAttribute") });
             MockEngine engine = new MockEngine(true);
             task.BuildEngine = engine;
@@ -364,8 +361,6 @@ namespace Microsoft.Build.UnitTests
             Assert.True(File.Exists(task.OutputFile.ItemSpec));
             Assert.Equal(folder.ItemSpec, task.OutputFile.ItemSpec.Substring(0, folder.ItemSpec.Length));
             Assert.Equal(".cs", task.OutputFile.ItemSpec.Substring(task.OutputFile.ItemSpec.Length - 3));
-
-            FileUtilities.DeleteWithoutTrailingBackslash(folder.ItemSpec, true);
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
+++ b/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
@@ -118,6 +118,26 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// Combine file and directory where the directory does not already exist
+        /// </summary>
+        [Fact]
+        public void FileWithPathAndDirectoryDoesNotExist()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+
+            TaskItem file = new TaskItem(Path.Combine(env.CreateFolder(folderPath: null, createFolder: false).Path, "File.tmp"));
+
+            WriteCodeFragment task = CreateTask("c#", null, file, new TaskItem[] { new TaskItem("aa") });
+            MockEngine engine = new MockEngine(true);
+            task.BuildEngine = engine;
+            bool result = task.Execute();
+
+            Assert.True(result);
+            Assert.Equal(file.ItemSpec, task.OutputFile.ItemSpec);
+            Assert.True(File.Exists(task.OutputFile.ItemSpec));
+        }
+
+        /// <summary>
         /// Ignore directory if file is rooted
         /// </summary>
         [Fact]
@@ -201,7 +221,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Bad file path
         /// </summary>
-        [Fact]
+        [WindowsOnlyFact(additionalMessage: "No invalid characters on Unix.")]
         public void InvalidFilePath()
         {
             WriteCodeFragment task = new WriteCodeFragment();

--- a/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
+++ b/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
@@ -95,13 +95,16 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Combine file and directory
+        /// Combine file and directory where the directory does not already exist
         /// </summary>
         [Fact]
         public void CombineFileDirectoryAndDirectoryDoesNotExist()
         {
-            // TODO: Replace folder name with a random unique directory name.
-            TaskItem folder = new TaskItem(Path.Combine(Path.GetTempPath(), "fred" + Path.DirectorySeparatorChar));
+            TaskItem folder;
+            do
+            {
+                folder = new TaskItem(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.DirectorySeparatorChar));
+            } while (Path.Exists(folder.ItemSpec));
             TaskItem file = new TaskItem("CombineFileDirectory.tmp");
             string expectedFile = Path.Combine(folder.ItemSpec, file.ItemSpec);
             WriteCodeFragment task = CreateTask("c#", folder, file, new TaskItem[] { new TaskItem("aa") });
@@ -342,13 +345,16 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Combine file and directory
+        /// Specify directory where the directory does not already exist
         /// </summary>
         [Fact]
         public void ToDirectoryAndDirectoryDoesNotExist()
         {
-            // TODO: Replace folder name with random unique directory name.
-            TaskItem folder = new TaskItem(Path.Combine(Path.GetTempPath(), "bob" + Path.DirectorySeparatorChar));
+            TaskItem folder;
+            do
+            {
+                folder = new TaskItem(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.DirectorySeparatorChar));
+            } while (Path.Exists(folder.ItemSpec));
             WriteCodeFragment task = CreateTask("c#", folder, null, new TaskItem[] { new TaskItem("System.AssemblyTrademarkAttribute") });
             MockEngine engine = new MockEngine(true);
             task.BuildEngine = engine;

--- a/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
+++ b/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
@@ -100,8 +100,8 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void CombineFileDirectoryAndDirectoryDoesNotExist()
         {
-            // ToDo: Replace "foo" with random unique directory name.
-            TaskItem folder = new TaskItem(Path.Combine(Path.GetTempPath(), "foo" + Path.DirectorySeparatorChar));
+            // TODO: Replace folder name with a random unique directory name.
+            TaskItem folder = new TaskItem(Path.Combine(Path.GetTempPath(), "fred" + Path.DirectorySeparatorChar));
             TaskItem file = new TaskItem("CombineFileDirectory.tmp");
             string expectedFile = Path.Combine(folder.ItemSpec, file.ItemSpec);
             WriteCodeFragment task = CreateTask("c#", folder, file, new TaskItem[] { new TaskItem("aa") });
@@ -347,8 +347,8 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ToDirectoryAndDirectoryDoesNotExist()
         {
-            // ToDo: Replace "foo" with random unique directory name.
-            TaskItem folder = new TaskItem(Path.Combine(Path.GetTempPath(), "foo" + Path.DirectorySeparatorChar));
+            // TODO: Replace folder name with random unique directory name.
+            TaskItem folder = new TaskItem(Path.Combine(Path.GetTempPath(), "bob" + Path.DirectorySeparatorChar));
             WriteCodeFragment task = CreateTask("c#", folder, null, new TaskItem[] { new TaskItem("System.AssemblyTrademarkAttribute") });
             MockEngine engine = new MockEngine(true);
             task.BuildEngine = engine;

--- a/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
+++ b/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
@@ -90,6 +90,30 @@ namespace Microsoft.Build.UnitTests
             string file = Path.Combine(Path.GetTempPath(), "CombineFileDirectory.tmp");
             Assert.Equal(file, task.OutputFile.ItemSpec);
             Assert.True(File.Exists(file));
+
+            File.Delete(task.OutputFile.ItemSpec);
+        }
+
+        /// <summary>
+        /// Combine file and directory
+        /// </summary>
+        [Fact]
+        public void CombineFileDirectoryAndDirectoryDoesNotExist()
+        {
+            // ToDo: Replace "foo" with random unique directory name.
+            TaskItem folder = new TaskItem(Path.Combine(Path.GetTempPath(), "foo" + Path.DirectorySeparatorChar));
+            TaskItem file = new TaskItem("CombineFileDirectory.tmp");
+            string expectedFile = Path.Combine(folder.ItemSpec, file.ItemSpec);
+            WriteCodeFragment task = CreateTask("c#", folder, file, new TaskItem[] { new TaskItem("aa") });
+            MockEngine engine = new MockEngine(true);
+            task.BuildEngine = engine;
+            bool result = task.Execute();
+
+            Assert.True(result);
+            Assert.Equal(expectedFile, task.OutputFile.ItemSpec);
+            Assert.True(File.Exists(expectedFile));
+
+            FileUtilities.DeleteWithoutTrailingBackslash(folder.ItemSpec, true);
         }
 
         /// <summary>
@@ -315,6 +339,27 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(".cs", task.OutputFile.ItemSpec.Substring(task.OutputFile.ItemSpec.Length - 3));
 
             File.Delete(task.OutputFile.ItemSpec);
+        }
+
+        /// <summary>
+        /// Combine file and directory
+        /// </summary>
+        [Fact]
+        public void ToDirectoryAndDirectoryDoesNotExist()
+        {
+            // ToDo: Replace "foo" with random unique directory name.
+            TaskItem folder = new TaskItem(Path.Combine(Path.GetTempPath(), "foo" + Path.DirectorySeparatorChar));
+            WriteCodeFragment task = CreateTask("c#", folder, null, new TaskItem[] { new TaskItem("System.AssemblyTrademarkAttribute") });
+            MockEngine engine = new MockEngine(true);
+            task.BuildEngine = engine;
+            bool result = task.Execute();
+
+            Assert.True(result);
+            Assert.True(File.Exists(task.OutputFile.ItemSpec));
+            Assert.Equal(folder.ItemSpec, task.OutputFile.ItemSpec.Substring(0, folder.ItemSpec.Length));
+            Assert.Equal(".cs", task.OutputFile.ItemSpec.Substring(task.OutputFile.ItemSpec.Length - 3));
+
+            FileUtilities.DeleteWithoutTrailingBackslash(folder.ItemSpec, true);
         }
 
         /// <summary>
@@ -874,7 +919,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// For backward-compatibility, if multiple constructors are found with the same number 
+        /// For backward-compatibility, if multiple constructors are found with the same number
         /// of position arguments that was specified in the metadata, then the constructor that
         /// has strings for every parameter should be used.
         /// </summary>
@@ -985,11 +1030,18 @@ namespace Microsoft.Build.UnitTests
 
         private WriteCodeFragment CreateTask(string language, params TaskItem[] attributes)
         {
-            WriteCodeFragment task = new();
-            task.Language = language;
-            task.OutputDirectory = new TaskItem(Path.GetTempPath());
-            task.AssemblyAttributes = attributes;
-            return task;
+            return CreateTask(language, new TaskItem(Path.GetTempPath()), null, attributes);
+        }
+
+        private WriteCodeFragment CreateTask(string language, TaskItem outputDirectory, TaskItem outputFile, params TaskItem[] attributes)
+        {
+            return new WriteCodeFragment()
+            {
+                Language = language,
+                OutputDirectory = outputDirectory,
+                OutputFile = outputFile,
+                AssemblyAttributes = attributes
+            };
         }
 
         private void ExecuteAndVerifySuccess(WriteCodeFragment task, params string[] expectedAttributes)

--- a/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
+++ b/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Build.UnitTests
             do
             {
                 folder = new TaskItem(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.DirectorySeparatorChar));
-            } while (Path.Exists(folder.ItemSpec));
+            } while (Directory.Exists(folder.ItemSpec));
             TaskItem file = new TaskItem("CombineFileDirectory.tmp");
             string expectedFile = Path.Combine(folder.ItemSpec, file.ItemSpec);
             WriteCodeFragment task = CreateTask("c#", folder, file, new TaskItem[] { new TaskItem("aa") });
@@ -354,7 +354,7 @@ namespace Microsoft.Build.UnitTests
             do
             {
                 folder = new TaskItem(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.DirectorySeparatorChar));
-            } while (Path.Exists(folder.ItemSpec));
+            } while (Directory.Exists(folder.ItemSpec));
             WriteCodeFragment task = CreateTask("c#", folder, null, new TaskItem[] { new TaskItem("System.AssemblyTrademarkAttribute") });
             MockEngine engine = new MockEngine(true);
             task.BuildEngine = engine;

--- a/src/Tasks/WriteCodeFragment.cs
+++ b/src/Tasks/WriteCodeFragment.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (OutputDirectory != null && !Path.IsPathRooted(OutputFile?.ItemSpec))
                 {
-                    _ = Directory.CreateDirectory(OutputDirectory.ItemSpec);
+                    FileUtilities.EnsureDirectoryExists(OutputDirectory.ItemSpec);
                 }
 
                 if (OutputFile != null && OutputDirectory != null && !Path.IsPathRooted(OutputFile.ItemSpec))

--- a/src/Tasks/WriteCodeFragment.cs
+++ b/src/Tasks/WriteCodeFragment.cs
@@ -106,17 +106,14 @@ namespace Microsoft.Build.Tasks
 
             try
             {
-                if (OutputDirectory != null && !Path.IsPathRooted(OutputFile?.ItemSpec))
-                {
-                    FileUtilities.EnsureDirectoryExists(OutputDirectory.ItemSpec);
-                }
-
                 if (OutputFile != null && OutputDirectory != null && !Path.IsPathRooted(OutputFile.ItemSpec))
                 {
                     OutputFile = new TaskItem(Path.Combine(OutputDirectory.ItemSpec, OutputFile.ItemSpec));
                 }
 
                 OutputFile ??= new TaskItem(FileUtilities.GetTemporaryFile(OutputDirectory.ItemSpec, null, extension));
+
+                FileUtilities.EnsureDirectoryExists(Path.GetDirectoryName(OutputFile.ItemSpec));
 
                 File.WriteAllText(OutputFile.ItemSpec, code); // Overwrites file if it already exists (and can be overwritten)
             }

--- a/src/Tasks/WriteCodeFragment.cs
+++ b/src/Tasks/WriteCodeFragment.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Build.Tasks
         /// The path to the file that was generated.
         /// If this is set, and a file name, the destination folder will be prepended.
         /// If this is set, and is rooted, the destination folder will be ignored.
-        /// If this is not set, the destination folder will be used, an arbitrary file name will be used, and 
+        /// If this is not set, the destination folder will be used, an arbitrary file name will be used, and
         /// the default extension for the language selected.
         /// </summary>
         [Output]
@@ -106,6 +106,11 @@ namespace Microsoft.Build.Tasks
 
             try
             {
+                if (OutputDirectory != null && !Path.IsPathRooted(OutputFile?.ItemSpec))
+                {
+                    _ = Directory.CreateDirectory(OutputDirectory.ItemSpec);
+                }
+
                 if (OutputFile != null && OutputDirectory != null && !Path.IsPathRooted(OutputFile.ItemSpec))
                 {
                     OutputFile = new TaskItem(Path.Combine(OutputDirectory.ItemSpec, OutputFile.ItemSpec));
@@ -481,7 +486,7 @@ namespace Microsoft.Build.Tasks
                     Log.LogMessageFromResources("WriteCodeFragment.MultipleConstructorsFound");
 
                     // Before parameter types could be specified, all parameter values were
-                    // treated as strings. To be backward-compatible, we need to prefer 
+                    // treated as strings. To be backward-compatible, we need to prefer
                     // the constructor that has all string parameters, if it exists.
                     var allStringParameters = candidates.FirstOrDefault(c => c.All(t => t == typeof(string)));
 
@@ -551,7 +556,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private CodeExpression ConvertParameterValueToInferredType(Type inferredType, string rawValue, string parameterName)
         {
-            // If we don't know what type the parameter should be, then we 
+            // If we don't know what type the parameter should be, then we
             // can't convert the type. We'll just treat is as a string.
             if (inferredType is null)
             {


### PR DESCRIPTION
Fixes #8516

### Context
Setting an `OutputDirectory` where the directory does not exist, and setting an `OutputFile` would fail.

(Setting an `OutputDirectory` where the directory does not exist, and not providing an `OutputFile` value would succeed because `FileUtilities.GetTemporaryFile` calls `Directory.CreateDirectory`.)

### Changes Made

#### WriteCodeFragment_Tests.cs
- Added new unit tests:
  - `CombineFileDirectoryAndDirectoryDoesNotExist` (pairs with `CombineFileDirectory`)
  - `ToDirectoryAndDirectoryDoesNotExist` (pairs with `ToDirectory`)
- Added overload of `CreateTask`

#### WriteCodeFragment.cs
- Changed task to call `FileUtilities.EnsureDirectoryExists`.

### Testing
Added unit tests first and confirmed failure.

Ran all unit tests on Windows 11 and macOS 12 (Monterey).

### Notes

