### PR TITLE
Fix graph target list for multitargetting projects using BuildProjectReferences=false

### DIFF
--- a/src/Tasks/Microsoft.Managed.After.targets
+++ b/src/Tasks/Microsoft.Managed.After.targets
@@ -36,16 +36,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Properties for extension of ProjectReferenceTargets.
       Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.
   -->
-  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
-    <!-- Empty case is for outer builds which do not import the target files that set BuildProjectReferences -->
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true'">
+    <!-- Empty case is for builds which do not import the target files that set BuildProjectReferences -->
     <_MainReferenceTargetForBuild Condition="'$(BuildProjectReferences)' == '' or '$(BuildProjectReferences)' == 'true'">.projectReferenceTargetsOrDefaultTargets</_MainReferenceTargetForBuild>
     <_MainReferenceTargetForBuild Condition="'$(_MainReferenceTargetForBuild)' == ''">GetTargetPath</_MainReferenceTargetForBuild>
 
     <ProjectReferenceTargetsForBuild>$(_MainReferenceTargetForBuild);GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
-
-    <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
-
-    <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
 
     <!-- Publish has the same logic as Build for the main reference target except it also takes $(NoBuild) into account. -->
     <_MainReferenceTargetForPublish Condition="'$(NoBuild)' == 'true'">GetTargetPath</_MainReferenceTargetForPublish>
@@ -58,23 +54,30 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)</ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' == 'true'">
+    <ProjectReferenceTargetsForBuild>.default;$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
+    <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
+  </PropertyGroup>
 
   <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
     <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true" />
-    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" />
+    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
     <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
 
     <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true" />
-    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" />
+    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
     <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
 
     <!--
      Note: SkipNonexistentTargets="true" on the following three items means that an outer build node's call to its existent GetTargetFrameworks target will fail if its inner build nodes don't define GetTargetFrameworksWithPlatformForSingleTargetFrameworks.
      This is necessary since the P2P protocol cannot express the targets called from the outer build to the inner build.
      -->
-    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" />
-    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" />
-    <ProjectReferenceTargets Include="Rebuild" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" />
+    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Rebuild" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
 
     <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
 


### PR DESCRIPTION
This change fixes graph builds for multitargetting projects using BuildProjectReferences=false

Previously, when using BuildProjectReferences=false the graph would consider the outer build calling GetTargetPath on the inner builds. However, it actually calls Build when dispatching to the inner builds, and those call GetTargetPath on their dependencies. In effect this is causing graph builds to be non-graph builds since the target list is not accurately described.

This change ensures the correct behavior by separating the ProjectReferenceTargets logic for single and multi-targetting projects.

## Before

Only the top-level project is in the graph, and the inner builds do not have "Build" as a predicted target:
![image](https://user-images.githubusercontent.com/6445614/225098959-c886fa55-9995-422c-a4ca-f10b272671cb.png)

Dispatching to inner builds does not come from cache:
![image](https://user-images.githubusercontent.com/6445614/225099046-dc048111-46d5-4df2-b3ae-ba33e67695d4.png)

Inner builds resolving dependencies does not come from cache:
![image](https://user-images.githubusercontent.com/6445614/225099285-0351acce-7611-4b7f-a6e9-dfc45dfc74ac.png)

## After

Everything is in the graph properly:
![image](https://user-images.githubusercontent.com/6445614/225099672-3fe1834d-5b67-4862-b93d-f7ee9728a338.png)

Dispatching to inner builds comes from cache:
![image](https://user-images.githubusercontent.com/6445614/225099854-ca017281-000a-4047-9cfc-86a657b34ea1.png)

Inner builds resolving dependencies comes from cache:
![image](https://user-images.githubusercontent.com/6445614/225099972-d07d0a5d-f43f-43d1-8a24-78ae3d2b4d94.png)

CC @rainersigwald who was hitting this as well.
CC @DmitriyShepelev who may be interested from an isolation standpoint.