### PR TITLE
Add bit shift intrinsic functions

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3388,34 +3388,25 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             double expectedResult = 9223372036854775807D + 20D;
             Assert.Equal(expectedResult.ToString(), result);
+        }
 
-            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::BitwiseOr(40, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+        /// <summary>
+        /// Expand intrinsic property functions that call a bit operator
+        /// </summary>
+        [Fact]
+        public void PropertyFunctionStaticMethodIntrinsicBitOperations()
+        {
+            PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Assert.Equal((40 | 2).ToString(), result);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
-            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::BitwiseAnd(42, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
-
-            Assert.Equal((42 & 2).ToString(), result);
-
-            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::BitwiseXor(213, 255))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
-
-            Assert.Equal((213 ^ 255).ToString(), result);
-
-            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::BitwiseNot(-43))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
-
-            Assert.Equal((~-43).ToString(), result);
-
-            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::LeftShift(1, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
-
-            Assert.Equal((1 << 2).ToString(), result);
-
-            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::RightShift(-8, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
-
-            Assert.Equal((-8 >> 2).ToString(), result);
-
-            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::RightShiftUnsigned(-8, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
-
-            Assert.Equal((-8 >>> 2).ToString(), result);
+            expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::BitwiseOr(40, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe((40 | 2).ToString());
+            expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::BitwiseAnd(42, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe((42 & 2).ToString());
+            expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::BitwiseXor(213, 255))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe((213 ^ 255).ToString());
+            expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::BitwiseNot(-43))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe((~-43).ToString());
+            expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::LeftShift(1, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe((1 << 2).ToString());
+            expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::RightShift(-8, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe((-8 >> 2).ToString());
+            expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::RightShiftUnsigned(-8, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe((-8 >>> 2).ToString());
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3404,6 +3404,18 @@ namespace Microsoft.Build.UnitTests.Evaluation
             result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::BitwiseNot(-43))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
             Assert.Equal((~-43).ToString(), result);
+
+            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::LeftShift(1, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+
+            Assert.Equal((1 << 2).ToString(), result);
+
+            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::RightShift(-8, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+
+            Assert.Equal((-8 >> 2).ToString(), result);
+
+            result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::RightShiftUnsigned(-8, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+
+            Assert.Equal((-8 >>> 2).ToString(), result);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3882,6 +3882,14 @@ namespace Microsoft.Build.Evaluation
                                 return true;
                             }
                         }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.Unescape), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArg(args, out string arg0))
+                            {
+                                returnVal = IntrinsicFunctions.Unescape(arg0);
+                                return true;
+                            }
+                        }
                         else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.GetPathOfFileAbove), StringComparison.OrdinalIgnoreCase))
                         {
                             if (TryGetArgs(args, out string arg0, out string arg1))

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3894,7 +3894,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (TryGetArgs(args, out double arg0, out double arg1))
                             {
-                                returnVal = arg0 + arg1;
+                                returnVal = IntrinsicFunctions.Add(arg0, arg1);
                                 return true;
                             }
                         }
@@ -3902,7 +3902,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (TryGetArgs(args, out double arg0, out double arg1))
                             {
-                                returnVal = arg0 - arg1;
+                                returnVal = IntrinsicFunctions.Subtract(arg0, arg1);
                                 return true;
                             }
                         }
@@ -3910,7 +3910,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (TryGetArgs(args, out double arg0, out double arg1))
                             {
-                                returnVal = arg0 * arg1;
+                                returnVal = IntrinsicFunctions.Multiply(arg0, arg1);
                                 return true;
                             }
                         }
@@ -3918,7 +3918,15 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (TryGetArgs(args, out double arg0, out double arg1))
                             {
-                                returnVal = arg0 / arg1;
+                                returnVal = IntrinsicFunctions.Divide(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.Modulo), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out double arg0, out double arg1))
+                            {
+                                returnVal = IntrinsicFunctions.Modulo(arg0, arg1);
                                 return true;
                             }
                         }

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4108,6 +4108,62 @@ namespace Microsoft.Build.Evaluation
                                 return true;
                             }
                         }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.BitwiseOr), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out int arg0, out int arg1))
+                            {
+                                returnVal = IntrinsicFunctions.BitwiseOr(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.BitwiseAnd), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out int arg0, out int arg1))
+                            {
+                                returnVal = IntrinsicFunctions.BitwiseAnd(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.BitwiseXor), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out int arg0, out int arg1))
+                            {
+                                returnVal = IntrinsicFunctions.BitwiseXor(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.BitwiseNot), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out int arg0))
+                            {
+                                returnVal = IntrinsicFunctions.BitwiseNot(arg0);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.LeftShift), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out int arg0, out int arg1))
+                            {
+                                returnVal = IntrinsicFunctions.LeftShift(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.RightShift), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out int arg0, out int arg1))
+                            {
+                                returnVal = IntrinsicFunctions.RightShift(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.RightShiftUnsigned), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out int arg0, out int arg1))
+                            {
+                                returnVal = IntrinsicFunctions.RightShiftUnsigned(arg0, arg1);
+                                return true;
+                            }
+                        }
                     }
                     else if (_receiverType == typeof(Path))
                     {
@@ -4482,6 +4538,18 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 return Enum.TryParse(comparisonTypeName, out arg1);
+            }
+
+            private static bool TryGetArgs(object[] args, out int arg0)
+            {
+                arg0 = 0;
+
+                if (args.Length != 1)
+                {
+                    return false;
+                }
+
+                return TryConvertToInt(args[0], out arg0);
             }
 
             private static bool TryGetArgs(object[] args, out int arg0, out int arg1)

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -165,6 +165,21 @@ namespace Microsoft.Build.Evaluation
             return ~first;
         }
 
+        internal static int LeftShift(int operand, int count)
+        {
+            return operand << count;
+        }
+
+        internal static int RightShift(int operand, int count)
+        {
+            return operand >> count;
+        }
+
+        internal static int RightShiftUnsigned(int operand, int count)
+        {
+            return operand >>> count;
+        }
+
         /// <summary>
         /// Get the value of the registry key and value, default value is null
         /// </summary>

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -46,9 +46,25 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Add two longs
+        /// </summary>
+        internal static long Add(long a, long b)
+        {
+            return a + b;
+        }
+
+        /// <summary>
         /// Subtract two doubles
         /// </summary>
         internal static double Subtract(double a, double b)
+        {
+            return a - b;
+        }
+
+        /// <summary>
+        /// Subtract two longs
+        /// </summary>
+        internal static long Subtract(long a, long b)
         {
             return a - b;
         }
@@ -62,6 +78,14 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Multiply two longs
+        /// </summary>
+        internal static long Multiply(long a, long b)
+        {
+            return a * b;
+        }
+
+        /// <summary>
         /// Divide two doubles
         /// </summary>
         internal static double Divide(double a, double b)
@@ -70,9 +94,25 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Divide two longs
+        /// </summary>
+        internal static long Divide(long a, long b)
+        {
+            return a / b;
+        }
+
+        /// <summary>
         /// Modulo two doubles
         /// </summary>
         internal static double Modulo(double a, double b)
+        {
+            return a % b;
+        }
+
+        /// <summary>
+        /// Modulo two longs
+        /// </summary>
+        internal static long Modulo(long a, long b)
         {
             return a % b;
         }

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -46,25 +46,9 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Add two longs
-        /// </summary>
-        internal static long Add(long a, long b)
-        {
-            return a + b;
-        }
-
-        /// <summary>
         /// Subtract two doubles
         /// </summary>
         internal static double Subtract(double a, double b)
-        {
-            return a - b;
-        }
-
-        /// <summary>
-        /// Subtract two longs
-        /// </summary>
-        internal static long Subtract(long a, long b)
         {
             return a - b;
         }
@@ -78,14 +62,6 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Multiply two longs
-        /// </summary>
-        internal static long Multiply(long a, long b)
-        {
-            return a * b;
-        }
-
-        /// <summary>
         /// Divide two doubles
         /// </summary>
         internal static double Divide(double a, double b)
@@ -94,25 +70,9 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Divide two longs
-        /// </summary>
-        internal static long Divide(long a, long b)
-        {
-            return a / b;
-        }
-
-        /// <summary>
         /// Modulo two doubles
         /// </summary>
         internal static double Modulo(double a, double b)
-        {
-            return a % b;
-        }
-
-        /// <summary>
-        /// Modulo two longs
-        /// </summary>
-        internal static long Modulo(long a, long b)
         {
             return a % b;
         }


### PR DESCRIPTION
Fixes #8551

### Context
The intrinsic functions include functions for bit And, Or, Xor, and Not operators but not for the bit shift operators.

### Changes Made
Added functions LeftShift, RightShift, and RightShiftUnsigned. The functions expect values of type `int` (32 bit) which matches the existing bit operator functions. `long` (64 bit) is not supported by any of the bit operator intrinsic functions.

### Testing
Tested on Windows 11 and macOS 12 Monterey.

Added to Expander_Tests.cs and ran unit tests.

Created and ran BitShift.proj project file with the following content:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

  <Target Name="Test">
    <PropertyGroup>
      <LeftShiftTest>$([MSBuild]::LeftShift(1, 2))</LeftShiftTest>
      <RightShiftTest>$([MSBuild]::RightShift(-8, 2))</RightShiftTest>
      <RightShiftUnsignedTest>$([MSBuild]::RightShiftUnsigned(-8, 2))</RightShiftUnsignedTest>
    </PropertyGroup>

    <Message Text="LeftShiftTest: $(LeftShiftTest)" />
    <Message Text="RightShiftTest: $(RightShiftTest)" />
    <Message Text="RightShiftUnsignedTest: $(RightShiftUnsignedTest)" />
  </Target>

</Project>

```

The project produced the following output (which matched the expected results):

```
Test:
  LeftShiftTest: 4
  RightShiftTest: -2
  RightShiftUnsignedTest: 1073741822
```

### Notes
