### PR TITLE
.NET projects produce a reference assembly by default

### DIFF
--- a/src/Tasks/Microsoft.NET.props
+++ b/src/Tasks/Microsoft.NET.props
@@ -20,7 +20,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
   -->
   <PropertyGroup>
-    <ProduceReferenceAssembly Condition=" '$(ProduceReferenceAssembly)' == '' ">true</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly Condition=" '$(ProduceReferenceAssembly)' == '' and '$(ProduceOnlyReferenceAssembly)' != 'true' ">true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.NET.props
+++ b/src/Tasks/Microsoft.NET.props
@@ -7,7 +7,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           impossible to load or build your projects from the command-line or the IDE.
 
 This file contains .NET-specific properties, and items. This file is imported for .NET Core, .NET Standard, and .NET Framework projects.
-these two files are used to encapsulate the multi-targeting and framework specific build process.
 
 Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************

--- a/src/Tasks/Microsoft.NET.props
+++ b/src/Tasks/Microsoft.NET.props
@@ -16,6 +16,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ============================================================
+                                        Reference Assemblies
+    Enable the production of a reference assembly by all .NET projects, by default.
+    ============================================================
+  -->
+  <PropertyGroup>
+    <ProduceReferenceAssembly Condition=" '$(ProduceReferenceAssembly)' == '' ">true</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <!--
+    ============================================================
                                         GetToolPaths
     Get the paths for the .NET Framework and .NET Core tools and sdk tools directories.
     This does not need to be a target since all of the values are availiable at project evaluation time.


### PR DESCRIPTION
In general we want to produce reference assemblies whenever possible, as they improve incremental build performance.

Making them work end-to-end requires support from other components, such as fast up-to-date checks in VS. While support was originally added for SDK-style projects, it was not present for legacy `.csproj` files. Accordingly, `ProduceReferenceAssemblies` was set `true` only when the target framework was `net5.0` or later for C#/VB projects. Similarly, F# added support during `net7.0`, so a similar check was added for F# projects.

VS 17.5 ships support for reference assemblies in the legacy CSPROJ fast up-to-date check, so all C#/VB projects are supported. Similarly, F# has full support. Consequently, it is now safe to enable the production and consumption of reference assemblies across all .NET project types, including .NET Framework, .NET Standard, .NET Core and .NET.

This PR changes the default `ProduceReferenceAssembly` value to `true` for all .NET projects.