### PR TITLE
Remove unnecessary remove from ProjectRootElementCache

### DIFF
--- a/src/Build/Collections/WeakValueDictionary.cs
+++ b/src/Build/Collections/WeakValueDictionary.cs
@@ -239,7 +239,11 @@ namespace Microsoft.Build.Collections
         {
             foreach (KeyValuePair<K, WeakReference<V>> kvp in _dictionary)
             {
-                if (kvp.Value is not null && kvp.Value.TryGetTarget(out V target))
+                if (kvp.Value is null)
+                {
+                    yield return new KeyValuePair<K, V>(kvp.Key, null);
+                }
+                else if (kvp.Value.TryGetTarget(out V target))
                 {
                     yield return new KeyValuePair<K, V>(kvp.Key, target);
                 }

--- a/src/Build/Collections/WeakValueDictionary.cs
+++ b/src/Build/Collections/WeakValueDictionary.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Build.Shared;
@@ -15,7 +16,7 @@ namespace Microsoft.Build.Collections
     /// </summary>
     /// <typeparam name="K">Type of key</typeparam>
     /// <typeparam name="V">Type of value, without the WeakReference wrapper.</typeparam>
-    internal class WeakValueDictionary<K, V>
+    internal class WeakValueDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
         where V : class
     {
         /// <summary>
@@ -233,5 +234,18 @@ namespace Microsoft.Build.Collections
         {
             _dictionary.Clear();
         }
+
+        public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+        {
+            foreach (KeyValuePair<K, WeakReference<V>> kvp in _dictionary)
+            {
+                if (kvp.Value is not null && kvp.Value.TryGetTarget(out V target))
+                {
+                    yield return new KeyValuePair<K, V>(kvp.Key, target);
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -460,7 +460,6 @@ namespace Microsoft.Build.Evaluation
                         }
                         else
                         {
-                            _strongCache.Remove(rootElement);
                             RaiseProjectRootElementRemovedFromStrongCache(rootElement);
                         }
                     }

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -445,6 +445,11 @@ namespace Microsoft.Build.Evaluation
 
                 foreach (KeyValuePair<string, ProjectRootElement> kvp in oldWeakCache)
                 {
+                    if (kvp.Value is null)
+                    {
+                        continue;
+                    }
+
                     if (kvp.Value.IsExplicitlyLoaded)
                     {
                         _weakCache[kvp.Key] = kvp.Value;

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -443,24 +443,22 @@ namespace Microsoft.Build.Evaluation
                 LinkedList<ProjectRootElement> oldStrongCache = _strongCache;
                 _strongCache = new LinkedList<ProjectRootElement>();
 
-                foreach (string projectPath in oldWeakCache.Keys)
+                foreach (KeyValuePair<string, ProjectRootElement> kvp in oldWeakCache)
                 {
-                    ProjectRootElement rootElement;
-
-                    if (oldWeakCache.TryGetValue(projectPath, out rootElement))
+                    if (kvp.Value.IsExplicitlyLoaded)
                     {
-                        if (rootElement.IsExplicitlyLoaded)
-                        {
-                            _weakCache[projectPath] = rootElement;
-                        }
+                        _weakCache[kvp.Key] = kvp.Value;
+                    }
 
-                        if (rootElement.IsExplicitlyLoaded && oldStrongCache.Contains(rootElement))
+                    if (oldStrongCache.Contains(kvp.Value))
+                    {
+                        if (kvp.Value.IsExplicitlyLoaded)
                         {
-                            _strongCache.AddFirst(rootElement);
+                            _strongCache.AddFirst(kvp.Value);
                         }
                         else
                         {
-                            RaiseProjectRootElementRemovedFromStrongCache(rootElement);
+                            RaiseProjectRootElementRemovedFromStrongCache(kvp.Value);
                         }
                     }
                 }


### PR DESCRIPTION
It's fairly straightforward to demonstrate that if we reach this block, then it isn't in the _strongCache anyway, so this is entirely unnecessary work.
