### PR TITLE
Log item self-expansion

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -28,6 +28,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Eliminate project string cache](https://github.com/dotnet/msbuild/pull/7965)
 - [Log an error when no provided search path for an import exists](https://github.com/dotnet/msbuild/pull/8095)
 - [Log assembly loads](https://github.com/dotnet/msbuild/pull/8316)
+- [Log item self-expansion](https://github.com/dotnet/msbuild/pull/8581)
 
 ### 17.4
 - [Respect deps.json when loading assemblies](https://github.com/dotnet/msbuild/pull/7520)

--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -793,7 +793,7 @@ namespace Microsoft.Build.UnitTests
                       </Target>
                     </Project>
                 """;
-            var projectFile = env.CreateFile("test.proj",  ObjectModelHelpers.CleanupFileContents(projectContent));
+            var projectFile = env.CreateFile("test.proj", ObjectModelHelpers.CleanupFileContents(projectContent));
 
             MockLogger logger = new MockLogger(_testOutput);
             ObjectModelHelpers.BuildTempProjectFileExpectSuccess(projectFile.Path, logger);

--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -787,8 +787,8 @@ namespace Microsoft.Build.UnitTests
                     <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
                      <ItemGroup>
                         <iout1 Include='a/b.foo' TargetPath='%(Filename)%(Extension)' />
-                        <iout1 Include='c\d.foo' TargetPath='%(Filename)%(Extension)' />
-                        <iout1 Include='g\h.foo' TargetPath='%(Filename)%(Extension)' />
+                        <iout1 Include='c/d.foo' TargetPath='%(Filename)%(Extension)' />
+                        <iout1 Include='g/h.foo' TargetPath='%(Filename)%(Extension)' />
                       </ItemGroup>
                       <Target Name='a'>
                         <Message Text="iout1=[@(iout1)]" Importance='High' />
@@ -802,7 +802,7 @@ namespace Microsoft.Build.UnitTests
 
                 Console.WriteLine(logger.FullLog);
 
-                logger.AssertLogContains("iout1=[a/b.foo;c\\d.foo;g\\h.foo]");
+                logger.AssertLogContains("iout1=[a/b.foo;c/d.foo;g/h.foo]");
                 logger.AssertLogContains("iout1-target-paths=[b.foo;d.foo;h.foo]");
             }
             finally
@@ -827,8 +827,8 @@ namespace Microsoft.Build.UnitTests
                       <Target Name='a'>
                         <ItemGroup>
                           <iin1 Include='a/b.foo' TargetPath='%(Filename)%(Extension)' />
-                          <iin1 Include='c\d.foo' TargetPath='%(Filename)%(Extension)' />
-                          <iin1 Include='g\h.foo' TargetPath='%(Filename)%(Extension)' />
+                          <iin1 Include='c/d.foo' TargetPath='%(Filename)%(Extension)' />
+                          <iin1 Include='g/h.foo' TargetPath='%(Filename)%(Extension)' />
                         </ItemGroup>
                         <Message Text="iin1=[@(iin1)]" Importance='High' />
                         <Message Text="iin1-target-paths=[@(iin1->'%(TargetPath)')]" Importance='High' />
@@ -841,9 +841,9 @@ namespace Microsoft.Build.UnitTests
 
                 Console.WriteLine(logger.FullLog);
 
-                logger.AssertLogDoesntContain("iin1=[a/b.foo;c\\d.foo;g\\h.foo]");
+                logger.AssertLogDoesntContain("iin1=[a/b.foo;c/d.foo;g/h.foo]");
                 logger.AssertLogDoesntContain("iin1-target-paths=[b.foo;d.foo;h.foo]");
-                logger.AssertLogContains("iin1=[a/b.foo;c\\d.foo;g\\h.foo;g\\h.foo]");
+                logger.AssertLogContains("iin1=[a/b.foo;c/d.foo;g/h.foo;g/h.foo]");
                 logger.AssertLogContains("iin1-target-paths=[;b.foo;b.foo;d.foo]");
 
                 logger.AssertLogContains("MSB4120: Item 'iin1' definition within target is referencing self via metadata 'Extension' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items");
@@ -871,8 +871,8 @@ namespace Microsoft.Build.UnitTests
                     <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
                       <ItemGroup>
                         <iout1 Include='a/b.foo'/>
-                        <iout1 Include='c\d.foo'/>
-                        <iout1 Include='g\h.foo'/>
+                        <iout1 Include='c/d.foo'/>
+                        <iout1 Include='g/h.foo'/>
                       </ItemGroup>
 
                       <Target Name='a'>
@@ -890,7 +890,7 @@ namespace Microsoft.Build.UnitTests
 
                 Console.WriteLine(logger.FullLog);
 
-                logger.AssertLogContains("iin1=[a/b.foo;c\\d.foo;g\\h.foo]");
+                logger.AssertLogContains("iin1=[a/b.foo;c/d.foo;g/h.foo]");
                 logger.AssertLogContains("iin1-target-paths=[b.foo;d.foo;h.foo]");
 
                 logger.AssertLogDoesntContain("MSB4120");

--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -846,7 +846,7 @@ namespace Microsoft.Build.UnitTests
                 logger.AssertLogContains("iin1=[a/b.foo;c\\d.foo;g\\h.foo;g\\h.foo]");
                 logger.AssertLogContains("iin1-target-paths=[;b.foo;b.foo;d.foo]");
 
-                logger.AssertLogContains("Item 'iin1' definition within target is referencing self via metadata 'Extension'. This can lead to unintended expansion and cross-applying of pre-existing items");
+                logger.AssertLogContains("MSB4120: Item 'iin1' definition within target is referencing self via metadata 'Extension' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items");
                 Assert.Equal(6, logger.WarningCount);
                 Assert.Equal(0, logger.ErrorCount);
             }

--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -847,7 +847,8 @@ namespace Microsoft.Build.UnitTests
                 logger.AssertLogContains("iin1-target-paths=[;b.foo;b.foo;d.foo]");
 
                 logger.AssertLogContains("MSB4120: Item 'iin1' definition within target is referencing self via metadata 'Extension' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items");
-                Assert.Equal(6, logger.WarningCount);
+                logger.AssertMessageCount("MSB4120", 6);
+                Assert.Equal(0, logger.WarningCount);
                 Assert.Equal(0, logger.ErrorCount);
             }
             finally

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -129,6 +129,36 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
+        ///  Helper method to create a message build event from a string resource and some parameters
+        /// </summary>
+        /// <param name="importance">Importance level of the message</param>
+        /// <param name="file">The file in which the event occurred</param>
+        /// <param name="messageResourceName">string within the resource which indicates the format string to use</param>
+        /// <param name="messageArgs">string resource arguments</param>
+        internal void LogComment(MessageImportance importance, BuildEventFileInfo file, string messageResourceName, params object[] messageArgs)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+
+            _loggingService.LogBuildEvent(new BuildMessageEventArgs(
+                null,
+                null,
+                file.File,
+                file.Line,
+                file.Column,
+                file.EndLine,
+                file.EndColumn,
+                ResourceUtilities.GetResourceString(messageResourceName),
+                helpKeyword: null,
+                senderName: "MSBuild",
+                importance,
+                DateTime.UtcNow,
+                messageArgs)
+            {
+                BuildEventContext = _eventContext
+            });
+        }
+
+        /// <summary>
         /// Helper method to create a message build event from a string
         /// </summary>
         /// <param name="importance">Importance level of the message</param>

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Build.BackEnd
                         // Referring to unqualified metadata of other item (transform) is fine.
                         child.Include.IndexOf("@(", StringComparison.Ordinal) == -1)
                     {
-                        expanderOptions |= ExpanderOptions.WarnOnItemMetadataSelfReference;
+                        expanderOptions |= ExpanderOptions.LogOnItemMetadataSelfReference;
                         // Temporary workaround of unavailability of full Location info on metadata: https://github.com/dotnet/msbuild/issues/8579
                         location = child.Location;
                     }

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
@@ -186,7 +187,11 @@ namespace Microsoft.Build.BackEnd
                 {
                     ExpanderOptions expanderOptions = ExpanderOptions.ExpandAll;
                     ElementLocation location = metadataInstance.Location;
-                    if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_6) && bucket.BucketSequenceNumber == 0)
+                    if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_6) &&
+                        // If multiple buckets were expanded - we do not want to repeat same error for same metadatum on a same line
+                        bucket.BucketSequenceNumber == 0 &&
+                        // Referring to unqualified metadata of other item (transform) is fine.
+                        child.Include.IndexOf("@(", StringComparison.Ordinal) == -1)
                     {
                         expanderOptions |= ExpanderOptions.WarnOnItemMetadataSelfReference;
                         // Temporary workaround of unavailability of full Location info on metadata: https://github.com/dotnet/msbuild/issues/8579

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Linq;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -625,7 +625,7 @@ namespace Microsoft.Build.BackEnd
         /// 1. The metadata table created for the bucket, may be null.
         /// 2. The metadata table derived from the item definition group, may be null.
         /// </summary>
-        private class NestedMetadataTable : IMetadataTable, IItemMetadata
+        private class NestedMetadataTable : IMetadataTable, IItemTypeDefinition
         {
             /// <summary>
             /// The table for all metadata added during expansion
@@ -736,7 +736,7 @@ namespace Microsoft.Build.BackEnd
                 _addTable[name] = value;
             }
 
-            string IItemMetadata.ItemType => _itemType;
+            string IItemTypeDefinition.ItemType => _itemType;
         }
     }
 }

--- a/src/Build/Definition/ProjectItemDefinition.cs
+++ b/src/Build/Definition/ProjectItemDefinition.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Evaluation
     /// ProjectMetadataElement, and these can be added, removed, and modified.
     /// </remarks>
     [DebuggerDisplay("{_itemType} #Metadata={MetadataCount}")]
-    public class ProjectItemDefinition : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadata>, IProjectMetadataParent
+    public class ProjectItemDefinition : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadata>, IProjectMetadataParent, IItemMetadata
     {
         /// <summary>
         /// Project that this item definition lives in.

--- a/src/Build/Definition/ProjectItemDefinition.cs
+++ b/src/Build/Definition/ProjectItemDefinition.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Evaluation
     /// ProjectMetadataElement, and these can be added, removed, and modified.
     /// </remarks>
     [DebuggerDisplay("{_itemType} #Metadata={MetadataCount}")]
-    public class ProjectItemDefinition : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadata>, IProjectMetadataParent, IItemMetadata
+    public class ProjectItemDefinition : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadata>, IProjectMetadataParent, IItemTypeDefinition
     {
         /// <summary>
         /// Project that this item definition lives in.

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -89,11 +89,11 @@ namespace Microsoft.Build.Evaluation
         Truncate = 0x40,
 
         /// <summary>
-        /// Issues warning if item references unqualified or qualified metadata odf self - as this can lead to unintended expansion and
+        /// Issues build message if item references unqualified or qualified metadata odf self - as this can lead to unintended expansion and
         ///  cross-combination of other items.
         /// More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata
         /// </summary>
-        WarnOnItemMetadataSelfReference = 0x80,
+        LogOnItemMetadataSelfReference = 0x80,
 
         /// <summary>
         /// Expand only properties and then item lists
@@ -1015,7 +1015,7 @@ namespace Microsoft.Build.Evaluation
                     LoggingContext loggingContext)
                 {
                     _metadata = metadata;
-                    _options = options & (ExpanderOptions.ExpandMetadata | ExpanderOptions.Truncate | ExpanderOptions.WarnOnItemMetadataSelfReference);
+                    _options = options & (ExpanderOptions.ExpandMetadata | ExpanderOptions.Truncate | ExpanderOptions.LogOnItemMetadataSelfReference);
                     _elementLocation = elementLocation;
                     _loggingContext = loggingContext;
 
@@ -1049,7 +1049,7 @@ namespace Microsoft.Build.Evaluation
                     {
                         metadataValue = _metadata.GetEscapedValue(itemType, metadataName);
 
-                        if ((_options & ExpanderOptions.WarnOnItemMetadataSelfReference) != 0 &&
+                        if ((_options & ExpanderOptions.LogOnItemMetadataSelfReference) != 0 &&
                             _loggingContext != null &&
                             !string.IsNullOrEmpty(metadataName) &&
                             _metadata is IItemMetadata itemMetadata &&

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1055,7 +1055,7 @@ namespace Microsoft.Build.Evaluation
                             _metadata is IItemMetadata itemMetadata &&
                             (string.IsNullOrEmpty(itemType) || string.Equals(itemType, itemMetadata.ItemType, StringComparison.Ordinal)))
                         {
-                            _loggingContext.LogWarning(null, new BuildEventFileInfo(_elementLocation),
+                            _loggingContext.LogComment(MessageImportance.High, new BuildEventFileInfo(_elementLocation),
                                 "ItemReferencingSelfInTarget", itemMetadata.ItemType, metadataName);
                         }
 

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1052,7 +1052,7 @@ namespace Microsoft.Build.Evaluation
                         if ((_options & ExpanderOptions.LogOnItemMetadataSelfReference) != 0 &&
                             _loggingContext != null &&
                             !string.IsNullOrEmpty(metadataName) &&
-                            _metadata is IItemMetadata itemMetadata &&
+                            _metadata is IItemTypeDefinition itemMetadata &&
                             (string.IsNullOrEmpty(itemType) || string.Equals(itemType, itemMetadata.ItemType, StringComparison.Ordinal)))
                         {
                             _loggingContext.LogComment(MessageImportance.High, new BuildEventFileInfo(_elementLocation),

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Issues warning if item references unqualified or qualified metadata odf self - as this can lead to unintended expansion and
         ///  cross-combination of other items.
-        /// TODO: add ms learn link (once the appropriate text is added there)
+        /// More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata
         /// </summary>
         WarnOnItemMetadataSelfReference = 0x80,
 
@@ -870,11 +870,6 @@ namespace Microsoft.Build.Evaluation
         /// </remarks>
         private static class MetadataExpander
         {
-            //internal static bool HasUnqualifiedOrSelfQualifiedMetadataRef(string itemName, string expression)
-            //{
-
-            //}
-
             /// <summary>
             /// Expands all embedded item metadata in the given string, using the bucketed items.
             /// Metadata may be qualified, like %(Compile.WarningLevel), or unqualified, like %(Compile).
@@ -883,6 +878,7 @@ namespace Microsoft.Build.Evaluation
             /// <param name="metadata">The metadata to be expanded.</param>
             /// <param name="options">Used to specify what to expand.</param>
             /// <param name="elementLocation">The location information for error reporting purposes.</param>
+            /// <param name="loggingContext">The logging context for this operation.</param>
             /// <returns>The string with item metadata expanded in-place, escaped.</returns>
             internal static string ExpandMetadataLeaveEscaped(string expression, IMetadataTable metadata, ExpanderOptions options, IElementLocation elementLocation, LoggingContext loggingContext = null)
             {

--- a/src/Build/Evaluation/IItemMetadata.cs
+++ b/src/Build/Evaluation/IItemMetadata.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+namespace Microsoft.Build.Evaluation;
+
+internal interface IItemMetadata
+{
+    /// <summary>
+    /// The item type to which this metadata applies.
+    /// </summary>
+    string ItemType { get; }
+}

--- a/src/Build/Evaluation/IItemTypeDefinition.cs
+++ b/src/Build/Evaluation/IItemTypeDefinition.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 namespace Microsoft.Build.Evaluation;
 
 internal interface IItemTypeDefinition

--- a/src/Build/Evaluation/IItemTypeDefinition.cs
+++ b/src/Build/Evaluation/IItemTypeDefinition.cs
@@ -4,7 +4,7 @@
 #nullable disable
 namespace Microsoft.Build.Evaluation;
 
-internal interface IItemMetadata
+internal interface IItemTypeDefinition
 {
     /// <summary>
     /// The item type to which this metadata applies.

--- a/src/Build/Instance/ProjectItemDefinitionInstance.cs
+++ b/src/Build/Instance/ProjectItemDefinitionInstance.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Execution
     /// Immutable.
     /// </summary>
     [DebuggerDisplay("{_itemType} #Metadata={MetadataCount}")]
-    public class ProjectItemDefinitionInstance : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadataInstance>, ITranslatable, IItemMetadata
+    public class ProjectItemDefinitionInstance : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadataInstance>, ITranslatable, IItemTypeDefinition
     {
         /// <summary>
         /// Item type, for example "Compile", that this item definition applies to
@@ -236,6 +236,6 @@ namespace Microsoft.Build.Execution
             return instance;
         }
 
-        string IItemMetadata.ItemType => _itemType;
+        string IItemTypeDefinition.ItemType => _itemType;
     }
 }

--- a/src/Build/Instance/ProjectItemDefinitionInstance.cs
+++ b/src/Build/Instance/ProjectItemDefinitionInstance.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Execution
     /// Immutable.
     /// </summary>
     [DebuggerDisplay("{_itemType} #Metadata={MetadataCount}")]
-    public class ProjectItemDefinitionInstance : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadataInstance>, ITranslatable
+    public class ProjectItemDefinitionInstance : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadataInstance>, ITranslatable, IItemMetadata
     {
         /// <summary>
         /// Item type, for example "Compile", that this item definition applies to
@@ -235,5 +235,7 @@ namespace Microsoft.Build.Execution
 
             return instance;
         }
+
+        string IItemMetadata.ItemType => _itemType;
     }
 }

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Build.Execution
         ITaskItem2,
         IMetadataTable,
         ITranslatable,
-        IMetadataContainer
+        IMetadataContainer,
+        IItemMetadata
     {
         /// <summary>
         /// The project instance to which this item belongs.
@@ -2125,7 +2126,7 @@ namespace Microsoft.Build.Execution
             /// Also, more importantly, because typically the same regular metadata values can be shared by many items,
             /// and keeping item-specific metadata out of it could allow it to be implemented as a copy-on-write table.
             /// </summary>
-            private class BuiltInMetadataTable : IMetadataTable
+            private class BuiltInMetadataTable : IMetadataTable, IItemMetadata
             {
                 /// <summary>
                 /// Item type
@@ -2183,6 +2184,8 @@ namespace Microsoft.Build.Execution
 
                     return value;
                 }
+
+                string IItemMetadata.ItemType => _itemType;
             }
         }
 

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Execution
         IMetadataTable,
         ITranslatable,
         IMetadataContainer,
-        IItemMetadata
+        IItemTypeDefinition
     {
         /// <summary>
         /// The project instance to which this item belongs.
@@ -2126,7 +2126,7 @@ namespace Microsoft.Build.Execution
             /// Also, more importantly, because typically the same regular metadata values can be shared by many items,
             /// and keeping item-specific metadata out of it could allow it to be implemented as a copy-on-write table.
             /// </summary>
-            private class BuiltInMetadataTable : IMetadataTable, IItemMetadata
+            private class BuiltInMetadataTable : IMetadataTable, IItemTypeDefinition
             {
                 /// <summary>
                 /// Item type
@@ -2185,7 +2185,7 @@ namespace Microsoft.Build.Execution
                     return value;
                 }
 
-                string IItemMetadata.ItemType => _itemType;
+                string IItemTypeDefinition.ItemType => _itemType;
             }
         }
 

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -162,7 +162,7 @@
     <Compile Include="BackEnd\Components\SdkResolution\SdkResolverException.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\TranslationHelpers.cs" />
     <Compile Include="FileSystem\*.cs" />
-    <Compile Include="Evaluation\IItemMetadata.cs" />
+    <Compile Include="Evaluation\IItemTypeDefinition.cs" />
     <Compile Include="Utilities\ReaderWriterLockSlimExtensions.cs" />
     <Compile Include="BackEnd\Node\ConsoleOutput.cs" />
     <Compile Include="BackEnd\Node\PartialBuildTelemetry.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -162,6 +162,7 @@
     <Compile Include="BackEnd\Components\SdkResolution\SdkResolverException.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\TranslationHelpers.cs" />
     <Compile Include="FileSystem\*.cs" />
+    <Compile Include="Evaluation\IItemMetadata.cs" />
     <Compile Include="Utilities\ReaderWriterLockSlimExtensions.cs" />
     <Compile Include="BackEnd\Node\ConsoleOutput.cs" />
     <Compile Include="BackEnd\Node\PartialBuildTelemetry.cs" />

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1983,4 +1983,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="NodeReused" xml:space="preserve">
     <value>Reusing node {0} (PID: {1}).</value>
   </data>
+  <data name="ItemReferencingSelfInTarget" xml:space="preserve">
+    <value>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</value>
+  </data>
 </root>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1984,7 +1984,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>Reusing node {0} (PID: {1}).</value>
   </data>
   <data name="ItemReferencingSelfInTarget" xml:space="preserve">
-    <value>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</value>
+    <value>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</value>
     <comment>{StrBegin="MSB4120: "}</comment>
   </data>
 </root>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1984,6 +1984,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>Reusing node {0} (PID: {1}).</value>
   </data>
   <data name="ItemReferencingSelfInTarget" xml:space="preserve">
-    <value>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</value>
+    <value>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</value>
+    <comment>{StrBegin="MSB4120: "}</comment>
   </data>
 </root>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1984,7 +1984,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>Reusing node {0} (PID: {1}).</value>
   </data>
   <data name="ItemReferencingSelfInTarget" xml:space="preserve">
-    <value>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</value>
+    <value>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</value>
     <comment>{StrBegin="MSB4120: "}</comment>
   </data>
 </root>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -154,6 +154,11 @@
         <target state="translated">Objekty EvaluationContext vytvořené pomocí SharingPolicy.Isolated nepodporují předávání souborového systému MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">Ukončuje se proces s pid = {0}.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -154,6 +154,11 @@
         <target state="translated">Die Übergabe eines MSBuildFileSystemBase-Dateisystems an EvaluationContext-Objekte, die mit "SharingPolicy.Isolated" erstellt wurden, wird nicht unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">Der Prozess mit PID {0} wird beendet.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -154,6 +154,11 @@
         <target state="translated">Los objetos EvaluationContext creados con SharingPolicy.Isolated no admiten que se les pase un sistema de archivos MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">Terminando el proceso con el PID = {0}.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -154,6 +154,11 @@
         <target state="translated">Les objets EvaluationContext créés avec SharingPolicy.Isolated ne prennent pas en charge le passage d'un système de fichiers MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">Arrêt du processus ayant le PID = {0}.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -154,6 +154,11 @@
         <target state="translated">Agli oggetti EvaluationContext creati con SharingPolicy.Isolated non è possibile passare un file system MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">Terminazione del processo con PID = {0}.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -154,6 +154,11 @@
         <target state="translated">SharingPolicy.Isolated を指定して作成された EvaluationContext オブジェクトに MSBuildFileSystemBase ファイル システムを渡すことはサポートされていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">PID = {0} のプロセスを中止しています。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -154,6 +154,11 @@
         <target state="translated">SharingPolicy.Isolated로 만든 EvaluationContext 개체는 MSBuildFileSystemBase 파일 시스템 전달을 지원하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">pid가 {0}인 프로세스를 종료하는 중입니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -154,6 +154,11 @@
         <target state="translated">Obiekty EvaluationContext utworzone za pomocą elementu SharingPolicy.Isolated nie obsługują przekazywania za pomocą systemu plików MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">Kasowanie procesu z identyfikatorem pid = {0}.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -154,6 +154,11 @@
         <target state="translated">Os objetos EvaluationContext criados com SharingPolicy.Isolated não são compatíveis com o recebimento de um sistema de arquivos MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">Encerrando o processo com o PID = {0}.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -154,6 +154,11 @@
         <target state="translated">Объекты EvaluationContext, созданные с помощью SharingPolicy.Isolated, не поддерживают передачу в файловую систему MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">Завершение процесса с идентификатором {0}.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -154,6 +154,11 @@
         <target state="translated">SharingPolicy.Isolated ile oluşturulan EvaluationContext nesneleri bir MSBuildFileSystemBase dosya sisteminin geçirilmesini desteklemez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">PID = {0} işlemi sonlandırılıyor.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -154,6 +154,11 @@
         <target state="translated">使用 SharingPolicy.Isolated 创建的 EvaluationContext 对象不支持通过 MSBuildFileSystemBase 文件系统传递。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">正在终止进程，pid = {0}。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -155,9 +155,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
-        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
-        <note />
+        <source>MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
+        <target state="new">MSB4120: Item '{0}' definition within target is referencing self via metadata '{1}' (qualified or unqualified). This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -155,8 +155,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">
-        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</source>
-        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://learn.microsoft.com/visualstudio/msbuild/msbuild-batching#item-batching-on-self-referencing-metadata</target>
+        <source>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</source>
+        <target state="new">MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</target>
         <note>{StrBegin="MSB4120: "}</note>
       </trans-unit>
       <trans-unit id="KillingProcessWithPid">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -154,6 +154,11 @@
         <target state="translated">使用 SharingPolicy.Isolated 建立的 EvaluationContext 物件不支援以 MSBuildFileSystemBase 檔案系統傳遞。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemReferencingSelfInTarget">
+        <source>&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</source>
+        <target state="new">&lt;TODO: Warn code&gt; Item '{0}' definition within target is referencing self via metadata '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: &lt;TODO: add MS learn link once documented&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KillingProcessWithPid">
         <source>Killing process with pid = {0}.</source>
         <target state="translated">正在終止 pid = {0} 的處理序。</target>


### PR DESCRIPTION
Fixes #8527

### Context
Self referencing item metadata in an item definition within the target leads to possible unintended expansion (and cross-applying of pre-existing item instances).

This behavior is not a bug - it's the implication of the target batching feature - but might be confusing. So detection and warning is added here

### Changes Made
A self reference (qualified or unqualified) of metadata within the item defeiniton (which is within a target) is detected and high importance message is issued.

### Testing
Tests added for a warning case and for a non-warning case (self-referencing metadata outside of target context)

### Doc
https://github.com/MicrosoftDocs/visualstudio-docs-pr/pull/11034

### Possible impact
It's unfortunately hard to obtain data on prevalence of this pattern due to limitations of available code searches (github search doesn't support '@' sign and no escaping option; SourceGraph, grep.app doesn't support regex lookaheads). So I cannot quantify (I'll try again later on).
But there are some sparse evidence of usage:

- https://github.com/JeremyAnsel/JeremyAnsel.HLSL.Targets/blob/master/JeremyAnsel.HLSL.Targets/JeremyAnsel.HLSL.Targets/JeremyAnsel.HLSL.Targets.csproj#L49
- https://github.com/neuecc/MessagePack-CSharp/blob/master/src/MessagePack.MSBuild.Tasks/MessagePack.MSBuild.Tasks.csproj#L35
- https://github.com/dotnet/aspnetcore/blob/main/eng/AfterSigning.targets#L22

all of those seem to be doing something else then intended (the variable part of path is empty, so it gets just the base directory), but they do not break.

**tl;dr;:** ~~unless we are able to better quantify, we might resort to demote the warning to a message~~ Demoted to Message severity