### PR TITLE
Tell bot to only post when a PR is opened or reopened and let it target more servicing branches

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -455,7 +455,6 @@
           "operator": "and",
           "operands": [
             {
-              }
               "operator": "or",
               "operands": [
                 {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -527,6 +527,18 @@
                   "parameters": {
                     "branchName": "vs17.10"
                   }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs16.11"
+                  }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs15.9"
+                  }
                 }
               ]
             }

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -455,10 +455,81 @@
           "operator": "and",
           "operands": [
             {
-              "name": "prTargetsBranch",
-              "parameters": {
-                "branchName": "vs17.4"
               }
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                },
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "reopened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs17.0"
+                  }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs17.2"
+                  }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs17.4"
+                  }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs17.5"
+                  }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs17.6"
+                  }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs17.7"
+                  }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs17.8"
+                  }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs17.9"
+                  }
+                },
+                {
+                  "name": "prTargetsBranch",
+                  "parameters": {
+                    "branchName": "vs17.10"
+                  }
+                }
+              ]
             }
           ]
         },

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -468,6 +468,12 @@
                   "parameters": {
                     "action": "reopened"
                   }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "Servicing-consider"
+                  }
                 }
               ]
             },


### PR DESCRIPTION
This updates the bot that currently posts whenever any action is taken on a PR targeting 17.4 (i.e., opened, closed, reopened, commented on, etc.) to only post when the action is to open or reopen a PR. It also extends the branches for which this takes effect to include a number of vs* branches, including some that don't currently exist.

I think this is the final or penultimate iteration. Specifically, I don't think it will fire if you target main, then retarget to vs* without closing and reopening it...unfortunately, retargeting isn't something fabric bot understands. We can add "label added:Servicing-approved" to the list of options as a proxy. That isn't perfect, but it would make it slightly more robust and slightly noisier. I'm open to doing that or not doing that.