### PR TITLE
Fix app.config not getting updated in output

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2464,7 +2464,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ====================================================================================================
   -->
   <Target Name="GenerateBindingRedirects"
-    Inputs="$(MSBuildAllProjects);@(AppConfigFile);$(ResolveAssemblyReferencesStateFile);$(SuggestedBindingRedirectsCacheFile)"
+    Inputs="$(MSBuildAllProjects);@(AppConfigWithTargetPath);$(ResolveAssemblyReferencesStateFile);$(SuggestedBindingRedirectsCacheFile)"
     Outputs="$(_GenerateBindingRedirectsIntermediateAppConfig)"
     Condition="'$(AutoGenerateBindingRedirects)' == 'true' and '$(GenerateBindingRedirectsOutputType)' == 'true'"
     DependsOnTargets="_GenerateSuggestedBindingRedirectsCache">


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1741178 (https://developercommunity.visualstudio.com/t/Always-copy-appconfig-to-executable-fol/10270579)

### Context
Customer reported that their app.config is not occasionaly getting updated in output folder.
Turns out to be a real issue specific to usage of `AutoGenerateBindingRedirects`.

### Reason
**tl;dr;:** Caused by wrong up-to-date condition on `GenerateBindingRedirects` target

**More details:**
Upon closer investigation, the app config is not getting copied as the up-to-date-check is comparing to the file in obj:

![image](https://user-images.githubusercontent.com/3809076/226918321-1cc5e979-429e-41bb-aa78-1539e0012bf4.png)

It's getting into that location with `GenerateBindingRedirects` - however that was skipped in repro case:

![image](https://user-images.githubusercontent.com/3809076/226919314-0ede4a6d-d1b0-4fe4-8037-819ebcbde9e6.png)

This turns out to be caused by a wrong item specified as input for the target - hence the target was skipped if the change occured only to the app.config


