### PR TITLE
Prefer sln-defined platforms for command-line builds over dynamic platform resolution

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1631,11 +1631,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <UseDefaultPlatformLookupTables Condition="'$(UseDefaultPlatformLookupTables)' == ''">true</UseDefaultPlatformLookupTables>
   </PropertyGroup>
 
-  <!-- This target skips VS builds because they already supply Platform and
-       Configuration information. -->
+  <!-- This target skips sln-based builds because they already supply Platform and
+       Configuration information. See AssignProjectConfiguration -->
   <Target Name="_GetProjectReferencePlatformProperties"
           Condition="'$(EnableDynamicPlatformResolution)' == 'true'
-                     and '$(BuildingInsideVisualStudio)' != 'true'
+                     and '$(CurrentSolutionConfigurationContents)' == ''
                      and '@(_MSBuildProjectReferenceExistent)' != ''">
 
     <!-- Allow preset SetPlatform to override this operation -->


### PR DESCRIPTION
Prefer sln-defined platforms for command-line builds over dynamic platform resolution

Today dynamic platform resolution is inconsistent due to the condition being based on `$(BuildingInsideVisualStudio)`, which is obviously only set in VS. Sln-based command-line builds wouldn't have that set though, so dynamic platform resolution would end up running. The comment on `_GetProjectReferencePlatformProperties` implies that sln-provided platforms should be used instead though, so this change switches the condition to check `$(CurrentSolutionConfigurationContents)` instead to make the experience consistent when building a sln in VS or command-line.