### PR TITLE
Use server in interactive mode only

### DIFF
--- a/src/Build/BackEnd/Client/MSBuildClientExitType.cs
+++ b/src/Build/BackEnd/Client/MSBuildClientExitType.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Build.Experimental
         /// This may happen when mutex that is regulating the server state throws.
         /// See: https://github.com/dotnet/msbuild/issues/7993.
         /// </remarks>
-        UnknownServerState
+        UnknownServerState,
+        /// <summary>
+        /// MSBuild usually has not advantages while used in non-interactive (output redirected) mode.
+        /// This would invoke a fallback behavior.
+        /// </summary>
+        NonInteractive
     }
 }

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -128,6 +128,10 @@ namespace Microsoft.Build.Framework
         /// Name of environment variables used to enable MSBuild server.
         /// </summary>
         public const string UseMSBuildServerEnvVarName = "MSBUILDUSESERVER";
+        /// <summary>
+        /// Name of environment variables used to use MSBuild server even if non interactive mode has been detected.
+        /// </summary>
+        public const string UseMSBuildServerInNonInteractiveEnvVarName = "MSBUILDUSESERVERINNONINTERACTIVE";
 
         public readonly bool DebugEngine = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBuildDebugEngine"));
         public readonly bool DebugScheduler;

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -26,37 +26,6 @@ using Path = System.IO.Path;
 
 namespace Microsoft.Build.Engine.UnitTests
 {
-    public class SleepingTask : Microsoft.Build.Utilities.Task
-    {
-        public int SleepTime { get; set; }
-
-        /// <summary>
-        /// Sleep for SleepTime milliseconds.
-        /// </summary>
-        /// <returns>Success on success.</returns>
-        public override bool Execute()
-        {
-            Thread.Sleep(SleepTime);
-            return !Log.HasLoggedErrors;
-        }
-    }
-
-    public class ProcessIdTask : Microsoft.Build.Utilities.Task
-    {
-        [Output]
-        public int Pid { get; set; }
-
-        /// <summary>
-        /// Log the id for this process.
-        /// </summary>
-        /// <returns></returns>
-        public override bool Execute()
-        {
-            Pid = Process.GetCurrentProcess().Id;
-            return true;
-        }
-    }
-
     public class MSBuildServer_Tests : IDisposable
     {
         private readonly ITestOutputHelper _output;
@@ -83,6 +52,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             _output = output;
             _env = TestEnvironment.Create(_output);
+            _env.SetEnvironmentVariable("MSBUILDUSESERVERINNONINTERACTIVE", "1");
         }
 
         public void Dispose() => _env.Dispose();
@@ -333,6 +303,37 @@ namespace Microsoft.Build.Engine.UnitTests
             Regex regex = new(@$"{toFind}(\d+)");
             Match match = regex.Match(searchString);
             return int.Parse(match.Groups[1].Value);
+        }
+    }
+
+    public class SleepingTask : Microsoft.Build.Utilities.Task
+    {
+        public int SleepTime { get; set; }
+
+        /// <summary>
+        /// Sleep for SleepTime milliseconds.
+        /// </summary>
+        /// <returns>Success on success.</returns>
+        public override bool Execute()
+        {
+            Thread.Sleep(SleepTime);
+            return !Log.HasLoggedErrors;
+        }
+    }
+
+    public class ProcessIdTask : Microsoft.Build.Utilities.Task
+    {
+        [Output]
+        public int Pid { get; set; }
+
+        /// <summary>
+        /// Log the id for this process.
+        /// </summary>
+        /// <returns></returns>
+        public override bool Execute()
+        {
+            Pid = Process.GetCurrentProcess().Id;
+            return true;
         }
     }
 }


### PR DESCRIPTION
Addresses https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1676390

### Context
It has been decided that MSBuild server will be used only in interactive mode, i.e. when output of CLI is console, and user is expecting to be in inner dev loop. 
So for example in CI/CD pipelines it will not be used as it does bring advantages only in short repeat builds loops.

### Changes Made
We consider it as non interactive mode when output is redirected.

### Testing
Local, and unit tests...

### Notes
Will need another PR on SDK, once this one is merged
