### PR TITLE
Demote WriteLinesToFile warning to message

### DIFF
--- a/src/Tasks.UnitTests/WriteLinesToFile_Tests.cs
+++ b/src/Tasks.UnitTests/WriteLinesToFile_Tests.cs
@@ -154,6 +154,28 @@ namespace Microsoft.Build.Tasks.UnitTests
             }
         }
 
+        [Fact]
+        public void RedundantParametersAreLogged()
+        {
+            using TestEnvironment testEnv = TestEnvironment.Create(_output);
+
+            MockEngine engine = new(_output);
+
+            string file = testEnv.ExpectFile().Path;
+
+            WriteLinesToFile task = new()
+            {
+                BuildEngine = engine,
+                File = new TaskItem(file),
+                Lines = new ITaskItem[] { new TaskItem($"{nameof(RedundantParametersAreLogged)} Test") },
+                WriteOnlyWhenDifferent = true,
+                Overwrite = false,
+            };
+
+            task.Execute().ShouldBeTrue();
+            engine.AssertLogContainsMessageFromResource(AssemblyResources.GetString, "WriteLinesToFile.UnusedWriteOnlyWhenDifferent", file);
+        }
+
         /// <summary>
         /// Should create directory structure when target <see cref="WriteLinesToFile.File"/> does not exist.
         /// </summary>

--- a/src/Tasks/FileIO/WriteLinesToFile.cs
+++ b/src/Tasks/FileIO/WriteLinesToFile.cs
@@ -122,9 +122,9 @@ namespace Microsoft.Build.Tasks
                     }
                     else
                     {
-                        if (WriteOnlyWhenDifferent && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_6))
+                        if (WriteOnlyWhenDifferent)
                         {
-                            Log.LogWarningWithCodeFromResources("WriteLinesToFile.UnusedWriteOnlyWhenDifferent", File.ItemSpec);
+                            Log.LogMessageFromResources(MessageImportance.Normal, "WriteLinesToFile.UnusedWriteOnlyWhenDifferent", File.ItemSpec);
                         }
                         Directory.CreateDirectory(directoryPath);
                         System.IO.File.AppendAllText(File.ItemSpec, buffer.ToString(), encoding);


### PR DESCRIPTION
The WPF repo and another Microsoft internal repo both reported problems
with the warning added in #8371. Since new warnings can be breaking
changes, demote the warning to a message.

Fixes #8605.
