### PR TITLE
[LiveLogger] Only show indicators for projects where relevant

### DIFF
--- a/src/MSBuild/LiveLogger/ProjectNode.cs
+++ b/src/MSBuild/LiveLogger/ProjectNode.cs
@@ -88,10 +88,29 @@ namespace Microsoft.Build.Logging.LiveLogger
             }
 
             ShouldRerender = false;
+
             // Summary (messages, warnings and errors)
-            string lineSummary = MessageCount + WarningCount + ErrorCount > 0 ? $"({MessageCount} ℹ️, {WarningCount} ⚠️, {ErrorCount} ❌)" : string.Empty;
+            List<string> lineSummaryList = new();
+            if (MessageCount > 0)
+            {
+                lineSummaryList.Add($"{MessageCount} ℹ️");
+            }
+
+            if (WarningCount > 0)
+            {
+                lineSummaryList.Add($"{WarningCount} ⚠️");
+            }
+
+            if (ErrorCount > 0)
+            {
+                lineSummaryList.Add($"{ErrorCount} ❌");
+            }
+
+            string lineSummary = lineSummaryList.Count > 0 ? "(" + string.Join(", ", lineSummaryList) + ")" : string.Empty;
+
             // Project details
             string lineContents = ANSIBuilder.Alignment.SpaceBetween(ToANSIString(), lineSummary, Console.BufferWidth - 1);
+
             // Create or update line
             if (Line is null)
             {

--- a/src/MSBuild/LiveLogger/ProjectNode.cs
+++ b/src/MSBuild/LiveLogger/ProjectNode.cs
@@ -88,8 +88,10 @@ namespace Microsoft.Build.Logging.LiveLogger
             }
 
             ShouldRerender = false;
+            // Summary (messages, warnings and errors)
+            string lineSummary = MessageCount + WarningCount + ErrorCount > 0 ? $"({MessageCount} ℹ️, {WarningCount} ⚠️, {ErrorCount} ❌)" : string.Empty;
             // Project details
-            string lineContents = ANSIBuilder.Alignment.SpaceBetween(ToANSIString(), $"({MessageCount} ℹ️, {WarningCount} ⚠️, {ErrorCount} ❌)", Console.BufferWidth - 1);
+            string lineContents = ANSIBuilder.Alignment.SpaceBetween(ToANSIString(), lineSummary, Console.BufferWidth - 1);
             // Create or update line
             if (Line is null)
             {


### PR DESCRIPTION
Fixes #8456

### Context
For each project, details regarding amount of messages, warnings and errors are shown. However, this information must be hidden where it is not relevant.

### Changes Made
Add the <number> ℹ️, <number> ⚠️, <number> ❌ output only when <number> is >0 (for each of the three).

### Testing
Manual testing

### Notes
