### PR TITLE
Add needs-triage to feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/06_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/06_feature_request.yml
@@ -1,7 +1,7 @@
 name: 💡 Feature  Request
 description: Suggest an idea for this project.
 title: "[Feature Request]: "
-labels: ["Feature Request"]
+labels: ["Feature Request", "needs-triage"]
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
We need to look at feature requests and approve them or reject them as appropriate. This adds a label to ensure we notice it as part of our triage process.

Fixes #

### Context


### Changes Made
Added a label

### Testing


### Notes
