### PR TITLE
Eliminate redundant items from _ReferencesFromRAR

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2808,7 +2808,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- We need to do this here because we only want references which have been passed into rar but are not project to project references. -->
     <ItemGroup>
-      <_ReferencesFromRAR Include="@(ReferencePath->WithMetadataValue('ReferenceSourceTarget', 'ResolveAssemblyReference'))"/>
+      <_ReferencesFromRAR Condition="$([MSBuild]::AreFeaturesEnabled('17.8'))" Include="@(ReferencePath->WithMetadataValue('ReferenceSourceTarget', 'ResolveAssemblyReference'))" Exclude="@(ReferencePath->HasMetadata('FrameworkReferenceName'))" />
+      <_ReferencesFromRAR Condition="!$([MSBuild]::AreFeaturesEnabled('17.8'))" Include="@(ReferencePath->WithMetadataValue('ReferenceSourceTarget', 'ResolveAssemblyReference'))" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
This come from ResolveAssemblyReferencesDesignTime, which is primarily used by the ProjectSystem, but the ProjectSystem does not actually use references from PackageReferences or FrameworkReferences, so it is just a waste of resources to include them.

Fixes #8623

### Context


### Changes Made


### Testing


### Notes
