### PR TITLE
Change IDE0055 (Fix Formatting) warning->message

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -295,6 +295,9 @@ dotnet_diagnostic.IDE0049.severity = suggestion
 # Use compound assignment
 dotnet_diagnostic.IDE0054.severity = suggestion
 
+# Fix formatting
+dotnet_diagnostic.IDE0055.severity = suggestion
+
 # Indexing can be simplified
 dotnet_diagnostic.IDE0056.severity = suggestion
 


### PR DESCRIPTION
Fixes #8618

### Context
IDE0055 is currently too unspecific - opting out of it.

### Sample error:

```
C:\src\msbuild\src\Build.UnitTests\BackEnd\MSBuild_Tests.cs(796,59): error IDE0055: Fix formatting [C:\src\msbuild\src\Buil
d.UnitTests\Microsoft.Build.Engine.UnitTests.csproj::TargetFramework=net472]
```

(changed to message and not blocking the build after this change)