### PR TITLE
Fix flaky test  CanShutdownServerProcess

### DIFF
--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -265,9 +265,10 @@ namespace Microsoft.Build.Experimental
                 return true;
             }
 
-            // Check that server is not busy.
-            bool serverWasBusy = ServerWasBusy();
-            if (serverWasBusy)
+            // Check and wait for server to be not busy for some short time to avoid race condition when server reports build is finished but had not released ServerBusy mutex yet.
+            // If during that short time, a script would try to shutdown server, it would be rejected and server would continue to run.
+            bool serverIsBusy = ServerIsBusyWithWaitAndRetry(250);
+            if (serverIsBusy)
             {
                 CommunicationsUtilities.Trace("Server cannot be shut down for it is not idle.");
                 return false;
@@ -289,6 +290,20 @@ namespace Microsoft.Build.Experimental
             ReadPacketsLoop(cancellationToken);
 
             return _exitResult.MSBuildClientExitType == MSBuildClientExitType.Success;
+        }
+
+        private bool ServerIsBusyWithWaitAndRetry(int milliseconds)
+        {
+            bool isBusy = ServerWasBusy();
+            Stopwatch sw = Stopwatch.StartNew();
+            while (isBusy && sw.Elapsed < TimeSpan.FromMilliseconds(milliseconds))
+            {
+                CommunicationsUtilities.Trace("Wait for server to be not busy - will retry soon...");
+                Thread.Sleep(100);
+                isBusy = ServerWasBusy();
+            }
+
+            return isBusy;
         }
 
         internal bool ServerIsRunning()

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Build.Experimental
         {
             bool isBusy = ServerWasBusy();
             Stopwatch sw = Stopwatch.StartNew();
-            while (isBusy && sw.Elapsed < TimeSpan.FromMilliseconds(milliseconds))
+            while (isBusy && sw.ElapsedMilliseconds < milliseconds)
             {
                 CommunicationsUtilities.Trace("Wait for server to be not busy - will retry soon...");
                 Thread.Sleep(100);

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -221,10 +221,6 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             _env.SetEnvironmentVariable("MSBUILDUSESERVER", "1");
 
-            // This test seems to be flaky, lets enable better logging to investigate it next time
-            // TODO: delete after investigated its flakiness
-            _env.WithTransientDebugEngineForNewProcesses(true);
-
             TransientTestFile project = _env.CreateFile("testProject.proj", printPidContents);
 
             // Start a server node and find its PID.


### PR DESCRIPTION
Fixes #8631

### Context
We have got him!
There was eluding low freq flaky test. It was caused by race condition between finishing build server client and server releasing its `I am busy` mutex.

### Changes Made
Wait and retry when it was detected busy for 500 ms.
Clean additional logging from test.

### Testing
Local, PR
