### PR TITLE
Avoid overly-specific cast in bulk metadata copy

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.6.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.6.1</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.5.0</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1391,8 +1391,8 @@ namespace Microsoft.Build.BackEnd
                                     newItem = new ProjectItemInstance(_projectInstance, outputTargetName, EscapingUtilities.Escape(output.ItemSpec), parameterLocationEscaped);
 
                                     newItem.SetMetadataOnTaskOutput(output.CloneCustomMetadata()
-                                        .Cast<KeyValuePair<string, string>>()
-                                        .Select(x => new KeyValuePair<string, string>(x.Key, EscapingUtilities.Escape(x.Value))));
+                                        .Cast<DictionaryEntry>()
+                                        .Select(x => new KeyValuePair<string, string>((string)x.Key, EscapingUtilities.Escape((string)x.Value))));
                                 }
                             }
 


### PR DESCRIPTION
### Summary

Projects that have tasks that run in the .NET Framework 3.5 environment that return metadata are unusable in MSBuild 17.6.0.

The return value of `ITaskItem.CloneCustomMetadata` is an `IDictionary`, which is generally (in modern MSBuild) backed by a `Dictionary<string, string>`, but can be (when given an item from a net35 taskhost) a `Hashtable`. In the latter situation, casting entries to `KeyValuePair<,>` fails, because they conform only to `DictionaryEntry`.

Use that less-well-typed approach--the casts were present in the pre-bulk-edit version of the code. Fixes #8645.

Work item (Internal use): [AB#1790945](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1790945)

### Customer Impact

Microsoft-internal customer reported breaks in projects that use WiX3.

### Regression?

Yes, from #8240.

### Testing

Manual validation of the sample project from customer.

### Risk

Low (fixes cast to match guaranteed behavior and uses only preexisting casts). But we could also revert #8240 entirely.
