### PR TITLE
Update NuGet packages to 6.5.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,7 +52,7 @@
     <MicrosoftExtensionsDependencyModelVersion>7.0.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftIORedistVersion>6.0.0</MicrosoftIORedistVersion>
     <MicrosoftNetCompilersToolsetVersion>4.6.0-2.23171.5</MicrosoftNetCompilersToolsetVersion>
-    <NuGetBuildTasksVersion>6.5.0-rc.149</NuGetBuildTasksVersion>
+    <NuGetBuildTasksVersion>6.5.0</NuGetBuildTasksVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemTextJsonVersion>7.0.0</SystemTextJsonVersion>
     <SystemThreadingTasksDataflowVersion>7.0.0</SystemThreadingTasksDataflowVersion>


### PR DESCRIPTION
This is a fairly low-pri but low-risk change. It updates from the RC packages to the GA ones.

The packages this applies to and their usages are:
* `Microsoft.Build.NuGetSdkResolver` is used by `MSBuild.csproj` and the bootstrap. For `MSBuild.csproj` only grabs an XML file from it (which points to the `Microsoft.Build.NuGetSdkResolver.dll` binary "2 directories up"; the actual binary ships separately), and is identical to the previous version.
* `NuGet.Build.Tasks` (and `NuGet.Build.Tasks.Console` once #8488 is merged) are only used in bootstrapping.
* `NuGet.Frameworks` is only used in UTs (`Microsoft.Build.Engine.UnitTests.csproj`)