### PR TITLE
Remove unreachable and unused overload methods from IntrinsicFunctions

### DIFF
--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -46,25 +46,9 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Add two longs
-        /// </summary>
-        internal static long Add(long a, long b)
-        {
-            return a + b;
-        }
-
-        /// <summary>
         /// Subtract two doubles
         /// </summary>
         internal static double Subtract(double a, double b)
-        {
-            return a - b;
-        }
-
-        /// <summary>
-        /// Subtract two longs
-        /// </summary>
-        internal static long Subtract(long a, long b)
         {
             return a - b;
         }
@@ -78,14 +62,6 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Multiply two longs
-        /// </summary>
-        internal static long Multiply(long a, long b)
-        {
-            return a * b;
-        }
-
-        /// <summary>
         /// Divide two doubles
         /// </summary>
         internal static double Divide(double a, double b)
@@ -94,25 +70,9 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Divide two longs
-        /// </summary>
-        internal static long Divide(long a, long b)
-        {
-            return a / b;
-        }
-
-        /// <summary>
         /// Modulo two doubles
         /// </summary>
         internal static double Modulo(double a, double b)
-        {
-            return a % b;
-        }
-
-        /// <summary>
-        /// Modulo two longs
-        /// </summary>
-        internal static long Modulo(long a, long b)
         {
             return a % b;
         }


### PR DESCRIPTION
Fixes # (issue to be created)

### Context
This is a change that was split out from PR #8569 at the [request](https://github.com/dotnet/msbuild/pull/8569#issuecomment-1485811063) of @rainersigwald.

The change removes type overload methods from `IntrinsicFunctions` that are unreachable via evaluation and that are unused within the repo.

This is cleanup that could support a future effort to add source generation for the 'fast path' lookup.

### Changes Made
Remove `long` variants of `Add`, `Subtract`, `Multiply`, `Divide`, and `Modulo`. Evaluation will always use the `double` variants.

### Testing
Built and ran unit tests on Windows 11 and macOS 12.

### Notes
