### PR TITLE
Add diagnostics to symlink embedding unittest

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -262,7 +262,8 @@ namespace Microsoft.Build.UnitTests
 
             // Can't just compare `Name` because `ZipArchive` does not handle unix directory separators well
             // thus producing garbled fully qualified paths in the actual .ProjectImports.zip entries
-            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"),
+                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
         }
 
         [RequiresSymbolicLinksFact]
@@ -321,10 +322,14 @@ namespace Microsoft.Build.UnitTests
 
             // Can't just compare `Name` because `ZipArchive` does not handle unix directory separators well
             // thus producing garbled fully qualified paths in the actual .ProjectImports.zip entries
-            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"));
-            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkName));
-            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkLvl2Name));
-            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(emptyFileName));
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"),
+                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkName),
+                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkLvl2Name),
+                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
+            zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(emptyFileName),
+                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
         }
 
         [Fact]

--- a/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
+++ b/src/UnitTests.Shared/RequiresSymbolicLinksFactAttribute.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.UnitTests
             // In Windows, a process can create symlinks only if it has sufficient permissions.
             // We simply try to create one and if it fails we skip the test.
             string sourceFile = FileUtilities.GetTemporaryFile();
-            string destinationFile = FileUtilities.GetTemporaryFile();
+            string destinationFile = FileUtilities.GetTemporaryFileName();
             try
             {
                 File.Create(sourceFile).Dispose();


### PR DESCRIPTION
Relates to https://github.com/dotnet/msbuild/issues/8643

### Context
Adding diagnostics to flaky test - to have more data on future repro
(logging the actual list of embedded files)