### PR TITLE
NoProfile in ToolTaskThatTimeoutAndRetry test

### DIFF
--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -846,10 +846,12 @@ namespace Microsoft.Build.UnitTests
         {
             using var env = TestEnvironment.Create(_output);
 
+            MockEngine engine = new();
+
             // Task under test:
             var task = new ToolTaskThatSleeps
             {
-                BuildEngine = new MockEngine(),
+                BuildEngine = engine,
                 InitialDelay = initialDelay,
                 FollowupDelay = followupDelay,
                 Timeout = timeout
@@ -861,6 +863,9 @@ namespace Microsoft.Build.UnitTests
             {
                 // Execute the task:
                 result = task.Execute();
+
+                _output.WriteLine(engine.Log);
+
                 task.RepeatCount.ShouldBe(i);
 
                 // The first execution may fail (timeout), but all following ones should succeed:
@@ -882,7 +887,7 @@ namespace Microsoft.Build.UnitTests
         private sealed class ToolTaskThatSleeps : ToolTask
         {
             // PowerShell command to sleep:
-            private readonly string _powerShellSleep = "-ExecutionPolicy RemoteSigned -Command \"Start-Sleep -Milliseconds {0}\"";
+            private readonly string _powerShellSleep = "-NoProfile -ExecutionPolicy RemoteSigned -Command \"Start-Sleep -Milliseconds {0}\"";
 
             // UNIX command to sleep:
             private readonly string _unixSleep = "-c \"sleep {0}\"";


### PR DESCRIPTION
This failed for me in an unrelated PR and on my dev box and at least on my dev box it was because sometimes my PowerShell profile took longer than 1 second to process.

Pass -NoProfile to avoid that time entirely when it's not necessary.

In addition, save the engine's log to the test log to give some clues if the test fails again.
