### PR TITLE
GetReferenceAssemblyPaths continues on error in design-time builds

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1232,7 +1232,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         RootPath="$(TargetFrameworkRootPath)"
         TargetFrameworkFallbackSearchPaths="$(TargetFrameworkFallbackSearchPaths)"
         BypassFrameworkInstallChecks="$(BypassFrameworkInstallChecks)"
-        >
+        ContinueOnError="!$(BuildingProject)">
       <Output TaskParameter="ReferenceAssemblyPaths" PropertyName="_TargetFrameworkDirectories"/>
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="_FullFrameworkReferenceAssemblyPaths"/>
       <Output TaskParameter="TargetFrameworkMonikerDisplayName" PropertyName="TargetFrameworkMonikerDisplayName" Condition="'$(TargetFrameworkMonikerDisplayName)' == ''"/>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/issues/19506

This fixes an issue where VS design-time builds would fail when reference assemblies could not be found.

By allowing the design-time build to continue, the .NET Project System will the nominate a restore which may bring in a package that provides those reference assemblies.

Without this addition, the task will fail and the build will end early, such that the restore does not occur and progress is not made.

This helps when users do not have targeting packs installed (such as for out-of-support versions of .NET Framework, like v4.5). With this change, a reference assembly package (like `Microsoft.NETFramework.ReferenceAssemblies.net45`) may be downloaded for the user to compile against.

Tested locally. See discussion in linked issue for further details.