### PR TITLE
Add tsa config file to enable validation pipeline

### DIFF
--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -7,4 +7,5 @@
 -TsaIterationPath DevDiv
 -TsaRepositoryName DotNet-msbuild-Trusted
 -TsaCodebaseName DotNet-msbuild-Trusted
+-TsaOnboard $True
 -TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -1,0 +1,10 @@
+-SourceToolsList @("policheck","credscan")
+-TsaInstanceURL https://devdiv.visualstudio.com/
+-TsaProjectName DEVDIV
+-TsaNotificationEmail dotnetdevexcli@microsoft.com
+-TsaCodebaseAdmin REDMOND\marcpop
+-TsaBugAreaPath "DevDiv\NET Tools\MSBuild"
+-TsaIterationPath DevDiv
+-TsaRepositoryName DotNet-msbuild-Trusted
+-TsaCodebaseName DotNet-msbuild-Trusted
+-TsaPublish $True


### PR DESCRIPTION
### Context
MSBuild had been added to the code validation pipeline but was missing the tsa config file. Per the instructions [here](https://github.com/dotnet/arcade/blob/36ac84d30381886c6bad6cd55c28771dcc4c0880/Documentation/Validation.md?plain=1#L40-L47) and after talking to Matt, adding this file

### Changes Made
Added a tsa config file by copying from SDK

### Testing
Not sure how to test this. I pushed an internal build but the checks didn't run as I'm told they run nightly in a separate pipeline.

### Notes
Validation pipeline: https://dev.azure.com/dnceng/internal/_build/results?buildId=2157183&view=results