### PR TITLE
Update sdk version to bump pulled runtime

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "7.0.200",
+    "dotnet": "7.0.203",
     "vs": {
       "version": "17.4.1"
     },


### PR DESCRIPTION
Fixes CVE-2023-28260

### Context
We need runtime 7.0.3 -> 7.0.5 bump, this comes with [SDK 7.0.203](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
