### PR TITLE
Enable prebuilt detection

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -2,9 +2,32 @@
   <IgnorePatterns>
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
 
-    <!-- This package targets net6.0. We don't have any net6.0 SBRPs in the 7.0 SBRP branch
-         at this point. Since msbuild is moving to 8.0 in the mid-term, and main does have this
-         SBRP, baseline. -->
+    <!-- These dependencies are a result of building for netframework TFMs. These are filtered out 
+         in full source-build, and would be filtered out if msbuild was using an 8.0 arcade + 8.0 SDK -->
+         <UsagePattern IdentityGlob="Microsoft.NETFramework.ReferenceAssemblies/*1.0.3*" />
+         <UsagePattern IdentityGlob="Microsoft.NETFramework.ReferenceAssemblies.net472/*1.0.3*" />
+
+    <!-- Baseline 7.0 dependencies until msbuild targets net8 and uses a net8 arcade, SBRP, etc.
+         These cannot be added to 7.0 SBRP, because they would are produced in the 7.0 build. -->
+    <UsagePattern IdentityGlob="Microsoft.Bcl.AsyncInterfaces/*7.0.0*" />
+    <UsagePattern IdentityGlob="Microsoft.Win32.SystemEvents/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.CodeDom/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Collections.Immutable/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Diagnostics.EventLog/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Drawing.Common/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Formats.Asn1/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Reflection.Metadata/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Resources.Extensions/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*7.0.1*" />
+    <UsagePattern IdentityGlob="System.Security.Permissions/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Text.Encoding.CodePages/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Text.Encodings.Web/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Text.Json/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*7.0.0*" />
     <UsagePattern IdentityGlob="System.Windows.Extensions/*7.0.0*" />
 
     <!-- Baseline sourcelink packages until https://github.com/dotnet/arcade/pull/13204 is merged and
@@ -14,9 +37,5 @@
     <UsagePattern IdentityGlob="Microsoft.SourceLink.Common/*1.1.0-beta-20206-02*" />
     <UsagePattern IdentityGlob="Microsoft.SourceLink.GitHub/*1.1.0-beta-20206-02*" />
 
-    <!-- These dependencies are a result of building for netframework TFMs. These are filtered out 
-         in full source-build, and would be filtered out if msbuild was using an 8.0 arcade + 8.0 SDK -->
-    <UsagePattern IdentityGlob="Microsoft.NETFramework.ReferenceAssemblies/*1.0.3*" />
-    <UsagePattern IdentityGlob="Microsoft.NETFramework.ReferenceAssemblies.net472/*1.0.3*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,5 +1,22 @@
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="*/*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
+
+    <!-- This package targets net6.0. We don't have any net6.0 SBRPs in the 7.0 SBRP branch
+         at this point. Since msbuild is moving to 8.0 in the mid-term, and main does have this
+         SBRP, baseline. -->
+    <UsagePattern IdentityGlob="System.Windows.Extensions/*7.0.0*" />
+
+    <!-- Baseline sourcelink packages until https://github.com/dotnet/arcade/pull/13204 is merged and
+         flowed to this repo -->
+    <UsagePattern IdentityGlob="Microsoft.Build.Tasks.Git/*1.1.0-beta-20206-02*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceLink.AzureRepos.Git/*1.1.0-beta-20206-02*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceLink.Common/*1.1.0-beta-20206-02*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceLink.GitHub/*1.1.0-beta-20206-02*" />
+
+    <!-- These dependencies are a result of building for netframework TFMs. These are filtered out 
+         in full source-build, and would be filtered out if msbuild was using an 8.0 arcade + 8.0 SDK -->
+    <UsagePattern IdentityGlob="Microsoft.NETFramework.ReferenceAssemblies/*1.0.3*" />
+    <UsagePattern IdentityGlob="Microsoft.NETFramework.ReferenceAssemblies.net472/*1.0.3*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.23218.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.23219.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>bc3b13c2f1669420679123c23b87e2d616c5a5d6</Sha>
+      <Sha>525b6c35cc5c5c9b80b47044be2e4e77858d505a</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,10 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
+  <ProductDependencies>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.23218.1">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>bc3b13c2f1669420679123c23b87e2d616c5a5d6</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
+  </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.23167.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>92c39a4f0bacef20812f63e2e1d3f7aa8776038d</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21480-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>8031e5220baf2acad991e661d8308b783d2acf3e</Sha>
+      <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21431.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/xliff-tasks</Uri>
+      <Sha>bc3233146e1fcd393ed471d5005333c83363e0fe</Sha>
+      <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="6.5.0-rc.149">
       <Uri>https://github.com/nuget/nuget.client</Uri>
@@ -13,6 +30,7 @@
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.6.0-2.23171.5">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>48b13597fee9df5ecfbd0b8c0758b3f46bc1d440</Sha>
+      <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.23167.1">
       <Uri>https://github.com/dotnet/arcade</Uri>


### PR DESCRIPTION
- Baseline a few dependencies until msbuild targets net8.0, or an arcade fix comes in
- Add SBRP dependencies (with subscription) and source build tags