### PR TITLE
ItemSpec: Do not call MatchCount when count is not needed

### DIFF
--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Build.Evaluation
 
             public override int MatchCount(string itemToMatch)
             {
-                return ReferencedItems.Count(v => v.ItemAsValueFragment.MatchCount(itemToMatch) > 0);
+                return ReferencedItems.Count(v => v.ItemAsValueFragment.IsMatch(itemToMatch));
             }
 
             public override bool IsMatch(string itemToMatch)


### PR DESCRIPTION
Relates to https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1728887/

### Context
ItemSpecFragment.MatchCount result is thrown away when called from ItemExpressionFragment.MatchCount (it just needs to get info about existing match).

The mentioned codepath is on the stack of the detected UI delay. While it might not be the rootcause, it doesn't hurt to improve this behavior.

Thanks @davkean for specific suggestions pointers during ivestigation 
