### PR TITLE
[LiveLogger ] Localize strings

### DIFF
--- a/src/MSBuild.UnitTests/MockTerminal.cs
+++ b/src/MSBuild.UnitTests/MockTerminal.cs
@@ -99,6 +99,8 @@ namespace Microsoft.Build.UnitTests
         public void Write(ReadOnlySpan<char> text) { AddOutput(text.ToString()); }
         public void WriteColor(TerminalColor color, string text) => AddOutput(text);
         public void WriteColorLine(TerminalColor color, string text) { AddOutput(text); AddOutput("\n"); }
+        public string RenderColor(TerminalColor color, string text) => text;
+
         public void WriteLine(string text) { AddOutput(text); AddOutput("\n"); }
         public void WriteLineFitToWidth(ReadOnlySpan<char> text)
         {

--- a/src/MSBuild/LiveLogger/ITerminal.cs
+++ b/src/MSBuild/LiveLogger/ITerminal.cs
@@ -63,6 +63,11 @@ internal interface ITerminal : IDisposable
     /// Writes a string to the output using the given color. Or buffers it if <see cref="BeginUpdate"/> was called.
     /// </summary>
     void WriteColorLine(TerminalColor color, string text);
+
+    /// <summary>
+    /// Return string representing text wrapped in VT100 color codes.
+    /// </summary>
+    string RenderColor(TerminalColor color, string text);
 }
 
 /// <summary>

--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -732,15 +732,15 @@ internal sealed class LiveLogger : INodeLogger
             // If the build failed, we print one of three red strings.
             string text = (hasError, hasWarning) switch
             {
-                (true, _) => ResourceUtilities.GetResourceString("BuildResult_FailedWithError"),
-                (false, true) => ResourceUtilities.GetResourceString("BuildResult_FailedWithWarn"),
+                (true, _) => ResourceUtilities.GetResourceString("BuildResult_FailedWithErrors"),
+                (false, true) => ResourceUtilities.GetResourceString("BuildResult_FailedWithWarnings"),
                 _ => ResourceUtilities.GetResourceString("BuildResult_Failed"),
             };
             return Terminal.RenderColor(TerminalColor.Red, text);
         }
         else if (hasWarning)
         {
-            return Terminal.RenderColor(TerminalColor.Yellow, ResourceUtilities.GetResourceString("BuildResult_SucceededWithWarn"));
+            return Terminal.RenderColor(TerminalColor.Yellow, ResourceUtilities.GetResourceString("BuildResult_SucceededWithWarnings"));
         }
         else
         {

--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -42,9 +42,20 @@ internal sealed class LiveLogger : INodeLogger
     {
         public override string ToString()
         {
+            string duration = Stopwatch.Elapsed.TotalSeconds.ToString("F1");
+
             return string.IsNullOrEmpty(TargetFramework)
-                ? $"{Indentation}{Project} {Target} ({Stopwatch.Elapsed.TotalSeconds:F1}s)"
-                : $"{Indentation}{Project} [{TargetFramework}] {Target} ({Stopwatch.Elapsed.TotalSeconds:F1}s)";
+                ? ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectBuilding_NoTF",
+                    Indentation,
+                    Project,
+                    Target,
+                    duration)
+                : ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectBuilding_WithTF",
+                    Indentation,
+                    Project,
+                    TargetFramework,
+                    Target,
+                    duration);
         }
     }
 
@@ -217,14 +228,12 @@ internal sealed class LiveLogger : INodeLogger
         Terminal.BeginUpdate();
         try
         {
+            double duration = (e.Timestamp - _buildStartTime).TotalSeconds;
 
             Terminal.WriteLine("");
-            Terminal.Write("Build ");
-
-            PrintBuildResult(e.Succeeded, _buildHasErrors, _buildHasWarnings);
-
-            double duration = (e.Timestamp - _buildStartTime).TotalSeconds;
-            Terminal.WriteLine($" in {duration:F1}s");
+            Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("BuildFinished",
+                RenderBuildResult(e.Succeeded, _buildHasErrors, _buildHasWarnings),
+                duration.ToString("F1")));
         }
         finally
         {
@@ -301,7 +310,8 @@ internal sealed class LiveLogger : INodeLogger
                 try
                 {
                     EraseNodes();
-                    Terminal.WriteLine($"Restore complete ({duration:F1}s)");
+                    Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreComplete",
+                        duration.ToString("F1")));
                     DisplayNodes();
                 }
                 finally
@@ -322,30 +332,36 @@ internal sealed class LiveLogger : INodeLogger
                 {
                     EraseNodes();
 
-                    double duration = project.Stopwatch.Elapsed.TotalSeconds;
+                    string duration = project.Stopwatch.Elapsed.TotalSeconds.ToString("F1");
                     ReadOnlyMemory<char>? outputPath = project.OutputPath;
 
-                    Terminal.Write(Indentation);
+                    string projectFile = e.ProjectFile is not null ?
+                        Path.GetFileNameWithoutExtension(e.ProjectFile) :
+                        string.Empty;
 
-                    if (e.ProjectFile is not null)
-                    {
-                        ReadOnlySpan<char> projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile.AsSpan());
-                        Terminal.Write(projectFile);
-                        Terminal.Write(" ");
-                    }
-                    if (!string.IsNullOrEmpty(project.TargetFramework))
-                    {
-                        Terminal.Write($"[{project.TargetFramework}] ");
-                    }
-
-                    // Print 'failed', 'succeeded with warnings', or 'succeeded' depending on the build result and diagnostic messages
+                    // Build result. One of 'failed', 'succeeded with warnings', or 'succeeded' depending on the build result and diagnostic messages
                     // reported during build.
                     bool haveErrors = project.BuildMessages?.Exists(m => m.Severity == MessageSeverity.Error) == true;
                     bool haveWarnings = project.BuildMessages?.Exists(m => m.Severity == MessageSeverity.Warning) == true;
-                    PrintBuildResult(e.Succeeded, haveErrors, haveWarnings);
+                    string buildResult = RenderBuildResult(e.Succeeded, haveErrors, haveWarnings);
 
-                    _buildHasErrors |= haveErrors;
-                    _buildHasWarnings |= haveWarnings;
+                    if (string.IsNullOrEmpty(project.TargetFramework))
+                    {
+                        Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_NoTF",
+                            Indentation,
+                            projectFile,
+                            buildResult,
+                            duration));
+                    }
+                    else
+                    {
+                        Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
+                            Indentation,
+                            projectFile,
+                            project.TargetFramework,
+                            buildResult,
+                            duration));
+                    }
 
                     // Print the output path as a link if we have it.
                     if (outputPath is not null)
@@ -360,15 +376,13 @@ internal sealed class LiveLogger : INodeLogger
                         {
                             // Ignore any GetDirectoryName exceptions.
                         }
-#if NETCOREAPP
-                        Terminal.WriteLine($" ({duration:F1}s) → {AnsiCodes.LinkPrefix}{url}{AnsiCodes.LinkInfix}{outputPath}{AnsiCodes.LinkSuffix}");
-#else
-                        Terminal.WriteLine($" ({duration:F1}s) → {AnsiCodes.LinkPrefix}{url.ToString()}{AnsiCodes.LinkInfix}{outputPath.ToString()}{AnsiCodes.LinkSuffix}");
-#endif
+
+                        Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath",
+                            $"{AnsiCodes.LinkPrefix}{url.ToString()}{AnsiCodes.LinkInfix}{outputPath}{AnsiCodes.LinkSuffix}"));
                     }
                     else
                     {
-                        Terminal.WriteLine($" ({duration:F1}s)");
+                        Terminal.WriteLine(string.Empty);
                     }
 
                     // Print diagnostic output under the Project -> Output line.
@@ -385,6 +399,9 @@ internal sealed class LiveLogger : INodeLogger
                             Terminal.WriteColorLine(color, $"{Indentation}{Indentation}{buildMessage.Message}");
                         }
                     }
+
+                    _buildHasErrors |= haveErrors;
+                    _buildHasWarnings |= haveWarnings;
 
                     DisplayNodes();
                 }
@@ -708,26 +725,26 @@ internal sealed class LiveLogger : INodeLogger
     /// <param name="succeeded">True if the build completed with success.</param>
     /// <param name="hasError">True if the build has logged at least one error.</param>
     /// <param name="hasWarning">True if the build has logged at least one warning.</param>
-    private void PrintBuildResult(bool succeeded, bool hasError, bool hasWarning)
+    private string RenderBuildResult(bool succeeded, bool hasError, bool hasWarning)
     {
         if (!succeeded)
         {
             // If the build failed, we print one of three red strings.
             string text = (hasError, hasWarning) switch
             {
-                (true, _) => "failed with errors",
-                (false, true) => "failed with warnings",
-                _ => "failed",
+                (true, _) => ResourceUtilities.GetResourceString("BuildResult_FailedWithError"),
+                (false, true) => ResourceUtilities.GetResourceString("BuildResult_FailedWithWarn"),
+                _ => ResourceUtilities.GetResourceString("BuildResult_Failed"),
             };
-            Terminal.WriteColor(TerminalColor.Red, text);
+            return Terminal.RenderColor(TerminalColor.Red, text);
         }
         else if (hasWarning)
         {
-            Terminal.WriteColor(TerminalColor.Yellow, "succeeded with warnings");
+            return Terminal.RenderColor(TerminalColor.Yellow, ResourceUtilities.GetResourceString("BuildResult_SucceededWithWarn"));
         }
         else
         {
-            Terminal.WriteColor(TerminalColor.Green, "succeeded");
+            return Terminal.RenderColor(TerminalColor.Green, ResourceUtilities.GetResourceString("BuildResult_Succeeded"));
         }
     }
 

--- a/src/MSBuild/LiveLogger/Terminal.cs
+++ b/src/MSBuild/LiveLogger/Terminal.cs
@@ -132,8 +132,14 @@ internal sealed class Terminal : ITerminal
         }
         else
         {
-            Write($"{AnsiCodes.CSI}{(int)color}{AnsiCodes.SetColor}{text}{AnsiCodes.SetDefaultColor}");
+            Write(RenderColor(color, text));
         }
+    }
+
+    /// <inheritdoc/>
+    public string RenderColor(TerminalColor color, string text)
+    {
+        return $"{AnsiCodes.CSI}{(int)color}{AnsiCodes.SetColor}{text}{AnsiCodes.SetDefaultColor}";
     }
 
     /// <inheritdoc/>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1370,24 +1370,24 @@
   <data name="RestoreComplete" xml:space="preserve">
     <value>Restore complete ({0}s)</value>
     <comment>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </comment>
   </data>
   <data name="BuildFinished" xml:space="preserve">
     <value>Build {0} in {1}s</value>
     <comment>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </comment>
   </data>
-  <data name="BuildResult_FailedWithError" xml:space="preserve">
+  <data name="BuildResult_FailedWithErrors" xml:space="preserve">
     <value>failed with errors</value>
     <comment>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </comment>
   </data>
-  <data name="BuildResult_FailedWithWarn" xml:space="preserve">
+  <data name="BuildResult_FailedWithWarnings" xml:space="preserve">
     <value>failed with warnings</value>
     <comment>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
@@ -1405,7 +1405,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </comment>
   </data>
-  <data name="BuildResult_SucceededWithWarn" xml:space="preserve">
+  <data name="BuildResult_SucceededWithWarnings" xml:space="preserve">
     <value>succeeded with warnings</value>
     <comment>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1366,6 +1366,102 @@
   <data name="UnsupportedSwitchForSolutionFiles" Visibility="Public">
     <value>The '{0}' switch is not supported for solution files.</value>
   </data>
+  <!-- **** LiveLogger strings begin **** -->
+  <data name="RestoreComplete" xml:space="preserve">
+    <value>Restore complete ({0}s)</value>
+    <comment>
+      Duration in seconds with 1 decimal point is: {0}"
+    </comment>
+  </data>
+  <data name="BuildFinished" xml:space="preserve">
+    <value>Build {0} in {1}s</value>
+    <comment>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </comment>
+  </data>
+  <data name="BuildResult_FailedWithError" xml:space="preserve">
+    <value>failed with errors</value>
+    <comment>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </comment>
+  </data>
+  <data name="BuildResult_FailedWithWarn" xml:space="preserve">
+    <value>failed with warnings</value>
+    <comment>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </comment>
+  </data>
+  <data name="BuildResult_Failed" xml:space="preserve">
+    <value>failed</value>
+    <comment>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </comment>
+  </data>
+  <data name="BuildResult_Succeeded" xml:space="preserve">
+    <value>succeeded</value>
+    <comment>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </comment>
+  </data>
+  <data name="BuildResult_SucceededWithWarn" xml:space="preserve">
+    <value>succeeded with warnings</value>
+    <comment>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </comment>
+  </data>
+  <data name="ProjectFinished_NoTF" xml:space="preserve">
+    <value>{0}{1} {2} ({3}s)</value>
+    <comment>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </comment>
+  </data>
+  <data name="ProjectFinished_WithTF" xml:space="preserve">
+    <value>{0}{1} [2] {3} ({4}s)</value>
+    <comment>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </comment>
+  </data>
+  <data name="ProjectFinished_OutputPath" xml:space="preserve">
+    <value> → {0}</value>
+    <comment>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </comment>
+  </data>
+  <data name="ProjectBuilding_NoTF" xml:space="preserve">
+    <value>{0}{1} {2} ({3}s)</value>
+    <comment>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </comment>
+  </data>
+  <data name="ProjectBuilding_WithTF" xml:space="preserve">
+    <value>{0}{1} [2] {3} ({4}s)</value>
+    <comment>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </comment>
+  </data>
+  <!-- **** LiveLogger strings end **** -->
+
     <!--
         The command line message bucket is: MSB1001 - MSB1999
 

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argumenty příkazového řádku = {0}</target>
@@ -1334,6 +1378,60 @@
         <target state="translated">Proces = {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: Soubor projektu neexistuje.</target>
@@ -1379,6 +1477,13 @@
         <target state="translated">{0} přišla z {1}</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1483,7 +1483,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1475,7 +1475,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Befehlszeilenargumente = "{0}"</target>
@@ -1326,6 +1370,60 @@
         <target state="translated">Prozess = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: Die Projektdatei ist nicht vorhanden.</target>
@@ -1371,6 +1469,13 @@
         <target state="translated">„{0}“ stammt aus „{1}“</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argumentos de la línea de comandos: "{0}"</target>
@@ -1333,6 +1377,60 @@
         <target state="translated">Proceso: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: El archivo de proyecto no existe.</target>
@@ -1378,6 +1476,13 @@
         <target state="translated">'{0}' procedía de '{1}'</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1482,7 +1482,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Arguments de ligne de commande = "{0}"</target>
@@ -1326,6 +1370,60 @@
         <target state="translated">Processus = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: Le fichier projet n'existe pas.</target>
@@ -1371,6 +1469,13 @@
         <target state="translated">'{0}' provient de '{1}'</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1475,7 +1475,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1486,7 +1486,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argomenti della riga di comando = "{0}"</target>
@@ -1337,6 +1381,60 @@
         <target state="translated">Processo = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: il file di progetto non esiste.</target>
@@ -1382,6 +1480,13 @@
         <target state="translated">'{0}' proviene da '{1}'</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1475,7 +1475,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">コマンド ライン引数 = "{0}"</target>
@@ -1326,6 +1370,60 @@
         <target state="translated">プロセス = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: プロジェクト ファイルが存在しません。</target>
@@ -1371,6 +1469,13 @@
         <target state="translated">`{0}`からの `{1}`</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">명령줄 인수 = "{0}"</target>
@@ -1326,6 +1370,60 @@
         <target state="translated">프로세스 = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: 프로젝트 파일이 없습니다.</target>
@@ -1371,6 +1469,13 @@
         <target state="translated">'{0}'은(는) '{1}'에서 제공되었습니다.</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1475,7 +1475,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argumenty wiersza polecenia = „{0}”</target>
@@ -1335,6 +1379,60 @@
         <target state="translated">Proces = „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: plik projektu nie istnieje.</target>
@@ -1380,6 +1478,13 @@
         <target state="translated">Element „{0}“ pochodzi z „{1}“</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1484,7 +1484,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1476,7 +1476,7 @@ arquivo de resposta.
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argumentos de linha de comando = "{0}"</target>
@@ -1327,6 +1371,60 @@ arquivo de resposta.
         <target state="translated">Processo = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: Arquivo de projeto não existe.</target>
@@ -1372,6 +1470,13 @@ arquivo de resposta.
         <target state="translated">'{0}' proveniente de '{1}'</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1474,7 +1474,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Аргументы командной строки = "{0}"</target>
@@ -1325,6 +1369,60 @@
         <target state="translated">Процесс = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: файл проекта не существует.</target>
@@ -1370,6 +1468,13 @@
         <target state="translated">\"{0}\" получен из \"{1}\"</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Komut satırı bağımsız değişkenleri = "{0}"</target>
@@ -1330,6 +1374,60 @@
         <target state="translated">İşlem = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: Proje dosyası yok.</target>
@@ -1375,6 +1473,13 @@
         <target state="translated">'{0}', '{1}' kaynağından geldi</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1479,7 +1479,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">命令行参数 = "{0}"</target>
@@ -1326,6 +1370,60 @@
         <target state="translated">进程 = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: 项目文件不存在。</target>
@@ -1371,6 +1469,13 @@
         <target state="translated">“{0}”来自“{1}”</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1475,7 +1475,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -10,6 +10,50 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="BuildFinished">
+        <source>Build {0} in {1}s</source>
+        <target state="new">Build {0} in {1}s</target>
+        <note>
+      Overall build summary
+      {0}: BuildResult_X bellow is
+      {1}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Failed">
+        <source>failed</source>
+        <target state="new">failed</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithError">
+        <source>failed with errors</source>
+        <target state="new">failed with errors</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithWarn">
+        <source>failed with warnings</source>
+        <target state="new">failed with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_Succeeded">
+        <source>succeeded</source>
+        <target state="new">succeeded</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_SucceededWithWarn">
+        <source>succeeded with warnings</source>
+        <target state="new">succeeded with warnings</target>
+        <note>
+      Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">命令列引數 = "{0}"</target>
@@ -1326,6 +1370,60 @@
         <target state="translated">流程 = "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectBuilding_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectBuilding_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: target
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_NoTF">
+        <source>{0}{1} {2} ({3}s)</source>
+        <target state="new">{0}{1} {2} ({3}s)</target>
+        <note>
+      Project finished summary.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: BuildResult_{X}
+      {3}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_OutputPath">
+        <source> → {0}</source>
+        <target state="new"> → {0}</target>
+        <note>
+      Info about project output - when known. Printed after ProjectFinished_NoTF or ProjectFinished_WithTF.
+      {0}: VT100 coded hyperlink to project output directory
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectFinished_WithTF">
+        <source>{0}{1} [2] {3} ({4}s)</source>
+        <target state="new">{0}{1} [2] {3} ({4}s)</target>
+        <note>
+      Project finished summary including target framework information.
+      {0}: indentation - few spaces to visually indent row
+      {1}: project name
+      {2}: target framework
+      {3}: BuildResult_{X}
+      {4}: duration in seconds with 1 decimal point
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <target state="translated">MSBUILD : error MSB1009: 專案檔不存在。</target>
@@ -1371,6 +1469,13 @@
         <target state="translated">'{0}' 來自 '{1}'</target>
         <note>
       These are response file switches with the location of the response file on disk.
+    </note>
+      </trans-unit>
+      <trans-unit id="RestoreComplete">
+        <source>Restore complete ({0}s)</source>
+        <target state="new">Restore complete ({0}s)</target>
+        <note>
+      Duration in seconds with 1 decimal point is: {0}"
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -15,7 +15,7 @@
         <target state="new">Build {0} in {1}s</target>
         <note>
       Overall build summary
-      {0}: BuildResult_X bellow is
+      {0}: BuildResult_X (below)
       {1}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
@@ -26,14 +26,14 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithError">
+      <trans-unit id="BuildResult_FailedWithErrors">
         <source>failed with errors</source>
         <target state="new">failed with errors</target>
         <note>
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_FailedWithWarn">
+      <trans-unit id="BuildResult_FailedWithWarnings">
         <source>failed with warnings</source>
         <target state="new">failed with warnings</target>
         <note>
@@ -47,7 +47,7 @@
       Part of Live Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
-      <trans-unit id="BuildResult_SucceededWithWarn">
+      <trans-unit id="BuildResult_SucceededWithWarnings">
         <source>succeeded with warnings</source>
         <target state="new">succeeded with warnings</target>
         <note>
@@ -1475,7 +1475,7 @@
         <source>Restore complete ({0}s)</source>
         <target state="new">Restore complete ({0}s)</target>
         <note>
-      Duration in seconds with 1 decimal point is: {0}"
+      {0}: duration in seconds with 1 decimal point
     </note>
       </trans-unit>
       <trans-unit id="SchemaFileLocation">


### PR DESCRIPTION
Partly Fixes #8391

### Context
Ensure all new strings used in the logger are localizable

### Changes Made
- introduce strings in resx
- using such resource strings
- modify code to allow better localization (from `write(part1); write(part2); write(part3)` into `str = formastringfromresources(); write(str)`

### Testing
local
unit tests

### Notes
