### PR TITLE
Add source generated files properties to project XSD

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1419,6 +1419,11 @@ elementFormDefault="qualified">
     <xs:element name="CLRSupport" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="UseDebugLibraries" type="msb:boolean" substitutionGroup="msb:Property"/>
     <xs:element name="CodePage" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="CompilerGeneratedFilesOutputPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="CompilerGeneratedFilesOutputPath" _locComment="" -->Controls where the source generated files are stored.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="Configuration" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="ConfigurationName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="ConfigurationOverrideFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
@@ -1700,6 +1705,11 @@ elementFormDefault="qualified">
         </xs:annotation>
     </xs:element>
     <xs:element name="DocumentationFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="EmitCompilerGeneratedFiles" type="msb:boolean" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="EmitCompilerGeneratedFiles" _locComment="" -->Controls if the source generated files will be saved</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="EnableASPDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="EnableASPXDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="EnableSQLServerDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1421,7 +1421,7 @@ elementFormDefault="qualified">
     <xs:element name="CodePage" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="CompilerGeneratedFilesOutputPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="CompilerGeneratedFilesOutputPath" _locComment="" -->Controls where the source generated files are stored.</xs:documentation>
+            <xs:documentation><!-- _locID_text="CompilerGeneratedFilesOutputPath" _locComment="" -->Controls where the source generated files are saved.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="Configuration" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1707,7 +1707,7 @@ elementFormDefault="qualified">
     <xs:element name="DocumentationFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="EmitCompilerGeneratedFiles" type="msb:boolean" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="EmitCompilerGeneratedFiles" _locComment="" -->Controls if source generated files will be saved.</xs:documentation>
+            <xs:documentation><!-- _locID_text="EmitCompilerGeneratedFiles" _locComment="" -->Controls whether source generated files will be saved.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="EnableASPDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1707,7 +1707,7 @@ elementFormDefault="qualified">
     <xs:element name="DocumentationFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="EmitCompilerGeneratedFiles" type="msb:boolean" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="EmitCompilerGeneratedFiles" _locComment="" -->Controls if the source generated files will be saved</xs:documentation>
+            <xs:documentation><!-- _locID_text="EmitCompilerGeneratedFiles" _locComment="" -->Controls if source generated files will be saved.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="EnableASPDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1421,7 +1421,7 @@ elementFormDefault="qualified">
     <xs:element name="CodePage" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="CompilerGeneratedFilesOutputPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="CompilerGeneratedFilesOutputPath" _locComment="" -->Controls where the source generated files are saved.</xs:documentation>
+            <xs:documentation><!-- _locID_text="CompilerGeneratedFilesOutputPath" _locComment="" -->Controls where source generated files are saved.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="Configuration" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>


### PR DESCRIPTION
Fixes #8471 

### Changes Made
Adds to Autocomplete
- EmitCompilerGeneratedFiles
- CompilerGeneratedFilesOutputPath
