### PR TITLE
Update the CG opt-in

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -55,200 +55,207 @@ stages:
         MirrorRepo: 'msbuild'
         MirrorBranch: 'main' # should match condition above
 
-  - job: Windows_NT
-    pool:
-      name: VSEngSS-MicroBuild2022-1ES
-      demands:
-      - agent.os -equals Windows_NT
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.runAsPublic, 'false'), or(startsWith(variables['Build.SourceBranch'], 'vs'), eq(variables['Build.SourceBranch'], 'main'))) }}:
+      disableComponentGovernance: false
+    ${{ else }}:
+      disableComponentGovernance: true
+    jobs:
+      - job: Windows_NT
+        pool:
+          name: VSEngSS-MicroBuild2022-1ES
+          demands:
+          - agent.os -equals Windows_NT
 
-    timeoutInMinutes: 180
+        timeoutInMinutes: 180
 
-    variables:
-    - group: DotNet-Blob-Feed
-    - group: DotNet-Symbol-Publish
-    - group: Publish-Build-Assets
-    - name: TeamName
-      value: MSBuild
-    - name: VisualStudio.MajorVersion
-      value: 17
-    - name: VisualStudio.ChannelName
-      value: 'int.main'
-    - name: VisualStudio.DropName
-      value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+        variables:
+        - group: DotNet-Blob-Feed
+        - group: DotNet-Symbol-Publish
+        - group: Publish-Build-Assets
+        - name: TeamName
+          value: MSBuild
+        - name: VisualStudio.MajorVersion
+          value: 17
+        - name: VisualStudio.ChannelName
+          value: 'int.main'
+        - name: VisualStudio.DropName
+          value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 
-    steps:
-    - task: NuGetToolInstaller@0
-      inputs:
-        versionSpec: '4.9.2'
+        steps:
+        - task: NuGetToolInstaller@0
+          inputs:
+            versionSpec: '4.9.2'
 
-    - task: NuGetCommand@2
-      displayName: Restore internal tools
-      inputs:
-        command: restore
-        feedsToUse: config
-        restoreSolution: 'eng\common\internal\Tools.csproj'
-        nugetConfigPath: 'NuGet.config'
-        restoreDirectory: '$(Build.SourcesDirectory)\.packages'
+        - task: NuGetCommand@2
+          displayName: Restore internal tools
+          inputs:
+            command: restore
+            feedsToUse: config
+            restoreSolution: 'eng\common\internal\Tools.csproj'
+            nugetConfigPath: 'NuGet.config'
+            restoreDirectory: '$(Build.SourcesDirectory)\.packages'
 
-    - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
-      inputs:
-        signType: $(SignType)
-        zipSources: false
-      condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
+        - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+          inputs:
+            signType: $(SignType)
+            zipSources: false
+          condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
 
-    - task: MicroBuildOptProfPlugin@6
-      inputs:
-        ProfilingInputsDropName: '$(VisualStudio.DropName)'
-        ShouldSkipOptimize: true
-        AccessToken: '$(System.AccessToken)'
-        feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-      displayName: 'Install OptProf Plugin'
+        - task: MicroBuildOptProfPlugin@6
+          inputs:
+            ProfilingInputsDropName: '$(VisualStudio.DropName)'
+            ShouldSkipOptimize: true
+            AccessToken: '$(System.AccessToken)'
+            feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+          displayName: 'Install OptProf Plugin'
 
-    # Required by MicroBuildBuildVSBootstrapper
-    - task: MicroBuildSwixPlugin@4
-      inputs:
-        dropName: $(VisualStudio.DropName)
+        # Required by MicroBuildBuildVSBootstrapper
+        - task: MicroBuildSwixPlugin@4
+          inputs:
+            dropName: $(VisualStudio.DropName)
 
-    - script: eng/CIBuild.cmd
-                -configuration $(BuildConfiguration)
-                -officialBuildId $(Build.BuildNumber)
-                -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
-                /p:RepositoryName=$(Build.Repository.Name)
-                /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
-                /p:VisualStudioDropAccessToken=$(System.AccessToken)
-                /p:VisualStudioDropName=$(VisualStudio.DropName)
-                /p:DotNetSignType=$(SignType)
-                /p:DotNetPublishToBlobFeed=true
-                /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-                /p:PublishToSymbolServer=true
-                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                /p:TeamName=MSBuild
-                /p:DotNetPublishUsingPipelines=true
-                /p:VisualStudioIbcDrop=$(OptProfDrop)
-                /p:GenerateSbom=true
-      displayName: Build
-      condition: succeeded()
+        - script: eng/CIBuild.cmd
+                    -configuration $(BuildConfiguration)
+                    -officialBuildId $(Build.BuildNumber)
+                    -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
+                    /p:RepositoryName=$(Build.Repository.Name)
+                    /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
+                    /p:VisualStudioDropAccessToken=$(System.AccessToken)
+                    /p:VisualStudioDropName=$(VisualStudio.DropName)
+                    /p:DotNetSignType=$(SignType)
+                    /p:DotNetPublishToBlobFeed=true
+                    /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                    /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                    /p:PublishToSymbolServer=true
+                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                    /p:TeamName=MSBuild
+                    /p:DotNetPublishUsingPipelines=true
+                    /p:VisualStudioIbcDrop=$(OptProfDrop)
+                    /p:GenerateSbom=true
+          displayName: Build
+          condition: succeeded()
 
-    # Required by Microsoft policy
-    - template: eng\common\templates\steps\generate-sbom.yml
+        # Required by Microsoft policy
+        - template: eng\common\templates\steps\generate-sbom.yml
 
-    # Publish OptProf configuration files
-    - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
-      inputs:
-        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
-        sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
-        toLowerCase: false
-        usePat: true
-      displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
-      condition: succeeded()
+        # Publish OptProf configuration files
+        - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+          inputs:
+            dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+            buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+            sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
+            toLowerCase: false
+            usePat: true
+          displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
+          condition: succeeded()
 
-    # Build VS bootstrapper
-    # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-    - task: MicroBuildBuildVSBootstrapper@2
-      inputs:
-        vsMajorVersion: $(VisualStudio.MajorVersion)
-        channelName: $(VisualStudio.ChannelName)
-        manifests: $(VisualStudio.SetupManifestList)
-        outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-        bootstrapperCoreVersion:
-      displayName: 'OptProf - Build VS bootstrapper'
-      condition: succeeded()
+        # Build VS bootstrapper
+        # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+        - task: MicroBuildBuildVSBootstrapper@2
+          inputs:
+            vsMajorVersion: $(VisualStudio.MajorVersion)
+            channelName: $(VisualStudio.ChannelName)
+            manifests: $(VisualStudio.SetupManifestList)
+            outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+            bootstrapperCoreVersion:
+          displayName: 'OptProf - Build VS bootstrapper'
+          condition: succeeded()
 
-    # Publish run settings
-    - task: PowerShell@2
-      inputs:
-        filePath: eng\common\sdk-task.ps1
-        arguments: -configuration $(BuildConfiguration)
-                  -task VisualStudio.BuildIbcTrainingSettings
-                  /p:VisualStudioDropName=$(VisualStudio.DropName)
-                  /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-                  /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
-      displayName: 'OptProf - Build IBC training settings'
-      condition: succeeded()
+        # Publish run settings
+        - task: PowerShell@2
+          inputs:
+            filePath: eng\common\sdk-task.ps1
+            arguments: -configuration $(BuildConfiguration)
+                      -task VisualStudio.BuildIbcTrainingSettings
+                      /p:VisualStudioDropName=$(VisualStudio.DropName)
+                      /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+                      /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
+          displayName: 'OptProf - Build IBC training settings'
+          condition: succeeded()
 
-    # Publish bootstrapper info
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-        ArtifactName: MicroBuildOutputs
-        ArtifactType: Container
-      displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-      condition: succeeded()
+        # Publish bootstrapper info
+        - task: PublishBuildArtifacts@1
+          inputs:
+            PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+            ArtifactName: MicroBuildOutputs
+            ArtifactType: Container
+          displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
+          condition: succeeded()
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: logs'
-      inputs:
-        PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
-        ArtifactName: logs
-      condition: succeededOrFailed()
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish Artifact: logs'
+          inputs:
+            PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
+            ArtifactName: logs
+          condition: succeededOrFailed()
 
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish Artifact: bin'
-      inputs:
-        path: 'artifacts\bin'
-        artifactName: bin
-      condition: succeededOrFailed()
+        - task: PublishPipelineArtifact@1
+          displayName: 'Publish Artifact: bin'
+          inputs:
+            path: 'artifacts\bin'
+            artifactName: bin
+          condition: succeededOrFailed()
 
-    # Publishes setup VSIXes to a drop.
-    # Note: The insertion tool looks for the display name of this task in the logs.
-    - task: MicroBuildUploadVstsDropFolder@2
-      displayName: Upload VSTS Drop
-      inputs:
-        DropName: $(VisualStudio.DropName)
-        DropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-        AccessToken: '$(System.AccessToken)'
-        DropServiceUri: 'https://devdiv.artifacts.visualstudio.com'
-        VSDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
-      condition: succeeded()
+        # Publishes setup VSIXes to a drop.
+        # Note: The insertion tool looks for the display name of this task in the logs.
+        - task: MicroBuildUploadVstsDropFolder@2
+          displayName: Upload VSTS Drop
+          inputs:
+            DropName: $(VisualStudio.DropName)
+            DropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+            AccessToken: '$(System.AccessToken)'
+            DropServiceUri: 'https://devdiv.artifacts.visualstudio.com'
+            VSDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
+          condition: succeeded()
 
-    # Publish an artifact that the RoslynInsertionTool is able to find by its name.
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: VSSetup'
-      inputs:
-        PathtoPublish: 'artifacts\VSSetup\$(BuildConfiguration)'
-        ArtifactName: VSSetup
-      condition: succeeded()
+        # Publish an artifact that the RoslynInsertionTool is able to find by its name.
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish Artifact: VSSetup'
+          inputs:
+            PathtoPublish: 'artifacts\VSSetup\$(BuildConfiguration)'
+            ArtifactName: VSSetup
+          condition: succeeded()
 
-    # Archive NuGet packages to DevOps.
-    # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
-    # arcade templates depend on the name.
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: packages'
-      inputs:
-        PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
-        ArtifactName: PackageArtifacts
-      condition: succeeded()
+        # Archive NuGet packages to DevOps.
+        # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
+        # arcade templates depend on the name.
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish Artifact: packages'
+          inputs:
+            PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
+            ArtifactName: PackageArtifacts
+          condition: succeeded()
 
-    # Publish "IntelliSense" XSD files to their own artifact
-    # so it can be consumed by the insertion-to-VS job
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish Artifact: xsd'
-      inputs:
-        path: 'artifacts\xsd'
-        artifactName: xsd
-      condition: succeeded()
+        # Publish "IntelliSense" XSD files to their own artifact
+        # so it can be consumed by the insertion-to-VS job
+        - task: PublishPipelineArtifact@1
+          displayName: 'Publish Artifact: xsd'
+          inputs:
+            path: 'artifacts\xsd'
+            artifactName: xsd
+          condition: succeeded()
 
-    # Publish Asset Manifests for Build Asset Registry job
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Asset Manifests
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
-        ArtifactName: AssetManifests
-      condition: succeeded()
+        # Publish Asset Manifests for Build Asset Registry job
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Asset Manifests
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
+            ArtifactName: AssetManifests
+          condition: succeeded()
 
-    # Tag the build at the very end when we know it's been successful.
-    - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-      displayName: Tag build as ready for optimization training
-      inputs:
-        tags: 'ready-for-training'
-      condition: succeeded()
+        # Tag the build at the very end when we know it's been successful.
+        - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+          displayName: Tag build as ready for optimization training
+          inputs:
+            tags: 'ready-for-training'
+          condition: succeeded()
 
-    - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-      displayName: Execute cleanup tasks
-      condition: succeededOrFailed()
+        - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+          displayName: Execute cleanup tasks
+          condition: succeededOrFailed()
 
   - template: /eng/common/templates/job/source-build.yml
     parameters:


### PR DESCRIPTION
Addresses the change in disabling CG step - introduced here https://github.com/dotnet/arcade/pull/13214/files

### Context
`disableComponentGovernance` is by default set for non-prod branches, where prod branch is recognized via name as 'main' or '*internal/release*'. MSBuild has nonstandard naming in this case and needs adjustment

### Changes Made
* Explicitly add the '/eng/common/templates/jobs/jobs.yml' template (not sure if that's correct, but I suppose this is otherwise somehow implicitly imported). Is this correct @wtgodbe?
* Added the conditional `disableComponentGovernance` for this template - recognizing prod branches by name as 'main' or 'vs*'
* Indented the `Windows_NT` job, to be using the jobs.yml template (again - not sure if this is correct)

### Notes
Open questions (@wtgodbe - can you please address those?):
 * Is this proper way of injecting the `disableComponentGovernance`, since we haven't explicitly used the jobs.yml template before?
 * Do we need to distinguish internal mirror run somehow other than `eq(parameters.runAsPublic, 'false')`? We do not have internal brnaches as other repos.
 * Is this no-op when going in prior consuming the Arcade change introduced in introduced here https://github.com/dotnet/arcade/pull/13214/files?