### PR TITLE
[RAR] Don't do I/O on SDK-provided references

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -22,6 +22,8 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 # Change Waves & Associated Features
 
 ## Current Rotation of Change Waves
+### 17.8
+- [[RAR] Don't do I/O on SDK-provided references](https://github.com/dotnet/msbuild/pull/8688)
 
 ### 17.6
 - [Parse invalid property under target](https://github.com/dotnet/msbuild/pull/8190)

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave17_2 = new Version(17, 2);
         internal static readonly Version Wave17_4 = new Version(17, 4);
         internal static readonly Version Wave17_6 = new Version(17, 6);
-        internal static readonly Version[] AllWaves = { Wave17_2, Wave17_4, Wave17_6 };
+        internal static readonly Version Wave17_7 = new Version(17, 7);
+        internal static readonly Version[] AllWaves = { Wave17_2, Wave17_4, Wave17_6, Wave17_7 };
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -24,11 +24,10 @@ namespace Microsoft.Build.Framework
     /// For dev docs: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves-Dev.md
     internal class ChangeWaves
     {
-        internal static readonly Version Wave17_2 = new Version(17, 2);
         internal static readonly Version Wave17_4 = new Version(17, 4);
         internal static readonly Version Wave17_6 = new Version(17, 6);
-        internal static readonly Version Wave17_7 = new Version(17, 7);
-        internal static readonly Version[] AllWaves = { Wave17_2, Wave17_4, Wave17_6, Wave17_7 };
+        internal static readonly Version Wave17_8 = new Version(17, 8);
+        internal static readonly Version[] AllWaves = { Wave17_4, Wave17_6, Wave17_8 };
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -189,6 +189,7 @@ namespace Microsoft.Build.Shared
         internal const string executableExtension = "ExecutableExtension";
         internal const string embedInteropTypes = "EmbedInteropTypes";
         internal const string frameworkReferenceName = "FrameworkReferenceName";
+        internal const string assemblyName = "AssemblyName";
         internal const string assemblyVersion = "AssemblyVersion";
         internal const string publicKeyToken = "PublicKeyToken";
 

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -188,6 +188,9 @@ namespace Microsoft.Build.Shared
         internal const string subType = "SubType";
         internal const string executableExtension = "ExecutableExtension";
         internal const string embedInteropTypes = "EmbedInteropTypes";
+        internal const string frameworkReferenceName = "FrameworkReferenceName";
+        internal const string assemblyVersion = "AssemblyVersion";
+        internal const string publicKeyToken = "PublicKeyToken";
 
         /// <summary>
         /// The output path for a given item.

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -8580,6 +8580,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             item.SetMetadata("FrameworkReferenceName", "Microsoft.NETCore.App");
             item.SetMetadata("FrameworkReferenceVersion", "8.0.0");
 
+            item.SetMetadata("AssemblyName", "System.Candy");
             item.SetMetadata("AssemblyVersion", "8.1.2.3");
             item.SetMetadata("PublicKeyToken", "b03f5f7f11d50a3a");
 
@@ -8616,6 +8617,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             rar.ResolvedFiles.Length.ShouldBe(1);
             rar.ResolvedFiles[0].ItemSpec.ShouldBe(refPath);
+            rar.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("System.Candy, Version=8.1.2.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
         }
     }
 }

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -8607,7 +8607,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 getRegistrySubKeyDefaultValue,
 #endif
                 _ => throw new ShouldAssertException("Unexpected GetLastWriteTime callback"),
-                getRuntimeVersion,
+                _ => throw new ShouldAssertException("Unexpected GetAssemblyRuntimeVersion callback"),
 #if FEATURE_WIN32_REGISTRY
                 openBaseKey,
 #endif

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,13 +12,14 @@ using System.Resources;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
-using Microsoft.Build.UnitTests.Shared;
+using Microsoft.Build.Tasks.AssemblyDependency;
 using Microsoft.Build.Utilities;
 using Microsoft.Win32;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.NetCore.Extensions;
+using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 
 #nullable disable
@@ -8563,6 +8565,57 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Directory.CreateDirectory(redistDirectory);
 
             File.WriteAllText(profileRedistList, profileListContents);
+        }
+
+        [Fact]
+        public void SDKReferencesAreResolvedWithoutIO()
+        {
+            InitializeRARwithMockEngine(_output, out MockEngine mockEngine, out ResolveAssemblyReference rar);
+
+            string refPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            TaskItem item = new TaskItem(refPath);
+            item.SetMetadata("ExternallyResolved", "true");
+
+            item.SetMetadata("FrameworkReferenceName", "Microsoft.NETCore.App");
+            item.SetMetadata("FrameworkReferenceVersion", "8.0.0");
+
+            item.SetMetadata("AssemblyVersion", "8.1.2.3");
+            item.SetMetadata("PublicKeyToken", "b03f5f7f11d50a3a");
+
+            rar.Assemblies = new ITaskItem[] { item };
+            rar.SearchPaths = new string[]
+            {
+                "{CandidateAssemblyFiles}",
+                "{HintPathFromItem}",
+                "{TargetFrameworkDirectory}",
+                "{RawFileName}",
+            };
+            rar.WarnOrErrorOnTargetArchitectureMismatch = "Warning";
+
+            // Execute RAR and assert that we receive no I/O callbacks because the task gets what it needs from item metadata.
+            rar.Execute(
+                _ => throw new ShouldAssertException("Unexpected FileExists callback"),
+                directoryExists,
+                getDirectories,
+                _ => throw new ShouldAssertException("Unexpected GetAssemblyName callback"),
+                (string path, ConcurrentDictionary<string, AssemblyMetadata> assemblyMetadataCache, out AssemblyNameExtension[] dependencies, out string[] scatterFiles, out FrameworkNameVersioning frameworkName)
+                  => throw new ShouldAssertException("Unexpected GetAssemblyMetadata callback"),
+#if FEATURE_WIN32_REGISTRY
+                getRegistrySubKeyNames,
+                getRegistrySubKeyDefaultValue,
+#endif
+                _ => throw new ShouldAssertException("Unexpected GetLastWriteTime callback"),
+                getRuntimeVersion,
+#if FEATURE_WIN32_REGISTRY
+                openBaseKey,
+#endif
+                checkIfAssemblyIsInGac,
+                isWinMDFile,
+                readMachineTypeFromPEHeader).ShouldBeTrue();
+
+            rar.ResolvedFiles.Length.ShouldBe(1);
+            rar.ResolvedFiles[0].ItemSpec.ShouldBe(refPath);
         }
     }
 }

--- a/src/Tasks.UnitTests/HintPathResolver_Tests.cs
+++ b/src/Tasks.UnitTests/HintPathResolver_Tests.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 sdkName: "",
                 rawFileNameCandidate: "FakeSystem.Net.Http",
                 isPrimaryProjectReference: true,
+                isImmutableFrameworkReference: false,
                 wantSpecificVersion: false,
                 executableExtensions: new string[] { ".winmd", ".dll", ".exe" },
                 hintPath: hintPath,

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
@@ -183,26 +183,13 @@ namespace Microsoft.Build.Tasks
             }
         }
 
-        /// <summary>
-        /// Resolve a reference to a specific file name.
-        /// </summary>
-        /// <param name="assemblyName">The assemblyname of the reference.</param>
-        /// <param name="sdkName">The sdkname of the reference.</param>
-        /// <param name="rawFileNameCandidate">The reference's 'include' treated as a raw file name.</param>
-        /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
-        /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
-        /// <param name="executableExtensions">Allowed executable extensions.</param>
-        /// <param name="hintPath">The item's hintpath value.</param>
-        /// <param name="assemblyFolderKey">Like "hklm\Vendor RegKey" as provided to a reference by the &lt;AssemblyFolderKey&gt; on the reference in the project.</param>
-        /// <param name="assembliesConsideredAndRejected">Receives the list of locations that this function tried to find the assembly. May be "null".</param>
-        /// <param name="foundPath">The path where the file was found.</param>
-        /// <param name="userRequestedSpecificFile">Whether or not the user wanted a specific file (for example, HintPath is a request for a specific file)</param>
-        /// <returns>True if the file was resolved.</returns>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
@@ -151,26 +151,13 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
             }
         }
 
-        /// <summary>
-        /// Resolve a reference to a specific file name.
-        /// </summary>
-        /// <param name="assemblyName">The assemblyname of the reference.</param>
-        /// <param name="sdkName">Not used by this type.</param>
-        /// <param name="rawFileNameCandidate">Not used by this type.</param>
-        /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
-        /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
-        /// <param name="executableExtensions">Allowed executable extensions.</param>
-        /// <param name="hintPath">Not used by this type.</param>
-        /// <param name="assemblyFolderKey">Not used by this type.</param>
-        /// <param name="assembliesConsideredAndRejected">Receives the list of locations that this function tried to find the assembly. May be "null".</param>
-        /// <param name="foundPath">The path where the file was found.</param>
-        /// <param name="userRequestedSpecificFile">Whether or not the user wanted a specific file (for example, HintPath is a request for a specific file)</param>
-        /// <returns>True if the file was resolved.</returns>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
@@ -27,26 +27,13 @@ namespace Microsoft.Build.Tasks
         {
         }
 
-        /// <summary>
-        /// Resolve a reference to a specific file name.
-        /// </summary>
-        /// <param name="assemblyName">The assemblyname of the reference.</param>
-        /// <param name="sdkName">The sdk name of the reference.</param>
-        /// <param name="rawFileNameCandidate">The reference's 'include' treated as a raw file name.</param>
-        /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
-        /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
-        /// <param name="executableExtensions">Allowed executable extensions.</param>
-        /// <param name="hintPath">The item's hintpath value.</param>
-        /// <param name="assemblyFolderKey">Like "hklm\Vendor RegKey" as provided to a reference by the &lt;AssemblyFolderKey&gt; on the reference in the project.</param>
-        /// <param name="assembliesConsideredAndRejected">Receives the list of locations that this function tried to find the assembly. May be "null".</param>
-        /// <param name="foundPath">The path where the file was found.</param>
-        /// <param name="userRequestedSpecificFile">Whether or not the user wanted a specific file (for example, HintPath is a request for a specific file)</param>
-        /// <returns>True if the file was resolved.</returns>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="sdkName"></param>
         /// <param name="rawFileNameCandidate">The file name to match if {RawFileName} is seen. (May be null).</param>
         /// <param name="isPrimaryProjectReference">True if this is a primary reference directly from the project file.</param>
+        /// <param name="isImmutableFrameworkReference">True if <paramref name="rawFileNameCandidate"/> is immutable and guaranteed to exist.</param>
         /// <param name="wantSpecificVersion"></param>
         /// <param name="executableExtensions">The filename extension of the assembly. Must be this or its no match.</param>
         /// <param name="hintPath">This reference's hintpath</param>
@@ -48,6 +49,7 @@ namespace Microsoft.Build.Tasks
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,
@@ -79,6 +81,7 @@ namespace Microsoft.Build.Tasks
                             sdkName,
                             rawFileNameCandidate,
                             isPrimaryProjectReference,
+                            isImmutableFrameworkReference,
                             wantSpecificVersion,
                             executableExtensions,
                             hintPath,

--- a/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
+++ b/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
@@ -36,26 +36,13 @@ namespace Microsoft.Build.Tasks
             _candidateAssemblyFiles = candidateAssemblyFiles;
         }
 
-        /// <summary>
-        /// Resolve a reference to a specific file name.
-        /// </summary>
-        /// <param name="assemblyName">The assemblyname of the reference.</param>
-        /// <param name="sdkName"></param>
-        /// <param name="rawFileNameCandidate">The reference's 'include' treated as a raw file name.</param>
-        /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
-        /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
-        /// <param name="executableExtensions">Allowed executable extensions.</param>
-        /// <param name="hintPath">The item's hintpath value.</param>
-        /// <param name="assemblyFolderKey">Like "hklm\Vendor RegKey" as provided to a reference by the &lt;AssemblyFolderKey&gt; on the reference in the project.</param>
-        /// <param name="assembliesConsideredAndRejected">Receives the list of locations that this function tried to find the assembly. May be "null".</param>
-        /// <param name="foundPath">The path where the file was found.</param>
-        /// <param name="userRequestedSpecificFile">Whether or not the user wanted a specific file (for example, HintPath is a request for a specific file)</param>
-        /// <returns>True if the file was resolved.</returns>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,

--- a/src/Tasks/AssemblyDependency/DirectoryResolver.cs
+++ b/src/Tasks/AssemblyDependency/DirectoryResolver.cs
@@ -22,26 +22,13 @@ namespace Microsoft.Build.Tasks
         {
         }
 
-        /// <summary>
-        /// Resolve a reference to a specific file name.
-        /// </summary>
-        /// <param name="assemblyName">The assemblyname of the reference.</param>
-        /// <param name="sdkName"></param>
-        /// <param name="rawFileNameCandidate">The reference's 'include' treated as a raw file name.</param>
-        /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
-        /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
-        /// <param name="executableExtensions">Allowed executable extensions.</param>
-        /// <param name="hintPath">The item's hintpath value.</param>
-        /// <param name="assemblyFolderKey">Like "hklm\Vendor RegKey" as provided to a reference by the &lt;AssemblyFolderKey&gt; on the reference in the project.</param>
-        /// <param name="assembliesConsideredAndRejected">Receives the list of locations that this function tried to find the assembly. May be "null".</param>
-        /// <param name="foundPath">The path where the file was found.</param>
-        /// <param name="userRequestedSpecificFile">Whether or not the user wanted a specific file (for example, HintPath is a request for a specific file)</param>
-        /// <returns>True if the file was resolved.</returns>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,

--- a/src/Tasks/AssemblyDependency/FrameworkPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/FrameworkPathResolver.cs
@@ -30,26 +30,13 @@ namespace Microsoft.Build.Tasks
             _installedAssemblies = installedAssemblies;
         }
 
-        /// <summary>
-        /// Resolve a reference to a specific file name.
-        /// </summary>
-        /// <param name="assemblyName">The assemblyname of the reference.</param>
-        /// <param name="sdkName"></param>
-        /// <param name="rawFileNameCandidate">The reference's 'include' treated as a raw file name.</param>
-        /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
-        /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
-        /// <param name="executableExtensions">Allowed executable extensions.</param>
-        /// <param name="hintPath">The item's hintpath value.</param>
-        /// <param name="assemblyFolderKey">Like "hklm\Vendor RegKey" as provided to a reference by the &lt;AssemblyFolderKey&gt; on the reference in the project.</param>
-        /// <param name="assembliesConsideredAndRejected">Receives the list of locations that this function tried to find the assembly. May be "null".</param>
-        /// <param name="foundPath">The path where the file was found.</param>
-        /// <param name="userRequestedSpecificFile">Whether or not the user wanted a specific file (for example, HintPath is a request for a specific file)</param>
-        /// <returns>True if the file was resolved.</returns>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,

--- a/src/Tasks/AssemblyDependency/GacResolver.cs
+++ b/src/Tasks/AssemblyDependency/GacResolver.cs
@@ -35,26 +35,13 @@ namespace Microsoft.Build.Tasks
             _getAssemblyPathInGac = getAssemblyPathInGac;
         }
 
-        /// <summary>
-        /// Resolve a reference to a specific file name.
-        /// </summary>
-        /// <param name="assemblyName">The assembly name object of the assembly.</param>
-        /// <param name="sdkName"></param>
-        /// <param name="rawFileNameCandidate">The reference's 'include' treated as a raw file name.</param>
-        /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
-        /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
-        /// <param name="executableExtensions">Allowed executable extensions.</param>
-        /// <param name="hintPath">The item's hintpath value.</param>
-        /// <param name="assemblyFolderKey">Like "hklm\Vendor RegKey" as provided to a reference by the &lt;AssemblyFolderKey&gt; on the reference in the project.</param>
-        /// <param name="assembliesConsideredAndRejected">Receives the list of locations that this function tried to find the assembly. May be "null".</param>
-        /// <param name="foundPath">The path where the file was found.</param>
-        /// <param name="userRequestedSpecificFile">Whether or not the user wanted a specific file (for example, HintPath is a request for a specific file)</param>
-        /// <returns>True if the file was resolved.</returns>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,

--- a/src/Tasks/AssemblyDependency/HintPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/HintPathResolver.cs
@@ -23,26 +23,13 @@ namespace Microsoft.Build.Tasks
         {
         }
 
-        /// <summary>
-        /// Resolve a reference to a specific file name.
-        /// </summary>
-        /// <param name="assemblyName">The assemblyname of the reference.</param>
-        /// <param name="sdkName"></param>
-        /// <param name="rawFileNameCandidate">The reference's 'include' treated as a raw file name.</param>
-        /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
-        /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
-        /// <param name="executableExtensions">Allowed executable extensions.</param>
-        /// <param name="hintPath">The item's hintpath value.</param>
-        /// <param name="assemblyFolderKey">Like "hklm\Vendor RegKey" as provided to a reference by the &lt;AssemblyFolderKey&gt; on the reference in the project.</param>
-        /// <param name="assembliesConsideredAndRejected">Receives the list of locations that this function tried to find the assembly. May be "null".</param>
-        /// <param name="foundPath">The path where the file was found.</param>
-        /// <param name="userRequestedSpecificFile">Whether or not the user wanted a specific file (for example, HintPath is a request for a specific file)</param>
-        /// <returns>True if the file was resolved.</returns>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,

--- a/src/Tasks/AssemblyDependency/RawFilenameResolver.cs
+++ b/src/Tasks/AssemblyDependency/RawFilenameResolver.cs
@@ -23,26 +23,13 @@ namespace Microsoft.Build.Tasks
         {
         }
 
-        /// <summary>
-        /// Resolve a reference to a specific file name.
-        /// </summary>
-        /// <param name="assemblyName">The assemblyname of the reference.</param>
-        /// <param name="sdkName"></param>
-        /// <param name="rawFileNameCandidate">The reference's 'include' treated as a raw file name.</param>
-        /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
-        /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
-        /// <param name="executableExtensions">Allowed executable extensions.</param>
-        /// <param name="hintPath">The item's hintpath value.</param>
-        /// <param name="assemblyFolderKey">Like "hklm\Vendor RegKey" as provided to a reference by the &lt;AssemblyFolderKey&gt; on the reference in the project.</param>
-        /// <param name="assembliesConsideredAndRejected">Receives the list of locations that this function tried to find the assembly. May be "null".</param>
-        /// <param name="foundPath">The path where the file was found.</param>
-        /// <param name="userRequestedSpecificFile">Whether or not the user wanted a specific file (for example, HintPath is a request for a specific file)</param>
-        /// <returns>True if the file was resolved.</returns>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,
@@ -57,7 +44,7 @@ namespace Microsoft.Build.Tasks
             if (rawFileNameCandidate != null)
             {
                 // {RawFileName} was passed in.
-                if (fileExists(rawFileNameCandidate))
+                if (isImmutableFrameworkReference || fileExists(rawFileNameCandidate))
                 {
                     userRequestedSpecificFile = true;
                     foundPath = rawFileNameCandidate;

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private readonly HashSet<string> _externallyResolvedPrimaryReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// The keys are normalized full paths of primary references resolved by an external entity to RAR and considered immutable, the values are assembly names or null if not known.
+        /// </summary>
+        private readonly Dictionary<string, AssemblyNameExtension> _externallyResolvedImmutableFiles = new Dictionary<string, AssemblyNameExtension>(StringComparer.OrdinalIgnoreCase);
+
         /// <summary>The table of remapped assemblies. Used for Unification.</summary>
         private IEnumerable<DependentAssembly> _remappedAssemblies = Enumerable.Empty<DependentAssembly>();
 
@@ -824,6 +829,29 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
+        /// Tries to create an <see cref="AssemblyNameExtension"/> out of a primary reference metadata.
+        /// </summary>
+        private static AssemblyNameExtension GetAssemblyNameFromItemMetadata(ITaskItem item)
+        {
+            string version = item.GetMetadata(ItemMetadataNames.assemblyVersion);
+            if (string.IsNullOrEmpty(version))
+            {
+                return null;
+            }
+
+            string publicKeyToken = item.GetMetadata(ItemMetadataNames.publicKeyToken);
+            if (string.IsNullOrEmpty(publicKeyToken))
+            {
+                return null;
+            }
+
+            string name = Path.GetFileNameWithoutExtension(item.ItemSpec);
+
+            AssemblyName assemblyName = new AssemblyName($"{name}, Version={version}, Culture=neutral, PublicKeyToken={publicKeyToken}");
+            return new AssemblyNameExtension(assemblyName);
+        }
+
+        /// <summary>
         /// Given an item that refers to a file name, make it a primary reference.
         /// </summary>
         private void SetPrimaryFileItem(ITaskItem referenceAssemblyFile)
@@ -1225,6 +1253,17 @@ namespace Microsoft.Build.Tasks
             string rawFileNameCandidate,
             Reference reference)
         {
+            bool isImmutableFrameworkReference = false;
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_7))
+            {
+                // For a path to be an immutable reference, it must be externally resolved and has a FrameworkReferenceName defined.
+                if (assemblyName == null && !string.IsNullOrEmpty(rawFileNameCandidate) && reference.IsPrimary && reference.ExternallyResolved)
+                {
+                    string frameworkReferenceName = reference.PrimarySourceItem.GetMetadata(ItemMetadataNames.frameworkReferenceName);
+                    isImmutableFrameworkReference = !string.IsNullOrEmpty(frameworkReferenceName);
+                }
+            }
+
             // Now, resolve this reference.
             string resolvedPath = null;
             string resolvedSearchPath = String.Empty;
@@ -1272,6 +1311,7 @@ namespace Microsoft.Build.Tasks
                     reference.SDKName,
                     rawFileNameCandidate,
                     reference.IsPrimary,
+                    isImmutableFrameworkReference,
                     reference.WantSpecificVersion,
                     reference.GetExecutableExtensions(_allowedAssemblyExtensions),
                     reference.HintPath,
@@ -1291,7 +1331,13 @@ namespace Microsoft.Build.Tasks
             // If the path was resolved, then specify the full path on the reference.
             if (resolvedPath != null)
             {
-                reference.FullPath = FileUtilities.NormalizePath(resolvedPath);
+                resolvedPath = FileUtilities.NormalizePath(resolvedPath);
+                if (isImmutableFrameworkReference)
+                {
+                    _externallyResolvedImmutableFiles[resolvedPath] = GetAssemblyNameFromItemMetadata(reference.PrimarySourceItem);
+                }
+                reference.FullPath = resolvedPath;
+
                 reference.ResolvedSearchPath = resolvedSearchPath;
                 reference.UserRequestedSpecificFile = userRequestedSpecificFile;
             }
@@ -3155,6 +3201,29 @@ namespace Microsoft.Build.Tasks
             }
 
             return anyMarkedReference;
+        }
+
+        /// <summary>
+        /// Returns true if the full path passed in <paramref name="path"/> represents a file that came from an external trusted
+        /// entity and is guaranteed to be immutable.
+        /// </summary>
+        /// <param name="path">The path to check.</param>
+        /// <returns>True if known to be immutable, false otherwise.</returns>
+        internal bool IsImmutableFile(string path)
+        {
+            return _externallyResolvedImmutableFiles.ContainsKey(path);
+        }
+
+        /// <summary>
+        /// Returns the assembly name of a file if the file came from an external trusted entity and is considered immutable.
+        /// </summary>
+        /// <param name="path">The file path.</param>
+        /// <returns>Assembly name or null if not known.</returns>
+        internal AssemblyNameExtension GetImmutableFileAssemblyName(string path)
+        {
+            return _externallyResolvedImmutableFiles.TryGetValue(path, out AssemblyNameExtension assemblyNameExtension)
+                ? assemblyNameExtension
+                : null;
         }
     }
 }

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -845,7 +845,7 @@ namespace Microsoft.Build.Tasks
                 return null;
             }
 
-            string name = Path.GetFileNameWithoutExtension(item.ItemSpec);
+            string name = item.GetMetadata(FileUtilities.ItemSpecModifiers.Filename);
 
             AssemblyName assemblyName = new AssemblyName($"{name}, Version={version}, Culture=neutral, PublicKeyToken={publicKeyToken}");
             return new AssemblyNameExtension(assemblyName);

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1254,7 +1254,7 @@ namespace Microsoft.Build.Tasks
             Reference reference)
         {
             bool isImmutableFrameworkReference = false;
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_7))
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_8))
             {
                 // For a path to be an immutable reference, it must be externally resolved and has a FrameworkReferenceName defined.
                 if (assemblyName == null && !string.IsNullOrEmpty(rawFileNameCandidate) && reference.IsPrimary && reference.ExternallyResolved)

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -845,7 +845,12 @@ namespace Microsoft.Build.Tasks
                 return null;
             }
 
-            string name = item.GetMetadata(FileUtilities.ItemSpecModifiers.Filename);
+            string name = item.GetMetadata(ItemMetadataNames.assemblyName);
+            if (string.IsNullOrEmpty(name))
+            {
+                // Fall back to inferring assembly name from file name.
+                name = item.GetMetadata(FileUtilities.ItemSpecModifiers.Filename);
+            }
 
             AssemblyName assemblyName = new AssemblyName($"{name}, Version={version}, Culture=neutral, PublicKeyToken={publicKeyToken}");
             return new AssemblyNameExtension(assemblyName);

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2291,7 +2291,6 @@ namespace Microsoft.Build.Tasks
 
                     // Load any prior saved state.
                     ReadStateFile(fileExists);
-                    _cache.SetGetLastWriteTime(getLastWriteTime);
                     _cache.SetInstalledAssemblyInformation(installedAssemblyTableInfo);
 
                     // Cache delegates.

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="sdkName">The name of the sdk to resolve.</param>
         /// <param name="rawFileNameCandidate">The reference's 'include' treated as a raw file name.</param>
         /// <param name="isPrimaryProjectReference">Whether or not this reference was directly from the project file (and therefore not a dependency)</param>
+        /// <param name="isImmutableFrameworkReference">True if <paramref name="rawFileNameCandidate"/> is guaranteed to exist on disk and never change.</param>
         /// <param name="wantSpecificVersion">Whether an exact version match is requested.</param>
         /// <param name="executableExtensions">Allowed executable extensions.</param>
         /// <param name="hintPath">The item's hintpath value.</param>
@@ -85,6 +86,7 @@ namespace Microsoft.Build.Tasks
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,

--- a/src/Tasks/InstalledSDKResolver.cs
+++ b/src/Tasks/InstalledSDKResolver.cs
@@ -30,14 +30,13 @@ namespace Microsoft.Build.Tasks
             _resolvedSDKs = resolvedSDKs;
         }
 
-        /// <summary>
-        /// Resolve references which are found in a specific SDK
-        /// </summary>
+        /// <inheritdoc/>
         public override bool Resolve(
             AssemblyNameExtension assemblyName,
             string sdkName,
             string rawFileNameCandidate,
             bool isPrimaryProjectReference,
+            bool isImmutableFrameworkReference,
             bool wantSpecificVersion,
             string[] executableExtensions,
             string hintPath,


### PR DESCRIPTION
Fixes #8634

### Context

For SDK/workload references, the SDK is currently already passing relevant metadata such as `AssemblyVersion` and `PublicKeyToken`, so there is no need for RAR to open these files and parse their .NET metadata tables to get this information. Also, barring corrupted installs, these files are guaranteed to exist on disk so there is no need for RAR to do any I/O on them (file-exists, get-time-stamp, ..)

### Changes Made

Tweaked RAR to trust the item metadata passed by the SDK. The feature is gated on the presence of the `FrameworkReferenceName` metadatum which is not documented and is used only by the relevant SDK tasks, to my best knowledge.

SDK does not specify the `Culture` component of assembly names so it's assumed to be `neutral`. This has passed all relevant validation so far. If non-neutral assemblies are ever used as references, we'll need to define a metadatum for SDK to set.

### Testing

- Existing and new unit tests.
- Experimental insertion with an assert that assembly names calculated from item metadata are equivalent to those extracted from assembly files (verifies that the `Culture=neutral` assumption is correct).
- Checked all assemblies specified in all `FrameworkList.xml` files shipped in the SDK (+ workloads) and verified that all of them are culture neutral.

### Perf results

RAR micro-benchmark where the task is invoked with parameters corresponding to building a simple AspNetCore app:
- 13.13 ms -> 3.27 ms per invocation without StateFile cache.
- 15.03 ms -> 5.13 ms per invocation with StateFile cache.

RAR task duration as reported with `/clp:PerformanceSummary` when building a simple AspNetCore app with MSBuild server enabled:
- 20 ms -> 10 ms.

### Notes

- The change is behind a 17.8 changewave.
- No changes have been made to per-project caching (via the `StateFile` parameter) to reduce scope. Changes to the per-project cache file will be done in another PR.
