### PR TITLE
Fix outputIsScreen on non-windows OS.

### DIFF
--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1531,6 +1531,8 @@ internal static class NativeMethods
         {
             // On posix OSes we expect console always supports VT100 coloring unless it is explicitly marked as "dumb".
             acceptAnsiColorCodes = Environment.GetEnvironmentVariable("TERM") != "dumb";
+            // It wasn't redirected as tested above so we assume output is screen/console
+            outputIsScreen = true; 
         }
         return (acceptAnsiColorCodes, outputIsScreen, originalConsoleMode);
     }


### PR DESCRIPTION
Detected while working on #8413

### Context
outputIsScreen  is always falls on on non-windows OS causing /tl:auto to reject live logger

### Changes Made
see files

### Testing
locally

### Notes
would effect MSB server VT100 output coloring as well.
