### PR TITLE
Customize opt-in for CG step

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -252,7 +252,7 @@ stages:
       
     - template: /eng/common/templates/steps/component-governance.yml
       parameters:
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.runAsPublic, 'false'), or(startsWith(variables['Build.SourceBranch'], 'vs'), eq(variables['Build.SourceBranch'], 'main'))) }}:
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'vs'), eq(variables['Build.SourceBranch'], 'main'))) }}:
           disableComponentGovernance: false
         ${{ else }}:
           disableComponentGovernance: true

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -249,7 +249,14 @@ stages:
     - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
       displayName: Execute cleanup tasks
       condition: succeededOrFailed()
-
+      
+    - template: /eng/common/templates/steps/component-governance.yml
+      parameters:
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.runAsPublic, 'false'), or(startsWith(variables['Build.SourceBranch'], 'vs'), eq(variables['Build.SourceBranch'], 'main'))) }}:
+          disableComponentGovernance: false
+        ${{ else }}:
+          disableComponentGovernance: true
+      
   - template: /eng/common/templates/job/source-build.yml
     parameters:
       platform:

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -252,7 +252,7 @@ stages:
       
     - template: /eng/common/templates/steps/component-governance.yml
       parameters:
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'vs'), eq(variables['Build.SourceBranch'], 'main'))) }}:
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
           disableComponentGovernance: false
         ${{ else }}:
           disableComponentGovernance: true


### PR DESCRIPTION
### Context
Explict call to `ComponentGovernanceComponentDetection@0` task (via `/eng/common/templates/steps/component-governance.yml` template) based on the branch name (so that this can be invoked for 'vs*' branches as well)

### Note
This will be breaking until we consume this arcade update: https://github.com/dotnet/arcade/commit/b1a9b866bd8e28f55a68b4048306bd1ccb3acb45, it's now flowing to MSBuild main in this PR: https://github.com/dotnet/msbuild/pull/8658

Testing the changes on: https://github.com/dotnet/msbuild/tree/vs-test-only
ADO run: (vs* branch, the CG step injected) https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7672204&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=424211a8-7b86-5e93-500e-ae39b50be1a7
