### PR TITLE
Using URI file schema for Live Logger hyperlinks

### DIFF
--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -377,8 +377,20 @@ internal sealed class LiveLogger : INodeLogger
                             // Ignore any GetDirectoryName exceptions.
                         }
 
+                        string urlString;
+                        try
+                        {
+                            // This should generate file:// schema url string which is better handled by various Terminal clients than raw folder name.
+                            urlString = new Uri(url.ToString()).AbsoluteUri;
+                        }
+                        catch
+                        {
+                            // If Uri constructor throws use raw folder name instead.
+                            urlString = url.ToString();
+                        }
+
                         Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath",
-                            $"{AnsiCodes.LinkPrefix}{url.ToString()}{AnsiCodes.LinkInfix}{outputPath}{AnsiCodes.LinkSuffix}"));
+                            $"{AnsiCodes.LinkPrefix}{urlString}{AnsiCodes.LinkInfix}{outputPath}{AnsiCodes.LinkSuffix}"));
                     }
                     else
                     {

--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -377,16 +377,11 @@ internal sealed class LiveLogger : INodeLogger
                             // Ignore any GetDirectoryName exceptions.
                         }
 
-                        string urlString;
-                        try
+                        // Generates file:// schema url string which is better handled by various Terminal clients than raw folder name.
+                        string urlString = url.ToString();
+                        if (Uri.TryCreate(urlString, UriKind.Absolute, out Uri? uri))
                         {
-                            // This should generate file:// schema url string which is better handled by various Terminal clients than raw folder name.
-                            urlString = new Uri(url.ToString()).AbsoluteUri;
-                        }
-                        catch
-                        {
-                            // If Uri constructor throws use raw folder name instead.
-                            urlString = url.ToString();
+                            urlString = uri.AbsoluteUri;
                         }
 
                         Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath",


### PR DESCRIPTION
Related to #8413

### Context
Some VT100 Terminal client requires

### Changes Made
Using URI file schema for Live Logger hyperlinks

### Testing
Manual local testing on Windows, VS code and Linux.

### Notes
It has been that way in Eduardo version before.
