### PR TITLE
Colorize TF instead of enclosing it in brackets

### DIFF
--- a/src/MSBuild/LiveLogger/AnsiCodes.cs
+++ b/src/MSBuild/LiveLogger/AnsiCodes.cs
@@ -85,4 +85,14 @@ internal static class AnsiCodes
     /// Shows/restores the cursor.
     /// </summary>
     public const string ShowCursor = "\x1b[?25h";
+
+    public static string Colorize(string? s, TerminalColor color)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return s ?? "";
+        }
+
+        return $"{CSI}{(int)color}{SetColor}{s}{SetDefaultColor}";
+    }
 }

--- a/src/MSBuild/LiveLogger/ITerminal.cs
+++ b/src/MSBuild/LiveLogger/ITerminal.cs
@@ -69,19 +69,3 @@ internal interface ITerminal : IDisposable
     /// </summary>
     string RenderColor(TerminalColor color, string text);
 }
-
-/// <summary>
-/// Enumerates the text colors supported by <see cref="ITerminal"/>.
-/// </summary>
-internal enum TerminalColor
-{
-    Black = 30,
-    Red = 31,
-    Green = 32,
-    Yellow = 33,
-    Blue = 34,
-    Magenta = 35,
-    Cyan = 36,
-    White = 37,
-    Default = 39
-}

--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -53,7 +53,7 @@ internal sealed class LiveLogger : INodeLogger
                 : ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectBuilding_WithTF",
                     Indentation,
                     Project,
-                    TargetFramework,
+                    AnsiCodes.Colorize(TargetFramework, TargetFrameworkColor),
                     Target,
                     duration);
         }
@@ -63,6 +63,8 @@ internal sealed class LiveLogger : INodeLogger
     /// The indentation to use for all build output.
     /// </summary>
     private const string Indentation = "  ";
+
+    private const TerminalColor TargetFrameworkColor = TerminalColor.Cyan;
 
     /// <summary>
     /// Protects access to state shared between the logger callbacks and the rendering thread.
@@ -363,7 +365,7 @@ internal sealed class LiveLogger : INodeLogger
                         Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
                             Indentation,
                             projectFile,
-                            project.TargetFramework,
+                            AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
                             buildResult,
                             duration));
                     }

--- a/src/MSBuild/LiveLogger/TerminalColor.cs
+++ b/src/MSBuild/LiveLogger/TerminalColor.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.Logging.LiveLogger;
+
+/// <summary>
+/// Enumerates the text colors supported by <see cref="ITerminal"/>.
+/// </summary>
+internal enum TerminalColor
+{
+    Black = 30,
+    Red = 31,
+    Green = 32,
+    Yellow = 33,
+    Blue = 34,
+    Magenta = 35,
+    Cyan = 36,
+    White = 37,
+    Default = 39
+}

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1422,7 +1422,7 @@
     </comment>
   </data>
   <data name="ProjectFinished_WithTF" xml:space="preserve">
-    <value>{0}{1} [{2}] {3} ({4}s)</value>
+    <value>{0}{1} {2} {3} ({4}s)</value>
     <comment>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1450,7 +1450,7 @@
     </comment>
   </data>
   <data name="ProjectBuilding_WithTF" xml:space="preserve">
-    <value>{0}{1} [{2}] {3} ({4}s)</value>
+    <value>{0}{1} {2} {3} ({4}s)</value>
     <comment>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1390,8 +1390,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1421,8 +1421,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1382,8 +1382,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1413,8 +1413,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1389,8 +1389,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1420,8 +1420,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1382,8 +1382,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1413,8 +1413,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1393,8 +1393,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1424,8 +1424,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1382,8 +1382,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1413,8 +1413,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1382,8 +1382,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1413,8 +1413,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1391,8 +1391,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1422,8 +1422,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1383,8 +1383,8 @@ arquivo de resposta.
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1414,8 +1414,8 @@ arquivo de resposta.
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1381,8 +1381,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1412,8 +1412,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1386,8 +1386,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1417,8 +1417,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1382,8 +1382,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1413,8 +1413,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1382,8 +1382,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectBuilding_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project building including target framework information.
       {0}: indentation - few spaces to visually indent row
@@ -1413,8 +1413,8 @@
     </note>
       </trans-unit>
       <trans-unit id="ProjectFinished_WithTF">
-        <source>{0}{1} [{2}] {3} ({4}s)</source>
-        <target state="new">{0}{1} [{2}] {3} ({4}s)</target>
+        <source>{0}{1} {2} {3} ({4}s)</source>
+        <target state="new">{0}{1} {2} {3} ({4}s)</target>
         <note>
       Project finished summary including target framework information.
       {0}: indentation - few spaces to visually indent row


### PR DESCRIPTION
Example:

https://user-images.githubusercontent.com/3347530/235191194-78d9e6bf-2f26-4310-a685-82139b69be66.mp4

I like this both because it highlights the TF more clearly _and_ because it saves two characters of line width.