### PR TITLE
Let env find bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink


### PR DESCRIPTION
Fixes source building under FreeBSD where a symlink has not been made for `bash`

### Context
`/bin/bash` is standard under OSes that ship with `bash` installed by default. FreeBSD does not have `bash` as a default shell.

### Changes Made
For portability `/usr/bin/env bash` is used on the shebang line. This also bring it inline with other dotnet repos.

### Testing
none needed?

### Notes
 `env` is standard at this point. I have been unable to find a non-historic UNIX-like system that places `env` in a location exclusively that is not `/usr/bin/`