### PR TITLE
Shouldly 4.2.1

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="PdbGit" Version="3.0.41" />
     <PackageVersion Update="PdbGit" Condition="'$(PdbGitVersion)' != ''" Version="$(PdbGitVersion)" />
 
-    <PackageVersion Include="Shouldly" Version="3.0.0" />
+    <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Update="Shouldly" Condition="'$(ShouldlyVersion)' != ''" Version="$(ShouldlyVersion)" />
 
     <PackageVersion Include="System.CodeDom" Version="7.0.0" />

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Build.UnitTests
                         TaskFactory="RoslynCodeTaskFactory"
                         AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
                         <ParameterGroup />
-                        <Task> 
+                        <Task>
                           <Using Namespace="System"/>
                           <Using Namespace="System.IO"/>
                           <Using Namespace="System.Reflection"/>
@@ -263,7 +263,7 @@ namespace Microsoft.Build.UnitTests
             // Can't just compare `Name` because `ZipArchive` does not handle unix directory separators well
             // thus producing garbled fully qualified paths in the actual .ProjectImports.zip entries
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"),
-                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
+                $"Embedded files: {string.Join(",", zipArchive.Entries)}");
         }
 
         [RequiresSymbolicLinksFact]
@@ -323,13 +323,13 @@ namespace Microsoft.Build.UnitTests
             // Can't just compare `Name` because `ZipArchive` does not handle unix directory separators well
             // thus producing garbled fully qualified paths in the actual .ProjectImports.zip entries
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith("testtaskoutputfile.txt"),
-                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
+                customMessage: $"Embedded files: {string.Join(",", zipArchive.Entries)}");
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkName),
-                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
+                customMessage: $"Embedded files: {string.Join(",", zipArchive.Entries)}");
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(symlinkLvl2Name),
-                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
+                customMessage: $"Embedded files: {string.Join(",", zipArchive.Entries)}");
             zipArchive.Entries.ShouldContain(zE => zE.Name.EndsWith(emptyFileName),
-                () => $"Embedded files: {string.Join(",", zipArchive.Entries)}");
+                customMessage: $"Embedded files: {string.Join(",", zipArchive.Entries)}");
         }
 
         [Fact]

--- a/src/Build.UnitTests/Collections/CopyOnWritePropertyDictionary_Tests.cs
+++ b/src/Build.UnitTests/Collections/CopyOnWritePropertyDictionary_Tests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             return dic;
         }
 
-        private sealed class MockValue : IKeyed, IValued, IEquatable<MockValue>, IImmutable
+        private sealed class MockValue : IKeyed, IValued, IEquatable<MockValue>, IEquatable<object>, IImmutable
         {
             public MockValue(string s) => Key = s;
 
@@ -209,6 +209,15 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             public bool Equals(MockValue? other)
             {
                 return other != null && Key == other.Key;
+            }
+
+            public new bool Equals(object? other)
+            {
+                if (other is MockValue mv)
+                {
+                    return Equals(mv);
+                }
+                return false;
             }
         }
     }

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -2651,18 +2651,18 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Version.TryParse(msbuildVersionProperty, out Version msbuildVersionAsVersion).ShouldBeTrue();
 
             msbuildVersionAsVersion.Minor.ShouldBeInRange(0, 20,
-                () => $"minor version {msbuildVersionProperty} looks fishy. If we're really in x.20.0, go ahead and change the constant. This is to guard against being nonsensical like 16.200.19");
+                customMessage: $"minor version {msbuildVersionProperty} looks fishy. If we're really in x.20.0, go ahead and change the constant. This is to guard against being nonsensical like 16.200.19");
 
             // Version parses missing elements into -1, and this property should be Major.Minor.Patch only
             msbuildVersionAsVersion.Revision.ShouldBe(-1);
 
             msbuildFileVersionProperty.ShouldBe(ProjectCollection.Version.ToString());
             ProjectCollection.Version.ToString().ShouldStartWith(msbuildVersionProperty,
-                "ProjectCollection.Version should match the property MSBuildVersion, but can contain another version part");
+                customMessage: "ProjectCollection.Version should match the property MSBuildVersion, but can contain another version part");
 
             msbuildSemanticVersionProperty.ShouldBe(ProjectCollection.DisplayVersion);
             ProjectCollection.DisplayVersion.ShouldStartWith(msbuildVersionProperty,
-                "DisplayVersion is semver2 while MSBuildVersion is Major.Minor.Build but should be a prefix match");
+                customMessage: "DisplayVersion is semver2 while MSBuildVersion is Major.Minor.Build but should be a prefix match");
         }
 
 

--- a/src/Build.UnitTests/Utilities_Tests.cs
+++ b/src/Build.UnitTests/Utilities_Tests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Build.UnitTests
             bool foundDoNotModify = false;
             foreach (string line in File.ReadLines(outputFile.Path))
             {
-                line.ShouldNotContain("<!---->", "This is what it will look like if we're loading read/only");
+                line.ShouldNotContain("<!---->", customMessage: "This is what it will look like if we're loading read/only");
 
                 if (line.Contains("DO NOT MODIFY")) // this is in a comment in our targets
                 {
@@ -170,7 +170,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 ObjectModelHelpers.CreateInMemoryProject(@"
-                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`> 
+                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <ProjectExtensions/>
                     <Import Project=`$(MSBuildBinPath)\\Microsoft.CSharp.Targets` />
                     <ProjectExtensions/>

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1314,8 +1314,7 @@ namespace Microsoft.Build.UnitTests
 
             string logContents = ExecuteMSBuildExeExpectSuccess(contents, envsToCreate: environmentVars, arguments: aggregateArguments);
 
-            string expected = $@"Task priority is '{expectedPrority}'";
-            logContents.ShouldContain(expected, () => logContents);
+            logContents.ShouldContain($@"Task priority is '{expectedPrority}'", customMessage: logContents);
         }
 
         /// <summary>
@@ -2173,8 +2172,8 @@ $@"<Project>
 
             string logContents = ExecuteMSBuildExeExpectSuccess(projectContents, arguments: "/t:Target1 /t:Target2");
 
-            logContents.ShouldContain("7514CB1641A948D0A3930C5EC2DC1940", () => logContents);
-            logContents.ShouldContain("E2C73B5843F94B63B067D9BEB2C4EC52", () => logContents);
+            logContents.ShouldContain("7514CB1641A948D0A3930C5EC2DC1940", customMessage: logContents);
+            logContents.ShouldContain("E2C73B5843F94B63B067D9BEB2C4EC52", customMessage: logContents);
         }
 
         [Theory]
@@ -2197,8 +2196,8 @@ $@"<Project>
 
             var output = RunnerUtilities.ExecMSBuild(parametersLoggerOptional, out bool successfulExit, _output);
             successfulExit.ShouldBe(true);
-            output.ShouldContain("Hello", output);
-            output.ShouldContain("The specified logger could not be created and will not be used.", output);
+            output.ShouldContain("Hello", customMessage: output);
+            output.ShouldContain("The specified logger could not be created and will not be used.", customMessage: output);
         }
 
         [Theory]
@@ -2463,7 +2462,7 @@ EndGlobal
         {
             (bool result, string output) = ExecuteMSBuildExe(projectContents, filesToCreate, envsToCreate, arguments);
 
-            result.ShouldBeTrue(() => output);
+            result.ShouldBeTrue(output);
 
             return output;
         }
@@ -2472,7 +2471,7 @@ EndGlobal
         {
             (bool result, string output) = ExecuteMSBuildExe(projectContents, filesToCreate, envsToCreate, arguments);
 
-            result.ShouldBeFalse(() => output);
+            result.ShouldBeFalse(output);
 
             return output;
         }

--- a/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
+++ b/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\..\Framework\Microsoft.Build.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Build.UnitTests
             }
 
             items.Count.ShouldBe(expectedItems.Length,
-                () => $"got items \"{string.Join(", ", items)}\", expected \"{string.Join(", ", expectedItems)}\"");
+                customMessage: $"got items \"{string.Join(", ", items)}\", expected \"{string.Join(", ", expectedItems)}\"");
 
             expectedItems.Length.ShouldBe(expectedDirectMetadataPerItem.Length);
         }
@@ -461,7 +461,7 @@ namespace Microsoft.Build.UnitTests
 
         internal static void AssertItemHasMetadata(string key, string value, ProjectItem item)
         {
-            item.DirectMetadataCount.ShouldBe(1, () => $"Expected 1 metadata, ({key}), got {item.DirectMetadataCount}");
+            item.DirectMetadataCount.ShouldBe(1, customMessage: $"Expected 1 metadata, ({key}), got {item.DirectMetadataCount}");
             item.GetMetadataValue(key).ShouldBe(value);
         }
 
@@ -469,7 +469,7 @@ namespace Microsoft.Build.UnitTests
         {
             expected ??= new Dictionary<string, string>();
 
-            item.DirectMetadataCount.ShouldBe(expected.Keys.Count, () => $"Expected {expected.Keys.Count} metadata, ({string.Join(", ", expected.Keys)}), got {item.DirectMetadataCount}");
+            item.DirectMetadataCount.ShouldBe(expected.Keys.Count, customMessage: $"Expected {expected.Keys.Count} metadata, ({string.Join(", ", expected.Keys)}), got {item.DirectMetadataCount}");
 
             foreach (var key in expected.Keys)
             {
@@ -1426,7 +1426,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Verify that a drive enumerating wildcard warning is logged or exception is thrown. 
+        /// Verify that a drive enumerating wildcard warning is logged or exception is thrown.
         /// </summary>
         internal static void CleanContentsAndBuildTargetWithDriveEnumeratingWildcard(string content, string failOnDriveEnumerationEnvVar, string targetName, ExpectedBuildResult expectedBuildResult, ITestOutputHelper testOutput = null)
         {

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -733,7 +733,7 @@ namespace Microsoft.Build.UnitTests
             Path.ShouldNotBe(@"\");
             Path.ShouldNotBe(@"/");
             System.IO.Path.GetFullPath(Path).ShouldNotBe(System.IO.Path.GetFullPath(System.IO.Path.GetTempPath()));
-            System.IO.Path.IsPathRooted(Path).ShouldBeTrue(() => $"{Path} is not rooted");
+            System.IO.Path.IsPathRooted(Path).ShouldBeTrue($"{Path} is not rooted");
 
             FileUtilities.DeleteDirectoryNoThrow(Path, true);
         }

--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 FileInfo file = new FileInfo(Path.Combine(folder.Path, "foo.txt"));
 
-                file.Exists.ShouldBeTrue(() => file.FullName);
+                file.Exists.ShouldBeTrue(file.FullName);
 
                 File.ReadAllText(file.FullName).ShouldBe("Success!");
 
@@ -121,7 +121,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 FileInfo file = new FileInfo(Path.Combine(folder.Path, filename));
 
-                file.Exists.ShouldBeTrue(() => file.FullName);
+                file.Exists.ShouldBeTrue(file.FullName);
 
                 File.ReadAllText(file.FullName).ShouldBe("Success!");
 
@@ -155,7 +155,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 FileInfo file = new FileInfo(Path.Combine(folder.Path, filename));
 
-                file.Exists.ShouldBeTrue(() => file.FullName);
+                file.Exists.ShouldBeTrue(file.FullName);
 
                 File.ReadAllText(file.FullName).ShouldBe("Success!");
 
@@ -172,7 +172,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 SourceUrl = "&&&&&"
             };
 
-            downloadFile.Execute().ShouldBeFalse(() => _mockEngine.Log);
+            downloadFile.Execute().ShouldBeFalse(_mockEngine.Log);
 
             _mockEngine.Log.ShouldContain("MSB3921");
         }
@@ -187,7 +187,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 SourceUrl = "http://notfound/foo.txt"
             };
 
-            downloadFile.Execute().ShouldBeFalse(() => _mockEngine.Log);
+            downloadFile.Execute().ShouldBeFalse(_mockEngine.Log);
 
             _mockEngine.Log.ShouldContain("Response status code does not indicate success: 404 (Not Found).");
         }
@@ -226,9 +226,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceUrl = "http://success/foo.txt"
                 };
 
-                downloadFile.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                downloadFile.Execute().ShouldBeTrue(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3924", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3924", customMessage: _mockEngine.Log);
             }
         }
 
@@ -244,9 +244,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                 SourceUrl = "http://notfound/foo.txt"
             };
 
-            downloadFile.Execute().ShouldBeFalse(() => _mockEngine.Log);
+            downloadFile.Execute().ShouldBeFalse(_mockEngine.Log);
 
-            _mockEngine.Log.ShouldContain("MSB3924", () => _mockEngine.Log);
+            _mockEngine.Log.ShouldContain("MSB3924", customMessage: _mockEngine.Log);
         }
 
         [Fact]
@@ -267,9 +267,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                 SourceUrl = "http://notfound/foo.txt"
             };
 
-            downloadFile.Execute().ShouldBeFalse(() => _mockEngine.Log);
+            downloadFile.Execute().ShouldBeFalse(_mockEngine.Log);
 
-            _mockEngine.Log.ShouldContain("MSB3923", () => _mockEngine.Log);
+            _mockEngine.Log.ShouldContain("MSB3923", customMessage: _mockEngine.Log);
         }
 
         [Fact]
@@ -306,7 +306,7 @@ namespace Microsoft.Build.Tasks.UnitTests
             runaway.IsCompleted.ShouldBeTrue("Task did not cancel");
 
             var result = await runaway;
-            result.ShouldBeFalse(() => _mockEngine.Log);
+            result.ShouldBeFalse(_mockEngine.Log);
         }
 
         [Fact]
@@ -339,7 +339,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 downloadFile.Execute().ShouldBeTrue();
 
-                _mockEngine.Log.ShouldContain("Did not download file from \"http://success/foo.txt\"", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("Did not download file from \"http://success/foo.txt\"", customMessage: _mockEngine.Log);
             }
         }
 
@@ -357,9 +357,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                 SourceUrl = "http://unknown/"
             };
 
-            downloadFile.Execute().ShouldBeFalse(() => _mockEngine.Log);
+            downloadFile.Execute().ShouldBeFalse(_mockEngine.Log);
 
-            _mockEngine.Log.ShouldContain("MSB3922", () => _mockEngine.Log);
+            _mockEngine.Log.ShouldContain("MSB3922", customMessage: _mockEngine.Log);
         }
 
         private sealed class MockHttpContent : HttpContent

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
             /* Unmerged change from project 'Microsoft.Build.Tasks.UnitTests (net7.0)'
             Before:
             Utilities.AssertLogContainsResource(t, "GenerateResource.OutputDoesntExist", t.OutputResources[0].ItemSpec);
-            
+
             Utilities.AssertStateFileWasWritten(t);
             After:
             Utilities.AssertLogContainsResource(t, "GenerateResource.OutputDoesntExist", t.OutputResources[0].ItemSpec);
@@ -1557,10 +1557,10 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
 
                 string generatedSource = File.ReadAllText(t.StronglyTypedFileName);
 
-                generatedSource.ShouldNotContain("object Image1", "Strongly-typed resource accessor is returning type `object` instead of `System.Drawing.Bitmap`");
+                generatedSource.ShouldNotContain("object Image1", customMessage: "Strongly-typed resource accessor is returning type `object` instead of `System.Drawing.Bitmap`");
                 generatedSource.ShouldContain("Bitmap Image1");
 
-                generatedSource.ShouldNotContain("object MyString", "Strongly-typed resource accessor is returning type `object` instead of `string`");
+                generatedSource.ShouldNotContain("object MyString", customMessage: "Strongly-typed resource accessor is returning type `object` instead of `string`");
                 generatedSource.ShouldContain("static string MyString");
                 generatedSource.ShouldMatch("//.*Looks up a localized string similar to MyValue", "Couldn't find a comment in the usual format for a string resource.");
             }
@@ -1718,7 +1718,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 /* Unmerged change from project 'Microsoft.Build.Tasks.UnitTests (net7.0)'
                 Before:
                 Assert.False(success);
-                
+
                 Utilities.AssertStateFileWasWritten(t);
                 After:
                 Assert.False(success);
@@ -1797,7 +1797,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 /* Unmerged change from project 'Microsoft.Build.Tasks.UnitTests (net7.0)'
                 Before:
                 Assert.False(success);
-                
+
                 Utilities.AssertStateFileWasWritten(t);
                 After:
                 Assert.False(success);
@@ -2317,7 +2317,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 /* Unmerged change from project 'Microsoft.Build.Tasks.UnitTests (net7.0)'
                 Before:
                 Assert.Equal(t.FilesWritten[2].ItemSpec, Path.ChangeExtension(t.Sources[3].ItemSpec, ".resources"));
-                
+
                 Utilities.AssertStateFileWasWritten(t);
                 After:
                 Assert.Equal(t.FilesWritten[2].ItemSpec, Path.ChangeExtension(t.Sources[3].ItemSpec, ".resources"));

--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -989,7 +989,7 @@ namespace InlineCode {{
 
             buildEngine.Errors.ShouldBe(1);
 
-            buildEngine.Log.ShouldContain(expectedErrorMessage, () => buildEngine.Log);
+            buildEngine.Log.ShouldContain(expectedErrorMessage, customMessage: buildEngine.Log);
         }
 
         private void TryLoadTaskBodyAndExpectSuccess(
@@ -1023,7 +1023,7 @@ namespace InlineCode {{
 
                 foreach (string expectedWarningMessage in expectedWarningMessages)
                 {
-                    output.ShouldContain(expectedWarningMessage, () => output);
+                    output.ShouldContain(expectedWarningMessage, customMessage: output);
                 }
             }
 

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) }
                 };
 
-                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeTrue(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("638AF4AE88A146E09CB69FE1CA7083DC", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("638AF4AE88A146E09CB69FE1CA7083DC", customMessage: _mockEngine.Log);
             }
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
                     FailIfNotIncremental = true,
                 };
-                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeFalse(_mockEngine.Log);
                 _mockEngine.Log = string.Empty;
 
                 // Run the task.
@@ -83,10 +83,10 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
                     FailIfNotIncremental = false,
                 };
-                unzip2.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                unzip2.Execute().ShouldBeTrue(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), customMessage: _mockEngine.Log);
 
                 // Question ran task, should be true
                 Unzip unzip3 = new Unzip
@@ -98,7 +98,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) },
                     FailIfNotIncremental = true,
                 };
-                unzip3.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                unzip3.Execute().ShouldBeTrue(_mockEngine.Log);
             }
         }
 
@@ -127,12 +127,12 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) }
                 };
 
-                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeTrue(customMessage: _mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "subdir", "F83E9633685494E53BEF3794EDEEE6A6.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "subdir", "21D6D4596067723B3AC5DF9A8B3CBFE7.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "subdir", "F83E9633685494E53BEF3794EDEEE6A6.txt"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "subdir", "21D6D4596067723B3AC5DF9A8B3CBFE7.txt"), customMessage: _mockEngine.Log);
                 Directory.Exists(Path.Combine(destination.Path, "emptyDir"));
             }
         }
@@ -146,9 +146,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                 DestinationFolder = new TaskItem(String.Empty)
             };
 
-            unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+            unzip.Execute().ShouldBeFalse(_mockEngine.Log);
 
-            _mockEngine.Log.ShouldContain("MSB3931", () => _mockEngine.Log);
+            _mockEngine.Log.ShouldContain("MSB3931", customMessage: _mockEngine.Log);
         }
 
         public static bool NotRunningAsRoot()
@@ -195,9 +195,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) }
                 };
 
-                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeFalse(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain($"D6DFD219DACE48F8B86EFCDF98433333.txt{(NativeMethodsShared.IsMono ? "\"" : "'")} is denied", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain($"D6DFD219DACE48F8B86EFCDF98433333.txt{(NativeMethodsShared.IsMono ? "\"" : "'")} is denied", customMessage: _mockEngine.Log);
             }
         }
 
@@ -217,9 +217,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceFiles = new ITaskItem[] { new TaskItem(file.Path), }
                 };
 
-                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeFalse(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3933", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3933", customMessage: _mockEngine.Log);
             }
         }
 
@@ -237,9 +237,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceFiles = new ITaskItem[] { new TaskItem(Path.Combine(testEnvironment.DefaultTestDirectory.Path, "foo.zip")), }
                 };
 
-                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeFalse(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3932", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3932", customMessage: _mockEngine.Log);
             }
         }
 
@@ -265,10 +265,10 @@ namespace Microsoft.Build.Tasks.UnitTests
                     Include = "BE78A17D30144B549D21F71D5C633F7D.txt"
                 };
 
-                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeTrue(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), customMessage: _mockEngine.Log);
             }
         }
 
@@ -294,10 +294,10 @@ namespace Microsoft.Build.Tasks.UnitTests
                     Exclude = "BE78A17D30144B549D21F71D5C633F7D.txt"
                 };
 
-                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeTrue(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), customMessage: _mockEngine.Log);
             }
         }
 
@@ -328,13 +328,13 @@ namespace Microsoft.Build.Tasks.UnitTests
                     Exclude = "*.js.map;sub\\*.js"
                 };
 
-                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeTrue(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "file1.js"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "file1.js.map"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "file2.js"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "readme.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "sub", "subfile.js"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "file1.js"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "file1.js.map"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "file2.js"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "readme.txt"), customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldNotContain(Path.Combine(destination.Path, "sub", "subfile.js"), customMessage: _mockEngine.Log);
             }
         }
 
@@ -360,9 +360,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     Include = "<BE78A17D30144B|549D21F71D5C633F7D/.txt"
                 };
 
-                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeFalse(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3937", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3937", customMessage: _mockEngine.Log);
             }
         }
 
@@ -388,9 +388,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     Include = "$(Include)"
                 };
 
-                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeFalse(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3938", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3938", customMessage: _mockEngine.Log);
             }
         }
 
@@ -416,9 +416,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     Exclude = "<BE78A17D30144B|549D21F71D5C633F7D/.txt"
                 };
 
-                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeFalse(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3937", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3937", customMessage: _mockEngine.Log);
             }
         }
 
@@ -444,9 +444,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     Exclude = "$(Include)"
                 };
 
-                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+                unzip.Execute().ShouldBeFalse(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3938", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3938", customMessage: _mockEngine.Log);
             }
         }
     }

--- a/src/Tasks.UnitTests/VerifyFileHash_Tests.cs
+++ b/src/Tasks.UnitTests/VerifyFileHash_Tests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.UnitTests
                 Hash = hash,
             };
 
-            task.Execute().ShouldBeFalse(() => _mockEngine.Log);
+            task.Execute().ShouldBeFalse(_mockEngine.Log);
 
             var errorEvent = _mockEngine.ErrorEvents.ShouldHaveSingleItem();
 

--- a/src/Tasks.UnitTests/ZipDirectory_Tests.cs
+++ b/src/Tasks.UnitTests/ZipDirectory_Tests.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceDirectory = new TaskItem(sourceFolder.Path)
                 };
 
-                zipDirectory.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                zipDirectory.Execute().ShouldBeTrue(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(sourceFolder.Path, () => _mockEngine.Log);
-                _mockEngine.Log.ShouldContain(zipFilePath, () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(sourceFolder.Path, customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(zipFilePath, customMessage: _mockEngine.Log);
 
                 using (FileStream stream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
@@ -80,10 +80,10 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceDirectory = new TaskItem(sourceFolder.Path)
                 };
 
-                zipDirectory.Execute().ShouldBeTrue(() => _mockEngine.Log);
+                zipDirectory.Execute().ShouldBeTrue(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(sourceFolder.Path, () => _mockEngine.Log);
-                _mockEngine.Log.ShouldContain(file.Path, () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(sourceFolder.Path, customMessage: _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(file.Path, customMessage: _mockEngine.Log);
 
                 using (FileStream stream = new FileStream(file.Path, FileMode.Open, FileAccess.Read, FileShare.Read))
                 using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
@@ -118,9 +118,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SourceDirectory = new TaskItem(folder.Path)
                 };
 
-                zipDirectory.Execute().ShouldBeFalse(() => _mockEngine.Log);
+                zipDirectory.Execute().ShouldBeFalse(_mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3942", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3942", customMessage: _mockEngine.Log);
             }
         }
 
@@ -133,9 +133,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                 SourceDirectory = new TaskItem(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")))
             };
 
-            zipDirectory.Execute().ShouldBeFalse(() => _mockEngine.Log);
+            zipDirectory.Execute().ShouldBeFalse(_mockEngine.Log);
 
-            _mockEngine.Log.ShouldContain("MSB3941", () => _mockEngine.Log);
+            _mockEngine.Log.ShouldContain("MSB3941", customMessage: _mockEngine.Log);
         }
     }
 }


### PR DESCRIPTION
Almost all changes are fallout from https://docs.shouldly.org/documentation/3to4#func-less-than-string-greater-than-custommessage-removed.

Fixes were: always materialize the string up front, and sometimes
explicitly specify `customMessage:` to disambiguate methods.
