### PR TITLE
[LiveLogger] Fix error and warning message alignment

### DIFF
--- a/src/MSBuild/LiveLogger/AnsiCodes.cs
+++ b/src/MSBuild/LiveLogger/AnsiCodes.cs
@@ -61,6 +61,14 @@ internal static class AnsiCodes
     public const string MoveForward = "C";
 
     /// <summary>
+    /// Moves backward (to the left) the specified number of characters.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="CSI"/>N<see cref="MoveBackward"/> to move N characters backward.
+    /// </remarks>
+    public const string MoveBackward = "D";
+
+    /// <summary>
     /// Clears everything from cursor to end of screen.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
### Context

The error and warning symbols may be rendered with different width on some terminals, resulting in misaligned output.

### Changes Made

To make sure that the message text is always aligned we
1. Print the symbol.
2. Move back to the start of the line.
3. Move forward to the desired column.
4. Print the message text.

### Testing

Windows terminal:

![image](https://user-images.githubusercontent.com/12206368/235614524-889aecef-6a74-4fc8-ad21-169b65168a54.png)

Windows cmd:

![image](https://user-images.githubusercontent.com/12206368/235614681-d8e3aece-8691-44d4-b764-9a3d4b343836.png)

Fedora terminal:

![image](https://user-images.githubusercontent.com/12206368/235613464-58c82f2d-aec3-49bb-a441-8ef1caa9a470.png)

### Notes

I've also tried saving & restoring cursor position (VT100 functions 7 and 8) but that didn't fully work on Windows. The red X was still off.