### PR TITLE
Add missing p2p annotations for BuildGenerateSources, BuildCompile, BuildLink, FindInvalidProjectReferences

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1027,6 +1027,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </MSBuild>
   </Target>
 
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargets Include="BuildGenerateSources" Targets="BuildGenerateSources" />
+  </ItemGroup>
+
   <!--
     ============================================================
                                         BuildCompile
@@ -1052,6 +1056,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </MSBuild>
   </Target>
 
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargets Include="BuildCompile" Targets="BuildCompile" />
+  </ItemGroup>
+
   <!--
     ============================================================
                                         BuildLink
@@ -1076,6 +1084,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)">
     </MSBuild>
   </Target>
+
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargets Include="BuildLink" Targets="BuildLink" />
+  </ItemGroup>
 
   <!--
     ============================================================
@@ -2697,6 +2709,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="TargetOutputs" ItemName="TargetPathWithTargetPlatformMoniker" />
     </MSBuild>
   </Target>
+
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true' and '$(FindInvalidProjectReferences)' == 'true'">
+    <ProjectReferenceTargets Include="Build" Targets="FindInvalidProjectReferences" />
+  </ItemGroup>
 
    <!--
     ============================================================

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1027,7 +1027,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </MSBuild>
   </Target>
 
-  <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true' and '$(BuildPassReferences)' == 'true'">
     <ProjectReferenceTargets Include="BuildGenerateSources" Targets="BuildGenerateSources" />
   </ItemGroup>
 
@@ -1056,7 +1056,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </MSBuild>
   </Target>
 
-  <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true' and '$(BuildPassReferences)' == 'true'">
     <ProjectReferenceTargets Include="BuildCompile" Targets="BuildCompile" />
   </ItemGroup>
 
@@ -1085,7 +1085,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </MSBuild>
   </Target>
 
-  <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true' and '$(BuildPassReferences)' == 'true'">
     <ProjectReferenceTargets Include="BuildLink" Targets="BuildLink" />
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2711,7 +2711,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Target>
 
   <ItemGroup Condition="'$(IsGraphBuild)' == 'true' and '$(FindInvalidProjectReferences)' == 'true'">
-    <ProjectReferenceTargets Include="Build" Targets="FindInvalidProjectReferences" />
+    <ProjectReferenceTargets Include="Build" Targets="GetTargetPathWithTargetPlatformMoniker" />
   </ItemGroup>
 
    <!--


### PR DESCRIPTION
Add missing p2p annotations for BuildGenerateSources, BuildCompile, BuildLink, FindInvalidProjectReferences

This change adds some missing `ProjectReferenceTargets` items which help with more correct graph construction.