### PR TITLE
[vs17.2] Update sdk version to bump pulled runtime

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.2.6</VersionPrefix>
+    <VersionPrefix>17.2.7</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "6.0.408",
+    "dotnet": "6.0.311",
     "vs": {
       "version": "17.0"
     }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "6.0.200",
+    "dotnet": "6.0.408",
     "vs": {
       "version": "17.0"
     }


### PR DESCRIPTION
Fixes - bunch of CVEs (up to 29): https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted?_a=alerts&typeId=15231688&alerts-view-option=active

### Context

We need to update runtime from 6.0.2 to at least 6.0.12 (this is taking it to 6.0.16 - as part of [SDK 6.0.408](https://dotnet.microsoft.com/en-us/download/dotnet/6.0))