### PR TITLE
Dont ngen taskhost Fixes our lack of optprof data

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -36,7 +36,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe.config
-  file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86 vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuildTaskHost.exe" 
+  file source=$(TaskHostBinPath)MSBuildTaskHost.exe 
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
   file source=$(X86BinPath)System.Buffers.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Memory.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -174,7 +174,7 @@ folder InstallDir:\MSBuild\Current\Bin\zh-Hant
 
 folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64
-  file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x64 vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\amd64\MSBuildTaskHost.exe" 
+  file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe
   file source=$(X64BinPath)MSBuild.exe.config
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe.config
 


### PR DESCRIPTION
MSBuild's TaskHosts are intended for net35 compatibility. They aren't critical from a speed perspective, but we were attempting to ngen them anyway.

That ngen'ing happened in a 4.0.3319 environment—far beyond the net35 compatibility it was intended for.

As a result, it failed. Then, when optprof tests attempted to run our tests, they failed to execute tasks...which expected to get the optimized task host...which meant that although we got _some_ optprof data, we didn't get any for our tasks assembly. This led to errors when we then tried to use those optprof dumps.

Before:
<img width="450" alt="image" src="https://user-images.githubusercontent.com/12969783/236926843-026bc7ef-c9f1-4c73-926b-35539b780d8d.png">

After:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/12969783/236927284-dfc8e729-abfc-4d1e-8310-1434dc828efb.png">