### PR TITLE
[vs17.2] Update vulnerable packages versions

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -28,7 +28,7 @@
     <PackageReference Update="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Update="System.Runtime" Version="4.3.1" />
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.1.2" />
+    <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
     <PackageReference Update="System.Security.Cryptography.Pkcs" Version="4.7.0" />
     <PackageReference Update="System.Security.Cryptography.Xml" Version="4.7.0" />
     <PackageReference Update="System.Security.Permissions" Version="4.7.0" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -15,6 +15,7 @@
     <PackageReference Update="Microsoft.IO.Redist" Version="6.0.0" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" />
     <PackageReference Update="Microsoft.Win32.Registry" Version="4.3.0" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Update="NuGet.Build.Tasks" Version="$(NuGetBuildTasksVersion)" />
     <PackageReference Update="NuGet.Frameworks" Version="$(NuGetBuildTasksVersion)" />
     <PackageReference Update="System.CodeDom" Version="4.4.0" />
@@ -22,9 +23,11 @@
     <PackageReference Update="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Memory" Version="4.5.4" />
+    <PackageReference Update="System.Private.Uri" Version="4.3.2" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.1.2" />
     <PackageReference Update="System.Security.Cryptography.Pkcs" Version="4.7.0" />
     <PackageReference Update="System.Security.Cryptography.Xml" Version="4.7.0" />
     <PackageReference Update="System.Security.Permissions" Version="4.7.0" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -26,6 +26,7 @@
     <PackageReference Update="System.Private.Uri" Version="4.3.2" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
+    <PackageReference Update="System.Runtime" Version="4.3.1" />
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.1.2" />
     <PackageReference Update="System.Security.Cryptography.Pkcs" Version="4.7.0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.2.7</VersionPrefix>
+    <VersionPrefix>17.2.8</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -54,6 +54,14 @@
     <PackageReference Remove="xunit" />
     <PackageReference Include="xunit.core" />
     <PackageReference Include="xunit.assert" />
+    
+    <!-- Force updated reference to this package because xunit and shouldly
+         are netstandard1.6 and transitively bring in an old reference -->
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" />
+
+    <!-- As of 17.3, one TF of Microsoft.NET.Test.Sdk depends on Newtonsoft.Json
+         9.0.1, causing it to be downloaded and flagged by component governance -->
+    <PackageReference Include="Newtonsoft.Json" />
 
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
 

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -228,9 +228,10 @@
     <Reference Include="System.Xml" />
     <PackageReference Include="LargeAddressAware" PrivateAssets="All" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
-    <PackageReference Include="Microsoft.Win32.Registry" />
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework' AND '$(DotNetBuildFromSource)' != 'true'">
+    <!-- Bump these to the latest version despite transitive references to older -->
+    <PackageReference Include="System.Private.Uri" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Build\Microsoft.Build.csproj" />

--- a/src/StringTools.Benchmark/StringTools.Benchmark.csproj
+++ b/src/StringTools.Benchmark/StringTools.Benchmark.csproj
@@ -14,6 +14,9 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <!-- Bump these to the latest version despite transitive references to older -->
+    <PackageReference Include="System.Private.Uri" />
+    <PackageReference Include="System.Runtime" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes: 5 remaining CG issues on vs17.2 (https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted?_a=alerts&typeId=15231688&alerts-view-option=active)

### Context
Couple packages were flagged by CG - updating those,
Plus taking inspiration from https://github.com/dotnet/msbuild/pull/7538 to override the transitive stale packages pull

### Important
Those changes are NOT to be merged into 17.4 (as those are already managed by dependabot there https://github.com/dotnet/msbuild/blob/vs17.4/eng/dependabot/Packages.props)