### PR TITLE
Optimize locking in ProjectCollection (low risk)

### DIFF
--- a/src/Build/Utilities/ReaderWriterLockSlimExtensions.cs
+++ b/src/Build/Utilities/ReaderWriterLockSlimExtensions.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Build.Internal;
 
 internal static class ReaderWriterLockSlimExtensions
 {
-    public static UpgradeableReadLockDisposer EnterDisposableUpgradeableReadLock(this ReaderWriterLockSlim rwLock)
+    public static DisposableReadLock EnterDisposableReadLock(this ReaderWriterLockSlim rwLock)
     {
-        rwLock.EnterUpgradeableReadLock();
-        return new UpgradeableReadLockDisposer(rwLock);
+        rwLock.EnterReadLock();
+        return new DisposableReadLock(rwLock);
     }
 
     public static DisposableWriteLock EnterDisposableWriteLock(this ReaderWriterLockSlim rwLock)
@@ -22,44 +22,21 @@ internal static class ReaderWriterLockSlimExtensions
         return new DisposableWriteLock(rwLock);
     }
 
-    // Officially, Dispose() being called more than once is allowable, but in this case if that were to happen
-    // that means something is very, very wrong. Since it's an internal type, better to be strict.
-
-    internal struct UpgradeableReadLockDisposer : IDisposable
+    internal readonly struct DisposableReadLock : IDisposable
     {
-        private ReaderWriterLockSlim? _rwLock;
+        private readonly ReaderWriterLockSlim _rwLock;
 
-        public UpgradeableReadLockDisposer(ReaderWriterLockSlim rwLock) => _rwLock = rwLock;
+        public DisposableReadLock(ReaderWriterLockSlim rwLock) => _rwLock = rwLock;
 
-        public void Dispose()
-        {
-            var rwLockToDispose = Interlocked.Exchange(ref _rwLock, null);
-
-            if (rwLockToDispose is null)
-            {
-                throw new ObjectDisposedException($"Somehow a {nameof(UpgradeableReadLockDisposer)} is being disposed twice.");
-            }
-
-            rwLockToDispose.ExitUpgradeableReadLock();
-        }
+        public void Dispose() => _rwLock.ExitReadLock();
     }
 
-    internal struct DisposableWriteLock : IDisposable
+    internal readonly struct DisposableWriteLock : IDisposable
     {
-        private ReaderWriterLockSlim? _rwLock;
+        private readonly ReaderWriterLockSlim _rwLock;
 
         public DisposableWriteLock(ReaderWriterLockSlim rwLock) => _rwLock = rwLock;
 
-        public void Dispose()
-        {
-            var rwLockToDispose = Interlocked.Exchange(ref _rwLock, null);
-
-            if (rwLockToDispose is null)
-            {
-                throw new ObjectDisposedException($"Somehow a {nameof(DisposableWriteLock)} is being disposed twice.");
-            }
-
-            rwLockToDispose.ExitWriteLock();
-        }
+        public void Dispose() => _rwLock.ExitWriteLock();
     }
 }


### PR DESCRIPTION
Fixes [AB#1811627](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1811627) (@davkean will likely file a GH issue)

### Context

`ProjectCollection` uses a `ReaderWriterLockSlim` but it never takes it just for reading with `EnterReadLock`. Instead it uses `EnterUpgradeableReadLock`, which effectively provides mutual exclusion when reading data and results in unnecessary contention. The reason cited in comments revolves around reentrancy but calling `EnterReadLock` while already holding the write lock is perfectly legal with `LockRecursionPolicy.SupportsRecursion` so there's no need to mutually exclude readers.

### Changes Made

- Made `ProjectCollection` use plain read lock instead of the upgradeable one.
- Simplified the `IDisposable` holder structs by removing the unneeded interlocked operation.

### Testing

Existing unit tests.

### Notes

This is a safer version of #8728, which attempts to optimize concurrency in this class even further at the expense of readability. In particular, many readers could be converted to volatile reads to eliminate the possibility of contention with writers, some of which may be long-running. Since the reader-writer contention should not happen in VS scenarios, that PR was closed due to unfavorable risk/benefit and left just for future reference.