### PR TITLE
[vs17.2] Expliciltly require matching version of VS for signing validation step

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.2.8</VersionPrefix>
+    <VersionPrefix>17.2.9</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/global.json
+++ b/global.json
@@ -6,9 +6,9 @@
     "dotnet": "6.0.311",
     "vs": {
       "version": "17.0"
-    }
+    },
+    "xcopy-msbuild": "17.0"
   },
-  "xcopy-msbuild": "17.0",
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.23221.7"

--- a/global.json
+++ b/global.json
@@ -8,6 +8,7 @@
       "version": "17.0"
     }
   },
+  "xcopy-msbuild": "17.0",
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.23221.7"


### PR DESCRIPTION
Fixes - failing signing validation step of vs17.2 build

### Context
vs17.2 Signing Validation is failing (https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7763789&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=cdcedd1f-8008-523f-9da1-cc35fbfef9a3):

```
(...)
##[error].packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.23221.7\tools\SdkTasks\SigningValidation.proj(0,0): error : Version 6.0.311 of the .NET SDK requires at least version 17.0.0 of MSBuild. The current available version of MSBuild is 16.10.0.26302. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
(...)
```

Inspecting the arcade scripts - the version used is comming from https://github.com/dotnet/msbuild/blob/vs17.2/eng/common/sdk-task.ps1#L67 and can be overwritten via 'xcopy-msbuild' in our global.json. 
We're already doing so on main and other release branches.

