### PR TITLE
[vs17.2] Update the build tools

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.2.9</VersionPrefix>
+    <VersionPrefix>17.2.10</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/global.json
+++ b/global.json
@@ -5,9 +5,9 @@
   "tools": {
     "dotnet": "6.0.311",
     "vs": {
-      "version": "17.0"
+      "version": "17.2.1"
     },
-    "xcopy-msbuild": "17.0"
+    "xcopy-msbuild": "17.2.1"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
Fixes broken 17.2 build

### Context
vs17.2 Signing Validation is failing (https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7772042&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=cdcedd1f-8008-523f-9da1-cc35fbfef9a3):

```
##[error](NETCORE_ENGINEERING_TELEMETRY=InitializeToolset) {"$id":"1","innerException":null,"message":"The resource RoslynTools.MSBuild.17.0.nupkg for package 'RoslynTools.MSBuild 17.0' doesn't exist. Did you mean roslyntools.msbuild.17.0.0.nupkg?","typeName":"Microsoft.VisualStudio.Services.NuGet.WebApi.Exceptions.PackageSubresourceNotFoundException, Microsoft.VisualStudio.Services.NuGet.WebApi","typeKey":"PackageSubresourceNotFoundException","errorCode":0,"eventId":3000}
```

So updating to 17.2.1 - to align the build tooling with vs17.4 branch

