### PR TITLE
Update package baseline to 17.6 GA version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>17.7.0</VersionPrefix>
-    <PackageValidationBaselineVersion>17.6.0-preview-23178-11</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>17.6.3</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>


### PR DESCRIPTION
Now that 17.6 is released to nuget.org, update to the GA version of the packages as a baseline.