### PR TITLE
Update to latest VSBootstrapper task

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -26,7 +26,7 @@ variables:
   # NOTE: the code is temporarily fixed. For the branches that should use opt-prof from the main branch we should use the latest working Opt-Prof collected from main 20230217.4.
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
     - name: OptProfDrop
-      value: 'OptimizationData/DotNet-msbuild-Trusted/main/20230217.4/7352286/1'   
+      value: 'OptimizationData/DotNet-msbuild-Trusted/main/20230217.4/7352286/1'
     - name: SourceBranch
       value: ''
   # if OptProfDropName is set as a parameter, set OptProfDrop to the parameter and unset SourceBranch
@@ -147,7 +147,7 @@ stages:
 
     # Build VS bootstrapper
     # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-    - task: MicroBuildBuildVSBootstrapper@2
+    - task: MicroBuildBuildVSBootstrapper@3
       inputs:
         vsMajorVersion: $(VisualStudio.MajorVersion)
         channelName: $(VisualStudio.ChannelName)


### PR DESCRIPTION
Fix internal official builds by updating to `MicroBuildBuildVSBootstrapper@3`, which has a fix for some internal VS infrastructure stuff.

Passed on `exp/` in https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=7795060
