### PR TITLE
Move release build leg to dnceng pool

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -100,7 +100,12 @@ jobs:
 - job: FullReleaseOnWindows
   displayName: "Windows Full Release (no bootstrap)"
   pool:
-    vmImage: 'windows-2022'
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCore-Public
+      demands: ImageOverride -equals windows.vs2022preview.amd64.open
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      name: VSEngSS-MicroBuild2022-1ES
+      demands: agent.os -equals Windows_NT
   steps:
   - task: BatchScript@1
     displayName: cibuild.cmd

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -838,7 +838,7 @@ namespace Microsoft.Build.UnitTests
         /// predefined amount of time. The first execution may time out, but all following ones won't. It is expected
         /// that all following executions return success.
         /// </remarks>
-        [Theory]
+        [Theory(Skip = "https://github.com/dotnet/msbuild/issues/8750")]
         [InlineData(1, 1, 1, -1)] // Normal case, no repeat.
         [InlineData(3, 1, 1, -1)] // Repeat without timeout.
         [InlineData(3, 10000, 1, 1000)] // Repeat with timeout.


### PR DESCRIPTION
Move (only) the `Windows Full Release (no bootstrap)` leg to the `windows.vs2022preview.amd64.open` pool, which has Visual Studio 17.6 on it already.

This will unblock #8674 by avoiding https://github.com/dotnet/sdk/issues/32691; the `MSBuild.exe.config` binding redirects in the 17.6 VS will keep the current versions working for the moment.

Internal test run, since it requires splitting definitions for internal vs external: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=7804696&view=logs&j=1522e9b9-b859-5e5f-ec86-a68fc9508baf&t=a8d37b2d-1a39-51d6-c11e-8665c8c9811e