### PR TITLE
Use live OptProf data again

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -23,12 +23,9 @@ variables:
   - name: SourceBranch
     value: $(IbcSourceBranchName)
   # If we're not on a vs* branch, use main as our optprof collection branch
-  # NOTE: the code is temporarily fixed. For the branches that should use opt-prof from the main branch we should use the latest working Opt-Prof collected from main 20230217.4.
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
-    - name: OptProfDrop
-      value: 'OptimizationData/DotNet-msbuild-Trusted/main/20230217.4/7352286/1'
     - name: SourceBranch
-      value: ''
+      value: main
   # if OptProfDropName is set as a parameter, set OptProfDrop to the parameter and unset SourceBranch
   - ${{ if ne(parameters.OptProfDropName, 'default') }}:
     - name: OptProfDrop


### PR DESCRIPTION
Return to using recently-produced OptProf data in official builds rather than the last snapshot of the old collected data. This was enabled with #8737 but we hadn't turned it on yet.

This reverts commit d434c0e464ee0c119bdd5ee87b448e16fe0786be (#8497).
