### PR TITLE
Enable ToolTaskThatTimeoutAndRetry test after change powershell.exe to cmd.exe

### DIFF
--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -842,7 +842,7 @@ namespace Microsoft.Build.UnitTests
         [Theory]
         [InlineData(1, 1, 1, -1)] // Normal case, no repeat.
         [InlineData(3, 1, 1, -1)] // Repeat without timeout.
-        [InlineData(3, 10001, 1, 1000)] // Repeat with timeout.
+        [InlineData(3, 10000, 1, 1000)] // Repeat with timeout.
         public void ToolTaskThatTimeoutAndRetry(int repeats, int initialDelay, int followupDelay, int timeout)
         {
             using var env = TestEnvironment.Create(_output);

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -838,10 +838,11 @@ namespace Microsoft.Build.UnitTests
         /// predefined amount of time. The first execution may time out, but all following ones won't. It is expected
         /// that all following executions return success.
         /// </remarks>
-        [Theory(Skip = "https://github.com/dotnet/msbuild/issues/8750")]
+        //[Theory(Skip = "https://github.com/dotnet/msbuild/issues/8750")]
+        [Theory]
         [InlineData(1, 1, 1, -1)] // Normal case, no repeat.
         [InlineData(3, 1, 1, -1)] // Repeat without timeout.
-        [InlineData(3, 10000, 1, 1000)] // Repeat with timeout.
+        [InlineData(3, 10001, 1, 1000)] // Repeat with timeout.
         public void ToolTaskThatTimeoutAndRetry(int repeats, int initialDelay, int followupDelay, int timeout)
         {
             using var env = TestEnvironment.Create(_output);

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -886,7 +886,7 @@ namespace Microsoft.Build.UnitTests
         /// </remarks>
         private sealed class ToolTaskThatSleeps : ToolTask
         {
-            // Windows command to sleep:
+            // Windows prompt command to sleep:
             private readonly string _windowsSleep = "/c start /wait timeout {0}";
 
             // UNIX command to sleep:

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -886,7 +886,7 @@ namespace Microsoft.Build.UnitTests
         /// </remarks>
         private sealed class ToolTaskThatSleeps : ToolTask
         {
-            // PowerShell command to sleep:
+            // Windows command to sleep:
             private readonly string _windowsSleep = "/c start /wait timeout {0}";
 
             // UNIX command to sleep:
@@ -898,7 +898,7 @@ namespace Microsoft.Build.UnitTests
             public ToolTaskThatSleeps()
                 : base()
             {
-                // Determines shell to use: PowerShell for Windows, sh for UNIX-like systems:
+                // Determines shell to use: cmd for Windows, sh for UNIX-like systems:
                 _pathToShell = NativeMethodsShared.IsUnixLike ? "/bin/sh" : "cmd.exe";
             }
 

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -838,7 +838,7 @@ namespace Microsoft.Build.UnitTests
         /// predefined amount of time. The first execution may time out, but all following ones won't. It is expected
         /// that all following executions return success.
         /// </remarks>
-        //[Theory(Skip = "https://github.com/dotnet/msbuild/issues/8750")]
+        /// [Theory(Skip = "https://github.com/dotnet/msbuild/issues/8750")]
         [Theory]
         [InlineData(1, 1, 1, -1)] // Normal case, no repeat.
         [InlineData(3, 1, 1, -1)] // Repeat without timeout.

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -838,7 +838,6 @@ namespace Microsoft.Build.UnitTests
         /// predefined amount of time. The first execution may time out, but all following ones won't. It is expected
         /// that all following executions return success.
         /// </remarks>
-        /// [Theory(Skip = "https://github.com/dotnet/msbuild/issues/8750")]
         [Theory]
         [InlineData(1, 1, 1, -1)] // Normal case, no repeat.
         [InlineData(3, 1, 1, -1)] // Repeat without timeout.
@@ -888,7 +887,7 @@ namespace Microsoft.Build.UnitTests
         private sealed class ToolTaskThatSleeps : ToolTask
         {
             // PowerShell command to sleep:
-            private readonly string _powerShellSleep = "-NoProfile -ExecutionPolicy RemoteSigned -Command \"Start-Sleep -Milliseconds {0}\"";
+            private readonly string _windowsSleep = "/c start /wait timeout {0}";
 
             // UNIX command to sleep:
             private readonly string _unixSleep = "-c \"sleep {0}\"";
@@ -900,7 +899,7 @@ namespace Microsoft.Build.UnitTests
                 : base()
             {
                 // Determines shell to use: PowerShell for Windows, sh for UNIX-like systems:
-                _pathToShell = NativeMethodsShared.IsUnixLike ? "/bin/sh" : FindOnPath("PowerShell.exe");
+                _pathToShell = NativeMethodsShared.IsUnixLike ? "/bin/sh" : "cmd.exe";
             }
 
             /// <summary>
@@ -941,7 +940,7 @@ namespace Microsoft.Build.UnitTests
             protected override string GenerateCommandLineCommands() =>
                 NativeMethodsShared.IsUnixLike ?
                 string.Format(_unixSleep, RepeatCount < 2 ? InitialDelay / 1000.0 : FollowupDelay / 1000.0) :
-                string.Format(_powerShellSleep, RepeatCount < 2 ? InitialDelay : FollowupDelay);
+                string.Format(_windowsSleep, RepeatCount < 2 ? InitialDelay / 1000.0 : FollowupDelay / 1000.0);
 
             /// <summary>
             /// Ensures that test parameters make sense.


### PR DESCRIPTION
Fixes [#8750](https://github.com/dotnet/msbuild/issues/8750)

### Context
[PowerShell](https://github.com/dotnet/msbuild/blob/main/src/Utilities.UnitTests/ToolTask_Tests.cs#L902) sleep is used for windows - that however prooves to be a bit unstable in CI

### Changes Made
Use cmd.exe 

### Testing
/azp run for several times. It passed.

### Notes
