### PR TITLE
Default to sha256 for RFC3161 timestamping of ClickOnce artifacts

### DIFF
--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -838,7 +838,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             {
                 commandLine.AppendFormat(CultureInfo.InvariantCulture,
                                             "{0} {1} ",
-                                            useRFC3161Timestamp ? "/tr" : "/t",
+                                            useRFC3161Timestamp ? "/td sha256 /tr" : "/t",
                                             timestampUrl.ToString());
             }
             commandLine.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\"", path);

--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -883,7 +883,7 @@ namespace System.Deployment.Internal.CodeSigning
                 // Try RFC3161 first
                 XmlElement signatureValueNode = licenseDom.SelectSingleNode("r:license/r:issuer/ds:Signature/ds:SignatureValue", nsm) as XmlElement;
                 string signatureValue = signatureValueNode.InnerText;
-                timestamp = ObtainRFC3161Timestamp(timeStampUrl, signatureValue, useSha256);
+                timestamp = ObtainRFC3161Timestamp(timeStampUrl, signatureValue, true);
             }
             // Catch CryptographicException to ensure fallback to old code (non-RFC3161)
             catch (CryptographicException)


### PR DESCRIPTION
Fixes AB#1822000

Work item (Internal use): [AB#1822000](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1822000/)

### Context
ClickOnce does not enforce SHA256 digest algo during RFC3161 timestamping of signed artifacts. For binaries, this means that depending on the version of signtool used, SHA1 is selected as the default digest algorithm.


### Changes Made
ClickOnce signing task has been updated to default to sha256 as the timestamping digest algo for both binary and manifest signing. For binaries, this is done by passing the /td switch to signtool.exe. For the XML manifests, this is done by passing the sha256 algo id to the CryptRetrieveTimeStamp API. 

### Testing
Debugged thorough the modified code.
CTI validated signing scenarios with a private.

### Notes
