### PR TITLE
Don't save data on immutable files to per-project disk cache

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -8618,6 +8618,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             rar.ResolvedFiles.Length.ShouldBe(1);
             rar.ResolvedFiles[0].ItemSpec.ShouldBe(refPath);
             rar.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("System.Candy, Version=8.1.2.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+
+            // The reference is not worth persisting in the per-instance cache.
+            rar._cache.IsDirty.ShouldBeFalse();
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceCacheSerialization.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceCacheSerialization.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             systemState.SerializeCache(_rarCacheFile, _taskLoggingHelper);
 
-            var deserialized = SystemState.DeserializeCache(_rarCacheFile, _taskLoggingHelper, typeof(SystemState));
+            var deserialized = StateFileBase.DeserializeCache<SystemState>(_rarCacheFile, _taskLoggingHelper);
 
             deserialized.ShouldNotBeNull();
         }
@@ -63,7 +63,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 cacheStream.Close();
             }
 
-            var deserialized = SystemState.DeserializeCache(_rarCacheFile, _taskLoggingHelper, typeof(SystemState));
+            var deserialized = StateFileBase.DeserializeCache<SystemState>(_rarCacheFile, _taskLoggingHelper);
 
             deserialized.ShouldNotBeNull();
         }
@@ -81,7 +81,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 cacheStream.Close();
             }
 
-            var deserialized = SystemState.DeserializeCache(_rarCacheFile, _taskLoggingHelper, typeof(SystemState));
+            var deserialized = StateFileBase.DeserializeCache<SystemState>(_rarCacheFile, _taskLoggingHelper);
 
             deserialized.ShouldBeNull();
         }
@@ -104,7 +104,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 TransientTestFile file = env.CreateFile();
                 sysState.SerializeCache(file.Path, null);
-                sysState2 = SystemState.DeserializeCache(file.Path, null, typeof(SystemState)) as SystemState;
+                sysState2 = StateFileBase.DeserializeCache<SystemState>(file.Path, null);
             }
 
             Dictionary<string, SystemState.FileState> cache2 = sysState2.instanceLocalFileStateCache;

--- a/src/Tasks.UnitTests/AssemblyRegistrationCache_Tests.cs
+++ b/src/Tasks.UnitTests/AssemblyRegistrationCache_Tests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.UnitTests
             {
                 TransientTestFile file = env.CreateFile();
                 arc.SerializeCache(file.Path, null);
-                arc2 = StateFileBase.DeserializeCache(file.Path, null, typeof(AssemblyRegistrationCache)) as AssemblyRegistrationCache;
+                arc2 = StateFileBase.DeserializeCache<AssemblyRegistrationCache>(file.Path, null);
             }
 
             arc2._assemblies.Count.ShouldBe(arc._assemblies.Count);

--- a/src/Tasks.UnitTests/ResolveComReference_Tests.cs
+++ b/src/Tasks.UnitTests/ResolveComReference_Tests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Build.UnitTests
             {
                 TransientTestFile file = env.CreateFile();
                 cache.SerializeCache(file.Path, null);
-                cache2 = StateFileBase.DeserializeCache(file.Path, null, typeof(ResolveComReferenceCache)) as ResolveComReferenceCache;
+                cache2 = StateFileBase.DeserializeCache<ResolveComReferenceCache>(file.Path, null);
             }
 
             cache2.tlbImpLocation.ShouldBe(cache.tlbImpLocation);

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2036,7 +2036,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal void ReadStateFile(FileExists fileExists)
         {
-            _cache = SystemState.DeserializeCache(_stateFile, Log, typeof(SystemState)) as SystemState;
+            _cache = SystemState.DeserializeCache<SystemState>(_stateFile, Log);
 
             // Construct the cache only if we can't find any caches.
             if (_cache == null && AssemblyInformationCachePaths != null && AssemblyInformationCachePaths.Length > 0)

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2313,7 +2313,7 @@ namespace Microsoft.Build.Tasks
                         {
                             // We don't want to perform I/O to see what the actual timestamp on disk is so we return a fixed made up value.
                             // Note that this value makes the file exist per the check in SystemState.FileTimestampIndicatesFileExists.
-                            return DateTime.MaxValue;
+                            return SystemState.FileState.ImmutableFileLastModifiedMarker;
                         }
                         return getLastWriteTime(path);
                     });

--- a/src/Tasks/RegisterAssembly.cs
+++ b/src/Tasks/RegisterAssembly.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Tasks
 
             if ((AssemblyListFile?.ItemSpec.Length > 0))
             {
-                cacheFile = (AssemblyRegistrationCache)StateFileBase.DeserializeCache(AssemblyListFile.ItemSpec, Log, typeof(AssemblyRegistrationCache)) ??
+                cacheFile = StateFileBase.DeserializeCache<AssemblyRegistrationCache>(AssemblyListFile.ItemSpec, Log) ??
                             new AssemblyRegistrationCache();
             }
 

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal static ResGenDependencies DeserializeCache(string stateFile, bool useSourcePath, TaskLoggingHelper log)
         {
-            var retVal = (ResGenDependencies)DeserializeCache(stateFile, log, typeof(ResGenDependencies)) ?? new ResGenDependencies();
+            var retVal = DeserializeCache<ResGenDependencies>(stateFile, log) ?? new ResGenDependencies();
 
             // Ensure that the cache is properly initialized with respect to how resgen will 
             // resolve linked files within .resx files.  ResGen has two different

--- a/src/Tasks/ResolveComReference.cs
+++ b/src/Tasks/ResolveComReference.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Build.Tasks
             allProjectRefs = new List<ComReferenceInfo>();
             allDependencyRefs = new List<ComReferenceInfo>();
 
-            _timestampCache = (ResolveComReferenceCache)StateFileBase.DeserializeCache(StateFile, Log, typeof(ResolveComReferenceCache));
+            _timestampCache = StateFileBase.DeserializeCache<ResolveComReferenceCache>(StateFile, Log);
 
             if (_timestampCache?.ToolPathsMatchCachePaths(_tlbimpPath, _aximpPath) != true)
             {

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -67,9 +67,9 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Reads the specified file from disk into a StateFileBase derived object.
         /// </summary>
-        internal static StateFileBase DeserializeCache(string stateFile, TaskLoggingHelper log, Type requiredReturnType)
+        internal static T DeserializeCache<T>(string stateFile, TaskLoggingHelper log) where T : StateFileBase
         {
-            StateFileBase retVal = null;
+            T retVal = null;
 
             // First, we read the cache from disk if one exists, or if one does not exist, we create one.
             try
@@ -90,21 +90,20 @@ namespace Microsoft.Build.Tasks
                             return null;
                         }
 
-                        var constructors = requiredReturnType.GetConstructors();
+                        var constructors = typeof(T).GetConstructors();
                         foreach (var constructor in constructors)
                         {
                             var parameters = constructor.GetParameters();
                             if (parameters.Length == 1 && parameters[0].ParameterType == typeof(ITranslator))
                             {
-                                retVal = constructor.Invoke(new object[] { translator }) as StateFileBase;
+                                retVal = constructor.Invoke(new object[] { translator }) as T;
                             }
                         }
 
-                        if (retVal == null || !requiredReturnType.IsInstanceOfType(retVal))
+                        if (retVal == null)
                         {
                             log.LogMessageFromResources("General.CouldNotReadStateFileMessage", stateFile,
                                 log.FormatResourceString("General.IncompatibleStateFileType"));
-                            retVal = null;
                         }
                     }
                 }

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -210,6 +210,16 @@ namespace Microsoft.Build.Tasks
                 get { return frameworkName; }
                 set { frameworkName = value; }
             }
+
+            /// <summary>
+            /// The last-modified value to use for immutable framework files which we don't do I/O on.
+            /// </summary>
+            internal static DateTime ImmutableFileLastModifiedMarker => DateTime.MaxValue;
+
+            /// <summary>
+            /// It is wasteful to persist entries for immutable framework files.
+            /// </summary>
+            internal bool IsWorthPersisting => lastModified != ImmutableFileLastModifiedMarker;
         }
 
         /// <summary>
@@ -258,7 +268,7 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
-        /// Flag that indicates
+        /// Flag that indicates that <see cref="instanceLocalFileStateCache"/> has been modified.
         /// </summary>
         /// <value></value>
         internal bool IsDirty
@@ -339,7 +349,7 @@ namespace Microsoft.Build.Tasks
         {
             // Looking up an assembly to get its metadata can be expensive for projects that reference large amounts
             // of assemblies. To avoid that expense, we remember and serialize this information betweeen runs in
-            // XXXResolveAssemblyReferencesInput.cache files in the intermediate directory and also store it in an
+            // <ProjectFileName>.AssemblyReference.cache files in the intermediate directory and also store it in an
             // process-wide cache to share between successive builds.
             //
             // To determine if this information is up-to-date, we use the last modified date of the assembly, however,
@@ -368,8 +378,8 @@ namespace Microsoft.Build.Tasks
             // If the process-wide cache contains an up-to-date FileState, always use it
             if (isProcessFileStateUpToDate)
             {
-                // For the next build, we may be using a different process. Update the file cache.
-                if (!isInstanceFileStateUpToDate)
+                // For the next build, we may be using a different process. Update the file cache if the entry is worth persisting.
+                if (!isInstanceFileStateUpToDate && cachedProcessFileState.IsWorthPersisting)
                 {
                     instanceLocalFileStateCache[path] = cachedProcessFileState;
                     isDirty = true;
@@ -399,9 +409,15 @@ namespace Microsoft.Build.Tasks
         private FileState InitializeFileState(string path, DateTime lastModified)
         {
             var fileState = new FileState(lastModified);
-            instanceLocalFileStateCache[path] = fileState;
+
+            // Dirty the instance-local cache only with entries that are worth persisting.
+            if (fileState.IsWorthPersisting)
+            {
+                instanceLocalFileStateCache[path] = fileState;
+                isDirty = true;
+            }
+
             s_processWideFileStateCache[path] = fileState;
-            isDirty = true;
 
             return fileState;
         }
@@ -450,7 +466,10 @@ namespace Microsoft.Build.Tasks
                 {
                     fileState.Assembly = AssemblyNameExtension.UnnamedAssembly;
                 }
-                isDirty = true;
+                if (fileState.IsWorthPersisting)
+                {
+                    isDirty = true;
+                }
             }
 
             if (fileState.Assembly.IsUnnamedAssembly)
@@ -471,7 +490,10 @@ namespace Microsoft.Build.Tasks
             if (String.IsNullOrEmpty(fileState.RuntimeVersion))
             {
                 fileState.RuntimeVersion = getAssemblyRuntimeVersion(path);
-                isDirty = true;
+                if (fileState.IsWorthPersisting)
+                {
+                    isDirty = true;
+                }
             }
 
             return fileState.RuntimeVersion;
@@ -503,7 +525,10 @@ namespace Microsoft.Build.Tasks
                     out fileState.scatterFiles,
                     out fileState.frameworkName);
 
-                isDirty = true;
+                if (fileState.IsWorthPersisting)
+                {
+                    isDirty = true;
+                }
             }
 
             dependencies = fileState.dependencies;

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -527,7 +527,7 @@ namespace Microsoft.Build.Tasks
             foreach (ITaskItem stateFile in stateFiles)
             {
                 // Verify that it's a real stateFile. Log message but do not error if not.
-                SystemState sysState = DeserializeCache(stateFile.ToString(), log, typeof(SystemState)) as SystemState;
+                SystemState sysState = DeserializeCache<SystemState>(stateFile.ToString(), log);
                 if (sysState == null)
                 {
                     continue;

--- a/src/Tasks/UnregisterAssembly.cs
+++ b/src/Tasks/UnregisterAssembly.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Build.Tasks
 
             if (AssemblyListFile != null)
             {
-                cacheFile = (AssemblyRegistrationCache)StateFileBase.DeserializeCache(AssemblyListFile.ItemSpec, Log, typeof(AssemblyRegistrationCache));
+                cacheFile = StateFileBase.DeserializeCache<AssemblyRegistrationCache>(AssemblyListFile.ItemSpec, Log);
 
                 // no cache file, nothing to do. In case there was a problem reading the cache file, we can't do anything anyway.
                 if (cacheFile == null)


### PR DESCRIPTION
Contributes to #8635

### Context

With #8688 we no longer need to cache data on immutable framework files on disk as obtaining this information is cheap and does not require I/O.

### Changes Made

Made `SystemState` (the RAR cache) not add such files to the per-instance dictionary. This dictionary is serialized to disk as `<project-file>.AssemblyReference.cache` so the change effectively makes the cache file smaller, saving on serialization and deserialization time.

Also refactored `DeserializeCache` into a generic method instead of taking a `Type` parameter.

For a simple ASP.NET Core app with one project reference and one package reference, the size of the cache file is reduced from 142 kB to 2 kB. Projects with no references other than the SDK will not have the cache file created at all.

### Testing

Existing unit tests, manual measurements.

### Notes

The actual "Don't read the file if the data is already in memory" change will be in a separate upcoming PR.