### PR TITLE
Clarify help text for verbosity Resolves #2359

### DIFF
--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -277,6 +277,10 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </value>
     <comment>
       LOCALIZATION: The following should not be localized:

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -278,7 +278,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </value>
     <comment>
       LOCALIZATION: The following should not be localized:

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -278,7 +278,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </value>
     <comment>
       LOCALIZATION: The following should not be localized:

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -278,9 +278,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </value>
     <comment>
       LOCALIZATION: The following should not be localized:

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -544,7 +544,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;úroveň&gt; Zobrazení daného množství informací v protokolu
                      událostí. Dostupné úrovně podrobností: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -544,9 +544,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;úroveň&gt; Zobrazení daného množství informací v protokolu
                      událostí. Dostupné úrovně podrobností: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -543,8 +543,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;úroveň&gt; Zobrazení daného množství informací v protokolu
+        <target state="needs-review-translation">  -verbosity:&lt;úroveň&gt; Zobrazení daného množství informací v protokolu
                      událostí. Dostupné úrovně podrobností: q[uiet], m[inimal],
                      n[ormal], d[etailed] a diag[nostic]. (Krátký tvar: -v)
                      Příklad:

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -544,7 +544,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;úroveň&gt; Zobrazení daného množství informací v protokolu
                      událostí. Dostupné úrovně podrobností: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -541,7 +541,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;Grad&gt; Zeigt diesen Grad von Informationen im Ereignisprotokoll an.
                      Folgende Ausführlichkeitsgrade sind verfügbar: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -541,9 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;Grad&gt; Zeigt diesen Grad von Informationen im Ereignisprotokoll an.
                      Folgende Ausführlichkeitsgrade sind verfügbar: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -541,7 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;Grad&gt; Zeigt diesen Grad von Informationen im Ereignisprotokoll an.
                      Folgende Ausführlichkeitsgrade sind verfügbar: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -540,8 +540,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;Grad&gt; Zeigt diesen Grad von Informationen im Ereignisprotokoll an.
+        <target state="needs-review-translation">  -verbosity:&lt;Grad&gt; Zeigt diesen Grad von Informationen im Ereignisprotokoll an.
                      Folgende Ausführlichkeitsgrade sind verfügbar: q[uiet], m[inimal],
                      n[ormal], d[etailed] und diag[nostic]. (Kurzform: -v)
                      Beispiel:

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -545,9 +545,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;nivel&gt; Muestra en el registro de eventos la cantidad de información especificada.
                      Los niveles de detalle disponibles son: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -545,7 +545,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;nivel&gt; Muestra en el registro de eventos la cantidad de información especificada.
                      Los niveles de detalle disponibles son: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -544,8 +544,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;nivel&gt; Muestra en el registro de eventos la cantidad de información especificada.
+        <target state="needs-review-translation">  -verbosity:&lt;nivel&gt; Muestra en el registro de eventos la cantidad de información especificada.
                      Los niveles de detalle disponibles son: q[uiet], m[inimal],
                      n[ormal], d[etailed] y diag[nostic]. (Forma corta: -v)
                      Ejemplo:

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -545,7 +545,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;nivel&gt; Muestra en el registro de eventos la cantidad de información especificada.
                      Los niveles de detalle disponibles son: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -541,7 +541,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;niveau&gt; Volume d'inform. affiché dans le journal des événements
          Les niveaux de détail disponibles sont : q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -541,7 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;niveau&gt; Volume d'inform. affiché dans le journal des événements
          Les niveaux de détail disponibles sont : q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -541,9 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;niveau&gt; Volume d'inform. affiché dans le journal des événements
          Les niveaux de détail disponibles sont : q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -540,8 +540,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;niveau&gt; Volume d'inform. affiché dans le journal des événements
+        <target state="needs-review-translation">  -verbosity:&lt;niveau&gt; Volume d'inform. affiché dans le journal des événements
          Les niveaux de détail disponibles sont : q[uiet], m[inimal],
          n[ormal], d[etailed] et diag[nostic]. (Forme abrégée : -v)
          Exemple :

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -548,7 +548,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;livello&gt; Visualizza la quantità di informazioni specificata nel log eventi.
                      I livelli di dettaglio disponibili sono: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -547,8 +547,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;livello&gt; Visualizza la quantità di informazioni specificata nel log eventi.
+        <target state="needs-review-translation">  -verbosity:&lt;livello&gt; Visualizza la quantità di informazioni specificata nel log eventi.
                      I livelli di dettaglio disponibili sono: q[uiet], m[inimal],
                      n[ormal], d[etailed] e diag[nostic]. Forma breve: -v.
                      Esempio:

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -548,9 +548,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;livello&gt; Visualizza la quantità di informazioni specificata nel log eventi.
                      I livelli di dettaglio disponibili sono: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -548,7 +548,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;livello&gt; Visualizza la quantità di informazioni specificata nel log eventi.
                      I livelli di dettaglio disponibili sono: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -540,8 +540,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;level&gt; イベント ログに表示する情報量です。
+        <target state="needs-review-translation">  -verbosity:&lt;level&gt; イベント ログに表示する情報量です。
                      利用可能な詳細レベル: q[uiet]、m[inimal]、
                      n[ormal]、d[etailed]、diag[nostic]。(短縮形: -v)
                      例:

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -541,7 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; イベント ログに表示する情報量です。
                      利用可能な詳細レベル: q[uiet]、m[inimal]、

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -541,9 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; イベント ログに表示する情報量です。
                      利用可能な詳細レベル: q[uiet]、m[inimal]、

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -541,7 +541,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; イベント ログに表示する情報量です。
                      利用可能な詳細レベル: q[uiet]、m[inimal]、

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -541,7 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; 이벤트 로그에 이 정보의 양을 표시합니다.
                      사용 가능한 세부 정보 표시 수준은 다음과 같습니다. q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -541,9 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; 이벤트 로그에 이 정보의 양을 표시합니다.
                      사용 가능한 세부 정보 표시 수준은 다음과 같습니다. q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -541,7 +541,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; 이벤트 로그에 이 정보의 양을 표시합니다.
                      사용 가능한 세부 정보 표시 수준은 다음과 같습니다. q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -540,8 +540,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;level&gt; 이벤트 로그에 이 정보의 양을 표시합니다.
+        <target state="needs-review-translation">  -verbosity:&lt;level&gt; 이벤트 로그에 이 정보의 양을 표시합니다.
                      사용 가능한 세부 정보 표시 수준은 다음과 같습니다. q[uiet], m[inimal],
                      n[ormal], d[etailed], 및 diag[nostic]. (약식: -v)
                      예:

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -548,7 +548,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;poziom&gt; Wyświetla podaną ilość informacji w dzienniku zdarzeń.
                      Dostępne poziomy szczegółowości: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -547,8 +547,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;poziom&gt; Wyświetla podaną ilość informacji w dzienniku zdarzeń.
+        <target state="needs-review-translation">  -verbosity:&lt;poziom&gt; Wyświetla podaną ilość informacji w dzienniku zdarzeń.
                      Dostępne poziomy szczegółowości: q[uiet], m[inimal],
                      n[ormal], d[etailed] i diag[nostic]. (Krótka wersja: /v)
                      Przykład:

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -548,7 +548,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;poziom&gt; Wyświetla podaną ilość informacji w dzienniku zdarzeń.
                      Dostępne poziomy szczegółowości: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -548,9 +548,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;poziom&gt; Wyświetla podaną ilość informacji w dzienniku zdarzeń.
                      Dostępne poziomy szczegółowości: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -541,8 +541,12 @@ arquivo de resposta.
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;level&gt; Exibir este volume de informações no log de eventos.
+        <target state="needs-review-translation">  -verbosity:&lt;level&gt; Exibir este volume de informações no log de eventos.
                      Os níveis de detalhamento disponíveis são: q[uiet], m[inimal],
                      n[ormal], d[etailed] e diag[nostic]. (Forma abreviada: -v)
                      Exemplo:

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -542,7 +542,9 @@ arquivo de resposta.
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; Exibir este volume de informações no log de eventos.
                      Os níveis de detalhamento disponíveis são: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -542,7 +542,7 @@ arquivo de resposta.
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; Exibir este volume de informações no log de eventos.
                      Os níveis de detalhamento disponíveis são: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -542,9 +542,7 @@ arquivo de resposta.
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; Exibir este volume de informações no log de eventos.
                      Os níveis de detalhamento disponíveis são: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -540,9 +540,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;уровень&gt; Отображать эти сведения в журнале событий.
                      Доступными уровнями детализации являются: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -540,7 +540,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;уровень&gt; Отображать эти сведения в журнале событий.
                      Доступными уровнями детализации являются: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -539,8 +539,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;уровень&gt; Отображать эти сведения в журнале событий.
+        <target state="needs-review-translation">  -verbosity:&lt;уровень&gt; Отображать эти сведения в журнале событий.
                      Доступными уровнями детализации являются: q[uiet], m[inimal],
                      n[ormal], d[etailed] и diag[nostic]. (Краткая форма: -v)
                      Пример:

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -540,7 +540,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;уровень&gt; Отображать эти сведения в журнале событий.
                      Доступными уровнями детализации являются: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -541,7 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;düzey&gt; Olay günlüğünde bu miktarda bilgi görüntüler.
                      Kullanılabilen ayrıntı düzeyleri: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -540,8 +540,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;düzey&gt; Olay günlüğünde bu miktarda bilgi görüntüler.
+        <target state="needs-review-translation">  -verbosity:&lt;düzey&gt; Olay günlüğünde bu miktarda bilgi görüntüler.
                      Kullanılabilen ayrıntı düzeyleri: q[uiet], m[inimal],
                      n[ormal], d[etailed] ve diag[nostic]. (Kısa biçim: -v)
                      Örnek:

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -541,9 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;düzey&gt; Olay günlüğünde bu miktarda bilgi görüntüler.
                      Kullanılabilen ayrıntı düzeyleri: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -541,7 +541,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;düzey&gt; Olay günlüğünde bu miktarda bilgi görüntüler.
                      Kullanılabilen ayrıntı düzeyleri: q[uiet], m[inimal],

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -541,7 +541,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; 在事件日志中显示此级别的信息量。
            可用的详细程度有: q[uiet]、 m[inimal]、

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -540,8 +540,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;level&gt; 在事件日志中显示此级别的信息量。
+        <target state="needs-review-translation">  -verbosity:&lt;level&gt; 在事件日志中显示此级别的信息量。
            可用的详细程度有: q[uiet]、 m[inimal]、
            n[ormal]、d[etailed] 和 diag[nostic]。(缩写: -v)
            示例:

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -541,7 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; 在事件日志中显示此级别的信息量。
            可用的详细程度有: q[uiet]、 m[inimal]、

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -541,9 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;level&gt; 在事件日志中显示此级别的信息量。
            可用的详细程度有: q[uiet]、 m[inimal]、

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -540,8 +540,12 @@
                      n[ormal], d[etailed], and diag[nostic]. (Short form: -v)
                      Example:
                        -verbosity:quiet
+
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
+                     Example:
+                       -flg:v=diag
 </source>
-        <target state="translated">  -verbosity:&lt;層級&gt; 在事件記錄檔中顯示此數量的資訊。
+        <target state="needs-review-translation">  -verbosity:&lt;層級&gt; 在事件記錄檔中顯示此數量的資訊。
                      可用的詳細程度層級為: q[uiet]、m[inimal]、
                      n[ormal]、d[etailed] 和 diag[nostic]。(簡短形式: -v)
                      範例:

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -541,7 +541,9 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set by -fileloggerparameters.
+                     Note: File loggers' verbosity
+                           is set separately by
+                           -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;層級&gt; 在事件記錄檔中顯示此數量的資訊。
                      可用的詳細程度層級為: q[uiet]、m[inimal]、

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -541,9 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters or -flg.
-                     Example:
-                       -flg:v=diag
+                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;層級&gt; 在事件記錄檔中顯示此數量的資訊。
                      可用的詳細程度層級為: q[uiet]、m[inimal]、

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -541,7 +541,7 @@
                      Example:
                        -verbosity:quiet
 
-                     Note: File loggers' verbosity is set separately by -fileloggerparameters.
+                     Note: File loggers' verbosity is set by -fileloggerparameters.
 </source>
         <target state="needs-review-translation">  -verbosity:&lt;層級&gt; 在事件記錄檔中顯示此數量的資訊。
                      可用的詳細程度層級為: q[uiet]、m[inimal]、


### PR DESCRIPTION
Fixes #2359

The help text for verbosity makes it sound like it affects file loggers, which isn't true. This makes that more clear.