### PR TITLE
add ConfigurationManager to Version.Details

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -36,5 +36,11 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>eeb78d042d8f2bef222c83790fa253c5a22675ce</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+         and flow in as dependencies of the packages produced by msbuild. -->
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,6 +6,12 @@
       <Sha>525b6c35cc5c5c9b80b47044be2e4e77858d505a</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+      and flow in as dependencies of the packages produced by msbuild. -->
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.23254.1">
@@ -35,12 +41,6 @@
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.23254.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>eeb78d042d8f2bef222c83790fa253c5a22675ce</Sha>
-    </Dependency>
-    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
-         and flow in as dependencies of the packages produced by msbuild. -->
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="7.0.0">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
### Context

Contributes to https://github.com/dotnet/source-build/issues/3043

Declaring the `System.Configuration.ConfigurationManager` dependency in `Version.Details.xml` will allow source-build to replace the currently used `7.0.0` version with the `n-1` version coming from previously source-built artifacts in the product / VMR build.

Without this change, once repo PvP is enabled, the source-build of `msbuild` will fail in the product build.


### Changes Made

  - added an entry for `System.Configuration.ConfigurationManager: 7.0.0` to `Version.Details.xml`

### Testing

### Notes
