### PR TITLE
Reduce allocations in ConditionEvaluator.UpdateConditionedPropertiesTable

### DIFF
--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4473,6 +4473,38 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
 
+        [Theory]
+        [InlineData("$(Hello)", 0, 8, "Hello")]
+        [InlineData("$(Hello)|$(World)", 9, 8, "World")]
+        [InlineData("$(He()o)", 0, 8, null)]
+        [InlineData("$)Hello(", 0, 8, null)]
+        [InlineData("$(Helloo", 0, 8, null)]
+        [InlineData("$Heello)", 0, 8, null)]
+        [InlineData("$(He$$o)", 0, 8, null)]
+        [InlineData(" $(Helo)", 0, 8, null)]
+        [InlineData("$(Helo) ", 0, 8, null)]
+        [InlineData("$()", 0, 3, "")]
+        [InlineData("$( Hello )", 0, 10, " Hello ")]
+        [InlineData("$(He-ll-o)", 0, 10, "He-ll-o")]
+        [InlineData("$(He ll o)", 0, 10, "He ll o")]
+        [InlineData("aaa$(Hello)", 3, 8, "Hello")]
+        [InlineData("aaa$(Hello)bbb", 3, 8, "Hello")]
+        public void TryGetSingleProperty(string input, int start, int length, string expected)
+        {
+            bool result = ConditionEvaluator.TryGetSingleProperty(input, start, length, out string actual);
+
+            if (expected is null)
+            {
+                Assert.False(result);
+                Assert.Null(actual);
+            }
+            else
+            {
+                Assert.True(result);
+                Assert.Equal(expected, actual);
+            }
+        }
+
         [Fact]
         public void VerifyMSBuildLastModifiedProjectForImport()
         {

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4491,17 +4491,17 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [InlineData("aaa$(Hello)bbb", 3, 8, "Hello")]
         public void TryGetSingleProperty(string input, int start, int length, string expected)
         {
-            bool result = ConditionEvaluator.TryGetSingleProperty(input, start, length, out string actual);
+            bool result = ConditionEvaluator.TryGetSingleProperty(input.AsSpan(), start, length, out ReadOnlySpan<char> actual);
 
             if (expected is null)
             {
                 Assert.False(result);
-                Assert.Null(actual);
+                Assert.True(actual.IsEmpty);
             }
             else
             {
                 Assert.True(result);
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, actual.ToString());
             }
         }
 

--- a/src/Build/Evaluation/ConditionEvaluator.cs
+++ b/src/Build/Evaluation/ConditionEvaluator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 using Microsoft.Build.BackEnd.Logging;
@@ -19,8 +18,6 @@ namespace Microsoft.Build.Evaluation
 {
     internal static class ConditionEvaluator
     {
-        private static readonly char[] InvalidPropertyNameCharacters = { '$', '(', ')' };
-
         /// <summary>
         /// Update our table which keeps track of all the properties that are referenced
         /// inside of a condition and the string values that they are being tested against.
@@ -58,7 +55,7 @@ namespace Microsoft.Build.Evaluation
                     var lastPiece = pieceSeparator < 0;
                     var pieceEnd = lastPiece ? leftValue.Length : pieceSeparator;
 
-                    if (TryGetSingleProperty(leftValue, pieceStart, pieceEnd - pieceStart, out string? propertyName))
+                    if (TryGetSingleProperty(leftValue.AsSpan(), pieceStart, pieceEnd - pieceStart, out ReadOnlySpan<char> propertyName))
                     {
                         // Find the first vertical bar on the right-hand-side expression.
                         var indexOfVerticalBar = rightValueExpanded.IndexOf('|');
@@ -85,10 +82,11 @@ namespace Microsoft.Build.Evaluation
 
                         // Get the string collection for this property name, if one already exists.
                         // If not already in the table, add a new entry for it.
-                        if (!conditionedPropertiesTable.TryGetValue(propertyName, out List<string>? conditionedPropertyValues))
+                        string propertyNameString = propertyName.ToString();
+                        if (!conditionedPropertiesTable.TryGetValue(propertyNameString, out List<string>? conditionedPropertyValues))
                         {
                             conditionedPropertyValues = new List<string>();
-                            conditionedPropertiesTable[propertyName] = conditionedPropertyValues;
+                            conditionedPropertiesTable[propertyNameString] = conditionedPropertyValues;
                         }
 
                         // If the "rightValueExpanded" is not already in the string collection
@@ -110,21 +108,29 @@ namespace Microsoft.Build.Evaluation
         }
 
         // Internal for testing purposes
-        internal static bool TryGetSingleProperty(string input, int beginning, int length, [NotNullWhen(returnValue: true)] out string? propertyName)
+        internal static bool TryGetSingleProperty(ReadOnlySpan<char> input, int beginning, int length, out ReadOnlySpan<char> propertyName)
         {
             // This code is simulating the regex pattern: ^\$\(([^\$\(\)]*)\)$
             if (input.Length < beginning + 3 ||
                 input[beginning] != '$' ||
                 input[beginning + 1] != '(' ||
                 input[beginning + length - 1] != ')' ||
-                input.IndexOfAny(InvalidPropertyNameCharacters, beginning + 2, length - 3) != -1)
+                ContainsInvalidCharacter(input.Slice(beginning + 2, length - 3)))
             {
                 propertyName = null;
                 return false;
             }
 
-            propertyName = input.Substring(beginning + 2, length - 3);
+            propertyName = input.Slice(beginning + 2, length - 3);
             return true;
+
+            static bool ContainsInvalidCharacter(ReadOnlySpan<char> span)
+            {
+                return
+                    span.IndexOf('$') != -1 ||
+                    span.IndexOf('(') != -1 ||
+                    span.IndexOf(')') != -1;
+            }
         }
 
         // Implements a pool of expression trees for each condition.

--- a/src/Build/Evaluation/ConditionEvaluator.cs
+++ b/src/Build/Evaluation/ConditionEvaluator.cs
@@ -7,18 +7,16 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 
-#nullable disable
+using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
+using BuildEventContext = Microsoft.Build.Framework.BuildEventContext;
+using ElementLocation = Microsoft.Build.Construction.ElementLocation;
+using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
+using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 
 namespace Microsoft.Build.Evaluation
 {
-    using Microsoft.Build.BackEnd.Logging;
-    using Microsoft.Build.Shared;
-    using Microsoft.Build.Shared.FileSystem;
-    using BuildEventContext = Microsoft.Build.Framework.BuildEventContext;
-    using ElementLocation = Microsoft.Build.Construction.ElementLocation;
-    using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
-    using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
-
     internal static class ConditionEvaluator
     {
         private static readonly Lazy<Regex> s_singlePropertyRegex = new Lazy<Regex>(
@@ -92,11 +90,8 @@ namespace Microsoft.Build.Evaluation
                         var propertyName = singlePropertyMatch.Groups[1].ToString();
 
                         // Get the string collection for this property name, if one already exists.
-                        List<string> conditionedPropertyValues;
-
-                        // If this property is not already represented in the table, add a new entry
-                        // for it.
-                        if (!conditionedPropertiesTable.TryGetValue(propertyName, out conditionedPropertyValues))
+                        // If not already in the table, add a new entry for it.
+                        if (!conditionedPropertiesTable.TryGetValue(propertyName, out List<string>? conditionedPropertyValues))
                         {
                             conditionedPropertyValues = new List<string>();
                             conditionedPropertiesTable[propertyName] = conditionedPropertyValues;
@@ -130,11 +125,11 @@ namespace Microsoft.Build.Evaluation
             private readonly ConcurrentDictionary<string, ConcurrentStack<GenericExpressionNode>> _conditionPools;
             private int _mOptimisticSize;
 
-            public int OptimisticSize => _mOptimisticSize;
+            public readonly int OptimisticSize => _mOptimisticSize;
 
             public ExpressionTreeForCurrentOptionsWithSize(ConcurrentDictionary<string, ConcurrentStack<GenericExpressionNode>> conditionPools)
             {
-                this._conditionPools = conditionPools;
+                _conditionPools = conditionPools;
                 _mOptimisticSize = conditionPools.Count;
             }
 
@@ -176,8 +171,8 @@ namespace Microsoft.Build.Evaluation
             ILoggingService loggingServices,
             BuildEventContext buildEventContext,
             IFileSystem fileSystem,
-            ProjectRootElementCacheBase projectRootElementCache = null,
-            LoggingContext loggingContext = null)
+            ProjectRootElementCacheBase? projectRootElementCache = null,
+            LoggingContext? loggingContext = null)
             where P : class, IProperty
             where I : class, IItem
         {
@@ -186,7 +181,7 @@ namespace Microsoft.Build.Evaluation
                 options,
                 expander,
                 expanderOptions,
-                null /* do not collect conditioned properties */,
+                conditionedPropertiesTable: null /* do not collect conditioned properties */,
                 evaluationDirectory,
                 elementLocation,
                 loggingServices,
@@ -208,14 +203,14 @@ namespace Microsoft.Build.Evaluation
             ParserOptions options,
             Expander<P, I> expander,
             ExpanderOptions expanderOptions,
-            Dictionary<string, List<string>> conditionedPropertiesTable,
+            Dictionary<string, List<string>>? conditionedPropertiesTable,
             string evaluationDirectory,
             ElementLocation elementLocation,
             ILoggingService loggingServices,
             BuildEventContext buildEventContext,
             IFileSystem fileSystem,
-            ProjectRootElementCacheBase projectRootElementCache = null,
-            LoggingContext loggingContext = null)
+            ProjectRootElementCacheBase? projectRootElementCache = null,
+            LoggingContext? loggingContext = null)
             where P : class, IProperty
             where I : class, IItem
         {
@@ -343,13 +338,13 @@ namespace Microsoft.Build.Evaluation
             ///     If this is null, as it is for command line builds, conditioned properties
             ///     are not recorded.
             /// </summary>
-            Dictionary<string, List<string>> ConditionedPropertiesInProject { get; }
+            Dictionary<string, List<string>>? ConditionedPropertiesInProject { get; }
 
             /// <summary>
             ///     May return null if the expression would expand to non-empty and it broke out early.
             ///     Otherwise, returns the correctly expanded expression.
             /// </summary>
-            string ExpandIntoStringBreakEarly(string expression, LoggingContext loggingContext = null);
+            string ExpandIntoStringBreakEarly(string expression, LoggingContext? loggingContext = null);
 
             /// <summary>
             ///     Expands the specified expression into a list of TaskItem's.
@@ -359,12 +354,12 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             ///     Expands the specified expression into a string.
             /// </summary>
-            string ExpandIntoString(string expression, LoggingContext loggingContext = null);
+            string ExpandIntoString(string expression, LoggingContext? loggingContext = null);
 
             /// <summary>
             ///     PRE cache
             /// </summary>
-            ProjectRootElementCacheBase LoadedProjectsCache { get; }
+            ProjectRootElementCacheBase? LoadedProjectsCache { get; }
 
             IFileSystem FileSystem { get; }
         }
@@ -398,22 +393,22 @@ namespace Microsoft.Build.Evaluation
             /// If this is null, as it is for command line builds, conditioned properties
             /// are not recorded.
             /// </summary>
-            public Dictionary<string, List<string>> ConditionedPropertiesInProject { get; }
+            public Dictionary<string, List<string>>? ConditionedPropertiesInProject { get; }
 
             /// <summary>
             /// PRE collection. 
             /// </summary>
-            public ProjectRootElementCacheBase LoadedProjectsCache { get; }
+            public ProjectRootElementCacheBase? LoadedProjectsCache { get; }
 
             internal ConditionEvaluationState(
                 string condition,
                 Expander<P, I> expander,
                 ExpanderOptions expanderOptions,
-                Dictionary<string, List<string>> conditionedPropertiesInProject,
+                Dictionary<string, List<string>>? conditionedPropertiesInProject,
                 string evaluationDirectory,
                 ElementLocation elementLocation,
                 IFileSystem fileSystem,
-                ProjectRootElementCacheBase projectRootElementCache = null)
+                ProjectRootElementCacheBase? projectRootElementCache = null)
             {
                 ErrorUtilities.VerifyThrowArgumentNull(condition, nameof(condition));
                 ErrorUtilities.VerifyThrowArgumentNull(expander, nameof(expander));
@@ -434,7 +429,7 @@ namespace Microsoft.Build.Evaluation
             /// May return null if the expression would expand to non-empty and it broke out early.
             /// Otherwise, returns the correctly expanded expression.
             /// </summary>
-            public string ExpandIntoStringBreakEarly(string expression, LoggingContext loggingContext = null)
+            public string ExpandIntoStringBreakEarly(string expression, LoggingContext? loggingContext = null)
             {
                 var originalValue = _expander.WarnForUninitializedProperties;
 
@@ -467,7 +462,7 @@ namespace Microsoft.Build.Evaluation
             /// <param name="expression">The expression to expand.</param>
             /// <param name="loggingContext"></param>
             /// <returns>The expanded string.</returns>
-            public string ExpandIntoString(string expression, LoggingContext loggingContext = null)
+            public string ExpandIntoString(string expression, LoggingContext? loggingContext = null)
             {
                 var originalValue = _expander.WarnForUninitializedProperties;
 


### PR DESCRIPTION
Fixes [AB#1824943](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1824943)

In order to parse the name of a property from an MSBuild expression, this method used a regular expression to parse a simple pattern, which results in significant amounts of allocations as identified by GCPauseWatson.

The actual pattern used is very simple and can be achieved regex.

This change extracts the parsing to a helper function and adds a unit test for it. I validated that the test passed with the prior implementation, then converted it to avoid regex allocations altogether.

While at it I null annotated `ConditionEvaluator`. That was done in its own commit, if you want to review the changes separately.