### PR TITLE
Don't allocate unused ImmutableArray builder

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -12,8 +12,6 @@ using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.CodeAnalysis.Collections;
 
-#nullable disable
-
 namespace Microsoft.Build.Evaluation
 {
     internal partial class LazyItemEvaluator<P, I, M, D>
@@ -21,7 +19,7 @@ namespace Microsoft.Build.Evaluation
         private class IncludeOperation : LazyItemOperation
         {
             private readonly int _elementOrder;
-            private readonly string _rootDirectory;
+            private readonly string? _rootDirectory;
             private readonly ImmutableSegmentedList<string> _excludes;
             private readonly ImmutableArray<ProjectMetadataElement> _metadata;
 
@@ -39,7 +37,7 @@ namespace Microsoft.Build.Evaluation
             {
                 var itemsToAdd = ImmutableArray.CreateBuilder<I>();
 
-                Lazy<Func<string, bool>> excludeTester = null;
+                Lazy<Func<string, bool>>? excludeTester = null;
                 ImmutableList<string>.Builder excludePatterns = ImmutableList.CreateBuilder<string>();
                 if (_excludes != null)
                 {
@@ -57,7 +55,7 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
-                ISet<string> excludePatternsForGlobs = null;
+                ISet<string>? excludePatternsForGlobs = null;
 
                 foreach (var fragment in _itemSpec.Fragments)
                 {
@@ -170,7 +168,7 @@ namespace Microsoft.Build.Evaluation
         private class IncludeOperationBuilder : OperationBuilderWithMetadata
         {
             public int ElementOrder { get; set; }
-            public string RootDirectory { get; set; }
+            public string? RootDirectory { get; set; }
 
             public ImmutableSegmentedList<string>.Builder Excludes { get; } = ImmutableSegmentedList.CreateBuilder<string>();
 

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Evaluation
 
             protected override ImmutableArray<I> SelectItems(OrderedItemDataCollection.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
-                var itemsToAdd = ImmutableArray.CreateBuilder<I>();
+                ImmutableArray<I>.Builder? itemsToAdd = null;
 
                 Lazy<Func<string, bool>>? excludeTester = null;
                 ImmutableList<string>.Builder excludePatterns = ImmutableList.CreateBuilder<string>();
@@ -71,6 +71,7 @@ namespace Microsoft.Build.Evaluation
                             isTransformExpression: out _,
                             elementLocation: _itemElement.IncludeLocation);
 
+                        itemsToAdd ??= ImmutableArray.CreateBuilder<I>();
                         itemsToAdd.AddRange(
                             excludeTester != null
                                 ? itemsFromExpression.Where(item => !excludeTester.Value(item.EvaluatedInclude))
@@ -82,8 +83,8 @@ namespace Microsoft.Build.Evaluation
 
                         if (excludeTester?.Value(EscapingUtilities.UnescapeAll(value)) != true)
                         {
-                            var item = _itemFactory.CreateItem(value, value, _itemElement.ContainingProject.FullPath);
-                            itemsToAdd.Add(item);
+                            itemsToAdd ??= ImmutableArray.CreateBuilder<I>();
+                            itemsToAdd.Add(_itemFactory.CreateItem(value, value, _itemElement.ContainingProject.FullPath));
                         }
                     }
                     else if (fragment is GlobFragment globFragment)
@@ -125,6 +126,7 @@ namespace Microsoft.Build.Evaluation
 
                             foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)
                             {
+                                itemsToAdd ??= ImmutableArray.CreateBuilder<I>();
                                 itemsToAdd.Add(_itemFactory.CreateItem(includeSplitFileEscaped, glob, _itemElement.ContainingProject.FullPath));
                             }
                         }
@@ -135,7 +137,7 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
-                return itemsToAdd.ToImmutable();
+                return itemsToAdd?.ToImmutable() ?? ImmutableArray<I>.Empty;
             }
 
             private static ISet<string> BuildExcludePatternsForGlobs(ImmutableHashSet<string> globsToIgnore, ImmutableList<string>.Builder excludePatterns)


### PR DESCRIPTION
Fixes [AB#1827935](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1827935)

In cases when `LazyItemEvaluator<>.IncludeOperation.SelectItems` returns an empty array, there's no need to allocate the `ImmutableArray<>.Builder` class instance.

This change makes the allocation occur only when needed.

This was identified as contributing to GC pauses via GCPauseWatson.

This change also null annotates the file.