### PR TITLE
Reduce allocations due to dictionary resizing

### DIFF
--- a/src/Build/Evaluation/EvaluatorMetadataTable.cs
+++ b/src/Build/Evaluation/EvaluatorMetadataTable.cs
@@ -28,11 +28,17 @@ namespace Microsoft.Build.Evaluation
         private string _implicitItemType;
 
         /// <summary>
+        /// The expected number of metadata entries in this table.
+        /// </summary>
+        private readonly int _capacity;
+
+        /// <summary>
         /// Creates a new table using the specified item type.
         /// </summary>
-        public EvaluatorMetadataTable(string implicitItemType)
+        public EvaluatorMetadataTable(string implicitItemType, int capacity = 0)
         {
             _implicitItemType = implicitItemType;
+            _capacity = capacity;
         }
 
         /// <summary>
@@ -90,7 +96,7 @@ namespace Microsoft.Build.Evaluation
         {
             if (_metadata == null)
             {
-                _metadata = new Dictionary<string, EvaluatorMetadata>(MSBuildNameIgnoreCaseComparer.Default);
+                _metadata = new Dictionary<string, EvaluatorMetadata>(_capacity, MSBuildNameIgnoreCaseComparer.Default);
             }
 
             _metadata[xml.Name] = new EvaluatorMetadata(xml, evaluatedValueEscaped);

--- a/src/Build/Evaluation/EvaluatorMetadataTable.cs
+++ b/src/Build/Evaluation/EvaluatorMetadataTable.cs
@@ -8,8 +8,6 @@ using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using EscapingUtilities = Microsoft.Build.Shared.EscapingUtilities;
 
-#nullable disable
-
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
@@ -22,7 +20,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// The actual metadata dictionary.
         /// </summary>
-        private Dictionary<string, EvaluatorMetadata> _metadata;
+        private Dictionary<string, EvaluatorMetadata>? _metadata;
 
         /// <summary>
         /// The type of item the metadata should be considered to apply to.
@@ -56,7 +54,7 @@ namespace Microsoft.Build.Evaluation
         /// Retrieves any value we have in our metadata table for the metadata name and item type specified.
         /// If no value is available, returns empty string.
         /// </summary>
-        public string GetEscapedValue(string itemType, string name)
+        public string GetEscapedValue(string? itemType, string name)
         {
             return GetEscapedValueIfPresent(itemType, name) ?? String.Empty;
         }
@@ -65,21 +63,18 @@ namespace Microsoft.Build.Evaluation
         /// Retrieves any value we have in our metadata table for the metadata name and item type specified.
         /// If no value is available, returns null.
         /// </summary>
-        public string GetEscapedValueIfPresent(string itemType, string name)
+        public string? GetEscapedValueIfPresent(string? itemType, string name)
         {
             if (_metadata == null)
             {
                 return null;
             }
 
-            string value = null;
+            string? value = null;
 
             if (itemType == null || String.Equals(_implicitItemType, itemType, StringComparison.OrdinalIgnoreCase))
             {
-                EvaluatorMetadata metadatum;
-                _metadata.TryGetValue(name, out metadatum);
-
-                if (metadatum != null)
+                if (_metadata.TryGetValue(name, out EvaluatorMetadata? metadatum))
                 {
                     value = metadatum.EvaluatedValueEscaped;
                 }

--- a/src/Build/Evaluation/IMetadataTable.cs
+++ b/src/Build/Evaluation/IMetadataTable.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
@@ -21,12 +19,12 @@ namespace Microsoft.Build.Evaluation
         /// If item type is null, it is ignored.
         /// If no value is available, returns empty string.
         /// </summary>
-        string GetEscapedValue(string itemType, string name);
+        string GetEscapedValue(string? itemType, string name);
 
         /// <summary>
         /// Returns the value if it exists, null otherwise.
         /// If item type is null, it is ignored.
         /// </summary>
-        string GetEscapedValueIfPresent(string itemType, string name);
+        string? GetEscapedValueIfPresent(string? itemType, string name);
     }
 }

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Build.Evaluation
                     {
                         // Metadata expressions are allowed here.
                         // Temporarily gather and expand these in a table so they can reference other metadata elements above.
-                        EvaluatorMetadataTable metadataTable = new EvaluatorMetadataTable(_itemType);
+                        EvaluatorMetadataTable metadataTable = new EvaluatorMetadataTable(_itemType, capacity: metadata.Length);
                         _expander.Metadata = metadataTable;
 
                         // Also keep a list of everything so we can get the predecessor objects correct.


### PR DESCRIPTION
Fixes [AB#1826604](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1826604)

This change allows the metadata dictionary to be constructed with the expected size, rather than some default size which is then subject to resizing (and increased GC pressure).

This code path was identified as a top contributor to GC pauses by GCPauseWatson.

Also null annotated the types involved (in a separate commit).