### PR TITLE
Use Array.Empty<T>

### DIFF
--- a/src/Deprecated/Engine/Engine/BuildTask.cs
+++ b/src/Deprecated/Engine/Engine/BuildTask.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Build.BuildEngine
         {
             if (this.taskElement == null)
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
 
             ArrayList list = new ArrayList();

--- a/src/Deprecated/Engine/Engine/Expander.cs
+++ b/src/Deprecated/Engine/Engine/Expander.cs
@@ -1521,7 +1521,7 @@ namespace Microsoft.Build.BuildEngine
                     // It may be that there are '()' but no actual arguments content
                     if (argumentStartIndex == expressionFunction.Length - 1)
                     {
-                        functionArguments = new string[0];
+                        functionArguments = Array.Empty<string>();
                     }
                     else
                     {
@@ -1531,7 +1531,7 @@ namespace Microsoft.Build.BuildEngine
                         // If there are no arguments, then just create an empty array
                         if (String.IsNullOrEmpty(argumentsContent))
                         {
-                            functionArguments = new string[0];
+                            functionArguments = Array.Empty<string>();
                         }
                         else
                         {
@@ -1547,7 +1547,7 @@ namespace Microsoft.Build.BuildEngine
                     int nextMethodIndex = expressionFunction.IndexOf('.', methodStartIndex);
                     int methodLength = expressionFunction.Length - methodStartIndex;
 
-                    functionArguments = new string[0];
+                    functionArguments = Array.Empty<string>();
 
                     if (nextMethodIndex > 0)
                     {

--- a/src/Deprecated/Engine/Engine/Node.cs
+++ b/src/Deprecated/Engine/Engine/Node.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Build.BuildEngine
             catch (Exception e)
             {
                 ReportUnhandledError(e);
-                return new CacheEntry[0];
+                return Array.Empty<CacheEntry>();
             }
         }
 

--- a/src/Deprecated/Engine/Engine/Project.cs
+++ b/src/Deprecated/Engine/Engine/Project.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Build.BuildEngine
                 this.targets = new TargetCollection(this);
 
                 // Initialize the default targets, initial targets, and project file name.
-                this.defaultTargetNames = new string[0];
+                this.defaultTargetNames = Array.Empty<string>();
                 this.initialTargetNamesInMainProject = new ArrayList();
                 this.initialTargetNamesInImportedProjects = new ArrayList();
                 this.FullFileName = String.Empty;
@@ -1532,7 +1532,7 @@ namespace Microsoft.Build.BuildEngine
 
             if (propertyValues == null)
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
             else
             {
@@ -3698,7 +3698,7 @@ namespace Microsoft.Build.BuildEngine
             this.evaluatedItemsIgnoringCondition.Clear();
             this.targets.Clear();
             this.nameOfFirstTarget = null;
-            this.defaultTargetNames = new string[0];
+            this.defaultTargetNames = Array.Empty<string>();
             this.initialTargetNamesInImportedProjects.Clear();
             this.initialTargetNamesInMainProject.Clear();
 

--- a/src/Deprecated/Engine/Engine/RegistryKeyWrapper.cs
+++ b/src/Deprecated/Engine/Engine/RegistryKeyWrapper.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Build.BuildEngine
         {
             try
             {
-                return Exists() ? WrappedKey.GetValueNames() : new string[] { };
+                return Exists() ? WrappedKey.GetValueNames() : Array.Empty<string>();
             }
             catch (Exception ex)
             {
@@ -139,7 +139,7 @@ namespace Microsoft.Build.BuildEngine
         {
             try
             {
-                return Exists() ? WrappedKey.GetSubKeyNames() : new string[] { };
+                return Exists() ? WrappedKey.GetSubKeyNames() : Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Deprecated/Engine/Engine/TaskExecutionModule.cs
+++ b/src/Deprecated/Engine/Engine/TaskExecutionModule.cs
@@ -509,7 +509,7 @@ namespace Microsoft.Build.BuildEngine
             {
                 return workerThread.GetWaitingTasksData(outstandingRequests);
             }
-            return new int[0];
+            return Array.Empty<int>();
         }
 
         internal void Shutdown()

--- a/src/Deprecated/Engine/Engine/ToolsetRegistryReader.cs
+++ b/src/Deprecated/Engine/Engine/ToolsetRegistryReader.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.BuildEngine
         {
             get
             {
-                string[] toolsVersionNames = new string[] { };
+                string[] toolsVersionNames = System.Array.Empty<string>();
                 try
                 {
                     toolsVersionNames = msbuildRegistryWrapper.OpenSubKey("ToolsVersions").GetSubKeyNames();

--- a/src/Deprecated/Engine/Engine/ToolsetState.cs
+++ b/src/Deprecated/Engine/Engine/ToolsetState.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Build.BuildEngine
                 {
                     this.defaultTaskRegistry = new TaskRegistry();
 
-                    string[] defaultTasksFiles = { };
+                    string[] defaultTasksFiles = Array.Empty<string>();
 
                     try
                     {

--- a/src/Deprecated/Engine/Logging/ParallelLogger/ParallelLoggerHelpers.cs
+++ b/src/Deprecated/Engine/Logging/ParallelLogger/ParallelLoggerHelpers.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Build.BuildEngine
             // or the event is raised before the project started event
             if (startedEvent == null)
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
 
             List<ProjectStartedEventMinimumFields> projectStackTrace = GetProjectCallStack(e);

--- a/src/Deprecated/Engine/Shared/AssemblyNameExtension.cs
+++ b/src/Deprecated/Engine/Shared/AssemblyNameExtension.cs
@@ -434,11 +434,11 @@ namespace Microsoft.Build.BuildEngine.Shared
             // Some assemblies (real case was interop assembly) may have null PKTs.
             if (aPKT == null)
             {
-                aPKT = new byte[0];
+                aPKT = Array.Empty<byte>();
             }
             if (bPKT == null)
             {
-                bPKT = new byte[0];
+                bPKT = Array.Empty<byte>();
             }
 
             if (aPKT.Length != bPKT.Length)

--- a/src/Deprecated/Engine/Shared/FileMatcher.cs
+++ b/src/Deprecated/Engine/Shared/FileMatcher.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.BuildEngine.Shared
 
             if (entries == null)
             {
-                entries = new string[0];
+                entries = Array.Empty<string>();
             }
 
             return entries;
@@ -181,12 +181,12 @@ namespace Microsoft.Build.BuildEngine.Shared
             catch (System.Security.SecurityException)
             {
                 // For code access security.
-                return new string[0];
+                return Array.Empty<string>();
             }
             catch (System.UnauthorizedAccessException)
             {
                 // For OS security.
-                return new string[0];
+                return Array.Empty<string>();
             }
         }
 
@@ -233,12 +233,12 @@ namespace Microsoft.Build.BuildEngine.Shared
             catch (System.Security.SecurityException)
             {
                 // For code access security.
-                return new string[0];
+                return Array.Empty<string>();
             }
             catch (System.UnauthorizedAccessException)
             {
                 // For OS security.
-                return new string[0];
+                return Array.Empty<string>();
             }
         }
 
@@ -1202,7 +1202,7 @@ namespace Microsoft.Build.BuildEngine.Shared
                     }
                     catch (ArgumentException)
                     {
-                        return new string[0];
+                        return Array.Empty<string>();
                     }
 
                     stripProjectDirectory = !String.Equals(fixedDirectoryPart, oldFixedDirectoryPart, StringComparison.OrdinalIgnoreCase);
@@ -1220,7 +1220,7 @@ namespace Microsoft.Build.BuildEngine.Shared
              */
             if (fixedDirectoryPart.Length > 0 && !directoryExists(fixedDirectoryPart))
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
 
             // determine if we need to use the regular expression to match the files


### PR DESCRIPTION
Empty arrays can be singletons. We should not be creating new instances when needed, but rather pooling an instance per type. This is what the `Array.Empty<T>` method does for us.

Note that this is in "deprecated" code. However traces are showing other allocations from these files (especially `FileMatcher`) are contributing to GC pauses, so I assume this code is still getting significant real world usage, and these changes seem pretty benign.