### PR TITLE
Remove redundant collection copy

### DIFF
--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Build.Shared
                 path,
                 pattern,
                 projectDirectory,
-                stripProjectDirectory).ToArray(),
+                stripProjectDirectory),
             fileEntryExpansionCache)
         {
         }


### PR DESCRIPTION
Seen while investigating [AB#1826498](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1826498)

The output of `GetAccessibleFileSystemEntries` is already an `IReadOnlyList<string>`, and each caller gets its own copy of that object. We do not need to produce another copy of it via the `ToArray` call that this commit removes.

