### PR TITLE
Use ToList over ToArray

### DIFF
--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -135,8 +135,8 @@ namespace Microsoft.Build.Shared
                         ? allEntriesForPath.Where(o => IsFileNameMatch(o, pattern))
                         : allEntriesForPath;
                     return stripProjectDirectory
-                        ? RemoveProjectDirectory(filteredEntriesForPath, directory).ToArray()
-                        : filteredEntriesForPath.ToArray();
+                        ? RemoveProjectDirectory(filteredEntriesForPath, directory).ToList()
+                        : filteredEntriesForPath.ToList();
                 };
         }
 
@@ -252,7 +252,7 @@ namespace Microsoft.Build.Shared
                         ? fileSystem.EnumerateFileSystemEntries(path, pattern)
                             .Where(o => IsFileNameMatch(o, pattern))
                         : fileSystem.EnumerateFileSystemEntries(path, pattern))
-                        .ToArray();
+                        .ToList();
                 }
                 // for OS security
                 catch (UnauthorizedAccessException)
@@ -349,7 +349,7 @@ namespace Microsoft.Build.Shared
                     files = RemoveInitialDotSlash(files);
                 }
 
-                return files.ToArray();
+                return files.ToList();
             }
             catch (System.Security.SecurityException)
             {
@@ -405,7 +405,7 @@ namespace Microsoft.Build.Shared
                     directories = RemoveInitialDotSlash(directories);
                 }
 
-                return directories.ToArray();
+                return directories.ToList();
             }
             catch (System.Security.SecurityException)
             {
@@ -501,7 +501,7 @@ namespace Microsoft.Build.Shared
                     }
                     else
                     {
-                        // getFileSystemEntries(...) returns an empty enumerable if longPath doesn't exist.
+                        // getFileSystemEntries(...) returns an empty list if longPath doesn't exist.
                         IReadOnlyList<string> entries = getFileSystemEntries(FileSystemEntity.FilesAndDirectories, longPath, parts[i], null, false);
 
                         if (0 == entries.Count)


### PR DESCRIPTION
Fixes [AB#1826498](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1826498)

Per the [Performance Best Practices wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-Collection?anchor=%E2%9C%94%EF%B8%8F-**do**-prefer-%60tolist%60-over-%60toarray%60-when-%22realizing%22-temporary-linq-queries), short-lived materialised versions of enumerations should be made using `ToList` rather than `ToArray`, as the latter commonly involves an additional copy of the results in order to trim unfilled entries from the end of the collection. When results are short lived &mdash; as they are in the code changed here &mdash; that extra copy only creates extra work and GC pressure.

This issue was flagged as a top issue by GCPauseWatson.

