### PR TITLE
Catch the illegal argument exception in Net Framework!

### DIFF
--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -876,7 +876,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 projectCollection.RegisterLogger(logger);
 
                 Assert.Throws<InvalidProjectFileException>(() => projectCollection.LoadProject(mainProjectPath));
-                logger.AssertLogContains("MSB4020");
+                logger.AssertLogContains("MSB4102");
             }
             finally
             {

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 #nullable disable
 
@@ -835,6 +836,47 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 Assert.Throws<InvalidProjectFileException>(() => projectCollection.LoadProject(mainProjectPath));
                 logger.AssertLogContains(@"MSB4226: The imported project """ + Path.Combine("$(UndefinedProperty)", "filenotfound.props")
                                             + @""" was not found. Also, tried to find");
+            }
+            finally
+            {
+                FileUtilities.DeleteNoThrow(mainProjectPath);
+                FileUtilities.DeleteDirectoryNoThrow(extnDir1, true);
+            }
+        }
+        /// <summary>
+        ///  https://github.com/dotnet/msbuild/issues/8762
+        /// </summary>
+        /// <param name="projectValue">imported project value expression</param>
+        [WindowsFullFrameworkOnlyTheory]
+        [InlineData("")]
+        [InlineData("|")]
+        public void FallbackImportWithInvalidProjectValue(string projectValue)
+        {
+            string mainTargetsFileContent = $"""
+                <Project>
+                    <PropertyGroup>
+                    <VSToolsPath>{projectValue}</VSToolsPath>
+                </PropertyGroup>
+                <Import Project="$(VSToolsPath)"/>
+                </Project>
+                """;
+
+            string extnDir1 = null;
+            string mainProjectPath = null;
+
+            try
+            {
+                // The path to "extensions1" fallback should exist, but the file doesn't need to
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("file.props"), string.Empty);
+
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
+                var projectCollection = GetProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
+                projectCollection.ResetToolsetsForTests(WriteConfigFileAndGetReader("VSToolsPath", @"$(FallbackExpandDir1)\Microsoft\VisualStudio\v99"));
+                var logger = new MockLogger();
+                projectCollection.RegisterLogger(logger);
+
+                Assert.Throws<InvalidProjectFileException>(() => projectCollection.LoadProject(mainProjectPath));
+                logger.AssertLogContains("MSB4020");
             }
             finally
             {

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -861,17 +861,13 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 </Project>
                 """;
 
-            string extnDir1 = null;
             string mainProjectPath = null;
 
             try
             {
-                // The path to "extensions1" fallback should exist, but the file doesn't need to
-                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("file.props"), string.Empty);
-
                 mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
-                var projectCollection = GetProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
-                projectCollection.ResetToolsetsForTests(WriteConfigFileAndGetReader("VSToolsPath", @"$(FallbackExpandDir1)\Microsoft\VisualStudio\v99"));
+                var projectCollection = GetProjectCollection();
+                projectCollection.ResetToolsetsForTests(WriteConfigFileAndGetReader("VSToolsPath", "temp"));
                 var logger = new MockLogger();
                 projectCollection.RegisterLogger(logger);
 
@@ -881,7 +877,6 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 FileUtilities.DeleteNoThrow(mainProjectPath);
-                FileUtilities.DeleteDirectoryNoThrow(extnDir1, true);
             }
         }
 

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -844,7 +844,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
         /// <summary>
-        ///  https://github.com/dotnet/msbuild/issues/8762
+        /// Fall-back search path on a property that is not valid. https://github.com/dotnet/msbuild/issues/8762
         /// </summary>
         /// <param name="projectValue">imported project value expression</param>
         [WindowsFullFrameworkOnlyTheory]

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2553,7 +2553,7 @@ namespace Microsoft.Build.Evaluation
                 }
                 catch (ArgumentException ex)
                 {
-                    // https://github.com/dotnet/msbuild/issues/8762 In NET Framework, Path.* function will throw exceptions if the path contains invalid characters.
+                    // https://github.com/dotnet/msbuild/issues/8762 .Catch the exceptions when extensionsPathPropValue is null or importExpandedWithDefaultPath is empty. In NET Framework, Path.* function also throws exceptions if the path contains invalid characters.
                     ProjectErrorUtilities.ThrowInvalidProject(importElement.Location, "InvalidAttributeValueWithException", importExpandedWithDefaultPath, XMakeAttributes.project, XMakeElements.import, ex.Message);
                     return;
                 }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2551,10 +2551,10 @@ namespace Microsoft.Build.Evaluation
                 {
                     relativeProjectPath = FileUtilities.MakeRelative(extensionsPathPropValue, importExpandedWithDefaultPath);
                 }
-                catch (ArgumentException)
+                catch (ArgumentException ex)
                 {
                     // https://github.com/dotnet/msbuild/issues/8762 In NET Framework, Path.* function will throw exceptions if the path contains invalid characters.
-                    ProjectErrorUtilities.ThrowInvalidProject(importElement.Location, "InvalidAttributeValue", importExpandedWithDefaultPath, XMakeAttributes.project, XMakeElements.import);
+                    ProjectErrorUtilities.ThrowInvalidProject(importElement.Location, "InvalidAttributeValueWithException", importExpandedWithDefaultPath, XMakeAttributes.project, XMakeElements.import, ex.Message);
                     return;
                 }
             }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2547,7 +2547,16 @@ namespace Microsoft.Build.Evaluation
                         importElement.Project.Replace(searchPathMatch.MsBuildPropertyFormat, extensionsPathPropValue),
                         ExpanderOptions.ExpandProperties, importElement.ProjectLocation);
 
-                relativeProjectPath = FileUtilities.MakeRelative(extensionsPathPropValue, importExpandedWithDefaultPath);
+                try
+                {
+                    relativeProjectPath = FileUtilities.MakeRelative(extensionsPathPropValue, importExpandedWithDefaultPath);
+                }
+                catch (ArgumentException)
+                {
+                    // https://github.com/dotnet/msbuild/issues/8762 In NET Framework, Path.* function wil throw exceptions if the path contains invalid characters.
+                    ProjectErrorUtilities.ThrowInvalidProject(importElement.Location, "InvalidAttributeValue", importExpandedWithDefaultPath, XMakeAttributes.project, XMakeElements.import);
+                    return;
+                }
             }
             else
             {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2553,7 +2553,7 @@ namespace Microsoft.Build.Evaluation
                 }
                 catch (ArgumentException)
                 {
-                    // https://github.com/dotnet/msbuild/issues/8762 In NET Framework, Path.* function wil throw exceptions if the path contains invalid characters.
+                    // https://github.com/dotnet/msbuild/issues/8762 In NET Framework, Path.* function will throw exceptions if the path contains invalid characters.
                     ProjectErrorUtilities.ThrowInvalidProject(importElement.Location, "InvalidAttributeValue", importExpandedWithDefaultPath, XMakeAttributes.project, XMakeElements.import);
                     return;
                 }


### PR DESCRIPTION
Fixes [#8762 ](https://github.com/dotnet/msbuild/issues/8762)

### Context
Catch the exceptions when extensionsPathPropValue is null or importExpandedWithDefaultPath is empty.
In NET Framework, Path.* function also throws exceptions if the path contains invalid characters

### Changes Made
Catch the exception.

### Testing
FallbackImportWithInvalidProjectValue

### Notes
