### PR TITLE
Update System.Security.Cryptography.Xml

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -49,7 +49,7 @@
     <PackageReference Update="System.Security.Cryptography.Pkcs" Version="6.0.1" />
     <PackageReference Update="System.Security.Cryptography.Pkcs" Condition="'$(SystemSecurityCryptographyPkcsVersion)' != ''" Version="$(SystemSecurityCryptographyPkcsVersion)" />
 
-    <PackageReference Update="System.Security.Cryptography.Xml" Version="6.0.0" />
+    <PackageReference Update="System.Security.Cryptography.Xml" Version="6.0.1" />
     <PackageReference Update="System.Security.Cryptography.Xml" Condition="'$(SystemSecurityCryptographyXmlVersion)' != ''" Version="$(SystemSecurityCryptographyXmlVersion)" />
 
     <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.3.2" />


### PR DESCRIPTION
Fixes [CVE-2022-34716 in vs17.4](https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted/alert/7392363?typeId=15421036)

### Changes Made
System.Security.Cryptography.Xml version update