### PR TITLE
Avoid OfTypeIterators when enumerating project xml children

### DIFF
--- a/src/BannedSymbols.txt
+++ b/src/BannedSymbols.txt
@@ -1,1 +1,2 @@
 M:System.Globalization.CompareInfo.IndexOf(System.String,System.Char);CompareInfo.IndexOf can unexpectedly allocate strings--use string.IndexOf
+P:Microsoft.Build.Construction.ProjectElementContainer.Children;Use ChildrenEnumerable instead to avoid boxing

--- a/src/Build.OM.UnitTests/Construction/ProjectImportElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectImportElement_Tests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             ProjectRootElement project = ProjectRootElement.Create();
 
-            Assert.Null(project.Imports.GetEnumerator().Current);
+            Assert.Empty(project.Imports);
         }
 
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/ProjectImportGroupElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectImportGroupElement_Tests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             ProjectRootElement project = ProjectRootElement.Create();
 
-            Assert.Null(project.Imports.GetEnumerator().Current);
+            Assert.Empty(project.Imports);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             ProjectImportGroupElement importGroup = (ProjectImportGroupElement)Helpers.GetFirst(project.ImportGroups);
 
-            Assert.Null(project.Imports.GetEnumerator().Current);
+            Assert.Empty(project.Imports);
             Assert.Equal(0, Helpers.Count(importGroup.Imports));
         }
 

--- a/src/Build.OM.UnitTests/Construction/ProjectItemDefinitionGroupElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemDefinitionGroupElement_Tests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             ProjectRootElement project = ProjectRootElement.Create();
             Assert.Equal(0, Helpers.Count(project.Children));
-            Assert.Null(project.ItemDefinitionGroups.GetEnumerator().Current);
+            Assert.Empty(project.ItemDefinitionGroups);
         }
 
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             ProjectRootElement project = ProjectRootElement.Create();
             Assert.Equal(0, Helpers.Count(project.Children));
-            Assert.Null(project.ItemGroups.GetEnumerator().Current);
+            Assert.Empty(project.ItemGroups);
         }
 
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/ProjectPropertyGroupElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectPropertyGroupElement_Tests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             ProjectRootElement project = ProjectRootElement.Create();
             Assert.Equal(0, Helpers.Count(project.Children));
-            Assert.Null(project.PropertyGroups.GetEnumerator().Current);
+            Assert.Empty(project.PropertyGroups);
         }
 
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/ProjectTargetElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectTargetElement_Tests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void ReadNoTarget()
         {
             ProjectRootElement project = ProjectRootElement.Create();
-            Assert.Null(project.Targets.GetEnumerator().Current);
+            Assert.Empty(project.Targets);
         }
 
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/ProjectUsingTaskElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectUsingTaskElement_Tests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             ProjectRootElement project = ProjectRootElement.Create();
 
-            Assert.Null(project.UsingTasks.GetEnumerator().Current);
+            Assert.Empty(project.UsingTasks);
         }
 
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/UsingTaskParameterGroup_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/UsingTaskParameterGroup_Tests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             UsingTaskParameterGroupElement parameterGroup = GetParameterGroupXml(s_contentEmptyParameterGroup);
             Assert.NotNull(parameterGroup);
             Assert.Equal(0, parameterGroup.Count);
-            Assert.Null(parameterGroup.Parameters.GetEnumerator().Current);
+            Assert.Empty(parameterGroup.Parameters);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectChooseElement.cs
+++ b/src/Build/Construction/ProjectChooseElement.cs
@@ -3,9 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Xml;
-using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
 
@@ -60,7 +58,7 @@ namespace Microsoft.Build.Construction
         /// Get the When children.
         /// Will contain at least one entry.
         /// </summary>
-        public ICollection<ProjectWhenElement> WhenElements => new ReadOnlyCollection<ProjectWhenElement>(Children.OfType<ProjectWhenElement>());
+        public ICollection<ProjectWhenElement> WhenElements => GetChildrenOfType<ProjectWhenElement>();
 
         /// <summary>
         /// Get any Otherwise child.

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -59,10 +60,15 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Get an enumerator over all children, gotten recursively.
-        /// Walks the children in a depth-first manner.
+        /// Get an enumerator over all descendants in a depth-first manner.
         /// </summary>
-        public IEnumerable<ProjectElement> AllChildren => GetChildrenRecursively();
+        public IEnumerable<ProjectElement> AllChildren => GetDescendants();
+
+        internal IEnumerable<T> GetAllChildrenOfType<T>()
+            where T : ProjectElement
+            => FirstChild == null
+                ? Array.Empty<T>()
+                : GetDescendantsOfType<T>();
 
         /// <summary>
         /// Get enumerable over all the children
@@ -70,12 +76,23 @@ namespace Microsoft.Build.Construction
         public ICollection<ProjectElement> Children
         {
             [DebuggerStepThrough]
-            get
-            {
-                return new Collections.ReadOnlyCollection<ProjectElement>(
-                        new ProjectElementSiblingEnumerable(FirstChild));
-            }
+            get => FirstChild == null
+                ? Array.Empty<ProjectElement>()
+                : new Collections.ReadOnlyCollection<ProjectElement>(new ProjectElementSiblingEnumerable(FirstChild));
         }
+
+#pragma warning disable RS0030 // The ref to the banned API is in a doc comment
+        /// <summary>
+        /// Use this instead of <see cref="Children"/> to avoid boxing.
+        /// </summary>
+#pragma warning restore RS0030
+        internal ProjectElementSiblingEnumerable ChildrenEnumerable => new ProjectElementSiblingEnumerable(FirstChild);
+
+        internal ProjectElementSiblingSubTypeCollection<T> GetChildrenOfType<T>()
+            where T : ProjectElement
+            => FirstChild == null
+                ? ProjectElementSiblingSubTypeCollection<T>.Empty
+                : new ProjectElementSiblingSubTypeCollection<T>(FirstChild);
 
         /// <summary>
         /// Get enumerable over all the children, starting from the last
@@ -83,12 +100,16 @@ namespace Microsoft.Build.Construction
         public ICollection<ProjectElement> ChildrenReversed
         {
             [DebuggerStepThrough]
-            get
-            {
-                return new Collections.ReadOnlyCollection<ProjectElement>(
-                        new ProjectElementSiblingEnumerable(LastChild, false /* reverse */));
-            }
+            get => LastChild == null
+                ? Array.Empty<ProjectElement>()
+                : new Collections.ReadOnlyCollection<ProjectElement>(new ProjectElementSiblingEnumerable(LastChild, forwards: false));
         }
+
+        internal ProjectElementSiblingSubTypeCollection<T> GetChildrenReversedOfType<T>()
+            where T : ProjectElement
+            => LastChild == null
+                ? ProjectElementSiblingSubTypeCollection<T>.Empty
+                : new ProjectElementSiblingSubTypeCollection<T>(LastChild, forwards: false);
 
         /// <summary>
         /// Number of children of any kind
@@ -318,7 +339,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         public void RemoveAllChildren()
         {
-            foreach (ProjectElement child in Children)
+            foreach (ProjectElement child in ChildrenEnumerable)
             {
                 RemoveChild(child);
             }
@@ -341,7 +362,7 @@ namespace Microsoft.Build.Construction
             RemoveAllChildren();
             CopyFrom(element);
 
-            foreach (ProjectElement child in element.Children)
+            foreach (ProjectElement child in element.ChildrenEnumerable)
             {
                 if (child is ProjectElementContainer childContainer)
                 {
@@ -395,7 +416,7 @@ namespace Microsoft.Build.Construction
             var clone = (ProjectElementContainer)Clone(factory);
             parent?.AppendChild(clone);
 
-            foreach (ProjectElement child in Children)
+            foreach (ProjectElement child in ChildrenEnumerable)
             {
                 if (child is ProjectElementContainer childContainer)
                 {
@@ -667,7 +688,7 @@ namespace Microsoft.Build.Construction
         /// Result does NOT include the element passed in.
         /// The caller could filter these.
         /// </summary>
-        private IEnumerable<ProjectElement> GetChildrenRecursively()
+        private IEnumerable<ProjectElement> GetDescendants()
         {
             ProjectElement child = FirstChild;
 
@@ -678,6 +699,30 @@ namespace Microsoft.Build.Construction
                 if (child is ProjectElementContainer container)
                 {
                     foreach (ProjectElement grandchild in container.AllChildren)
+                    {
+                        yield return grandchild;
+                    }
+                }
+
+                child = child.NextSibling;
+            }
+        }
+
+        private IEnumerable<T> GetDescendantsOfType<T>()
+            where T : ProjectElement
+        {
+            ProjectElement child = FirstChild;
+
+            while (child != null)
+            {
+                if (child is T childOfType)
+                {
+                    yield return childOfType;
+                }
+
+                if (child is ProjectElementContainer container)
+                {
+                    foreach (T grandchild in container.GetAllChildrenOfType<T>())
                     {
                         yield return grandchild;
                     }
@@ -721,44 +766,182 @@ namespace Microsoft.Build.Construction
             return referenceSibling != null;
         }
 
+        internal sealed class ProjectElementSiblingSubTypeCollection<T> : ICollection<T>, ICollection
+            where T : ProjectElement
+        {
+            private readonly ProjectElement _initial;
+            private readonly bool _forwards;
+            private List<T> _realizedElements;
+
+            internal ProjectElementSiblingSubTypeCollection(ProjectElement initial, bool forwards = true)
+            {
+                _initial = initial;
+                _forwards = forwards;
+            }
+
+            public static ProjectElementSiblingSubTypeCollection<T> Empty { get; } = new ProjectElementSiblingSubTypeCollection<T>(initial: null);
+
+            public int Count => RealizedElements.Count;
+
+            public bool IsReadOnly => true;
+
+            bool ICollection.IsSynchronized => false;
+
+            object ICollection.SyncRoot => this;
+
+            private List<T> RealizedElements
+            {
+                get
+                {
+                    if (_realizedElements == null)
+                    {
+                        // Note! Don't use the List ctor which takes an IEnumerable as it casts to an ICollection and calls Count,
+                        // which leads to a StackOverflow exception in this implementation (see Count above)
+                        List<T> list = new();
+                        foreach (T element in this)
+                        {
+                            list.Add(element);
+                        }
+
+                        _realizedElements = list;
+                    }
+
+                    return _realizedElements;
+                }
+            }
+
+            public void Add(T item) => ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+
+            public void Clear() => ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+
+            public bool Contains(T item) => RealizedElements.Contains(item);
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+                ErrorUtilities.VerifyThrowArgumentNull(array, nameof(array));
+
+                if (_realizedElements != null)
+                {
+                    _realizedElements.CopyTo(array, arrayIndex);
+                }
+                else
+                {
+                    int i = arrayIndex;
+                    foreach (T entry in this)
+                    {
+                        array[i] = entry;
+                        i++;
+                    }
+                }
+            }
+
+            public bool Remove(T item)
+            {
+                ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+                return false;
+            }
+
+            public IEnumerator<T> GetEnumerator() => new Enumerator(_initial, _forwards);
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            void ICollection.CopyTo(Array array, int index)
+            {
+                ErrorUtilities.VerifyThrowArgumentNull(array, nameof(array));
+
+                int i = index;
+                foreach (T entry in this)
+                {
+                    array.SetValue(entry, i);
+                    i++;
+                }
+            }
+
+            public struct Enumerator : IEnumerator<T>
+            {
+                // Note! Should not be readonly or we run into infinite loop issues with mutable structs
+                private ProjectElementSiblingEnumerable.Enumerator _innerEnumerator;
+                private T _current;
+
+                internal Enumerator(ProjectElement initial, bool forwards = true)
+                {
+                    _innerEnumerator = new ProjectElementSiblingEnumerable.Enumerator(initial, forwards);
+                }
+
+                public T Current
+                {
+                    get
+                    {
+                        if (_current != null)
+                        {
+                            return _current;
+                        }
+
+                        throw new InvalidOperationException();
+                    }
+                }
+
+                object IEnumerator.Current => Current;
+
+                public readonly void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    while (_innerEnumerator.MoveNext())
+                    {
+                        ProjectElement innerCurrent = _innerEnumerator.Current;
+                        if (innerCurrent is T innerCurrentOfType)
+                        {
+                            _current = innerCurrentOfType;
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                public void Reset()
+                {
+                    _innerEnumerator.Reset();
+                    _current = null;
+                }
+            }
+        }
+
         /// <summary>
         /// Enumerable over a series of sibling ProjectElement objects
         /// </summary>
-        private struct ProjectElementSiblingEnumerable : IEnumerable<ProjectElement>
+        internal readonly struct ProjectElementSiblingEnumerable : IEnumerable<ProjectElement>
         {
             /// <summary>
             /// The enumerator
             /// </summary>
-            private readonly ProjectElementSiblingEnumerator _enumerator;
+            private readonly Enumerator _enumerator;
 
             /// <summary>
             /// Constructor allowing reverse enumeration
             /// </summary>
             internal ProjectElementSiblingEnumerable(ProjectElement initial, bool forwards = true)
             {
-                _enumerator = new ProjectElementSiblingEnumerator(initial, forwards);
+                _enumerator = new Enumerator(initial, forwards);
             }
 
             /// <summary>
             /// Get enumerator
             /// </summary>
-            public readonly IEnumerator<ProjectElement> GetEnumerator()
-            {
-                return _enumerator;
-            }
+            public readonly IEnumerator<ProjectElement> GetEnumerator() => _enumerator;
 
             /// <summary>
             /// Get non generic enumerator
             /// </summary>
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            {
-                return _enumerator;
-            }
+            IEnumerator IEnumerable.GetEnumerator() => _enumerator;
 
             /// <summary>
             /// Enumerator over a series of sibling ProjectElement objects
             /// </summary>
-            private struct ProjectElementSiblingEnumerator : IEnumerator<ProjectElement>
+            public struct Enumerator : IEnumerator<ProjectElement>
             {
                 /// <summary>
                 /// First element
@@ -775,7 +958,7 @@ namespace Microsoft.Build.Construction
                 /// <summary>
                 /// Constructor taking the first element
                 /// </summary>
-                internal ProjectElementSiblingEnumerator(ProjectElement initial, bool forwards)
+                internal Enumerator(ProjectElement initial, bool forwards)
                 {
                     _initial = initial;
                     Current = null;
@@ -792,7 +975,7 @@ namespace Microsoft.Build.Construction
                 /// Current element.
                 /// Throws if MoveNext() hasn't been called
                 /// </summary>
-                object System.Collections.IEnumerator.Current
+                object IEnumerator.Current
                 {
                     get
                     {

--- a/src/Build/Construction/ProjectImportGroupElement.cs
+++ b/src/Build/Construction/ProjectImportGroupElement.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
 
@@ -51,7 +49,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Get any contained properties.
         /// </summary>
-        public ICollection<ProjectImportElement> Imports => new ReadOnlyCollection<ProjectImportElement>(Children.OfType<ProjectImportElement>());
+        public ICollection<ProjectImportElement> Imports => GetChildrenOfType<ProjectImportElement>();
 
         #endregion // Properties
 

--- a/src/Build/Construction/ProjectItemDefinitionElement.cs
+++ b/src/Build/Construction/ProjectItemDefinitionElement.cs
@@ -3,9 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Xml;
-using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
 
@@ -52,7 +50,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Get any child metadata definitions.
         /// </summary>
-        public ICollection<ProjectMetadataElement> Metadata => new ReadOnlyCollection<ProjectMetadataElement>(Children.OfType<ProjectMetadataElement>());
+        public ICollection<ProjectMetadataElement> Metadata => GetChildrenOfType<ProjectMetadataElement>();
 
         /// <summary>
         /// Convenience method to add a piece of metadata to this item definition.

--- a/src/Build/Construction/ProjectItemDefinitionGroupElement.cs
+++ b/src/Build/Construction/ProjectItemDefinitionGroupElement.cs
@@ -3,9 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Xml;
-using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
 
@@ -47,7 +45,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Get a list of child item definitions.
         /// </summary>
-        public ICollection<ProjectItemDefinitionElement> ItemDefinitions => new ReadOnlyCollection<ProjectItemDefinitionElement>(Children.OfType<ProjectItemDefinitionElement>());
+        public ICollection<ProjectItemDefinitionElement> ItemDefinitions => GetChildrenOfType<ProjectItemDefinitionElement>();
 
         /// <summary>
         /// Convenience method that picks a location based on a heuristic:

--- a/src/Build/Construction/ProjectItemElement.cs
+++ b/src/Build/Construction/ProjectItemElement.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Xml;
-using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
 
@@ -285,7 +283,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Get any child metadata.
         /// </summary>
-        public ICollection<ProjectMetadataElement> Metadata => new ReadOnlyCollection<ProjectMetadataElement>(Children.OfType<ProjectMetadataElement>());
+        public ICollection<ProjectMetadataElement> Metadata => GetChildrenOfType<ProjectMetadataElement>();
 
         /// <summary>
         /// Location of the include attribute

--- a/src/Build/Construction/ProjectItemGroupElement.cs
+++ b/src/Build/Construction/ProjectItemGroupElement.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
@@ -55,7 +54,7 @@ namespace Microsoft.Build.Construction
         /// Get any child items.
         /// This is a live collection.
         /// </summary>
-        public ICollection<ProjectItemElement> Items => new ReadOnlyCollection<ProjectItemElement>(Children.OfType<ProjectItemElement>());
+        public ICollection<ProjectItemElement> Items => GetChildrenOfType<ProjectItemElement>();
 
         /// <summary>
         /// True if it is known that no child items have wildcards in their

--- a/src/Build/Construction/ProjectOtherwiseElement.cs
+++ b/src/Build/Construction/ProjectOtherwiseElement.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
 
@@ -57,17 +55,17 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Get an enumerator over any child item groups
         /// </summary>
-        public ICollection<ProjectItemGroupElement> ItemGroups => new ReadOnlyCollection<ProjectItemGroupElement>(Children.OfType<ProjectItemGroupElement>());
+        public ICollection<ProjectItemGroupElement> ItemGroups => GetChildrenOfType<ProjectItemGroupElement>();
 
         /// <summary>
         /// Get an enumerator over any child property groups
         /// </summary>
-        public ICollection<ProjectPropertyGroupElement> PropertyGroups => new ReadOnlyCollection<ProjectPropertyGroupElement>(Children.OfType<ProjectPropertyGroupElement>());
+        public ICollection<ProjectPropertyGroupElement> PropertyGroups => GetChildrenOfType<ProjectPropertyGroupElement>();
 
         /// <summary>
         /// Get an enumerator over any child chooses
         /// </summary>
-        public ICollection<ProjectChooseElement> ChooseElements => new ReadOnlyCollection<ProjectChooseElement>(Children.OfType<ProjectChooseElement>());
+        public ICollection<ProjectChooseElement> ChooseElements => GetChildrenOfType<ProjectChooseElement>();
 
         #endregion
 

--- a/src/Build/Construction/ProjectPropertyGroupElement.cs
+++ b/src/Build/Construction/ProjectPropertyGroupElement.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
 
@@ -47,12 +45,12 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Get any contained properties.
         /// </summary>
-        public ICollection<ProjectPropertyElement> Properties => new ReadOnlyCollection<ProjectPropertyElement>(Children.OfType<ProjectPropertyElement>());
+        public ICollection<ProjectPropertyElement> Properties => GetChildrenOfType<ProjectPropertyElement>();
 
         /// <summary>
         /// Get any contained properties.
         /// </summary>
-        public ICollection<ProjectPropertyElement> PropertiesReversed => new ReadOnlyCollection<ProjectPropertyElement>(ChildrenReversed.OfType<ProjectPropertyElement>());
+        public ICollection<ProjectPropertyElement> PropertiesReversed => GetChildrenReversedOfType<ProjectPropertyElement>();
 
         /// <summary>
         /// Convenience method that picks a location based on a heuristic:

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -287,81 +287,81 @@ namespace Microsoft.Build.Construction
         /// <remarks>
         /// The name is inconsistent to make it more understandable, per API review.
         /// </remarks>
-        public ICollection<ProjectChooseElement> ChooseElements => new ReadOnlyCollection<ProjectChooseElement>(Children.OfType<ProjectChooseElement>());
+        public ICollection<ProjectChooseElement> ChooseElements => GetChildrenOfType<ProjectChooseElement>();
 
         /// <summary>
         /// Get a read-only collection of the child item definition groups, if any
         /// </summary>
-        public ICollection<ProjectItemDefinitionGroupElement> ItemDefinitionGroups => new ReadOnlyCollection<ProjectItemDefinitionGroupElement>(Children.OfType<ProjectItemDefinitionGroupElement>());
+        public ICollection<ProjectItemDefinitionGroupElement> ItemDefinitionGroups => GetChildrenOfType<ProjectItemDefinitionGroupElement>();
 
         /// <summary>
         /// Get a read-only collection of the child item definitions, if any, in all item definition groups anywhere in the project file.
         /// </summary>
-        public ICollection<ProjectItemDefinitionElement> ItemDefinitions => new ReadOnlyCollection<ProjectItemDefinitionElement>(AllChildren.OfType<ProjectItemDefinitionElement>());
+        public ICollection<ProjectItemDefinitionElement> ItemDefinitions => new ReadOnlyCollection<ProjectItemDefinitionElement>(GetAllChildrenOfType<ProjectItemDefinitionElement>());
 
         /// <summary>
         /// Get a read-only collection over the child item groups, if any.
         /// Does not include any that may not be at the root, i.e. inside Choose elements.
         /// </summary>
-        public ICollection<ProjectItemGroupElement> ItemGroups => new ReadOnlyCollection<ProjectItemGroupElement>(Children.OfType<ProjectItemGroupElement>());
+        public ICollection<ProjectItemGroupElement> ItemGroups => GetChildrenOfType<ProjectItemGroupElement>();
 
         /// <summary>
         /// Get a read-only collection of the child items, if any, in all item groups anywhere in the project file.
         /// Not restricted to root item groups: traverses through Choose elements.
         /// </summary>
-        public ICollection<ProjectItemElement> Items => new ReadOnlyCollection<ProjectItemElement>(AllChildren.OfType<ProjectItemElement>());
+        public ICollection<ProjectItemElement> Items => new ReadOnlyCollection<ProjectItemElement>(GetAllChildrenOfType<ProjectItemElement>());
 
         /// <summary>
         /// Get a read-only collection of the child import groups, if any.
         /// </summary>
-        public ICollection<ProjectImportGroupElement> ImportGroups => new ReadOnlyCollection<ProjectImportGroupElement>(Children.OfType<ProjectImportGroupElement>());
+        public ICollection<ProjectImportGroupElement> ImportGroups => GetChildrenOfType<ProjectImportGroupElement>();
 
         /// <summary>
         /// Get a read-only collection of the child imports
         /// </summary>
-        public ICollection<ProjectImportElement> Imports => new ReadOnlyCollection<ProjectImportElement>(AllChildren.OfType<ProjectImportElement>());
+        public ICollection<ProjectImportElement> Imports => new ReadOnlyCollection<ProjectImportElement>(GetAllChildrenOfType<ProjectImportElement>());
 
         /// <summary>
         /// Get a read-only collection of the child property groups, if any.
         /// Does not include any that may not be at the root, i.e. inside Choose elements.
         /// </summary>
-        public ICollection<ProjectPropertyGroupElement> PropertyGroups => new ReadOnlyCollection<ProjectPropertyGroupElement>(Children.OfType<ProjectPropertyGroupElement>());
+        public ICollection<ProjectPropertyGroupElement> PropertyGroups => GetChildrenOfType<ProjectPropertyGroupElement>();
 
         /// <summary>
         /// Geta read-only collection of the child properties, if any, in all property groups anywhere in the project file.
         /// Not restricted to root property groups: traverses through Choose elements.
         /// </summary>
-        public ICollection<ProjectPropertyElement> Properties => new ReadOnlyCollection<ProjectPropertyElement>(AllChildren.OfType<ProjectPropertyElement>());
+        public ICollection<ProjectPropertyElement> Properties => new ReadOnlyCollection<ProjectPropertyElement>(GetAllChildrenOfType<ProjectPropertyElement>());
 
         /// <summary>
         /// Get a read-only collection of the child targets
         /// </summary>
-        public ICollection<ProjectTargetElement> Targets => new ReadOnlyCollection<ProjectTargetElement>(Children.OfType<ProjectTargetElement>());
+        public ICollection<ProjectTargetElement> Targets => GetChildrenOfType<ProjectTargetElement>();
 
         /// <summary>
         /// Get a read-only collection of the child usingtasks, if any
         /// </summary>
-        public ICollection<ProjectUsingTaskElement> UsingTasks => new ReadOnlyCollection<ProjectUsingTaskElement>(Children.OfType<ProjectUsingTaskElement>());
+        public ICollection<ProjectUsingTaskElement> UsingTasks => GetChildrenOfType<ProjectUsingTaskElement>();
 
         /// <summary>
         /// Get a read-only collection of the child item groups, if any, in reverse order
         /// </summary>
-        public ICollection<ProjectItemGroupElement> ItemGroupsReversed => new ReadOnlyCollection<ProjectItemGroupElement>(ChildrenReversed.OfType<ProjectItemGroupElement>());
+        public ICollection<ProjectItemGroupElement> ItemGroupsReversed => GetChildrenReversedOfType<ProjectItemGroupElement>();
 
         /// <summary>
         /// Get a read-only collection of the child item definition groups, if any, in reverse order
         /// </summary>
-        public ICollection<ProjectItemDefinitionGroupElement> ItemDefinitionGroupsReversed => new ReadOnlyCollection<ProjectItemDefinitionGroupElement>(ChildrenReversed.OfType<ProjectItemDefinitionGroupElement>());
+        public ICollection<ProjectItemDefinitionGroupElement> ItemDefinitionGroupsReversed => GetChildrenReversedOfType<ProjectItemDefinitionGroupElement>();
 
         /// <summary>
         /// Get a read-only collection of the child import groups, if any, in reverse order
         /// </summary>
-        public ICollection<ProjectImportGroupElement> ImportGroupsReversed => new ReadOnlyCollection<ProjectImportGroupElement>(ChildrenReversed.OfType<ProjectImportGroupElement>());
+        public ICollection<ProjectImportGroupElement> ImportGroupsReversed => GetChildrenReversedOfType<ProjectImportGroupElement>();
 
         /// <summary>
         /// Get a read-only collection of the child property groups, if any, in reverse order
         /// </summary>
-        public ICollection<ProjectPropertyGroupElement> PropertyGroupsReversed => new ReadOnlyCollection<ProjectPropertyGroupElement>(ChildrenReversed.OfType<ProjectPropertyGroupElement>());
+        public ICollection<ProjectPropertyGroupElement> PropertyGroupsReversed => GetChildrenReversedOfType<ProjectPropertyGroupElement>();
 
         #endregion
 
@@ -702,7 +702,7 @@ namespace Microsoft.Build.Construction
         /// Not public as we do not wish to encourage the use of ProjectExtensions.
         /// </remarks>
         internal ProjectExtensionsElement ProjectExtensions
-            => ChildrenReversed.OfType<ProjectExtensionsElement>().FirstOrDefault();
+            => GetChildrenReversedOfType<ProjectExtensionsElement>().FirstOrDefault();
 
         /// <summary>
         /// Returns an unlocalized indication of how this file was last dirtied.
@@ -1905,15 +1905,18 @@ namespace Microsoft.Build.Construction
                 }
             }
 
-            foreach (var sdkNode in Children.OfType<ProjectSdkElement>())
+            foreach (ProjectElement child in ChildrenEnumerable)
             {
-                var referencedSdk = new SdkReference(
-                    sdkNode.XmlElement.GetAttribute("Name"),
-                    sdkNode.XmlElement.GetAttribute("Version"),
-                    sdkNode.XmlElement.GetAttribute("MinimumVersion"));
+                if (child is ProjectSdkElement sdkNode)
+                {
+                    var referencedSdk = new SdkReference(
+                        sdkNode.XmlElement.GetAttribute("Name"),
+                        sdkNode.XmlElement.GetAttribute("Version"),
+                        sdkNode.XmlElement.GetAttribute("MinimumVersion"));
 
-                nodes.Add(ProjectImportElement.CreateImplicit("Sdk.props", currentProjectOrImport, ImplicitImportLocation.Top, referencedSdk, sdkNode));
-                nodes.Add(ProjectImportElement.CreateImplicit("Sdk.targets", currentProjectOrImport, ImplicitImportLocation.Bottom, referencedSdk, sdkNode));
+                    nodes.Add(ProjectImportElement.CreateImplicit("Sdk.props", currentProjectOrImport, ImplicitImportLocation.Top, referencedSdk, sdkNode));
+                    nodes.Add(ProjectImportElement.CreateImplicit("Sdk.targets", currentProjectOrImport, ImplicitImportLocation.Bottom, referencedSdk, sdkNode));
+                }
             }
 
             return nodes;

--- a/src/Build/Construction/ProjectTargetElement.cs
+++ b/src/Build/Construction/ProjectTargetElement.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using Microsoft.Build.Collections;
 using Microsoft.Build.Execution;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
@@ -58,22 +56,22 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Get an enumerator over any child item groups
         /// </summary>
-        public ICollection<ProjectItemGroupElement> ItemGroups => new ReadOnlyCollection<ProjectItemGroupElement>(Children.OfType<ProjectItemGroupElement>());
+        public ICollection<ProjectItemGroupElement> ItemGroups => GetChildrenOfType<ProjectItemGroupElement>();
 
         /// <summary>
         /// Get an enumerator over any child property groups
         /// </summary>
-        public ICollection<ProjectPropertyGroupElement> PropertyGroups => new ReadOnlyCollection<ProjectPropertyGroupElement>(Children.OfType<ProjectPropertyGroupElement>());
+        public ICollection<ProjectPropertyGroupElement> PropertyGroups => GetChildrenOfType<ProjectPropertyGroupElement>();
 
         /// <summary>
         /// Get an enumerator over any child tasks
         /// </summary>
-        public ICollection<ProjectTaskElement> Tasks => new ReadOnlyCollection<ProjectTaskElement>(Children.OfType<ProjectTaskElement>());
+        public ICollection<ProjectTaskElement> Tasks => GetChildrenOfType<ProjectTaskElement>();
 
         /// <summary>
         /// Get an enumerator over any child onerrors
         /// </summary>
-        public ICollection<ProjectOnErrorElement> OnErrors => new ReadOnlyCollection<ProjectOnErrorElement>(Children.OfType<ProjectOnErrorElement>());
+        public ICollection<ProjectOnErrorElement> OnErrors => GetChildrenOfType<ProjectOnErrorElement>();
 
         #endregion
 

--- a/src/Build/Construction/ProjectTaskElement.cs
+++ b/src/Build/Construction/ProjectTaskElement.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Xml;
 using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
@@ -126,7 +125,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Gets any output children.
         /// </summary>
-        public ICollection<ProjectOutputElement> Outputs => new Collections.ReadOnlyCollection<ProjectOutputElement>(Children.OfType<ProjectOutputElement>());
+        public ICollection<ProjectOutputElement> Outputs => GetChildrenOfType<ProjectOutputElement>();
 
         /// <summary>
         /// Enumerable over the unevaluated parameters on the task.

--- a/src/Build/Construction/ProjectWhenElement.cs
+++ b/src/Build/Construction/ProjectWhenElement.cs
@@ -3,9 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Xml;
-using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
 
@@ -48,17 +46,17 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Get an enumerator over any child chooses
         /// </summary>
-        public ICollection<ProjectChooseElement> ChooseElements => new ReadOnlyCollection<ProjectChooseElement>(Children.OfType<ProjectChooseElement>());
+        public ICollection<ProjectChooseElement> ChooseElements => GetChildrenOfType<ProjectChooseElement>();
 
         /// <summary>
         /// Get an enumerator over any child item groups
         /// </summary>
-        public ICollection<ProjectItemGroupElement> ItemGroups => new ReadOnlyCollection<ProjectItemGroupElement>(Children.OfType<ProjectItemGroupElement>());
+        public ICollection<ProjectItemGroupElement> ItemGroups => GetChildrenOfType<ProjectItemGroupElement>();
 
         /// <summary>
         /// Get an enumerator over any child property groups
         /// </summary>
-        public ICollection<ProjectPropertyGroupElement> PropertyGroups => new ReadOnlyCollection<ProjectPropertyGroupElement>(Children.OfType<ProjectPropertyGroupElement>());
+        public ICollection<ProjectPropertyGroupElement> PropertyGroups => GetChildrenOfType<ProjectPropertyGroupElement>();
 
         #endregion
 

--- a/src/Build/Construction/UsingTaskParameterGroupElement.cs
+++ b/src/Build/Construction/UsingTaskParameterGroupElement.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using Microsoft.Build.Collections;
 using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared;
 using ProjectXmlUtilities = Microsoft.Build.Internal.ProjectXmlUtilities;
@@ -59,7 +57,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Get any contained parameters.
         /// </summary>
-        public ICollection<ProjectUsingTaskParameterElement> Parameters => new ReadOnlyCollection<ProjectUsingTaskParameterElement>(Children.OfType<ProjectUsingTaskParameterElement>());
+        public ICollection<ProjectUsingTaskParameterElement> Parameters => GetChildrenOfType<ProjectUsingTaskParameterElement>();
 
         /// <summary>
         /// This does not allow conditions, so it should not be called.

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -1062,7 +1062,7 @@ namespace Microsoft.Build.Evaluation
                             preserveFormatting: false);
                     }
 
-                    foreach (ProjectElement elementXml in projectRootElement.Children)
+                    foreach (ProjectElement elementXml in projectRootElement.ChildrenEnumerable)
                     {
                         ProjectUsingTaskElement usingTask = elementXml as ProjectUsingTaskElement;
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Build.Evaluation
             List<ProjectTargetInstanceChild> targetChildren = new List<ProjectTargetInstanceChild>(targetElement.Count);
             List<ProjectOnErrorInstance> targetOnErrorChildren = new List<ProjectOnErrorInstance>();
 
-            foreach (ProjectElement targetChildElement in targetElement.Children)
+            foreach (ProjectElement targetChildElement in targetElement.ChildrenEnumerable)
             {
                 using (evaluationProfiler.TrackElement(targetChildElement))
                 {
@@ -881,7 +881,7 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
-                foreach (ProjectElement element in currentProjectOrImport.Children)
+                foreach (ProjectElement element in currentProjectOrImport.ChildrenEnumerable)
                 {
                     switch (element)
                     {
@@ -1499,7 +1499,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     if (EvaluateConditionCollectingConditionedProperties(whenElement, ExpanderOptions.ExpandProperties, ParserOptions.AllowProperties))
                     {
-                        EvaluateWhenOrOtherwiseChildren(whenElement.Children);
+                        EvaluateWhenOrOtherwiseChildren(whenElement.ChildrenEnumerable);
                         return;
                     }
                 }
@@ -1507,7 +1507,7 @@ namespace Microsoft.Build.Evaluation
                 // "Otherwise" elements never have a condition
                 if (chooseElement.OtherwiseElement != null)
                 {
-                    EvaluateWhenOrOtherwiseChildren(chooseElement.OtherwiseElement.Children);
+                    EvaluateWhenOrOtherwiseChildren(chooseElement.OtherwiseElement.ChildrenEnumerable);
                 }
             }
         }
@@ -1517,7 +1517,7 @@ namespace Microsoft.Build.Evaluation
         /// Returns true if the condition was true, so subsequent
         /// WhenElements and Otherwise can be skipped.
         /// </summary>
-        private bool EvaluateWhenOrOtherwiseChildren(IEnumerable<ProjectElement> children)
+        private bool EvaluateWhenOrOtherwiseChildren(ProjectElementContainer.ProjectElementSiblingEnumerable children)
         {
             foreach (ProjectElement element in children)
             {

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -79,7 +79,7 @@
     <PackageReference Update="Microsoft.NETCore.App" PrivateAssets="All" />
 
     <!-- Configure analyzer to forbid certain API calls -->
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" Condition=" '$(IsUnitTestProject)' != 'true' " />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(GenerateReferenceAssemblySource)' == 'true'">

--- a/src/Shared/ReadOnlyCollection.cs
+++ b/src/Shared/ReadOnlyCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Collections
     /// Thus this is an omission from the BCL.
     /// </remarks>
     /// <typeparam name="T">Type of element in the collection</typeparam>
-    internal class ReadOnlyCollection<T> : ICollection<T>, ICollection
+    internal sealed class ReadOnlyCollection<T> : ICollection<T>, ICollection
     {
         /// <summary>
         /// Backing live enumerable.


### PR DESCRIPTION
### Summary

Performance improvement with noticeable impact when using static graph in large repos.

### Customer Impact

~10% reduction in static graph construction time in a specific large repo.

### Regression?

No.

### Testing

Automated tests, manual runs on reporting repo showing noticeable improvement.

### Risk

Low.

### Details

Avoid OfTypeIterators when enumerating project xml children

In a recent profile of a graph construction, it was observed that a large amount of boxing was happening for `ProjectElementSiblingEnumerable`. This change simplifies how xml children are enumerated by adding an internal `ChildrenEnumerable` property which directly exposes the `ProjectElementSiblingEnumerable` which should avoid boxing, at least in some code paths (the public API makes it hard to avoid everywhere...).

Additionally, a very common usage of enumerating children was to do `Children.OfType<T>` and wrap it in a `ReadOnlyCollection<T>`, so I introduced a `GetChildrenOfType` (and `GetChildrenReversedOfType`) method which exposes an `ICollection<T>` which does the same thing but without the boxing of `ProjectElementSiblingEnumerable` and without the `OfType` class. It's just 1 collection allocation.

![image](https://github.com/dotnet/msbuild/assets/6445614/8b0c2a5f-19d3-4818-9f72-1452fb155c2e)

![image](https://github.com/dotnet/msbuild/assets/6445614/7058c65d-ca60-4dda-8f5b-6100104cd8e7)

![image](https://github.com/dotnet/msbuild/assets/6445614/18a99a8a-31b2-4bd3-99e8-e29abfba509e)
