### PR TITLE
Remove references to BinaryFormatter from comments

### DIFF
--- a/src/Tasks/AssemblyRegistrationCache.cs
+++ b/src/Tasks/AssemblyRegistrationCache.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Shared;
@@ -13,8 +12,6 @@ namespace Microsoft.Build.Tasks
     /// <remarks>
     /// This class is a caching mechanism for the Register/UnregisterAssembly task to keep track of registered assemblies to clean up
     /// </remarks>
-    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
-    [Serializable]
     internal sealed class AssemblyRegistrationCache : StateFileBase, ITranslatable
     {
         /// <summary>

--- a/src/Tasks/DependencyFile.cs
+++ b/src/Tasks/DependencyFile.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Build.Tasks
     /// Represents a single input to a compilation-style task.
     /// Keeps track of timestamp for later comparison.
     /// </remarks>
-    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
-    [Serializable]
     internal class DependencyFile
     {
         // Filename

--- a/src/Tasks/DependencyFile.cs
+++ b/src/Tasks/DependencyFile.cs
@@ -14,7 +14,12 @@ namespace Microsoft.Build.Tasks
     /// <remarks>
     /// Represents a single input to a compilation-style task.
     /// Keeps track of timestamp for later comparison.
+    ///
+    /// Must be serializable because instances may be marshaled cross-AppDomain, see <see cref="ProcessResourceFiles.PortableLibraryCacheInfo"/>.
     /// </remarks>
+#if FEATURE_APPDOMAIN
+    [Serializable]
+#endif
     internal class DependencyFile
     {
         // Filename

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Build.Tasks
     /// 
     /// This is an on-disk serialization format, don't change field names or types or use readonly.
     /// </remarks>
-    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
-    [Serializable]
     internal sealed class ResGenDependencies : StateFileBase, ITranslatable
     {
         /// <summary>
@@ -221,8 +219,6 @@ namespace Microsoft.Build.Tasks
         /// 
         /// This is an on-disk serialization format, don't change field names or types or use readonly.
         /// </remarks>
-        /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
-        [Serializable]
         internal sealed class ResXFile : DependencyFile, ITranslatable
         {
             // Files contained within this resx file.
@@ -326,9 +322,12 @@ namespace Microsoft.Build.Tasks
         /// 0 to many ResW files.
         /// 
         /// This is an on-disk serialization format, don't change field names or types or use readonly.
+        ///
+        /// Must be serializable because instances may be marshaled cross-AppDomain, see <see cref="ProcessResourceFiles.PortableLibraryCacheInfo"/>.
         /// </remarks>
-        /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
+#if FEATURE_APPDOMAIN
         [Serializable]
+#endif
         internal sealed class PortableLibraryFile : DependencyFile, ITranslatable
         {
             internal string[] outputFiles;

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Build.Tasks
     /// <remarks>
     /// This class is a caching mechanism for the resgen task to keep track of linked
     /// files within processed .resx files.
-    /// 
-    /// This is an on-disk serialization format, don't change field names or types or use readonly.
     /// </remarks>
     internal sealed class ResGenDependencies : StateFileBase, ITranslatable
     {
@@ -216,8 +214,6 @@ namespace Microsoft.Build.Tasks
 
         /// <remarks>
         /// Represents a single .resx file in the dependency cache.
-        /// 
-        /// This is an on-disk serialization format, don't change field names or types or use readonly.
         /// </remarks>
         internal sealed class ResXFile : DependencyFile, ITranslatable
         {
@@ -321,8 +317,6 @@ namespace Microsoft.Build.Tasks
         /// Represents a single assembly in the dependency cache, which may produce 
         /// 0 to many ResW files.
         /// 
-        /// This is an on-disk serialization format, don't change field names or types or use readonly.
-        ///
         /// Must be serializable because instances may be marshaled cross-AppDomain, see <see cref="ProcessResourceFiles.PortableLibraryCacheInfo"/>.
         /// </remarks>
 #if FEATURE_APPDOMAIN

--- a/src/Tasks/ResolveComReferenceCache.cs
+++ b/src/Tasks/ResolveComReferenceCache.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Build.Tasks
     /// 
     /// This is an on-disk serialization format, don't change field names or types or use readonly.
     /// </remarks>
-    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
-    [Serializable]
     internal sealed class ResolveComReferenceCache : StateFileBase, ITranslatable
     {
         /// <summary>

--- a/src/Tasks/ResolveComReferenceCache.cs
+++ b/src/Tasks/ResolveComReferenceCache.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Build.Tasks
     /// an earlier revision of a COM component, its timestamp can go back in time and we still need to regenerate its
     /// wrapper. So in ResolveComReference we compare the stored timestamp with the current component timestamp, and if 
     /// they are different, we regenerate the wrapper.
-    /// 
-    /// This is an on-disk serialization format, don't change field names or types or use readonly.
     /// </remarks>
     internal sealed class ResolveComReferenceCache : StateFileBase, ITranslatable
     {

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Build.Tasks
     /// <remarks>
     /// Base class for task state files.
     /// </remarks>
-    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
-    [Serializable]
     internal abstract class StateFileBase
     {
         // Current version for serialization. This should be changed when breaking changes

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Class is used to cache system state.
     /// </summary>
-    /// Serializable should be included in all state files. It permits BinaryFormatter-based calls, including from GenerateResource, which we cannot move off BinaryFormatter.
-    [Serializable]
     internal sealed class SystemState : StateFileBase, ITranslatable
     {
         /// <summary>


### PR DESCRIPTION
Related to #8827

### Context

Some of the comments mentioning `BinaryFormatter` are misleading. Most of the classes don't need to be serializable. The only exception is `PortableLibraryFile` which is serialized cross-domain on .NET Framework.

### Changes Made

Removed `[Serializable]` and the comment about `BinaryFormatter`-based calls from several classes. Left it on `PortableLibraryFile`, ifdef'ed to .NET Framework builds only.

### Testing

Experimental insertion confirmed that `PortableLibraryFile` is indeed marshaled cross-domain in some scenarios. Confirmed that it is the only such type by code inspection.