### PR TITLE
Add support for ShouldUnsetParentConfigurationAndPlatform in solution-based graph construction

### DIFF
--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -681,6 +681,8 @@ namespace Microsoft.Build.Graph.UnitTests
             // This test exercises two key features of solution-based builds from AssignProjectConfiguration:
             // 1. Adding synthetic project references
             // 2. Resolving project configuration based on the sln
+            // 3. Handling unresolved project references with ShouldUnsetParentConfigurationAndPlatform=true
+            // 4. Handling unresolved project references with ShouldUnsetParentConfigurationAndPlatform=false
             using (var env = TestEnvironment.Create())
             {
                 const string SolutionFileContents = """
@@ -766,21 +768,37 @@ namespace Microsoft.Build.Graph.UnitTests
                 project1Xml.AddItem("ProjectReference", "Project2.vcxproj");
 
                 ProjectRootElement project2Xml = ProjectRootElement.Create();
+
+                // Project 2 depends on Project 4, which is not in the solution and uses ShouldUnsetParentConfigurationAndPlatform=true (the default)
+                project2Xml.AddItem("ProjectReference", "Project4.vcxproj");
+                project2Xml.AddProperty("ShouldUnsetParentConfigurationAndPlatform", "true");
+
                 ProjectRootElement project3Xml = ProjectRootElement.Create();
+
+                // Project 3 depends on Project 5, which is not in the solution and uses ShouldUnsetParentConfigurationAndPlatform=false
+                project3Xml.AddItem("ProjectReference", "Project5.vcxproj");
+                project3Xml.AddProperty("ShouldUnsetParentConfigurationAndPlatform", "false");
+
+                ProjectRootElement project4Xml = ProjectRootElement.Create();
+                ProjectRootElement project5Xml = ProjectRootElement.Create();
 
                 string project1Path = Path.Combine(env.DefaultTestDirectory.Path, "Project1.csproj");
                 string project2Path = Path.Combine(env.DefaultTestDirectory.Path, "Project2.vcxproj");
                 string project3Path = Path.Combine(env.DefaultTestDirectory.Path, "Project3.vcxproj");
+                string project4Path = Path.Combine(env.DefaultTestDirectory.Path, "Project4.vcxproj");
+                string project5Path = Path.Combine(env.DefaultTestDirectory.Path, "Project5.vcxproj");
 
                 project1Xml.Save(project1Path);
                 project2Xml.Save(project2Path);
                 project3Xml.Save(project3Path);
+                project4Xml.Save(project4Path);
+                project5Xml.Save(project5Path);
 
                 var projectGraph = new ProjectGraph(slnFile.Path);
                 projectGraph.EntryPointNodes.Count.ShouldBe(3);
                 projectGraph.GraphRoots.Count.ShouldBe(1);
                 projectGraph.GraphRoots.First().ProjectInstance.FullPath.ShouldBe(project1Path);
-                projectGraph.ProjectNodes.Count.ShouldBe(3);
+                projectGraph.ProjectNodes.Count.ShouldBe(5);
 
                 ProjectGraphNode project1Node = projectGraph.ProjectNodes.Single(node => node.ProjectInstance.FullPath == project1Path);
                 project1Node.ProjectInstance.GlobalProperties["Configuration"].ShouldBe("Debug");
@@ -790,12 +808,24 @@ namespace Microsoft.Build.Graph.UnitTests
                 ProjectGraphNode project2Node = projectGraph.ProjectNodes.Single(node => node.ProjectInstance.FullPath == project2Path);
                 project2Node.ProjectInstance.GlobalProperties["Configuration"].ShouldBe("Debug");
                 project2Node.ProjectInstance.GlobalProperties["Platform"].ShouldBe("Win32");
-                project2Node.ProjectReferences.Count.ShouldBe(0);
+                project2Node.ProjectReferences.Count.ShouldBe(1);
 
                 ProjectGraphNode project3Node = projectGraph.ProjectNodes.Single(node => node.ProjectInstance.FullPath == project3Path);
                 project3Node.ProjectInstance.GlobalProperties["Configuration"].ShouldBe("Debug");
                 project3Node.ProjectInstance.GlobalProperties["Platform"].ShouldBe("Win32");
-                project3Node.ProjectReferences.Count.ShouldBe(0);
+                project3Node.ProjectReferences.Count.ShouldBe(1);
+
+                // Configuration and Platform get unset
+                ProjectGraphNode project4Node = projectGraph.ProjectNodes.Single(node => node.ProjectInstance.FullPath == project4Path);
+                project4Node.ProjectInstance.GlobalProperties.ContainsKey("Configuration").ShouldBeFalse();
+                project4Node.ProjectInstance.GlobalProperties.ContainsKey("Platform").ShouldBeFalse();
+                project4Node.ProjectReferences.Count.ShouldBe(0);
+
+                // Configuration and Platform are inherited from the referencing project
+                ProjectGraphNode project5Node = projectGraph.ProjectNodes.Single(node => node.ProjectInstance.FullPath == project5Path);
+                project5Node.ProjectInstance.GlobalProperties["Configuration"].ShouldBe("Debug");
+                project5Node.ProjectInstance.GlobalProperties["Platform"].ShouldBe("Win32");
+                project5Node.ProjectReferences.Count.ShouldBe(0);
             }
         }
 

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -34,8 +34,9 @@ namespace Microsoft.Build.Graph
         private const string PlatformLookupTableMetadataName = "PlatformLookupTable";
         private const string PlatformMetadataName = "Platform";
         private const string PlatformsMetadataName = "Platforms";
-        private const string EnableDynamicPlatformResolutionMetadataName = "EnableDynamicPlatformResolution";
+        private const string EnableDynamicPlatformResolutionPropertyName = "EnableDynamicPlatformResolution";
         private const string OverridePlatformNegotiationValue = "OverridePlatformNegotiationValue";
+        private const string ShouldUnsetParentConfigurationAndPlatformPropertyName = "ShouldUnsetParentConfigurationAndPlatform";
         private const string ProjectMetadataName = "Project";
         private const string ConfigurationMetadataName = "Configuration";
 
@@ -120,7 +121,7 @@ namespace Microsoft.Build.Graph
                 }
 
                 string projectReferenceFullPath = projectReferenceItem.GetMetadataValue(FullPathMetadataName);
-                bool enableDynamicPlatformResolution = ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionMetadataName));
+                bool enableDynamicPlatformResolution = ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionPropertyName));
 
                 PropertyDictionary<ProjectPropertyInstance> referenceGlobalProperties = GetGlobalPropertiesForItem(
                     projectReferenceItem,
@@ -153,8 +154,13 @@ namespace Microsoft.Build.Graph
                     }
                     else
                     {
-                        referenceGlobalProperties.Remove(ConfigurationMetadataName);
-                        referenceGlobalProperties.Remove(PlatformMetadataName);
+                        // Note: ShouldUnsetParentConfigurationAndPlatform defaults to true in the AssignProjectConfiguration target when building a solution, so check that it's not false instead of checking that it's true.
+                        bool shouldUnsetParentConfigurationAndPlatform = !ConversionUtilities.ValidBooleanFalse(requesterInstance.GetPropertyValue(ShouldUnsetParentConfigurationAndPlatformPropertyName));
+                        if (shouldUnsetParentConfigurationAndPlatform)
+                        {
+                            referenceGlobalProperties.Remove(ConfigurationMetadataName);
+                            referenceGlobalProperties.Remove(PlatformMetadataName);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Add support for ShouldUnsetParentConfigurationAndPlatform in solution-based graph construction

This is a continuation of #8625, where I didn't implement this feature of `AssignProjectConfiguration`