### PR TITLE
Reënable static graph restore

### DIFF
--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -246,6 +246,9 @@
     <Copy SourceFiles="$(RepoRoot)src\MSBuild.Bootstrap\RedirectNuGetConsoleProcess.After.Microsoft.Common.targets"
           DestinationFolder="$(BootstrapDestination)\Current\Microsoft.Common.targets\ImportAfter" />
 
+    <Copy SourceFiles="$(RepoRoot)src\MSBuild.Bootstrap\RedirectNuGetConsoleProcess.After.Microsoft.Common.targets"
+          DestinationFolder="$(BootstrapDestination)\Current\SolutionFile\ImportAfter" />
+
     <!-- Disable workload resolver until we can figure out whether it can work in the bootstrap
          https://github.com/dotnet/msbuild/issues/6566 -->
     <Touch Files="$(BootstrapDestination)\DisableWorkloadResolver.sentinel" AlwaysCreate="true" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -2,13 +2,9 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
 
-<!-- Commented out as a temporary fix for the msbuild CI.
-Waiting for https://github.com/NuGet/NuGet.Client/pull/5010 fix to flow to CI machines. -->
-<!--
   <PropertyGroup>
     <RestoreUseStaticGraphEvaluation Condition="'$(DotNetBuildFromSource)' != 'true'">true</RestoreUseStaticGraphEvaluation>
   </PropertyGroup>
--->
 
   <ItemGroup>
 	<!-- Remove all sln files globbed by arcade so far and add only MSBuild.sln to the build.


### PR DESCRIPTION
Reverts dotnet/msbuild#8498 which should no longer be necessary now that 17.6 has rolled out broadly--it's everywhere I checked (official build, hosted agents, the pre queue).