### PR TITLE
Avoid delegate allocation in EvaluatorData constructor

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Build.Evaluation
 
                 _lazyEvaluator = lazyEvaluator;
 
-                _evaluatorData = new EvaluatorData(_lazyEvaluator._outerEvaluatorData, itemType => GetReferencedItems(itemType, ImmutableHashSet<string>.Empty));
+                _evaluatorData = new EvaluatorData(_lazyEvaluator._outerEvaluatorData, _referencedItemLists);
                 _itemFactory = new ItemFactoryWrapper(_itemElement, _lazyEvaluator._itemFactory);
                 _expander = new Expander<P, I>(_evaluatorData, _evaluatorData, _lazyEvaluator.EvaluationContext);
 
@@ -82,18 +82,6 @@ namespace Microsoft.Build.Evaluation
             protected virtual void MutateItems(ImmutableArray<I> items) { }
 
             protected virtual void SaveItems(ImmutableArray<I> items, OrderedItemDataCollection.Builder listBuilder) { }
-
-            private IList<I> GetReferencedItems(string itemType, ImmutableHashSet<string> globsToIgnore)
-            {
-                if (_referencedItemLists.TryGetValue(itemType, out var itemList))
-                {
-                    return itemList.GetMatchedItems(globsToIgnore);
-                }
-                else
-                {
-                    return ImmutableList<I>.Empty;
-                }
-            }
 
             [DebuggerDisplay(@"{DebugString()}")]
             protected readonly struct ItemBatchingContext

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -52,20 +52,13 @@ namespace Microsoft.Build.Evaluation
         {
             _outerEvaluatorData = data;
             _outerExpander = new Expander<P, I>(_outerEvaluatorData, _outerEvaluatorData, evaluationContext);
-            _evaluatorData = new EvaluatorData(_outerEvaluatorData, itemType => GetItems(itemType));
+            _evaluatorData = new EvaluatorData(_outerEvaluatorData, _itemLists);
             _expander = new Expander<P, I>(_evaluatorData, _evaluatorData, evaluationContext);
             _itemFactory = itemFactory;
             _loggingContext = loggingContext;
             _evaluationProfiler = evaluationProfiler;
 
             EvaluationContext = evaluationContext;
-        }
-
-        private ImmutableList<I> GetItems(string itemType)
-        {
-            return _itemLists.TryGetValue(itemType, out LazyItemList itemList) ?
-                itemList.GetMatchedItems(ImmutableHashSet<string>.Empty) :
-                ImmutableList<I>.Empty;
         }
 
         public bool EvaluateConditionWithCurrentState(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions)


### PR DESCRIPTION
Fixes [AB#1827934](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1827934)

### Context

The `EvaluatorData` class accepts a delegate via which it may query for items of a given item type. GCPauseWatson identified the per-instance allocation of these delegates as contributing to GC pauses.

### Changes Made

By passing `IReadOnlyDictionary<string, LazyItemList>` instead, `EvaluatorData` can perform the lookup itself directly via that interface, rather than having a heap-allocated delegate per instance.

### Testing

Existing unit tests and eyeballs.

### Notes

Credit to @davkean for the proposed fix here.