### PR TITLE
Reduce allocation in UsedUninitializedProperties

### DIFF
--- a/src/Build.UnitTests/Evaluation/UsedUninitializedProperties_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/UsedUninitializedProperties_Tests.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Shared;
+using Microsoft.Build.UnitTests;
+
+using Xunit;
+
+namespace Microsoft.Build.Evaluation;
+
+public sealed class UsedUninitializedProperties_Tests
+{
+    [Fact]
+    public void Basics()
+    {
+        UsedUninitializedProperties props = new();
+
+        Assert.False(props.TryGetPropertyElementLocation("Hello", out IElementLocation? elementLocation));
+        Assert.Null(elementLocation);
+
+        props.RemoveProperty("Hello");
+
+        IElementLocation location1 = new MockElementLocation("File1");
+        IElementLocation location2 = new MockElementLocation("File2");
+
+        props.TryAdd("Hello", location1);
+        props.TryAdd("Hello", location2);
+
+        Assert.True(props.TryGetPropertyElementLocation("Hello", out elementLocation));
+        Assert.Same(location1, elementLocation);
+
+        Assert.True(props.TryGetPropertyElementLocation("Hello", out elementLocation));
+        Assert.Same(location1, elementLocation);
+
+        props.RemoveProperty("Hello");
+
+        Assert.False(props.TryGetPropertyElementLocation("Hello", out elementLocation));
+        Assert.Null(elementLocation);
+
+        props.RemoveProperty("Hello");
+    }
+}

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1316,12 +1316,12 @@ namespace Microsoft.Build.Evaluation
                 {
                     // Is the property we are currently setting in the list of properties which have been used but not initialized
                     IElementLocation elementWhichUsedProperty;
-                    bool isPropertyInList = _expander.UsedUninitializedProperties.Properties.TryGetValue(propertyElement.Name, out elementWhichUsedProperty);
+                    bool isPropertyInList = _expander.UsedUninitializedProperties.TryGetPropertyElementLocation(propertyElement.Name, out elementWhichUsedProperty);
 
                     if (isPropertyInList)
                     {
                         // Once we are going to warn for a property once, remove it from the list so we do not add it again.
-                        _expander.UsedUninitializedProperties.Properties.Remove(propertyElement.Name);
+                        _expander.UsedUninitializedProperties.RemoveProperty(propertyElement.Name);
                         _evaluationLoggingContext.LogWarning(null, new BuildEventFileInfo(propertyElement.Location), "UsedUninitializedProperty", propertyElement.Name, elementWhichUsedProperty.LocationString);
                     }
                 }

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1521,18 +1521,16 @@ namespace Microsoft.Build.Evaluation
                     // We also do not want to add the property to the list if the environment variable is not set, also we do not want to add the property to the list if we are currently
                     // evaluating a condition because a common pattern for msbuild projects is to see if the property evaluates to empty and then set a value as this would cause a considerable number of false positives.   <A Condition="'$(A)' == ''">default</A>
                     //
-                    // Another pattern used is where a property concatonates with other values,  <a>$(a);something</a> however we do not want to add the a element to the list because again this would make a number of
+                    // Another pattern used is where a property concatenates with other values,  <a>$(a);something</a> however we do not want to add the a element to the list because again this would make a number of
                     // false positives. Therefore we check to see what element we are currently evaluating and if it is the same as our property we do not add the property to the list.
                     if (usedUninitializedProperties.Warn && usedUninitializedProperties.CurrentlyEvaluatingPropertyElementName != null)
                     {
                         // Check to see if the property name does not match the property we are currently evaluating, note the property we are currently evaluating in the element name, this means no $( or )
                         if (!MSBuildNameIgnoreCaseComparer.Default.Equals(usedUninitializedProperties.CurrentlyEvaluatingPropertyElementName, propertyName, startIndex, endIndex - startIndex + 1))
                         {
-                            string propertyTrimed = propertyName.Substring(startIndex, endIndex - startIndex + 1);
-                            if (!usedUninitializedProperties.Properties.ContainsKey(propertyTrimed))
-                            {
-                                usedUninitializedProperties.Properties.Add(propertyTrimed, elementLocation);
-                            }
+                            usedUninitializedProperties.TryAdd(
+                                propertyName: propertyName.Substring(startIndex, endIndex - startIndex + 1),
+                                elementLocation);
                         }
                     }
 
@@ -5279,26 +5277,45 @@ namespace Microsoft.Build.Evaluation
         }
     }
 
+#nullable enable
     /// <summary>
     /// This class wraps information about properties which have been used before they are initialized.
     /// </summary>
     internal class UsedUninitializedProperties
     {
         /// <summary>
-        /// This class wraps information about properties which have been used before they are initialized.
+        /// Lazily allocated collection of properties and the element which used them.
         /// </summary>
-        internal UsedUninitializedProperties()
+        private Dictionary<string, IElementLocation>? _properties;
+
+        internal void TryAdd(string propertyName, IElementLocation elementLocation)
         {
-            Properties = new Dictionary<string, IElementLocation>(StringComparer.OrdinalIgnoreCase);
+            if (_properties is null)
+            {
+                _properties = new(StringComparer.OrdinalIgnoreCase);
+            }
+            else if (_properties.ContainsKey(propertyName))
+            {
+                return;
+            }
+
+            _properties.Add(propertyName, elementLocation);
         }
 
-        /// <summary>
-        /// Hash set of properties which have been used before being initialized.
-        /// </summary>
-        internal IDictionary<string, IElementLocation> Properties
+        internal bool TryGetPropertyElementLocation(string propertyName, [NotNullWhen(returnValue: true)] out IElementLocation? elementLocation)
         {
-            get;
-            set;
+            if (_properties is null)
+            {
+                elementLocation = null;
+                return false;
+            }
+
+            return _properties.TryGetValue(propertyName, out elementLocation);
+        }
+
+        internal void RemoveProperty(string propertyName)
+        {
+            _properties?.Remove(propertyName);
         }
 
         /// <summary>
@@ -5313,7 +5330,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         ///  What is the currently evaluating property element, this is so that we do not add a un initialized property if we are evaluating that property.
         /// </summary>
-        internal string CurrentlyEvaluatingPropertyElementName
+        internal string? CurrentlyEvaluatingPropertyElementName
         {
             get;
             set;

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -5281,7 +5281,7 @@ namespace Microsoft.Build.Evaluation
     /// <summary>
     /// This class wraps information about properties which have been used before they are initialized.
     /// </summary>
-    internal class UsedUninitializedProperties
+    internal sealed class UsedUninitializedProperties
     {
         /// <summary>
         /// Lazily allocated collection of properties and the element which used them.


### PR DESCRIPTION
Fixes [AB#1824492](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1824492)

### Context

This class would always allocate a `Dictionary<string, IElementLocation>`, even when the object is unused. This allocation was showing up as contributing to GC pauses by GCPauseWatson.

### Changes Made

To reduce those allocations, we defer such an allocation until it is actually needed.

### Testing

Added unit tests.

### Notes
