### PR TITLE
Fix TaskRegistry CPUWatson issues due to false optimistic concurrency

### DIFF
--- a/src/Build.UnitTests/TestComparers/TaskRegistryComparers.cs
+++ b/src/Build.UnitTests/TestComparers/TaskRegistryComparers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
@@ -28,7 +29,9 @@ namespace Microsoft.Build.Engine.UnitTests.TestComparers
                     {
                         Assert.Equal(xp.Key, yp.Key, TaskRegistry.RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
                         Assert.Equal(xp.Value, yp.Value, new RegisteredTaskRecordComparer());
-                    });
+                    },
+                    TaskRegistry.RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact,
+                    true);
 
                 return true;
             }

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Build.Execution
         /// Cache of tasks already found using exact matching,
         /// keyed by the task identity requested.
         /// </summary>
-        private Dictionary<RegisteredTaskIdentity, RegisteredTaskRecord> _cachedTaskRecordsWithExactMatch;
+        private readonly Lazy<Dictionary<RegisteredTaskIdentity, RegisteredTaskRecord>> _cachedTaskRecordsWithExactMatch = new(() => new(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact));
 
         /// <summary>
         /// Cache of tasks already found using fuzzy matching,
@@ -144,7 +144,7 @@ namespace Microsoft.Build.Execution
         /// Task name may be qualified or not.
         /// This field may be null.
         /// </summary>
-        private Dictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>> _taskRegistrations;
+        private ConcurrentDictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>> _taskRegistrations;
 
         /// <summary>
         /// The cache to load the *.tasks files into
@@ -485,7 +485,7 @@ namespace Microsoft.Build.Execution
             {
                 if (exactMatchRequired)
                 {
-                    if (_cachedTaskRecordsWithExactMatch != null && _cachedTaskRecordsWithExactMatch.TryGetValue(taskIdentity, out taskRecord))
+                    if (_cachedTaskRecordsWithExactMatch.IsValueCreated && _cachedTaskRecordsWithExactMatch.Value.TryGetValue(taskIdentity, out taskRecord))
                     {
                         retrievedFromCache = true;
                         return taskRecord;
@@ -556,8 +556,7 @@ namespace Microsoft.Build.Execution
             // Cache the result, even if it is null.  We should never again do the work we just did, for this task name.
             if (exactMatchRequired)
             {
-                _cachedTaskRecordsWithExactMatch ??= new Dictionary<RegisteredTaskIdentity, RegisteredTaskRecord>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
-                _cachedTaskRecordsWithExactMatch[taskIdentity] = taskRecord;
+                _cachedTaskRecordsWithExactMatch.Value[taskIdentity] = taskRecord;
             }
             else
             {
@@ -667,13 +666,9 @@ namespace Microsoft.Build.Execution
 
             // since more than one task can have the same name, we want to keep track of all assemblies that are declared to
             // contain tasks with a given name...
-            List<RegisteredTaskRecord> registeredTaskEntries;
             RegisteredTaskIdentity taskIdentity = new RegisteredTaskIdentity(taskName, taskFactoryParameters);
-            if (!_taskRegistrations.TryGetValue(taskIdentity, out registeredTaskEntries))
-            {
-                registeredTaskEntries = new List<RegisteredTaskRecord>();
-                _taskRegistrations[taskIdentity] = registeredTaskEntries;
-            }
+            List<RegisteredTaskRecord> registeredTaskEntries =
+                _taskRegistrations.GetOrAdd(taskIdentity, new List<RegisteredTaskRecord>());
 
             RegisteredTaskRecord newRecord = new RegisteredTaskRecord(taskName, assemblyLoadInfo, taskFactory, taskFactoryParameters, inlineTaskRecord);
 
@@ -706,14 +701,17 @@ namespace Microsoft.Build.Execution
                 }
             }
 
-            registeredTaskEntries.Add(newRecord);
+            lock (registeredTaskEntries)
+            {
+                registeredTaskEntries.Add(newRecord);
+            }
         }
 
-        private static Dictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>> CreateRegisteredTaskDictionary(int? capacity = null)
+        private static ConcurrentDictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>> CreateRegisteredTaskDictionary(int? capacity = null)
         {
             return capacity != null
-                ? new Dictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>>(capacity.Value, RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact)
-                : new Dictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
+                ? new ConcurrentDictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>>(Environment.ProcessorCount, capacity.Value, RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact)
+                : new ConcurrentDictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
         }
 
         /// <summary>
@@ -1791,7 +1789,7 @@ namespace Microsoft.Build.Execution
 
             if (translator.Mode == TranslationDirection.ReadFromStream)
             {
-                _taskRegistrations = (Dictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>>)copy;
+                _taskRegistrations = (ConcurrentDictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>>)copy;
             }
         }
 

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Build.Execution
         /// Cache of tasks already found using exact matching,
         /// keyed by the task identity requested.
         /// </summary>
-        private readonly Lazy<Dictionary<RegisteredTaskIdentity, RegisteredTaskRecord>> _cachedTaskRecordsWithExactMatch = new(() => new(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact));
+        private readonly Lazy<ConcurrentDictionary<RegisteredTaskIdentity, RegisteredTaskRecord>> _cachedTaskRecordsWithExactMatch = new(() => new(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact));
 
         /// <summary>
         /// Cache of tasks already found using fuzzy matching,

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1769,12 +1769,12 @@ namespace Microsoft.Build.Execution
 
             IDictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>> copy = _taskRegistrations;
             translator.TranslateDictionary(ref copy, TranslateTaskRegistrationKey, TranslateTaskRegistrationValue, count => CreateRegisteredTaskDictionary(count));
-            // Ensure that mutations of the deserialized task registry are getting unique order ids.
-            s_nextRegistrationOrderId = Math.Max(s_nextRegistrationOrderId, copy.Count);
 
             if (translator.Mode == TranslationDirection.ReadFromStream)
             {
                 _taskRegistrations = (ConcurrentDictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>>)copy;
+                // Ensure that mutations of the deserialized task registry are getting unique order ids.
+                s_nextRegistrationOrderId = Math.Max(s_nextRegistrationOrderId, copy?.Count ?? 0);
             }
         }
 

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
@@ -457,7 +459,7 @@ namespace Microsoft.Build.Execution
             // Project-level override tasks are keyed by task name (unqualified).
             // Because Foo.Bar and Baz.Bar are both valid, they are stored
             // in a dictionary keyed as `Bar` because most tasks are called unqualified
-            if (overriddenTasks.TryGetValue(taskName, out List<RegisteredTaskRecord> recs))
+            if (_overriddenTasks.TryGetValue(taskName, out List<RegisteredTaskRecord> recs))
             {
                 // When we determine this task was overridden, search all task records
                 // to find the most correct registration. Search with the fully qualified name (if applicable)
@@ -637,7 +639,7 @@ namespace Microsoft.Build.Execution
 
         // Create another set containing architecture-specific task entries.
         // Then when we look for them, check if the name exists in that.
-        private Dictionary<string, List<RegisteredTaskRecord>> overriddenTasks = new Dictionary<string, List<RegisteredTaskRecord>>();
+        private readonly ConcurrentDictionary<string, List<RegisteredTaskRecord>> _overriddenTasks = new();
 
         /// <summary>
         /// Registers an evaluated using task tag for future
@@ -682,26 +684,25 @@ namespace Microsoft.Build.Execution
                 string[] nameComponents = taskName.Split('.');
                 string unqualifiedTaskName = nameComponents[nameComponents.Length - 1];
 
-                // Is the task already registered?
-                if (overriddenTasks.TryGetValue(unqualifiedTaskName, out List<RegisteredTaskRecord> recs))
+                List<RegisteredTaskRecord> records = _overriddenTasks.GetOrAdd(unqualifiedTaskName, new List<RegisteredTaskRecord>());
+
+                lock (records)
                 {
-                    foreach (RegisteredTaskRecord rec in recs)
+                    if (records.Count == 0)
                     {
-                        if (rec.RegisteredName.Equals(taskIdentity.Name, StringComparison.OrdinalIgnoreCase))
-                        {
-                            loggingService.LogError(context, null, new BuildEventFileInfo(projectUsingTaskInXml.OverrideLocation), "DuplicateOverrideUsingTaskElement", taskName);
-                            break;
-                        }
+                        // New record's name may be fully qualified. Use it anyway to account for partial matches.
+                        records.Add(newRecord);
+                        loggingService.LogComment(context, MessageImportance.Low, "OverrideUsingTaskElementCreated", taskName, projectUsingTaskInXml.OverrideLocation);
                     }
-                    recs.Add(newRecord);
-                }
-                else
-                {
-                    // New record's name may be fully qualified. Use it anyway to account for partial matches.
-                    List<RegisteredTaskRecord> unqualifiedTaskNameMatches = new();
-                    unqualifiedTaskNameMatches.Add(newRecord);
-                    overriddenTasks.Add(unqualifiedTaskName, unqualifiedTaskNameMatches);
-                    loggingService.LogComment(context, MessageImportance.Low, "OverrideUsingTaskElementCreated", taskName, projectUsingTaskInXml.OverrideLocation);
+                    // Is the task already registered?
+                    else if (records.Any(rec => rec.RegisteredName.Equals(taskIdentity.Name, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        loggingService.LogError(context, null, new BuildEventFileInfo(projectUsingTaskInXml.OverrideLocation), "DuplicateOverrideUsingTaskElement", taskName);
+                    }
+                    else
+                    {
+                        records.Add(newRecord);
+                    }
                 }
             }
 

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -17,7 +17,6 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
-using Microsoft.Build.Utilities;
 using Microsoft.NET.StringTools;
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
@@ -16,6 +17,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.Utilities;
 using Microsoft.NET.StringTools;
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
@@ -525,23 +527,11 @@ namespace Microsoft.Build.Execution
                     }
                 }
 
-                Dictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>> registrations = GetRelevantRegistrations(taskIdentity, exactMatchRequired);
+                IEnumerable<RegisteredTaskRecord> registrations = GetRelevantOrderedRegistrations(taskIdentity, exactMatchRequired);
 
                 // look for the given task name in the registry; if not found, gather all registered task names that partially
                 // match the given name
-                foreach (KeyValuePair<RegisteredTaskIdentity, List<RegisteredTaskRecord>> registration in registrations)
-                {
-                    // if the given task name is longer than the registered task name
-                    // we will use the longer name to help disambiguate between multiple matches
-                    string mostSpecificTaskName = (taskName.Length > registration.Key.Name.Length) ? taskName : registration.Key.Name;
-
-                    taskRecord = GetMatchingRegistration(mostSpecificTaskName, registration.Value, taskProjectFile, taskIdentityParameters, targetLoggingContext, elementLocation);
-
-                    if (taskRecord != null)
-                    {
-                        break;
-                    }
-                }
+                taskRecord = GetMatchingRegistration(taskName, registrations, taskProjectFile, taskIdentityParameters, targetLoggingContext, elementLocation);
             }
 
             // If we didn't find the task but we have a fallback registry in the toolset state, try that one.
@@ -593,41 +583,25 @@ namespace Microsoft.Build.Execution
                 typeof(Microsoft.Build.Framework.ITaskFactory).IsAssignableFrom(type);
         }
 
-        /// <summary>
-        /// Searches all task declarations for the given task name.
-        /// If no exact match is found, looks for partial matches.
-        /// A task name that is not fully qualified may produce several partial matches.
-        /// </summary>
-        private Dictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>> GetRelevantRegistrations(RegisteredTaskIdentity taskIdentity, bool exactMatchRequired)
+        private IEnumerable<RegisteredTaskRecord> GetRelevantOrderedRegistrations(RegisteredTaskIdentity taskIdentity, bool exactMatchRequired)
         {
-            Dictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>> relevantTaskRegistrations =
-                new Dictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
-
-            List<RegisteredTaskRecord> taskAssemblies;
-
             // if we find an exact match
-            if (_taskRegistrations.TryGetValue(taskIdentity, out taskAssemblies))
+            if (_taskRegistrations.TryGetValue(taskIdentity, out List<RegisteredTaskRecord> taskAssemblies))
             {
                 // we're done
-                relevantTaskRegistrations[taskIdentity] = taskAssemblies;
-                return relevantTaskRegistrations;
+                //  (records for single key should be ordered by order of registrations - as they are inserted into the list)
+                return taskAssemblies;
             }
 
             if (exactMatchRequired)
             {
-                return relevantTaskRegistrations;
+                return Enumerable.Empty<RegisteredTaskRecord>();
             }
 
-            // look through all task declarations for partial matches
-            foreach (KeyValuePair<RegisteredTaskIdentity, List<RegisteredTaskRecord>> taskRegistration in _taskRegistrations)
-            {
-                if (RegisteredTaskIdentity.RegisteredTaskIdentityComparer.IsPartialMatch(taskIdentity, taskRegistration.Key))
-                {
-                    relevantTaskRegistrations[taskRegistration.Key] = taskRegistration.Value;
-                }
-            }
-
-            return relevantTaskRegistrations;
+            return _taskRegistrations
+                .Where(tp => RegisteredTaskIdentity.RegisteredTaskIdentityComparer.IsPartialMatch(taskIdentity, tp.Key))
+                .SelectMany(tp => tp.Value)
+                .OrderBy(r => r.RegistrationOrderId);
         }
 
         // Create another set containing architecture-specific task entries.
@@ -673,7 +647,7 @@ namespace Microsoft.Build.Execution
                 string[] nameComponents = taskName.Split('.');
                 string unqualifiedTaskName = nameComponents[nameComponents.Length - 1];
 
-                List<RegisteredTaskRecord> records = _overriddenTasks.GetOrAdd(unqualifiedTaskName, new List<RegisteredTaskRecord>());
+                List<RegisteredTaskRecord> records = _overriddenTasks.GetOrAdd(unqualifiedTaskName, _ => new List<RegisteredTaskRecord>());
 
                 lock (records)
                 {
@@ -714,23 +688,22 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private RegisteredTaskRecord GetMatchingRegistration(
             string taskName,
-            List<RegisteredTaskRecord> taskRecords,
+            IEnumerable<RegisteredTaskRecord> taskRecords,
             string taskProjectFile,
             IDictionary<string, string> taskIdentityParameters,
             TargetLoggingContext targetLoggingContext,
             ElementLocation elementLocation)
-        {
-            foreach (RegisteredTaskRecord record in taskRecords)
-            {
-                if (record.CanTaskBeCreatedByFactory(taskName, taskProjectFile, taskIdentityParameters, targetLoggingContext, elementLocation))
-                {
-                    return record;
-                }
-            }
-
-            // Cannot find the task in any of the records
-            return null;
-        }
+            =>
+                taskRecords.FirstOrDefault(r =>
+                    r.CanTaskBeCreatedByFactory(
+                        // if the given task name is longer than the registered task name
+                        // we will use the longer name to help disambiguate between multiple matches
+                        (taskName.Length > r.TaskIdentity.Name.Length) ? taskName : r.TaskIdentity.Name,
+                        taskProjectFile,
+                        taskIdentityParameters,
+                        targetLoggingContext,
+                        elementLocation));
+        
 
         /// <summary>
         /// An object representing the identity of a task -- not just task name, but also
@@ -1110,6 +1083,12 @@ namespace Microsoft.Build.Execution
             /// </summary>
             private ParameterGroupAndTaskElementRecord _parameterGroupAndTaskBody;
 
+            private static int s_nextRegistrationOrderId = 0;
+            /// <summary>
+            /// The registration order id for this task.  This is used to determine the order in which tasks are registered.
+            /// </summary>
+            private int _registrationOrderId;
+
             /// <summary>
             /// Constructor
             /// </summary>
@@ -1121,6 +1100,7 @@ namespace Microsoft.Build.Execution
                 _taskFactoryParameters = taskFactoryParameters;
                 _taskIdentity = new RegisteredTaskIdentity(registeredName, taskFactoryParameters);
                 _parameterGroupAndTaskBody = inlineTask;
+                _registrationOrderId = Interlocked.Increment(ref s_nextRegistrationOrderId);
 
                 if (String.IsNullOrEmpty(taskFactory))
                 {
@@ -1200,6 +1180,11 @@ namespace Microsoft.Build.Execution
             /// Identity of this task.
             /// </summary>
             internal RegisteredTaskIdentity TaskIdentity => _taskIdentity;
+
+            /// <summary>
+            /// The registration order id for this task.  This is used to determine the order in which tasks are registered.
+            /// </summary>
+            internal int RegistrationOrderId => _registrationOrderId;
 
             /// <summary>
             /// Ask the question, whether or not the task name can be created by the task factory.
@@ -1755,6 +1740,7 @@ namespace Microsoft.Build.Execution
                 translator.Translate(ref _taskFactoryAssemblyLoadInfo, AssemblyLoadInfo.FactoryForTranslation);
                 translator.Translate(ref _taskFactory);
                 translator.Translate(ref _parameterGroupAndTaskBody);
+                translator.Translate(ref _registrationOrderId);
 
                 IDictionary<string, string> localParameters = _taskFactoryParameters;
                 translator.TranslateDictionary(ref localParameters, count => CreateTaskFactoryParametersDictionary(count));

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1104,7 +1104,9 @@ namespace Microsoft.Build.Execution
             /// When ever a taskName is checked against the factory we cache the result so we do not have to
             /// make possibly expensive calls over and over again.
             /// </summary>
-            private Dictionary<RegisteredTaskIdentity, object> _taskNamesCreatableByFactory;
+            private readonly Lazy<ConcurrentDictionary<RegisteredTaskIdentity, object>> _taskNamesCreatableByFactory
+                = new Lazy<ConcurrentDictionary<RegisteredTaskIdentity, object>>(() =>
+                    new(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact));
 
             /// <summary>
             /// Set of parameters that can be used by the task factory specifically.
@@ -1216,18 +1218,13 @@ namespace Microsoft.Build.Execution
             /// <returns>true if the task can be created by the factory, false if it cannot be created</returns>
             internal bool CanTaskBeCreatedByFactory(string taskName, string taskProjectFile, IDictionary<string, string> taskIdentityParameters, TargetLoggingContext targetLoggingContext, ElementLocation elementLocation)
             {
-                // Keep a cache of task identities which have been checked against the factory, this is useful because we ask this question everytime we get a registered task record or a taskFactory wrapper.
-                if (_taskNamesCreatableByFactory == null)
-                {
-                    _taskNamesCreatableByFactory = new Dictionary<RegisteredTaskIdentity, object>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
-                }
-
                 RegisteredTaskIdentity taskIdentity = new RegisteredTaskIdentity(taskName, taskIdentityParameters);
 
                 // See if the task name as already been checked against the factory, return the value if it has
                 object creatableByFactory = null;
-                if (!_taskNamesCreatableByFactory.TryGetValue(taskIdentity, out creatableByFactory))
+                if (!_taskNamesCreatableByFactory.Value.TryGetValue(taskIdentity, out creatableByFactory))
                 {
+                    // Multiple threads can enter here for a single taskIdentity and create the factory, only one will be stored in the dictionary
                     try
                     {
                         bool haveTaskFactory = GetTaskFactory(targetLoggingContext, elementLocation, taskProjectFile);
@@ -1293,7 +1290,7 @@ namespace Microsoft.Build.Execution
                     }
                     finally
                     {
-                        _taskNamesCreatableByFactory[taskIdentity] = creatableByFactory;
+                        _taskNamesCreatableByFactory.Value[taskIdentity] = creatableByFactory;
                     }
                 }
 

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -126,6 +126,12 @@ namespace Microsoft.Build.Execution
         private static string s_potentialTasksCoreLocation = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, s_tasksCoreFilename);
 
         /// <summary>
+        /// Monotonically increasing counter for registered tasks.
+        /// It's not guaranteed not to have gaps, but it's purpose is the uniqueness.
+        /// </summary>
+        private static int s_nextRegistrationOrderId = 0;
+
+        /// <summary>
         /// Cache of tasks already found using exact matching,
         /// keyed by the task identity requested.
         /// </summary>
@@ -137,7 +143,7 @@ namespace Microsoft.Build.Execution
         /// Value is a dictionary of all possible matches for that
         /// task name, by unique identity.
         /// </summary>
-        private Lazy<ConcurrentDictionary<string, ConcurrentDictionary<RegisteredTaskIdentity, RegisteredTaskRecord>>> _cachedTaskRecordsWithFuzzyMatch = new(() => new(StringComparer.OrdinalIgnoreCase));
+        private readonly Lazy<ConcurrentDictionary<string, ConcurrentDictionary<RegisteredTaskIdentity, RegisteredTaskRecord>>> _cachedTaskRecordsWithFuzzyMatch = new(() => new(StringComparer.OrdinalIgnoreCase));
 
         /// <summary>
         /// Cache of task declarations i.e. the &lt;UsingTask&gt; tags fed to this registry,
@@ -566,7 +572,6 @@ namespace Microsoft.Build.Execution
                         _ => new (RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact));
 
                 taskRecords[taskIdentity] = taskRecord;
-                _cachedTaskRecordsWithFuzzyMatch.Value[taskIdentity.Name] = taskRecords;
             }
 
             return taskRecord;
@@ -1082,7 +1087,6 @@ namespace Microsoft.Build.Execution
             /// </summary>
             private ParameterGroupAndTaskElementRecord _parameterGroupAndTaskBody;
 
-            private static int s_nextRegistrationOrderId = 0;
             /// <summary>
             /// The registration order id for this task.  This is used to determine the order in which tasks are registered.
             /// </summary>
@@ -1765,6 +1769,8 @@ namespace Microsoft.Build.Execution
 
             IDictionary<RegisteredTaskIdentity, List<RegisteredTaskRecord>> copy = _taskRegistrations;
             translator.TranslateDictionary(ref copy, TranslateTaskRegistrationKey, TranslateTaskRegistrationValue, count => CreateRegisteredTaskDictionary(count));
+            // Ensure that mutations of the deserialized task registry are getting unique order ids.
+            s_nextRegistrationOrderId = Math.Max(s_nextRegistrationOrderId, copy.Count);
 
             if (translator.Mode == TranslationDirection.ReadFromStream)
             {

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Build.Execution
         /// Value is a dictionary of all possible matches for that
         /// task name, by unique identity.
         /// </summary>
-        private Dictionary<string, Dictionary<RegisteredTaskIdentity, RegisteredTaskRecord>> _cachedTaskRecordsWithFuzzyMatch;
+        private Lazy<ConcurrentDictionary<string, ConcurrentDictionary<RegisteredTaskIdentity, RegisteredTaskRecord>>> _cachedTaskRecordsWithFuzzyMatch = new(() => new(StringComparer.OrdinalIgnoreCase));
 
         /// <summary>
         /// Cache of task declarations i.e. the &lt;UsingTask&gt; tags fed to this registry,
@@ -493,9 +493,7 @@ namespace Microsoft.Build.Execution
                 }
                 else
                 {
-                    Dictionary<RegisteredTaskIdentity, RegisteredTaskRecord> taskRecords;
-
-                    if (_cachedTaskRecordsWithFuzzyMatch != null && _cachedTaskRecordsWithFuzzyMatch.TryGetValue(taskIdentity.Name, out taskRecords))
+                    if (_cachedTaskRecordsWithFuzzyMatch.IsValueCreated && _cachedTaskRecordsWithFuzzyMatch.Value.TryGetValue(taskIdentity.Name, out ConcurrentDictionary<RegisteredTaskIdentity, RegisteredTaskRecord> taskRecords))
                     {
                         // if we've looked up this exact one before, just grab it and return
                         if (taskRecords.TryGetValue(taskIdentity, out taskRecord))
@@ -560,8 +558,6 @@ namespace Microsoft.Build.Execution
             }
             else
             {
-                _cachedTaskRecordsWithFuzzyMatch ??= new Dictionary<string, Dictionary<RegisteredTaskIdentity, RegisteredTaskRecord>>(StringComparer.OrdinalIgnoreCase);
-
                 // Since this is a fuzzy match, we could conceivably have several sets of task identity parameters that match
                 // each other ... but might be mutually exclusive themselves.  E.g. CLR4|x86 and CLR2|x64 both match *|*.  
                 //
@@ -576,14 +572,12 @@ namespace Microsoft.Build.Execution
                 // 3. Look up Foo | baz (gets its own entry because it doesn't match Foo | bar)
                 // 4. Look up Foo | * (should get the Foo | * under Foo | bar, but depending on what the dictionary looks up 
                 //    first, might get Foo | baz, which also matches, instead) 
-                Dictionary<RegisteredTaskIdentity, RegisteredTaskRecord> taskRecords;
-                if (!_cachedTaskRecordsWithFuzzyMatch.TryGetValue(taskIdentity.Name, out taskRecords))
-                {
-                    taskRecords = new Dictionary<RegisteredTaskIdentity, RegisteredTaskRecord>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
-                }
+                ConcurrentDictionary<RegisteredTaskIdentity, RegisteredTaskRecord> taskRecords
+                    = _cachedTaskRecordsWithFuzzyMatch.Value.GetOrAdd(taskIdentity.Name,
+                        _ => new (RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact));
 
                 taskRecords[taskIdentity] = taskRecord;
-                _cachedTaskRecordsWithFuzzyMatch[taskIdentity.Name] = taskRecords;
+                _cachedTaskRecordsWithFuzzyMatch.Value[taskIdentity.Name] = taskRecords;
             }
 
             return taskRecord;
@@ -668,7 +662,7 @@ namespace Microsoft.Build.Execution
             // contain tasks with a given name...
             RegisteredTaskIdentity taskIdentity = new RegisteredTaskIdentity(taskName, taskFactoryParameters);
             List<RegisteredTaskRecord> registeredTaskEntries =
-                _taskRegistrations.GetOrAdd(taskIdentity, new List<RegisteredTaskRecord>());
+                _taskRegistrations.GetOrAdd(taskIdentity, _ => new List<RegisteredTaskRecord>());
 
             RegisteredTaskRecord newRecord = new RegisteredTaskRecord(taskName, assemblyLoadInfo, taskFactory, taskFactoryParameters, inlineTaskRecord);
 

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1263,7 +1263,7 @@ namespace Microsoft.Build.UnitTests
             IDictionary<K, V> x,
             IDictionary<K, V> y,
             Action<KeyValuePair<K, V>, KeyValuePair<K, V>> assertPairsEqual,
-            IEqualityComparer<K>? keysComparer = null,
+            IEqualityComparer<K> keysComparer = null,
             bool ignoreOrder = false)
         {
             if (x == null || y == null)


### PR DESCRIPTION
Fixes [ADO#1801351](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1801351) and [ADO#1801341](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1801341)

### Context
Various `TaskRegistry` methods were reported to have infinite loops caused by corrupted dictionary state.

### Changes Made
Replacing the flagged Dictionaries and as well other ones on similar execution paths with ConcurrentDictionaries, plus where appropriate guarded access to inner structures as well (where reads are expected only after all writes - simple lock was added)

