### PR TITLE
Remove stale .vsconfig components

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,12 +1,7 @@
 {
   "version": "1.0",
   "components": [
-    "Microsoft.Net.Component.4.8.SDK",
-    "Microsoft.Net.Component.4.7.2.SDK",
-    "Microsoft.Net.Component.4.TargetingPack",
-    "Microsoft.Net.Component.4.7.2.TargetingPack",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
-    "Microsoft.Net.Component.3.5.DeveloperTools",
-    "Microsoft.VisualStudio.Workload.NetCoreTools"
+    "Microsoft.Net.Component.3.5.DeveloperTools"
   ]
 }


### PR DESCRIPTION
.NET (Core) stuff is implied by ManagedDesktop now, and we require only "some .NET Framework SDK", so no need to specify explicitly as one will be delivered by ManagedDesktop.

We do still target .NET Framework 3.5, though . . .
