### PR TITLE
Add IsAotCompatible to Microsoft.Build.CommonTypes.xsd

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1844,6 +1844,11 @@ elementFormDefault="qualified">
             <xs:documentation><!-- _locID_text="EnableDefaultItems" _locComment="" -->Defaults to true, and if set to false will disable all default item globs.</xs:documentation>
         </xs:annotation>
     </xs:element>
+    <xs:element name="IsAotCompatible" type="msb:boolean" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="IsAotCompatible" _locComment="" -->Indicates whether a class library is compatible with native AOT. Setting to true will enable trimming, single file, and AOT analyzers.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="IsWebBootstrapper" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="JCPA" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="Keyword" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>


### PR DESCRIPTION
### Context
https://github.com/dotnet/sdk/pull/31766 adds support for a single property that enables all Roslyn analyzers necessary for AOT compatibility. This change adds the property to the MSBuild schema so auto-complete works in VS.

cc @agocke @MichalStrehovsky @sbomer 