### PR TITLE
Use NetCurrent to pull target .NET version from Arcade

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,8 +24,12 @@
           scripts/Deploy-MSBuild.ps1
           src/Framework/README.md
           src/Utilities/README.md
+
+        Special-case while MSBuild uses Arcade 6 to build: 17.7 should
+        continue to target .NET 7, so bump a 6 here to 7.
      -->
-    <LatestDotNetCoreForMSBuild>net7.0</LatestDotNetCoreForMSBuild>
+    <LatestDotNetCoreForMSBuild>$(NetCurrent)</LatestDotNetCoreForMSBuild>
+    <LatestDotNetCoreForMSBuild Condition=" '$(NetCurrent)' == 'net6.0' ">net7.0</LatestDotNetCoreForMSBuild>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This is required for source-build in .NET 8 now, so that we target 8
in the sourcebuilt builds, even when the product must target 7.

Fixes #8468.

