### PR TITLE
Add hook for a post-Directory.Build.props import

### DIFF
--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -31,7 +31,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
 
-  <Import Project="$(AfterDirectoryBuildPropsImport)" Condition="'$(AfterDirectoryBuildPropsImport)' != ''" />
+  <Import Project="$(CustomAfterDirectoryBuildProps)" Condition="'$(CustomAfterDirectoryBuildProps)' != ''" />
 
   <!--
       Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -29,6 +29,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <DirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsBasePath)' != '' and '$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildPropsBasePath)', '$(_DirectoryBuildPropsFile)'))</DirectoryBuildPropsPath>
   </PropertyGroup>
 
+  <Import Project="$(CustomBeforeDirectoryBuildProps)" Condition="'$(CustomBeforeDirectoryBuildProps)' != ''" />
+
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
 
   <Import Project="$(CustomAfterDirectoryBuildProps)" Condition="'$(CustomAfterDirectoryBuildProps)' != ''" />

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -31,6 +31,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
 
+  <Import Project="$(AfterDirectoryBuildPropsImport)" Condition="'$(AfterDirectoryBuildPropsImport)' != ''" />
+
   <!--
       Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
         $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.props

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -48,6 +48,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <DirectoryBuildTargetsPath Condition="'$(_DirectoryBuildTargetsBasePath)' != '' and '$(_DirectoryBuildTargetsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildTargetsBasePath)', '$(_DirectoryBuildTargetsFile)'))</DirectoryBuildTargetsPath>
   </PropertyGroup>
 
+  <Import Project="$(CustomBeforeDirectoryBuildTargets)" Condition="'$(CustomBeforeDirectoryBuildTargets)' != ''" />
+
   <Import Project="$(DirectoryBuildTargetsPath)" Condition="'$(ImportDirectoryBuildTargets)' == 'true' and exists('$(DirectoryBuildTargetsPath)')"/>
+
+  <Import Project="$(CustomAfterDirectoryBuildTargets)" Condition="'$(CustomAfterDirectoryBuildTargets)' != ''" />
 
 </Project>


### PR DESCRIPTION
Fixes #8876

### Context
The SDK has logic it wants to run immediately after importing Directory.Build.props. This adds a hook for that so the SDK doesn't have to manually import it, disable importing Microsoft.Common.props, then re-implement part of it.

### Changes Made


### Testing


### Notes
