### PR TITLE
Adding in option to filter projects that DynamicPlatformResolution was unable to resolve

### DIFF
--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Build.Graph
         private const string PlatformMetadataName = "Platform";
         private const string PlatformsMetadataName = "Platforms";
         private const string EnableDynamicPlatformResolutionPropertyName = "EnableDynamicPlatformResolution";
+        private const string EnableDynamicPlatformFilteringPropertyName = "EnableDynamicPlatformFiltering";
         private const string OverridePlatformNegotiationValue = "OverridePlatformNegotiationValue";
         private const string ShouldUnsetParentConfigurationAndPlatformPropertyName = "ShouldUnsetParentConfigurationAndPlatform";
         private const string ProjectMetadataName = "Project";
@@ -122,6 +123,7 @@ namespace Microsoft.Build.Graph
 
                 string projectReferenceFullPath = projectReferenceItem.GetMetadataValue(FullPathMetadataName);
                 bool enableDynamicPlatformResolution = ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionPropertyName));
+                bool enableDynamicPlatformFiltering = ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformFilteringPropertyName));
 
                 PropertyDictionary<ProjectPropertyInstance> referenceGlobalProperties = GetGlobalPropertiesForItem(
                     projectReferenceItem,
@@ -179,13 +181,17 @@ namespace Microsoft.Build.Graph
 
                     var selectedPlatform = PlatformNegotiation.GetNearestPlatform(overridePlatformNegotiationMetadataValue, projectInstance.GetPropertyValue(PlatformMetadataName), projectInstance.GetPropertyValue(PlatformsMetadataName), projectInstance.GetPropertyValue(PlatformLookupTableMetadataName), requesterInstance.GetPropertyValue(PlatformLookupTableMetadataName), projectInstance.FullPath, requesterInstance.GetPropertyValue(PlatformMetadataName));
 
-                    if (selectedPlatform.Equals(String.Empty))
+                    if (enableDynamicPlatformFiltering && !selectedPlatform.Item1)
+                    {
+                        continue;
+                    }
+                    else if (selectedPlatform.Equals(String.Empty))
                     {
                         referenceGlobalProperties.Remove(PlatformMetadataName);
                     }
                     else
                     {
-                        SetProperty(referenceGlobalProperties, PlatformMetadataName, selectedPlatform);
+                        SetProperty(referenceGlobalProperties, PlatformMetadataName, selectedPlatform.Item2);
                     }
                 }
 

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Build.Graph
                     {
                         continue;
                     }
-                    else if (selectedPlatform.Equals(String.Empty))
+                    else if (selectedPlatform.Item2.Equals(string.Empty))
                     {
                         referenceGlobalProperties.Remove(PlatformMetadataName);
                     }

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Build.Shared
                 // Keep NearestPlatform empty, log a warning. Common.CurrentVersion.targets will undefine 
                 // Platform/PlatformTarget when this is the case.
                 log?.LogWarningWithCodeFromResources("GetCompatiblePlatform.NoCompatiblePlatformFound", projectPath);
+                return Tuple.Create(false, buildProjectReferenceAs);
             }
             // If the referenced project has a defined `Platform` that's compatible, it will build that way by default.
             // If we're about to tell the reference to build using its default platform, don't pass it as a global property.

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -19,14 +19,14 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal static class PlatformNegotiation
     {
-        internal static string GetNearestPlatform(string overridePlatformValue, string referencedProjectPlatform, string projectReferencePlatformsMetadata, string projectReferenceLookupTableMetadata, string platformLookupTable, string projectPath, string currentProjectPlatform, TaskLoggingHelper? log = null)
+        internal static Tuple<bool, String> GetNearestPlatform(string overridePlatformValue, string referencedProjectPlatform, string projectReferencePlatformsMetadata, string projectReferenceLookupTableMetadata, string platformLookupTable, string projectPath, string currentProjectPlatform, TaskLoggingHelper? log = null)
         {
             Dictionary<string, string>? currentProjectLookupTable = ExtractLookupTable(platformLookupTable, log);
 
             if (string.IsNullOrEmpty(projectReferencePlatformsMetadata) && string.IsNullOrEmpty(referencedProjectPlatform))
             {
                 log?.LogWarningWithCodeFromResources("GetCompatiblePlatform.NoPlatformsListed", projectPath);
-                return string.Empty;
+                return Tuple.Create(false, string.Empty);
             }
 
             // Pull platformLookupTable metadata from the referenced project. This allows custom
@@ -94,8 +94,9 @@ namespace Microsoft.Build.Shared
                 log?.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.ReferencedProjectHasDefinitivePlatform", projectPath, referencedProjectPlatform);
                 buildProjectReferenceAs = string.Empty;
             }
-            return buildProjectReferenceAs;
+            return Tuple.Create(true, buildProjectReferenceAs);
         }
+
         internal static Dictionary<string, string>? ExtractLookupTable(string stringTable, TaskLoggingHelper? log = null)
         {
             if (string.IsNullOrEmpty(stringTable))

--- a/src/Shared/PlatformNegotiation.cs
+++ b/src/Shared/PlatformNegotiation.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal static class PlatformNegotiation
     {
-        internal static Tuple<bool, String> GetNearestPlatform(string overridePlatformValue, string referencedProjectPlatform, string projectReferencePlatformsMetadata, string projectReferenceLookupTableMetadata, string platformLookupTable, string projectPath, string currentProjectPlatform, TaskLoggingHelper? log = null)
+        internal static Tuple<bool, string> GetNearestPlatform(string overridePlatformValue, string referencedProjectPlatform, string projectReferencePlatformsMetadata, string projectReferenceLookupTableMetadata, string platformLookupTable, string projectPath, string currentProjectPlatform, TaskLoggingHelper? log = null)
         {
             Dictionary<string, string>? currentProjectLookupTable = ExtractLookupTable(platformLookupTable, log);
 

--- a/src/Tasks/GetCompatiblePlatform.cs
+++ b/src/Tasks/GetCompatiblePlatform.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Tasks
                 string projectReferenceLookupTableMetadata = AssignedProjectsWithPlatform[i].GetMetadata("PlatformLookupTable");
                 string projectReferenceOverridePlatformNegotiationMetadata = AssignedProjectsWithPlatform[i].GetMetadata("OverridePlatformNegotiationValue");
 
-                string? buildProjectReferenceAs = PlatformNegotiation.GetNearestPlatform(projectReferenceOverridePlatformNegotiationMetadata, referencedProjectPlatform, projectReferencePlatformsMetadata, projectReferenceLookupTableMetadata, PlatformLookupTable, AssignedProjectsWithPlatform[i].ItemSpec, CurrentProjectPlatform, Log);
+                string? buildProjectReferenceAs = PlatformNegotiation.GetNearestPlatform(projectReferenceOverridePlatformNegotiationMetadata, referencedProjectPlatform, projectReferencePlatformsMetadata, projectReferenceLookupTableMetadata, PlatformLookupTable, AssignedProjectsWithPlatform[i].ItemSpec, CurrentProjectPlatform, Log).Item2;
 
                 AssignedProjectsWithPlatform[i].SetMetadata("NearestPlatform", buildProjectReferenceAs);
                 Log.LogMessageFromResources(MessageImportance.Low, "GetCompatiblePlatform.DisplayChosenPlatform", AssignedProjectsWithPlatform[i].ItemSpec, buildProjectReferenceAs);


### PR DESCRIPTION
…

Fixes #

### Context
Currently dynamic platform resolution will leave the "platform" global property of a depending project blank if it is unable to determine the correct architecture to build a project as. This is helpful but in certain situations, especially traversal style projects it makes more sense to remove dependent projects that don't build as a compatible platform.

### Changes Made
I added a property that can be added to projects so that if dynamic platform resolution is unable to determine what platform a project should be built as it will be removed from the graph.

### Testing


### Notes

linking bug https://github.com/dotnet/msbuild/issues/8890

