### PR TITLE
Removing sln level turn off of setplatform feature

### DIFF
--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Build.Graph
         {
             public TargetSpecification(string target, bool skipIfNonexistent)
             {
-                // Verify that if this target is skippable then it equals neither 
+                // Verify that if this target is skippable then it equals neither
                 // ".default" nor ".projectReferenceTargetsOrDefaultTargets".
                 ErrorUtilities.VerifyThrow(
                     !skipIfNonexistent || (!target.Equals(MSBuildConstants.DefaultTargetsMarker)
@@ -131,6 +131,8 @@ namespace Microsoft.Build.Graph
                     allowCollectionReuse: solutionConfiguration == null && !enableDynamicPlatformResolution,
                     globalPropertiesModifiers);
 
+                bool configurationDefined = false;
+
                 // Match what AssignProjectConfiguration does to resolve project references.
                 if (solutionConfiguration != null)
                 {
@@ -151,6 +153,8 @@ namespace Microsoft.Build.Graph
                         {
                             referenceGlobalProperties.Remove(PlatformMetadataName);
                         }
+
+                        configurationDefined = true;
                     }
                     else
                     {
@@ -161,11 +165,16 @@ namespace Microsoft.Build.Graph
                             referenceGlobalProperties.Remove(ConfigurationMetadataName);
                             referenceGlobalProperties.Remove(PlatformMetadataName);
                         }
+                        else
+                        {
+                            configurationDefined = true;
+                        }
                     }
                 }
 
-                // Note: Dynamic platform resolution is not enabled for sln-based builds.
-                else if (!projectReferenceItem.HasMetadata(SetPlatformMetadataName) && enableDynamicPlatformResolution)
+                // Note: Dynamic platform resolution is not enabled for sln-based builds,
+                // unless the project isn't known to the solution.
+                if (enableDynamicPlatformResolution && !configurationDefined && !projectReferenceItem.HasMetadata(SetPlatformMetadataName))
                 {
                     string requesterPlatform = requesterInstance.GetPropertyValue("Platform");
                     string requesterPlatformLookupTable = requesterInstance.GetPropertyValue("PlatformLookupTable");

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1648,7 +1648,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
        Configuration information. See AssignProjectConfiguration -->
   <Target Name="_GetProjectReferencePlatformProperties"
           Condition="'$(EnableDynamicPlatformResolution)' == 'true'
-                     and '$(CurrentSolutionConfigurationContents)' == ''
                      and '@(_MSBuildProjectReferenceExistent)' != ''">
 
     <!-- Allow preset SetPlatform to override this operation -->


### PR DESCRIPTION
### Summary

Allow dynamic platform resolution for projects not mentioned in a solution.

### Customer Impact

Enables adoption of dynamic platform resolution for dev-desktop scenarios in a large internal repo.

### Regression?

No.

### Testing

This was tested in the VS repo on the VC sln which covers lots of scenarios

### Risk

Low--feature has low adoption because of sticking points like this, so blast radius of regression is low.

## Details

### Context

Currently we turn off dynamic platform resolution for a whole solution if a single project in the solution is assigned a configuration. This is problematic as some projects are outside of the scope of the solution but still have certain targets that run on them that are architecture specific. These projects will build as the wrong architecture because no configuration is defined and no platform negotiation takes place.

### Changes Made
I removed the conditional that turns platform negotiation off on a sln level. The logic to turn this off on a project level is already in place through checking is a projectreference has setplatform appended to it. This will make sure no projects with configurations defined will be negotiated for as MSbuild ads setplatform metadata to projectreferences with configurations.
