### PR TITLE
Add localization setup for main and release branches

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -36,20 +36,39 @@ variables:
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
+  - name: EnableReleaseOneLocBuild
+    value: false
 
 stages:
 - stage: build
   displayName: Build
 
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/vs17.2') }}: # should track next-release's active dev branch
-    - template: /eng/common/templates/job/onelocbuild.yml
-      parameters:
-        LclSource: lclFilesfromPackage
-        LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
-        MirrorRepo: 'msbuild'
-        MirrorBranch: 'main' # should match condition above
-
+  - ${{ if and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    # The localization setup for release/ branches. Note difference in LclPackageId. main branch is handled separately below.
+    # Used for vs17.2, vs17.4, vs17.6 etc. branches only.
+    # When the branch is setup for localization (the localization ticket needs to be created - https://aka.ms/ceChangeLocConfig, requesting change from one release branch to another),
+    #  set 'EnableReleaseOneLocBuild' to true.
+    - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/vs') }}:
+      - template: /eng/common/templates/job/onelocbuild.yml
+        parameters:
+          MirrorRepo: 'msbuild'
+          LclSource: lclFilesfromPackage
+          LclPackageId: 'LCL-JUNO-PROD-MSBUILDREL'
+          MirrorBranch: replace(variables['Build.SourceBranch'], 'refs/heads/', '')
+          JobNameSuffix: '_release'
+          condition: $(EnableReleaseOneLocBuild)
+    # The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
+    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+      - template: /eng/common/templates/job/onelocbuild.yml
+        parameters:
+          MirrorRepo: 'msbuild'
+          LclSource: lclFilesfromPackage
+          LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
+          MirrorBranch: 'main'
+          JobNameSuffix: '_main'
+          condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+          
   - job: Windows_NT
     pool:
       name: VSEngSS-MicroBuild2022-1ES

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.2.11</VersionPrefix>
+    <VersionPrefix>17.2.12</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>


### PR DESCRIPTION
Fixes #8838

### Context
MSBuild has had localization for 17.2 only, while running it in multiple release branches + main and targetting all changes to main.

### Changes Made
Requested separate localization setup for main and release branches and created conditioned pipeline jobs that ran for main and latest release branch with proper localization package ids

FYI @cristianosuzuki77 
