### PR TITLE
add Security.Cryptography to Version.Details

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,9 +6,13 @@
       <Sha>525b6c35cc5c5c9b80b47044be2e4e77858d505a</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+    <!-- Necessary for source-build. This allows the packages to be retrieved from previously-source-built artifacts
       and flow in as dependencies of the packages produced by msbuild. -->
     <Dependency Name="System.Configuration.ConfigurationManager" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="7.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
     </Dependency>


### PR DESCRIPTION
### Context

Contributes to https://github.com/dotnet/source-build/issues/3043.

Declaring the `System.Security.Cryptography.Pkcs` dependency in `Version.Details.xml` will allow source-build to replace the currently used `7.0.0` version with the `n-1` version coming from previously source-built artifacts in the product / VMR build.

Without this change, once repo PvP is enabled, an ref pack of `7.0.0` will be bundled with the produced package, causing build time exceptions for consumers that try to load in the dependency.

This is a follow-up to https://github.com/dotnet/msbuild/pull/8818 - the change should've been included with the mentioned PR but the issue described was originally missed during testing.

### Changes Made

- added an entry for `System.Security.Cryptography.Pkcs: 7.0.0` to `Version.Details.xml`.

### Testing


### Notes
