### PR TITLE
Update sdk version to bump pulled runtime

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "7.0.203",
+    "dotnet": "7.0.304",
     "vs": {
       "version": "17.4.1"
     },


### PR DESCRIPTION
Fixes about a dozen CVEs ([internal link] https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted?_a=alerts&typeId=8799614&alerts-view-option=active)

### Context
We need runtime 7.0.5 -> 7.0.7 bump, this comes with [SDK 7.0.304](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
(7.0.2xx channel is not updated with this relase)
