### PR TITLE
Fix expressions for OneLocBuild

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -55,9 +55,9 @@ stages:
           MirrorRepo: 'msbuild'
           LclSource: lclFilesfromPackage
           LclPackageId: 'LCL-JUNO-PROD-MSBUILDREL'
-          MirrorBranch: replace(variables['Build.SourceBranch'], 'refs/heads/', '')
+          MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
           JobNameSuffix: '_release'
-          condition: $(EnableReleaseOneLocBuild)
+          condition: ${{ variables.EnableReleaseOneLocBuild }}
     # The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
     - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
       - template: /eng/common/templates/job/onelocbuild.yml

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.2.12</VersionPrefix>
+    <VersionPrefix>17.2.13</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>


### PR DESCRIPTION
### Context
The expressions in #8887 were not proper ADO syntax

### Changes Made
Fixed the ADO syntax