### PR TITLE
[Don't merge] RAR cache file optimization

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceCacheSerialization.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceCacheSerialization.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                         Assembly = null,
                         RuntimeVersion = "v4.0.30319",
                         FrameworkNameAttribute = new FrameworkName(".NETFramework", Version.Parse("4.7.2"), "Profile"),
-                        scatterFiles = new string[] { "first", "second" } } } };
+                        ScatterFiles = new string[] { "first", "second" } } } };
             ResolveAssemblyReferenceCache rarCache = new();
             rarCache.instanceLocalFileStateCache = cache;
             ResolveAssemblyReferenceCache rarCache2 = null;
@@ -116,8 +116,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             dll2.FrameworkNameAttribute.FullName.ShouldBe(dll.FrameworkNameAttribute.FullName);
             dll2.LastModified.ShouldBe(dll.LastModified);
             dll2.RuntimeVersion.ShouldBe(dll.RuntimeVersion);
-            dll2.scatterFiles.Length.ShouldBe(dll.scatterFiles.Length);
-            dll2.scatterFiles[1].ShouldBe(dll.scatterFiles[1]);
+            dll2.ScatterFiles.Length.ShouldBe(dll.ScatterFiles.Length);
+            dll2.ScatterFiles[1].ShouldBe(dll.ScatterFiles[1]);
         }
     }
 }

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceCacheSerialization.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceCacheSerialization.cs
@@ -39,13 +39,13 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         }
 
         [Fact]
-        public void RoundTripEmptyState()
+        public void RoundTripEmptyCache()
         {
-            SystemState systemState = new();
+            ResolveAssemblyReferenceCache rarCache = new();
 
-            systemState.SerializeCache(_rarCacheFile, _taskLoggingHelper);
+            rarCache.SerializeCache(_rarCacheFile, _taskLoggingHelper);
 
-            var deserialized = StateFileBase.DeserializeCache<SystemState>(_rarCacheFile, _taskLoggingHelper);
+            var deserialized = StateFileBase.DeserializeCache<ResolveAssemblyReferenceCache>(_rarCacheFile, _taskLoggingHelper);
 
             deserialized.ShouldNotBeNull();
         }
@@ -53,9 +53,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void CorrectFileVersion()
         {
-            SystemState systemState = new();
+            ResolveAssemblyReferenceCache rarCache = new();
 
-            systemState.SerializeCache(_rarCacheFile, _taskLoggingHelper);
+            rarCache.SerializeCache(_rarCacheFile, _taskLoggingHelper);
             using (var cacheStream = new FileStream(_rarCacheFile, FileMode.Open, FileAccess.ReadWrite))
             {
                 cacheStream.Seek(0, SeekOrigin.Begin);
@@ -63,7 +63,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 cacheStream.Close();
             }
 
-            var deserialized = StateFileBase.DeserializeCache<SystemState>(_rarCacheFile, _taskLoggingHelper);
+            var deserialized = StateFileBase.DeserializeCache<ResolveAssemblyReferenceCache>(_rarCacheFile, _taskLoggingHelper);
 
             deserialized.ShouldNotBeNull();
         }
@@ -71,9 +71,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void WrongFileVersion()
         {
-            SystemState systemState = new();
+            ResolveAssemblyReferenceCache rarCache = new();
 
-            systemState.SerializeCache(_rarCacheFile, _taskLoggingHelper);
+            rarCache.SerializeCache(_rarCacheFile, _taskLoggingHelper);
             using (var cacheStream = new FileStream(_rarCacheFile, FileMode.Open, FileAccess.ReadWrite))
             {
                 cacheStream.Seek(0, SeekOrigin.Begin);
@@ -81,7 +81,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 cacheStream.Close();
             }
 
-            var deserialized = StateFileBase.DeserializeCache<SystemState>(_rarCacheFile, _taskLoggingHelper);
+            var deserialized = StateFileBase.DeserializeCache<ResolveAssemblyReferenceCache>(_rarCacheFile, _taskLoggingHelper);
 
             deserialized.ShouldBeNull();
         }
@@ -89,29 +89,29 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void ValidateSerializationAndDeserialization()
         {
-            Dictionary<string, SystemState.FileState> cache = new() {
-                    { "path1", new SystemState.FileState(DateTime.Now) },
-                    { "path2", new SystemState.FileState(DateTime.Now) { Assembly = new AssemblyNameExtension("hi") } },
-                    { "dllName", new SystemState.FileState(DateTime.Now.AddSeconds(-10)) {
+            Dictionary<string, ResolveAssemblyReferenceCache.FileState> cache = new() {
+                    { "path1", new ResolveAssemblyReferenceCache.FileState(DateTime.Now) },
+                    { "path2", new ResolveAssemblyReferenceCache.FileState(DateTime.Now) { Assembly = new AssemblyNameExtension("hi") } },
+                    { "dllName", new ResolveAssemblyReferenceCache.FileState(DateTime.Now.AddSeconds(-10)) {
                         Assembly = null,
                         RuntimeVersion = "v4.0.30319",
                         FrameworkNameAttribute = new FrameworkName(".NETFramework", Version.Parse("4.7.2"), "Profile"),
                         scatterFiles = new string[] { "first", "second" } } } };
-            SystemState sysState = new();
-            sysState.instanceLocalFileStateCache = cache;
-            SystemState sysState2 = null;
+            ResolveAssemblyReferenceCache rarCache = new();
+            rarCache.instanceLocalFileStateCache = cache;
+            ResolveAssemblyReferenceCache rarCache2 = null;
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 TransientTestFile file = env.CreateFile();
-                sysState.SerializeCache(file.Path, null);
-                sysState2 = StateFileBase.DeserializeCache<SystemState>(file.Path, null);
+                rarCache.SerializeCache(file.Path, null);
+                rarCache2 = StateFileBase.DeserializeCache<ResolveAssemblyReferenceCache>(file.Path, null);
             }
 
-            Dictionary<string, SystemState.FileState> cache2 = sysState2.instanceLocalFileStateCache;
+            Dictionary<string, ResolveAssemblyReferenceCache.FileState> cache2 = rarCache2.instanceLocalFileStateCache;
             cache2.Count.ShouldBe(cache.Count);
             cache2["path2"].Assembly.Name.ShouldBe(cache["path2"].Assembly.Name);
-            SystemState.FileState dll = cache["dllName"];
-            SystemState.FileState dll2 = cache2["dllName"];
+            ResolveAssemblyReferenceCache.FileState dll = cache["dllName"];
+            ResolveAssemblyReferenceCache.FileState dll2 = cache2["dllName"];
             dll2.Assembly.ShouldBe(dll.Assembly);
             dll2.FrameworkNameAttribute.FullName.ShouldBe(dll.FrameworkNameAttribute.FullName);
             dll2.LastModified.ShouldBe(dll.LastModified);

--- a/src/Tasks.UnitTests/RARPrecomputedCache_Tests.cs
+++ b/src/Tasks.UnitTests/RARPrecomputedCache_Tests.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                 {
                     _cache = new SystemState()
                 };
-                t._cache.instanceLocalFileStateCache = new Dictionary<string, SystemState.FileState>() {
-                    { Path.Combine(standardCache.Path, "assembly1"), new SystemState.FileState(DateTime.Now) },
-                    { Path.Combine(standardCache.Path, "assembly2"), new SystemState.FileState(DateTime.Now) { Assembly = new Shared.AssemblyNameExtension("hi") } } };
+                t._cache.instanceLocalFileStateCache = new Dictionary<string, ResolveAssemblyReferenceCache.FileState>() {
+                    { Path.Combine(standardCache.Path, "assembly1"), new ResolveAssemblyReferenceCache.FileState(DateTime.Now) },
+                    { Path.Combine(standardCache.Path, "assembly2"), new ResolveAssemblyReferenceCache.FileState(DateTime.Now) { Assembly = new Shared.AssemblyNameExtension("hi") } } };
                 t._cache.IsDirty = true;
                 t.StateFile = standardCache.Path;
                 t.WriteStateFile();
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 {
                     _cache = new SystemState()
                 };
-                rarWriterTask._cache.instanceLocalFileStateCache = new Dictionary<string, SystemState.FileState>();
+                rarWriterTask._cache.instanceLocalFileStateCache = new Dictionary<string, ResolveAssemblyReferenceCache.FileState>();
                 rarWriterTask.StateFile = standardCache.Path;
                 rarWriterTask._cache.IsDirty = true;
                 // Write standard cache
@@ -65,7 +65,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 string dllName = Path.Combine(Path.GetDirectoryName(standardCache.Path), "randomFolder", "dll.dll");
                 rarWriterTask._cache.instanceLocalFileStateCache.Add(dllName,
-                    new SystemState.FileState(DateTime.Now)
+                    new ResolveAssemblyReferenceCache.FileState(DateTime.Now)
                     {
                         Assembly = null,
                         RuntimeVersion = "v4.0.30319",
@@ -105,10 +105,10 @@ namespace Microsoft.Build.Tasks.UnitTests
                     _cache = new SystemState()
                 };
                 string dllName = Path.Combine(Path.GetDirectoryName(precomputedCache.Path), "randomFolder", "dll.dll");
-                rarWriterTask._cache.instanceLocalFileStateCache = new Dictionary<string, SystemState.FileState>() {
-                    { Path.Combine(precomputedCache.Path, "..", "assembly1", "assembly1"), new SystemState.FileState(DateTime.Now) },
-                    { Path.Combine(precomputedCache.Path, "assembly2"), new SystemState.FileState(DateTime.Now) { Assembly = new Shared.AssemblyNameExtension("hi") } },
-                    { dllName, new SystemState.FileState(DateTime.Now) {
+                rarWriterTask._cache.instanceLocalFileStateCache = new Dictionary<string, ResolveAssemblyReferenceCache.FileState>() {
+                    { Path.Combine(precomputedCache.Path, "..", "assembly1", "assembly1"), new ResolveAssemblyReferenceCache.FileState(DateTime.Now) },
+                    { Path.Combine(precomputedCache.Path, "assembly2"), new ResolveAssemblyReferenceCache.FileState(DateTime.Now) { Assembly = new Shared.AssemblyNameExtension("hi") } },
+                    { dllName, new ResolveAssemblyReferenceCache.FileState(DateTime.Now) {
                         Assembly = null,
                         RuntimeVersion = "v4.0.30319",
                         FrameworkNameAttribute = new System.Runtime.Versioning.FrameworkName(".NETFramework", Version.Parse("4.7.2"), "Profile"),
@@ -133,7 +133,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 // Then we verify that the information contained in that cache matches what we'd expect.
                 rarReaderTask.ReadStateFile(p => true);
                 rarReaderTask._cache.instanceLocalFileStateCache.ShouldContainKey(dllName);
-                SystemState.FileState assembly3 = rarReaderTask._cache.instanceLocalFileStateCache[dllName];
+                ResolveAssemblyReferenceCache.FileState assembly3 = rarReaderTask._cache.instanceLocalFileStateCache[dllName];
                 assembly3.Assembly.ShouldBeNull();
                 assembly3.RuntimeVersion.ShouldBe("v4.0.30319");
                 assembly3.FrameworkNameAttribute.Version.ShouldBe(Version.Parse("4.7.2"));

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2036,18 +2036,15 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal void ReadStateFile(FileExists fileExists)
         {
-            _cache = SystemState.DeserializeCache<SystemState>(_stateFile, Log);
+            ResolveAssemblyReferenceCache rarDiskCache = StateFileBase.DeserializeCache<ResolveAssemblyReferenceCache>(_stateFile, Log);
 
             // Construct the cache only if we can't find any caches.
-            if (_cache == null && AssemblyInformationCachePaths != null && AssemblyInformationCachePaths.Length > 0)
+            if (rarDiskCache == null && AssemblyInformationCachePaths != null && AssemblyInformationCachePaths.Length > 0)
             {
-                _cache = SystemState.DeserializePrecomputedCaches(AssemblyInformationCachePaths, Log, fileExists);
+                rarDiskCache = ResolveAssemblyReferenceCache.DeserializePrecomputedCaches(AssemblyInformationCachePaths, Log, fileExists);
             }
 
-            if (_cache == null)
-            {
-                _cache = new SystemState();
-            }
+            _cache = (rarDiskCache != null ? new SystemState(rarDiskCache) : new SystemState());
         }
 
         /// <summary>

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -550,6 +550,7 @@
     <Compile Include="XamlTaskFactory\XamlTaskFactory.cs" />
     <Compile Include="StateFileBase.cs" />
     <Compile Include="SystemState.cs" />
+    <Compile Include="ResolveAssemblyReferenceCache.cs" />
     <Compile Include="DependencyFile.cs" />
     <Compile Include="ZipDirectory.cs" />
   </ItemGroup>

--- a/src/Tasks/ResolveAssemblyReferenceCache.cs
+++ b/src/Tasks/ResolveAssemblyReferenceCache.cs
@@ -42,9 +42,14 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
+        /// True if we this cache is empty.
+        /// </summary>
+        internal bool IsInstanceLocalCacheEmpty => instanceLocalFileStateCache.Count == 0;
+
+        /// <summary>
         /// Class that holds the current file state.
         /// </summary>
-        internal record class FileState : ITranslatable
+        internal sealed class FileState : ITranslatable, IEquatable<FileState>
         {
             /// <summary>
             /// The last modified time for this file.
@@ -107,6 +112,17 @@ namespace Microsoft.Build.Tasks
                 translator.Translate(ref scatterFiles);
                 translator.Translate(ref runtimeVersion);
                 translator.Translate(ref frameworkName);
+            }
+
+            public bool Equals(FileState other)
+            {
+                return
+                    lastModified == other.LastModified &&
+                    assemblyName.Equals(other.assemblyName) &&
+                    Enumerable.SequenceEqual(dependencies, other.dependencies) &&
+                    Enumerable.SequenceEqual(scatterFiles, other.scatterFiles) &&
+                    frameworkName.Equals(other.frameworkName) &&
+                    runtimeVersion == other.runtimeVersion;
             }
 
             /// <summary>

--- a/src/Tasks/ResolveAssemblyReferenceCache.cs
+++ b/src/Tasks/ResolveAssemblyReferenceCache.cs
@@ -1,0 +1,269 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
+
+#nullable disable
+
+namespace Microsoft.Build.Tasks
+{
+    /// <summary>
+    /// Represents the on-disk serialization format of the RAR cache.
+    /// </summary>
+    internal class ResolveAssemblyReferenceCache : StateFileBase, ITranslatable
+    {
+        /// <summary>
+        /// Cache at the ResolveAssemblyReferenceCache instance level. It is serialized and reused between instances.
+        /// </summary>
+        internal Dictionary<string, FileState> instanceLocalFileStateCache = new Dictionary<string, FileState>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// True if the contents have changed.
+        /// </summary>
+        protected bool isDirty;
+
+        /// <summary>
+        /// Flag that indicates that <see cref="instanceLocalFileStateCache"/> has been modified.
+        /// </summary>
+        /// <value></value>
+        internal bool IsDirty
+        {
+            get { return isDirty; }
+            set { isDirty = value; }
+        }
+
+        /// <summary>
+        /// Class that holds the current file state.
+        /// </summary>
+        [Serializable]
+        internal sealed class FileState : ITranslatable
+        {
+            /// <summary>
+            /// The last modified time for this file.
+            /// </summary>
+            private DateTime lastModified;
+
+            /// <summary>
+            /// The fusion name of this file.
+            /// </summary>
+            private AssemblyNameExtension assemblyName;
+
+            /// <summary>
+            /// The assemblies that this file depends on.
+            /// </summary>
+            internal AssemblyNameExtension[] dependencies;
+
+            /// <summary>
+            /// The scatter files associated with this assembly.
+            /// </summary>
+            internal string[] scatterFiles;
+
+            /// <summary>
+            /// FrameworkName the file was built against
+            /// </summary>
+            internal FrameworkName frameworkName;
+
+            /// <summary>
+            /// The CLR runtime version for the assembly.
+            /// </summary>
+            internal string runtimeVersion;
+
+            /// <summary>
+            /// Default construct.
+            /// </summary>
+            internal FileState(DateTime lastModified)
+            {
+                this.lastModified = lastModified;
+            }
+
+            /// <summary>
+            /// Ctor for translator deserialization
+            /// </summary>
+            internal FileState(ITranslator translator)
+            {
+                Translate(translator);
+            }
+
+            /// <summary>
+            /// Reads/writes this class
+            /// </summary>
+            public void Translate(ITranslator translator)
+            {
+                ErrorUtilities.VerifyThrowArgumentNull(translator, nameof(translator));
+
+                translator.Translate(ref lastModified);
+                translator.Translate(ref assemblyName,
+                    (ITranslator t) => new AssemblyNameExtension(t));
+                translator.TranslateArray(ref dependencies,
+                    (ITranslator t) => new AssemblyNameExtension(t));
+                translator.Translate(ref scatterFiles);
+                translator.Translate(ref runtimeVersion);
+                translator.Translate(ref frameworkName);
+            }
+
+            /// <summary>
+            /// Gets the last modified date.
+            /// </summary>
+            /// <value></value>
+            internal DateTime LastModified
+            {
+                get { return lastModified; }
+            }
+
+            /// <summary>
+            /// Get or set the assemblyName.
+            /// </summary>
+            /// <value></value>
+            internal AssemblyNameExtension Assembly
+            {
+                get { return assemblyName; }
+                set { assemblyName = value; }
+            }
+
+            /// <summary>
+            /// Get or set the runtimeVersion
+            /// </summary>
+            /// <value></value>
+            internal string RuntimeVersion
+            {
+                get { return runtimeVersion; }
+                set { runtimeVersion = value; }
+            }
+
+            /// <summary>
+            /// Get or set the framework name the file was built against
+            /// </summary>
+            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Could be used in other assemblies")]
+            internal FrameworkName FrameworkNameAttribute
+            {
+                get { return frameworkName; }
+                set { frameworkName = value; }
+            }
+
+            /// <summary>
+            /// The last-modified value to use for immutable framework files which we don't do I/O on.
+            /// </summary>
+            internal static DateTime ImmutableFileLastModifiedMarker => DateTime.MaxValue;
+
+            /// <summary>
+            /// It is wasteful to persist entries for immutable framework files.
+            /// </summary>
+            internal bool IsWorthPersisting => lastModified != ImmutableFileLastModifiedMarker;
+        }
+
+        public ResolveAssemblyReferenceCache()
+        {
+        }
+
+        public ResolveAssemblyReferenceCache(ITranslator translator)
+        {
+            Translate(translator);
+        }
+
+        protected ResolveAssemblyReferenceCache(ResolveAssemblyReferenceCache anotherCache)
+        {
+            if (anotherCache != null)
+            {
+                instanceLocalFileStateCache = anotherCache.instanceLocalFileStateCache;
+                isDirty = anotherCache.isDirty;
+            }
+        }
+
+        /// <summary>
+        /// Reads/writes this class.
+        /// Used for serialization and deserialization of this class persistent cache.
+        /// </summary>
+        public override void Translate(ITranslator translator)
+        {
+            if (instanceLocalFileStateCache is null)
+            {
+                throw new NullReferenceException(nameof(instanceLocalFileStateCache));
+            }
+
+            translator.TranslateDictionary(
+                ref instanceLocalFileStateCache,
+                StringComparer.OrdinalIgnoreCase,
+                (ITranslator t) => new FileState(t));
+
+            // IsDirty should be false for either direction. Either this cache was brought
+            // up-to-date with the on-disk cache or vice versa. Either way, they agree.
+            IsDirty = false;
+        }
+
+        /// <summary>
+        /// Reads in cached data from stateFiles to build an initial cache. Avoids logging warnings or errors.
+        /// </summary>
+        /// <param name="stateFiles">List of locations of caches on disk.</param>
+        /// <param name="log">How to log</param>
+        /// <param name="fileExists">Whether a file exists</param>
+        /// <returns>A cache representing key aspects of file states.</returns>
+        internal static ResolveAssemblyReferenceCache DeserializePrecomputedCaches(ITaskItem[] stateFiles, TaskLoggingHelper log, FileExists fileExists)
+        {
+            ResolveAssemblyReferenceCache retVal = new ResolveAssemblyReferenceCache();
+            retVal.isDirty = stateFiles.Length > 0;
+            HashSet<string> assembliesFound = new HashSet<string>();
+
+            foreach (ITaskItem stateFile in stateFiles)
+            {
+                // Verify that it's a real stateFile. Log message but do not error if not.
+                ResolveAssemblyReferenceCache cache = DeserializeCache<ResolveAssemblyReferenceCache>(stateFile.ToString(), log);
+                if (cache == null)
+                {
+                    continue;
+                }
+                foreach (KeyValuePair<string, FileState> kvp in cache.instanceLocalFileStateCache)
+                {
+                    string relativePath = kvp.Key;
+                    if (!assembliesFound.Contains(relativePath))
+                    {
+                        FileState fileState = kvp.Value;
+                        string fullPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(stateFile.ToString()), relativePath));
+                        if (fileExists(fullPath))
+                        {
+                            // Correct file path
+                            retVal.instanceLocalFileStateCache[fullPath] = fileState;
+                            assembliesFound.Add(relativePath);
+                        }
+                    }
+                }
+            }
+
+            return retVal;
+        }
+
+        /// <summary>
+        /// Modifies this object to be more portable across machines, then writes it to filePath.
+        /// </summary>
+        /// <param name="stateFile">Path to which to write the precomputed cache</param>
+        /// <param name="log">How to log</param>
+        internal void SerializePrecomputedCache(string stateFile, TaskLoggingHelper log)
+        {
+            // Save a copy of instanceLocalFileStateCache so we can restore it later. SerializeCacheByTranslator serializes
+            // instanceLocalFileStateCache by default, so change that to the relativized form, then change it back.
+            Dictionary<string, FileState> oldFileStateCache = instanceLocalFileStateCache;
+            instanceLocalFileStateCache = instanceLocalFileStateCache.ToDictionary(kvp => FileUtilities.MakeRelative(Path.GetDirectoryName(stateFile), kvp.Key), kvp => kvp.Value);
+
+            try
+            {
+                if (FileUtilities.FileExistsNoThrow(stateFile))
+                {
+                    log.LogWarningWithCodeFromResources("General.StateFileAlreadyPresent", stateFile);
+                }
+                SerializeCache(stateFile, log);
+            }
+            finally
+            {
+                instanceLocalFileStateCache = oldFileStateCache;
+            }
+        }
+    }
+}

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -411,24 +411,28 @@ namespace Microsoft.Build.Tasks
             out FrameworkName frameworkName)
         {
             FileState fileState = GetFileState(path);
-            if (fileState.dependencies == null)
+            if (fileState.Dependencies == null)
             {
                 getAssemblyMetadata(
                     path,
                     assemblyMetadataCache,
-                    out fileState.dependencies,
-                    out fileState.scatterFiles,
-                    out fileState.frameworkName);
+                    out dependencies,
+                    out scatterFiles,
+                    out frameworkName);
+
+                fileState.SetAssemblyMetadata(dependencies, scatterFiles, frameworkName);
 
                 if (fileState.IsWorthPersisting)
                 {
                     SetIsDirty();
                 }
             }
-
-            dependencies = fileState.dependencies;
-            scatterFiles = fileState.scatterFiles;
-            frameworkName = fileState.frameworkName;
+            else
+            {
+                dependencies = fileState.Dependencies;
+                scatterFiles = fileState.ScatterFiles;
+                frameworkName = fileState.FrameworkName;
+            }
         }
 
         /// <summary>

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -5,15 +5,10 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Runtime.Versioning;
-using Microsoft.Build.BackEnd;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks.AssemblyDependency;
-using Microsoft.Build.Utilities;
 
 #nullable disable
 
@@ -22,18 +17,13 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Class is used to cache system state.
     /// </summary>
-    internal sealed class SystemState : StateFileBase, ITranslatable
+    internal sealed class SystemState : ResolveAssemblyReferenceCache
     {
         /// <summary>
-        /// Cache at the SystemState instance level. Has the same contents as <see cref="instanceLocalFileStateCache"/>.
+        /// Cache at the SystemState instance level. Has the same contents as <see cref="ResolveAssemblyReferenceCache.instanceLocalFileStateCache"/>.
         /// It acts as a flag to enforce that an entry has been checked for staleness only once.
         /// </summary>
         private Dictionary<string, FileState> upToDateLocalFileStateCache = new Dictionary<string, FileState>(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// Cache at the SystemState instance level. It is serialized and reused between instances.
-        /// </summary>
-        internal Dictionary<string, FileState> instanceLocalFileStateCache = new Dictionary<string, FileState>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// LastModified information is purely instance-local. It doesn't make sense to
@@ -67,11 +57,6 @@ namespace Microsoft.Build.Tasks
         private RedistList redistList;
 
         /// <summary>
-        /// True if the contents have changed.
-        /// </summary>
-        private bool isDirty;
-
-        /// <summary>
         /// Delegate used internally.
         /// </summary>
         private GetLastWriteTime getLastWriteTime;
@@ -102,134 +87,15 @@ namespace Microsoft.Build.Tasks
         private GetAssemblyRuntimeVersion getAssemblyRuntimeVersion;
 
         /// <summary>
-        /// Class that holds the current file state.
-        /// </summary>
-        [Serializable]
-        internal sealed class FileState : ITranslatable
-        {
-            /// <summary>
-            /// The last modified time for this file.
-            /// </summary>
-            private DateTime lastModified;
-
-            /// <summary>
-            /// The fusion name of this file.
-            /// </summary>
-            private AssemblyNameExtension assemblyName;
-
-            /// <summary>
-            /// The assemblies that this file depends on.
-            /// </summary>
-            internal AssemblyNameExtension[] dependencies;
-
-            /// <summary>
-            /// The scatter files associated with this assembly.
-            /// </summary>
-            internal string[] scatterFiles;
-
-            /// <summary>
-            /// FrameworkName the file was built against
-            /// </summary>
-            internal FrameworkName frameworkName;
-
-            /// <summary>
-            /// The CLR runtime version for the assembly.
-            /// </summary>
-            internal string runtimeVersion;
-
-            /// <summary>
-            /// Default construct.
-            /// </summary>
-            internal FileState(DateTime lastModified)
-            {
-                this.lastModified = lastModified;
-            }
-
-            /// <summary>
-            /// Ctor for translator deserialization
-            /// </summary>
-            internal FileState(ITranslator translator)
-            {
-                Translate(translator);
-            }
-
-            /// <summary>
-            /// Reads/writes this class
-            /// </summary>
-            public void Translate(ITranslator translator)
-            {
-                ErrorUtilities.VerifyThrowArgumentNull(translator, nameof(translator));
-
-                translator.Translate(ref lastModified);
-                translator.Translate(ref assemblyName,
-                    (ITranslator t) => new AssemblyNameExtension(t));
-                translator.TranslateArray(ref dependencies,
-                    (ITranslator t) => new AssemblyNameExtension(t));
-                translator.Translate(ref scatterFiles);
-                translator.Translate(ref runtimeVersion);
-                translator.Translate(ref frameworkName);
-            }
-
-            /// <summary>
-            /// Gets the last modified date.
-            /// </summary>
-            /// <value></value>
-            internal DateTime LastModified
-            {
-                get { return lastModified; }
-            }
-
-            /// <summary>
-            /// Get or set the assemblyName.
-            /// </summary>
-            /// <value></value>
-            internal AssemblyNameExtension Assembly
-            {
-                get { return assemblyName; }
-                set { assemblyName = value; }
-            }
-
-            /// <summary>
-            /// Get or set the runtimeVersion
-            /// </summary>
-            /// <value></value>
-            internal string RuntimeVersion
-            {
-                get { return runtimeVersion; }
-                set { runtimeVersion = value; }
-            }
-
-            /// <summary>
-            /// Get or set the framework name the file was built against
-            /// </summary>
-            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Could be used in other assemblies")]
-            internal FrameworkName FrameworkNameAttribute
-            {
-                get { return frameworkName; }
-                set { frameworkName = value; }
-            }
-
-            /// <summary>
-            /// The last-modified value to use for immutable framework files which we don't do I/O on.
-            /// </summary>
-            internal static DateTime ImmutableFileLastModifiedMarker => DateTime.MaxValue;
-
-            /// <summary>
-            /// It is wasteful to persist entries for immutable framework files.
-            /// </summary>
-            internal bool IsWorthPersisting => lastModified != ImmutableFileLastModifiedMarker;
-        }
-
-        /// <summary>
         /// Construct.
         /// </summary>
         public SystemState()
         {
         }
 
-        public SystemState(ITranslator translator)
+        public SystemState(ResolveAssemblyReferenceCache resolveAssemblyReferenceCache)
+            : base(resolveAssemblyReferenceCache)
         {
-            Translate(translator);
         }
 
         /// <summary>
@@ -242,37 +108,6 @@ namespace Microsoft.Build.Tasks
             AssemblyTableInfo[] installedAssemblyTableInfos)
         {
             redistList = RedistList.GetRedistList(installedAssemblyTableInfos);
-        }
-
-        /// <summary>
-        /// Reads/writes this class.
-        /// Used for serialization and deserialization of this class persistent cache.
-        /// </summary>
-        public override void Translate(ITranslator translator)
-        {
-            if (instanceLocalFileStateCache is null)
-            {
-                throw new NullReferenceException(nameof(instanceLocalFileStateCache));
-            }
-
-            translator.TranslateDictionary(
-                ref instanceLocalFileStateCache,
-                StringComparer.OrdinalIgnoreCase,
-                (ITranslator t) => new FileState(t));
-
-            // IsDirty should be false for either direction. Either this cache was brought
-            // up-to-date with the on-disk cache or vice versa. Either way, they agree.
-            IsDirty = false;
-        }
-
-        /// <summary>
-        /// Flag that indicates that <see cref="instanceLocalFileStateCache"/> has been modified.
-        /// </summary>
-        /// <value></value>
-        internal bool IsDirty
-        {
-            get { return isDirty; }
-            set { isDirty = value; }
         }
 
         /// <summary>
@@ -532,73 +367,6 @@ namespace Microsoft.Build.Tasks
             dependencies = fileState.dependencies;
             scatterFiles = fileState.scatterFiles;
             frameworkName = fileState.frameworkName;
-        }
-
-        /// <summary>
-        /// Reads in cached data from stateFiles to build an initial cache. Avoids logging warnings or errors.
-        /// </summary>
-        /// <param name="stateFiles">List of locations of caches on disk.</param>
-        /// <param name="log">How to log</param>
-        /// <param name="fileExists">Whether a file exists</param>
-        /// <returns>A cache representing key aspects of file states.</returns>
-        internal static SystemState DeserializePrecomputedCaches(ITaskItem[] stateFiles, TaskLoggingHelper log, FileExists fileExists)
-        {
-            SystemState retVal = new SystemState();
-            retVal.isDirty = stateFiles.Length > 0;
-            HashSet<string> assembliesFound = new HashSet<string>();
-
-            foreach (ITaskItem stateFile in stateFiles)
-            {
-                // Verify that it's a real stateFile. Log message but do not error if not.
-                SystemState sysState = DeserializeCache<SystemState>(stateFile.ToString(), log);
-                if (sysState == null)
-                {
-                    continue;
-                }
-                foreach (KeyValuePair<string, FileState> kvp in sysState.instanceLocalFileStateCache)
-                {
-                    string relativePath = kvp.Key;
-                    if (!assembliesFound.Contains(relativePath))
-                    {
-                        FileState fileState = kvp.Value;
-                        string fullPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(stateFile.ToString()), relativePath));
-                        if (fileExists(fullPath))
-                        {
-                            // Correct file path
-                            retVal.instanceLocalFileStateCache[fullPath] = fileState;
-                            assembliesFound.Add(relativePath);
-                        }
-                    }
-                }
-            }
-
-            return retVal;
-        }
-
-        /// <summary>
-        /// Modifies this object to be more portable across machines, then writes it to filePath.
-        /// </summary>
-        /// <param name="stateFile">Path to which to write the precomputed cache</param>
-        /// <param name="log">How to log</param>
-        internal void SerializePrecomputedCache(string stateFile, TaskLoggingHelper log)
-        {
-            // Save a copy of instanceLocalFileStateCache so we can restore it later. SerializeCacheByTranslator serializes
-            // instanceLocalFileStateCache by default, so change that to the relativized form, then change it back.
-            Dictionary<string, FileState> oldFileStateCache = instanceLocalFileStateCache;
-            instanceLocalFileStateCache = instanceLocalFileStateCache.ToDictionary(kvp => FileUtilities.MakeRelative(Path.GetDirectoryName(stateFile), kvp.Key), kvp => kvp.Value);
-
-            try
-            {
-                if (FileUtilities.FileExistsNoThrow(stateFile))
-                {
-                    log.LogWarningWithCodeFromResources("General.StateFileAlreadyPresent", stateFile);
-                }
-                SerializeCache(stateFile, log);
-            }
-            finally
-            {
-                instanceLocalFileStateCache = oldFileStateCache;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
Attempts to fix #8635

### Context

The per-project RAR cache is always read from disk and deserialized prior to actual RAR execution. This is wasteful in situations when we already have all required data in memory - when RAR is hosted in a long-running process like MSBuild server or out-of-proc node. This PR attempts to implement a mechanism by which the load could be avoided, while maintaining the guarantee that the cache file has well-defined contents after RAR is done.

### Changes Made

- Made loading of the cache file lazy/on demand. If everything is satisfied from the process-wide cache, the file is not loaded. When the file is loaded, its contents are merged with what we've calculated to be the per-project cached data so far.
- Made saving of the cache file conditional as well, by following an elaborate scheme. We cache metadata about the file in memory to decide if it should be saved after RAR has done executing.

### Testing

- Functional: Verified that when building with MSBuild server enabled and `/m:1`, in large solutions like OrchardCore zero loads and saves of cache files occur in incremental builds. Everything is satisfied from memory.
- Performance: Measured the wall clock time savings in incremental build compared to baseline. Even with the baseline being larger cache files without #8802, the best I could get was ~5% faster RAR.

### Notes

I am opening the PR for posterity but the impact is currently not high enough to justify the churn and added complexity. The 5% cited above is achievable only in very special cases like server + `/m:1`. In real-world parallel builds, due to non-deterministic scheduling of projects to nodes, it takes a very long time for all nodes to get warmed up to the point where most cache loads can actually be avoided.

We could do better if we loosen up the requirements for saves (see [this comment](https://github.com/dotnet/msbuild/commit/45f704e55f1afd8ac3e804d723777d0adc49d32e#diff-81a7afe73fef8c5ab9186b64cfc47b8eb107a3a8ac4080e3fa825a8eb0744f55R2069-R2091)) but I'm afraid that would come back to bite us in the future.