### PR TITLE
[vs17.2] Update sdk version to bump pulled runtime

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "6.0.311",
+    "dotnet": "6.0.313",
     "vs": {
       "version": "17.2.1"
     },


### PR DESCRIPTION
Fixes couple nuget CVEs ([internal link] https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted?_a=alerts&typeId=15231688&alerts-view-option=active)

### Context
We need runtime 6.0.16 -> 6.0.18 bump, this comes with [SDK 6.0.313](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
