### PR TITLE
[vs17.4] Update vulnerable System.Security.Cryptography.Pkcs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.4.7</VersionPrefix>
+    <VersionPrefix>17.4.8</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -46,7 +46,7 @@
     <PackageReference Update="System.Runtime" Version="4.3.1" />
     <PackageReference Update="System.Runtime" Condition="'$(SystemRuntimeVersion)' != ''" Version="$(SystemRuntimeVersion)" />
 
-    <PackageReference Update="System.Security.Cryptography.Pkcs" Version="6.0.1" />
+    <PackageReference Update="System.Security.Cryptography.Pkcs" Version="6.0.3" />
     <PackageReference Update="System.Security.Cryptography.Pkcs" Condition="'$(SystemSecurityCryptographyPkcsVersion)' != ''" Version="$(SystemSecurityCryptographyPkcsVersion)" />
 
     <PackageReference Update="System.Security.Cryptography.Xml" Version="6.0.1" />


### PR DESCRIPTION
Fixes CVE-2023-29331

### Context
[CVE-2023-29331](https://github.com/advisories/GHSA-555c-2p6r-68mm)