### PR TITLE
[vs17.6] Update sdk version to bump pulled runtime

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -295,6 +295,9 @@ dotnet_diagnostic.IDE0049.severity = suggestion
 # Use compound assignment
 dotnet_diagnostic.IDE0054.severity = suggestion
 
+# Fix formatting
+dotnet_diagnostic.IDE0055.severity = suggestion
+
 # Indexing can be simplified
 dotnet_diagnostic.IDE0056.severity = suggestion
 
@@ -386,6 +389,9 @@ dotnet_diagnostic.IDE0241.severity = suggestion
 
 # Struct can be made 'readonly'
 dotnet_diagnostic.IDE0250.severity = suggestion
+
+# Struct methods can be made 'readonly'
+dotnet_diagnostic.IDE0251.severity = suggestion
 
 # Null check can be simplified
 dotnet_diagnostic.IDE0270.severity = suggestion

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Collections" Version="$(MicrosoftCodeAnalysisCollectionsVersion)" />
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistVersion)" />
+	<PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" Condition="'$(UsingToolMicrosoftNetCompilers)' != 'true'" />
     <PackageVersion Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksVersion)" />
     <PackageVersion Include="NuGet.Frameworks" Version="$(NuGetBuildTasksVersion)" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.23167.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.23313.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>92c39a4f0bacef20812f63e2e1d3f7aa8776038d</Sha>
+      <Sha>91616785a1a6578c83f7e93d98c34a1eb83d6223</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="NuGet.Build.Tasks" Version="6.5.0-rc.149">
+    <Dependency Name="NuGet.Build.Tasks" Version="6.7.0-preview.2.51">
       <Uri>https://github.com/nuget/nuget.client</Uri>
-      <Sha>ca5029046d7b6e55f322c45abb7b342054543710</Sha>
+      <Sha>f3bb337e310ce44abda4ad73cdb0755ed940809d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.6.0-2.23166.9">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.7.0-3.23311.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>48b13597fee9df5ecfbd0b8c0758b3f46bc1d440</Sha>
+      <Sha>4cbfec964e59687cd9cc8601df42b936c9c06f63</Sha>
+      <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.23167.1">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.23313.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>92c39a4f0bacef20812f63e2e1d3f7aa8776038d</Sha>
+      <Sha>91616785a1a6578c83f7e93d98c34a1eb83d6223</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,11 +49,11 @@
          Otherwise, this version of dotnet will not be installed and the build will error out. -->
     <DotNetCliVersion>$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\global.json')), '"dotnet": "([^"]*)"').Groups.get_Item(1))</DotNetCliVersion>
     <MicrosoftCodeAnalysisCollectionsVersion>4.2.0-1.22102.8</MicrosoftCodeAnalysisCollectionsVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.23167.1</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.23313.5</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftExtensionsDependencyModelVersion>7.0.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftIORedistVersion>6.0.0</MicrosoftIORedistVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.6.0-2.23166.9</MicrosoftNetCompilersToolsetVersion>
-    <NuGetBuildTasksVersion>6.5.0-rc.149</NuGetBuildTasksVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.7.0-3.23311.1</MicrosoftNetCompilersToolsetVersion>
+    <NuGetBuildTasksVersion>6.7.0-preview.2.51</NuGetBuildTasksVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemTextJsonVersion>7.0.0</SystemTextJsonVersion>
     <SystemThreadingTasksDataflowVersion>7.0.0</SystemThreadingTasksDataflowVersion>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "7.0.200",
+    "dotnet": "7.0.304",
     "vs": {
       "version": "17.4.1"
     },

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -1016,7 +1016,7 @@
     <PackageReference Include="System.Security.Permissions" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
-    <Content Include="$(NuGetPackageRoot)microsoft.net.compilers.toolset\$(MicrosoftNetCompilersToolsetVersion)\tasks\net6.0\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
+    <Content Include="$(NuGetPackageRoot)microsoft.net.compilers.toolset\$(MicrosoftNetCompilersToolsetVersion)\tasks\netcore\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MonoBuild)' == 'true'">


### PR DESCRIPTION
Fixes CVE-2023-28260

### Context
Same change as this bump on main https://github.com/dotnet/msbuild/pull/8894