### PR TITLE
Overwrite colorized lines instead of incremental updates

### DIFF
--- a/src/MSBuild.UnitTests/LiveLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/LiveLogger_Tests.cs
@@ -256,5 +256,34 @@ namespace Microsoft.Build.UnitTests
                 await Verify(_outputWriter.ToString(), _settings);
             });
         }
+
+        [Fact]
+        public async Task DisplayNodesOverwritesWithNewTargetFramework()
+        {
+            BuildStarted?.Invoke(_eventSender, MakeBuildStartedEventArgs());
+
+            ProjectStartedEventArgs pse = MakeProjectStartedEventArgs(_projectFile, "Build");
+            pse.GlobalProperties = new Dictionary<string, string>() { ["TargetFramework"] = "tfName" };
+
+            ProjectStarted?.Invoke(_eventSender, pse);
+
+            TargetStarted?.Invoke(_eventSender, MakeTargetStartedEventArgs(_projectFile, "Build"));
+            TaskStarted?.Invoke(_eventSender, MakeTaskStartedEventArgs(_projectFile, "Task"));
+
+            _liveLogger.DisplayNodes();
+
+            // This is a bit fast and loose with the events that would be fired
+            // in a real "stop building that TF for the project and start building
+            // a new TF of the same project" situation, but it's enough now.
+            ProjectStartedEventArgs pse2 = MakeProjectStartedEventArgs(_projectFile, "Build");
+            pse2.GlobalProperties = new Dictionary<string, string>() { ["TargetFramework"] = "tf2" };
+
+            ProjectStarted?.Invoke(_eventSender, pse2);
+            TargetStarted?.Invoke(_eventSender, MakeTargetStartedEventArgs(_projectFile, "Build"));
+
+            _liveLogger.DisplayNodes();
+
+            await Verify(_outputWriter.ToString(), _settings);
+        }
     }
 }

--- a/src/MSBuild.UnitTests/LiveLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/LiveLogger_Tests.cs
@@ -245,5 +245,16 @@ namespace Microsoft.Build.UnitTests
         }
 
         #endregion
+
+        [Fact]
+        public void DisplayNodesShowsCurrent()
+        {
+            InvokeLoggerCallbacksForSimpleProject(succeeded: false, async () =>
+            {
+                _liveLogger.DisplayNodes();
+
+                await Verify(_outputWriter.ToString(), _settings);
+            });
+        }
     }
 }

--- a/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.DisplayNodesOverwritesWithNewTargetFramework.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.DisplayNodesOverwritesWithNewTargetFramework.verified.txt
@@ -1,0 +1,5 @@
+﻿[?25l[1F
+  project [36;1mtfName[m Build (0.0s)
+[?25h[?25l[2F
+  project [36;1mtf2[m Build (0.0s)[K
+[?25h

--- a/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.DisplayNodesShowsCurrent.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.DisplayNodesShowsCurrent.verified.txt
@@ -1,0 +1,3 @@
+﻿[?25l[1F
+  project Build (0.0s)
+[?25h

--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -740,21 +740,22 @@ internal sealed class LiveLogger : INodeLogger
                     if (!previous.SequenceEqual(needed))
                     {
                         int commonPrefixLen = previous.CommonPrefixLength(needed);
-                        if (commonPrefixLen == 0)
+
+                        if (commonPrefixLen != 0 && needed.Slice(0, commonPrefixLen).IndexOf('\x1b') == -1)
                         {
-                            // whole string
-                            sb.Append(needed);
+                            // no escape codes, so can trivially skip substrings
+                            sb.Append($"{AnsiCodes.CSI}{commonPrefixLen}{AnsiCodes.MoveForward}");
+                            sb.Append(needed.Slice(commonPrefixLen));
                         }
                         else
                         {
-                            // set cursor to different char
-                            sb.Append($"{AnsiCodes.CSI}{commonPrefixLen}{AnsiCodes.MoveForward}");
-                            sb.Append(needed.Slice(commonPrefixLen));
-                            // Shall we clear rest of line
-                            if (needed.Length < previous.Length)
-                            {
-                                sb.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
-                            }
+                            sb.Append(needed);
+                        }
+
+                        // Shall we clear rest of line
+                        if (needed.Length < previous.Length)
+                        {
+                            sb.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
                         }
                     }
                 }

--- a/src/MSBuild/LiveLogger/LiveLogger.cs
+++ b/src/MSBuild/LiveLogger/LiveLogger.cs
@@ -611,7 +611,7 @@ internal sealed class LiveLogger : INodeLogger
     /// Render Nodes section.
     /// It shows what all build nodes do.
     /// </summary>
-    private void DisplayNodes()
+    internal void DisplayNodes()
     {
         NodesFrame newFrame = new NodesFrame(_nodes, width: Terminal.Width, height: Terminal.Height);
 

--- a/src/MSBuild/LiveLogger/Terminal.cs
+++ b/src/MSBuild/LiveLogger/Terminal.cs
@@ -107,7 +107,7 @@ internal sealed class Terminal : ITerminal
         }
         else
         {
-            Console.Write(text);
+            Output.Write(text);
         }
     }
 


### PR DESCRIPTION
The root cause of #8781 is that the optimize-output-by-skipping-identical-characters logic is not aware of escape sequences, so it goes horribly awry when the replacing line differs after the first escape sequence.
    
Instead, apply the previous logic only if there are no escape sequences; if there are, replace the entire line.
    
If this proves to cause too much flicker or perform slowly, we could implement escape-sequence-aware truncation, length, and comparison, but we can wait for feedback to that effect.