### PR TITLE
Correct success for /preprocess /targets builds

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1148,7 +1148,7 @@ namespace Microsoft.Build.CommandLine
                 InitializationException.Throw(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ProjectUpgradeNeededToVcxProj", projectFile), null);
             }
 
-            bool success = false;
+            bool success = true;
 
             ProjectCollection projectCollection = null;
             bool onlyLogCriticalEvents = false;
@@ -1292,7 +1292,7 @@ namespace Microsoft.Build.CommandLine
                     }
                     else
                     {
-                        success = PrintTargets(projectFile, toolsVersion, globalProperties, targetsWriter, projectCollection);
+                        success &= PrintTargets(projectFile, toolsVersion, globalProperties, targetsWriter, projectCollection);
                     }
                 }
 


### PR DESCRIPTION
This is not yet a problem but only because neither /preprocess nor /targets are supported for solution files.

The root of the problem is if someone chooses to specify both /preprocess and /targets. If /preprocess fails but /targets succeeds, it currently will erroneously display success. This fixes that.

As I said, that scenario doesn't currently exist but only because /targets cannot succeed unless /preprocess succeeded, but that is not guaranteed going forward. Notably, if /preprocess is extended to support solution files before /targets is, this will become an issue.