### PR TITLE
ResolveAssemblyReference CPU optimizations

### DIFF
--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -521,6 +521,8 @@ namespace Microsoft.Build.Execution
 
         IEnumerable<KeyValuePair<string, string>> IMetadataContainer.EnumerateMetadata() => _taskItem.EnumerateMetadata();
 
+        void IMetadataContainer.ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata) => _taskItem.ImportMetadata(metadata);
+
         #region IMetadataTable Members
 
         /// <summary>
@@ -1035,6 +1037,19 @@ namespace Microsoft.Build.Execution
             }
 
             /// <summary>
+            /// Sets the given metadata.
+            /// Equivalent to calling <see cref="SetMetadata(string,string)"/> for each item in <paramref name="metadata"/>.
+            /// </summary>
+            /// <param name="metadata">The metadata to set.</param>
+            public void ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
+            {
+                ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
+
+                _directMetadata ??= new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
+                _directMetadata.ImportProperties(metadata.Select(kvp => new ProjectMetadataInstance(kvp.Key, kvp.Value, allowItemSpecModifiers: true)));
+            }
+
+            /// <summary>
             /// Used to return metadata from another AppDomain. Can't use yield return because the
             /// generated state machine is not marked as [Serializable], so we need to allocate.
             /// </summary>
@@ -1371,9 +1386,7 @@ namespace Microsoft.Build.Execution
                     originalItemSpec = destinationItem.GetMetadata("OriginalItemSpec");
                 }
 
-                TaskItem destinationAsTaskItem = destinationItem as TaskItem;
-
-                if (destinationAsTaskItem != null && destinationAsTaskItem._directMetadata == null)
+                if (destinationItem is TaskItem destinationAsTaskItem && destinationAsTaskItem._directMetadata == null)
                 {
                     ProjectInstance.VerifyThrowNotImmutable(destinationAsTaskItem._isImmutable);
 
@@ -1390,6 +1403,14 @@ namespace Microsoft.Build.Execution
                     {
                         destinationAsTaskItem._itemDefinitions.AddRange(_itemDefinitions);
                     }
+                }
+                else if (destinationItem is IMetadataContainer destinationItemAsMetadataContainer)
+                {
+                    // The destination implements IMetadataContainer so we can use the ImportMetadata bulk-set operation.
+                    IEnumerable<ProjectMetadataInstance> metadataEnumerable = MetadataCollection;
+                    destinationItemAsMetadataContainer.ImportMetadata(metadataEnumerable
+                        .Where(metadatum => string.IsNullOrEmpty(destinationItem.GetMetadata(metadatum.Name)))
+                        .Select(metadatum => new KeyValuePair<string, string>(metadatum.Name, GetMetadataEscaped(metadatum.Name))));
                 }
                 else
                 {

--- a/src/Framework/IMetadataContainer.cs
+++ b/src/Framework/IMetadataContainer.cs
@@ -20,5 +20,17 @@ namespace Microsoft.Build.Framework
         /// in the binary logger.
         /// </summary>
         IEnumerable<KeyValuePair<string, string>> EnumerateMetadata();
+
+        /// <summary>
+        /// Sets the given metadata. The operation is equivalent to calling
+        /// <see cref="ITaskItem.SetMetadata"/> on all items, but taking
+        /// advantage of a faster bulk-set operation where applicable. The
+        /// implementation may not perform the same parameter validation
+        /// as SetMetadata.
+        /// </summary>
+        /// <param name="metadata">The metadata to set. The keys are assumed
+        /// to be unique and values are assumed to be escaped.
+        /// </param>
+        void ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata);
     }
 }

--- a/src/Framework/TaskItemData.cs
+++ b/src/Framework/TaskItemData.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Build.Framework
 
         IEnumerable<KeyValuePair<string, string>> IMetadataContainer.EnumerateMetadata() => Metadata;
 
+        void IMetadataContainer.ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
+            => throw new NotImplementedException();
+
         public int MetadataCount => Metadata.Count;
 
         public ICollection MetadataNames => (ICollection)Metadata.Keys;

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -856,6 +856,14 @@ namespace Microsoft.Build.BackEnd
                     yield return unescaped;
                 }
             }
+
+            public void ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
+            {
+                foreach (KeyValuePair<string, string> kvp in metadata)
+                {
+                    SetMetadata(kvp.Key, kvp.Value);
+                }
+            }
         }
     }
 }

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -852,8 +852,7 @@ namespace Microsoft.Build.Tasks
                 name = item.GetMetadata(FileUtilities.ItemSpecModifiers.Filename);
             }
 
-            AssemblyName assemblyName = new AssemblyName($"{name}, Version={version}, Culture=neutral, PublicKeyToken={publicKeyToken}");
-            return new AssemblyNameExtension(assemblyName);
+            return new AssemblyNameExtension($"{name}, Version={version}, Culture=neutral, PublicKeyToken={publicKeyToken}");
         }
 
         /// <summary>

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -2676,36 +2676,44 @@ namespace Microsoft.Build.Tasks
             // Set up the main item.
             TaskItem referenceItem = new TaskItem();
             referenceItem.ItemSpec = reference.FullPath;
-            referenceItem.SetMetadata(ItemMetadataNames.resolvedFrom, reference.ResolvedSearchPath);
 
-            // Set the CopyLocal metadata.
-            referenceItem.SetMetadata(ItemMetadataNames.copyLocal, reference.IsCopyLocal ? "true" : "false");
-
-            // Set the Redist name metadata.
-            if (!String.IsNullOrEmpty(reference.RedistName))
+            // Enumerate common metadata with an iterator to allow using a more efficient bulk-set operation.
+            IEnumerable<KeyValuePair<string, string>> EnumerateCommonMetadata()
             {
-                referenceItem.SetMetadata(ItemMetadataNames.redist, reference.RedistName);
-            }
+                yield return new KeyValuePair<string, string>(ItemMetadataNames.resolvedFrom, reference.ResolvedSearchPath);
 
-            if (Reference.IsFrameworkFile(reference.FullPath, _frameworkPaths) || (_installedAssemblies?.FrameworkAssemblyEntryInRedist(assemblyName) == true))
-            {
-                if (!IsAssemblyRemovedFromDotNetFramework(assemblyName, reference.FullPath, _frameworkPaths, _installedAssemblies))
+                // Set the CopyLocal metadata.
+                yield return new KeyValuePair<string, string>(ItemMetadataNames.copyLocal, reference.IsCopyLocal ? "true" : "false");
+
+                // Set the Redist name metadata.
+                if (!string.IsNullOrEmpty(reference.RedistName))
                 {
-                    referenceItem.SetMetadata(ItemMetadataNames.frameworkFile, "true");
+                    yield return new KeyValuePair<string, string>(ItemMetadataNames.redist, reference.RedistName);
+                }
+
+                if (Reference.IsFrameworkFile(reference.FullPath, _frameworkPaths) || (_installedAssemblies?.FrameworkAssemblyEntryInRedist(assemblyName) == true))
+                {
+                    if (!IsAssemblyRemovedFromDotNetFramework(assemblyName, reference.FullPath, _frameworkPaths, _installedAssemblies))
+                    {
+                        yield return new KeyValuePair<string, string>(ItemMetadataNames.frameworkFile, "true");
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(reference.ImageRuntime))
+                {
+                    yield return new KeyValuePair<string, string>(ItemMetadataNames.imageRuntime, reference.ImageRuntime);
+                }
+
+                // The redist root is "null" when there was no IsRedistRoot flag in the Redist XML
+                // (or there was no redist XML at all for this item).
+                if (reference.IsRedistRoot != null)
+                {
+                    yield return new KeyValuePair<string, string>(ItemMetadataNames.isRedistRoot, (bool)reference.IsRedistRoot ? "true" : "false");
                 }
             }
 
-            if (!String.IsNullOrEmpty(reference.ImageRuntime))
-            {
-                referenceItem.SetMetadata(ItemMetadataNames.imageRuntime, reference.ImageRuntime);
-            }
-
-            // The redist root is "null" when there was no IsRedistRoot flag in the Redist XML
-            // (or there was no redist XML at all for this item).
-            if (reference.IsRedistRoot != null)
-            {
-                referenceItem.SetMetadata(ItemMetadataNames.isRedistRoot, (bool)reference.IsRedistRoot ? "true" : "false");
-            }
+            IMetadataContainer referenceItemAsMetadataContainer = referenceItem;
+            referenceItemAsMetadataContainer.ImportMetadata(EnumerateCommonMetadata());
 
             // If there was a primary source item, then forward metadata from it.
             // It's important that the metadata from the primary source item
@@ -2879,10 +2887,7 @@ namespace Microsoft.Build.Tasks
             // nonForwardableMetadata should be null here if relatedFileExtensions, satellites, serializationAssemblyFiles, and scatterFiles were all empty.
             if (nonForwardableMetadata != null)
             {
-                foreach (KeyValuePair<string, string> kvp in nonForwardableMetadata)
-                {
-                    referenceItem.SetMetadata(kvp.Key, kvp.Value);
-                }
+                referenceItemAsMetadataContainer.ImportMetadata(nonForwardableMetadata);
             }
 
             return referenceItem;

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -480,6 +480,12 @@ namespace Microsoft.Build.Utilities
             return EnumerateMetadataLazy();
         }
 
+        void IMetadataContainer.ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
+        {
+            _metadata ??= new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default);
+            _metadata.SetItems(metadata.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value ?? string.Empty)));
+        }
+
         private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataEager()
         {
             if (_metadata == null)


### PR DESCRIPTION
### Context

Low-hanging fruit is showing in RAR performance profiles.

### Changes Made

1. Avoided constructing `AssemblyName` on a hot path as the constructor makes expensive Fusion calls on .NET Framework. The problematic code was introduced in #8688.

2. Added a metadata bulk-set operation to the internal `IMetadataContainer` interface. Calling `SetMetadata` for more than a couple of metadata is slow if `ImmutableDictionary` is used as a backing storage. RAR is heavy on metadata manipulation and switching to the new operation saves about 10% of RAR run-time when building OrchardCore. 

### Testing

Existing and new (to-be-added) unit tests. Measured the perf impact by building OC.
