### PR TITLE
[vs17.6] Dont ngen taskhost Fixes our lack of optprof data (#8737)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.6.7</VersionPrefix>
+    <VersionPrefix>17.6.8</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.5.0</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -36,7 +36,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe.config
-  file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86 vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuildTaskHost.exe" 
+  file source=$(TaskHostBinPath)MSBuildTaskHost.exe 
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
   file source=$(X86BinPath)System.Buffers.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Memory.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
@@ -174,7 +174,7 @@ folder InstallDir:\MSBuild\Current\Bin\zh-Hant
 
 folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64
-  file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x64 vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\amd64\MSBuildTaskHost.exe" 
+  file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe
   file source=$(X64BinPath)MSBuild.exe.config
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe.config
 


### PR DESCRIPTION
### Context
OptProf failing on vs17.6 after recent changes

### Fix
Cherrypicked https://github.com/dotnet/msbuild/pull/8737
