### PR TITLE
ProjectInstance: create a ProjectItemInstance dictionary of the correct size in copying constructor

### DIFF
--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -609,7 +609,7 @@ namespace Microsoft.Build.Execution
                     _properties.Set(property.DeepClone(_isImmutable));
                 }
 
-                _items = new ItemDictionary<ProjectItemInstance>(that._items.ItemTypes.Count);
+                _items = new ItemDictionary<ProjectItemInstance>(that._items.Count);
 
                 foreach (ProjectItemInstance item in that.Items)
                 {


### PR DESCRIPTION
Fixes [Bug 1835789](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1835789): [GCPauseWatson] MSBuild: ProjectInstance.DeepClone resizing an ItemDictionary because its passing the wrong capacity (31 MB/s)

The ProjectInstance copying constructor creates an item dictionary using an initial capacity of the number of _item types_ instead of the number of items are being added to the collection. This is causing it to be resized.