### PR TITLE
Support all codepages in path to app.config

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -2911,7 +2911,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// </summary>
         /// <param name="appConfigFile"></param>
         /// <param name="redirects"></param>
-        protected static string WriteAppConfig(string redirects)
+        protected static string WriteAppConfig(string redirects, string appConfigNameSuffix = null)
         {
             string appConfigContents =
             "<configuration>\n" +
@@ -2920,7 +2920,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             "    </runtime>\n" +
             "</configuration>";
 
-            string appConfigFile = FileUtilities.GetTemporaryFileName();
+            string appConfigFile = FileUtilities.GetTemporaryFileName() + appConfigNameSuffix;
             File.WriteAllText(appConfigFile, appConfigContents);
             return appConfigFile;
         }

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -46,7 +46,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         /// </summary>
         [Theory]
         [InlineData(null)]
-        [InlineData("")]
+        [InlineData("\uE025\uE026")]
         public void Exists(string appConfigNameSuffix)
         {
             // Create the engine.

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -38,13 +38,16 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         /// - An app.config was passed in that promotes UnifyMe version from 1.0.0.0 to 2.0.0.0
         /// - Version 1.0.0.0 of UnifyMe exists.
         /// - Version 2.0.0.0 of UnifyMe exists.
+        /// - The case is attempted on special unicode characters in path as well.
         /// Expected:
         /// - The resulting UnifyMe returned should be 2.0.0.0.
         /// Rationale:
         /// Strongly named dependencies should unify according to the bindingRedirects in the app.config.
         /// </summary>
-        [Fact]
-        public void Exists()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Exists(string appConfigNameSuffix)
         {
             // Create the engine.
             MockEngine engine = new MockEngine(_output);
@@ -59,7 +62,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
                     "        <dependentAssembly>\n" +
                     "            <assemblyIdentity name='UnifyMe' PublicKeyToken='b77a5c561934e089' culture='neutral' />\n" +
                     "            <bindingRedirect oldVersion='1.0.0.0' newVersion='2.0.0.0' />\n" +
-                    "        </dependentAssembly>\n");
+                    "        </dependentAssembly>\n",
+                    appConfigNameSuffix);
 
             // Now, pass feed resolved primary references into ResolveAssemblyReference.
             ResolveAssemblyReference t = new ResolveAssemblyReference();

--- a/src/Tasks/AppConfig/AppConfig.cs
+++ b/src/Tasks/AppConfig/AppConfig.cs
@@ -25,14 +25,15 @@ namespace Microsoft.Build.Tasks
             XmlReader reader = null;
             try
             {
-                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true};
 
                 // it's important to normalize the path as it may contain two slashes
                 // see https://github.com/dotnet/msbuild/issues/4335 for details.
                 appConfigFile = FileUtilities.NormalizePath(appConfigFile);
 
-                // Need a filestream as the XmlReader doesn't support nonstandard unicode characters in path
-                using FileStream fs = File.OpenRead(appConfigFile);
+                // Need a filestream as the XmlReader doesn't support nonstandard unicode characters in path.
+                // No need to dispose - as 'CloseInput' was passed to XmlReaderSettings
+                FileStream fs = File.OpenRead(appConfigFile);
                 reader = XmlReader.Create(fs, readerSettings);
                 Read(reader);
             }

--- a/src/Tasks/AppConfig/AppConfig.cs
+++ b/src/Tasks/AppConfig/AppConfig.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using System.Xml;
 
 using Microsoft.Build.Shared;
@@ -30,7 +31,9 @@ namespace Microsoft.Build.Tasks
                 // see https://github.com/dotnet/msbuild/issues/4335 for details.
                 appConfigFile = FileUtilities.NormalizePath(appConfigFile);
 
-                reader = XmlReader.Create(appConfigFile, readerSettings);
+                // Need a filestream as the XmlReader doesn't support nonstandard unicode characters in path
+                using FileStream fs = File.OpenRead(appConfigFile);
+                reader = XmlReader.Create(fs, readerSettings);
                 Read(reader);
             }
             catch (XmlException e)


### PR DESCRIPTION
Fixes [#ADO-1827728](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1827728)

### Context
Build of FullFW app was failing for customer with specific nonenglish characters  in path

### Changes Made
Passing `Stream` to `XmlReader.Create` instead of path - that is not grace handled 

### Testing
Explicit test added that failed before the fix

