### PR TITLE
Failing LiveLogger tests are fixed

### DIFF
--- a/src/MSBuild.UnitTests/LiveLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/LiveLogger_Tests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.UnitTests
 
         private VerifySettings _settings = new();
 
-        private static Regex s_elapsedTime = new($@"\(\d+{Regex.Escape(CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator)}\ds\)", RegexOptions.Compiled);
+        private static Regex s_elapsedTime = new($@"\d+{Regex.Escape(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator)}\ds", RegexOptions.Compiled);
 
         public LiveLogger_Tests()
         {
@@ -56,7 +56,7 @@ namespace Microsoft.Build.UnitTests
             {
                 string line = lineBuilder.ToString();
                 lineBuilder.Clear();
-                lineBuilder.Append(s_elapsedTime.Replace(line, "(0.0s)"));
+                lineBuilder.Append(s_elapsedTime.Replace(line, "0.0s"));
             });
         }
 

--- a/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.PrintBuildSummary_Failed.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.PrintBuildSummary_Failed.verified.txt
@@ -1,4 +1,4 @@
 ﻿]9;4;3;\[?25l[1F
 [?25h
-Build [31;1mfailed[m in 5.0s
+Build [31;1mfailed[m in 0.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.PrintBuildSummary_FailedWithErrors.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.PrintBuildSummary_FailedWithErrors.verified.txt
@@ -2,5 +2,5 @@
 [31;1m    ❌︎[7D[6C MSBUILD : error : Error![m
 [?25l[1F
 [?25h
-Build [31;1mfailed with errors[m in 5.0s
+Build [31;1mfailed with errors[m in 0.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.PrintBuildSummary_SucceededWithWarnings.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.PrintBuildSummary_SucceededWithWarnings.verified.txt
@@ -2,5 +2,5 @@
 [33;1m    ⚠︎[7D[6C MSBUILD : warning : Warning![m
 [?25l[1F
 [?25h
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with warnings[m in 0.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.PrintsBuildSummary_Succeeded.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/LiveLogger_Tests.PrintsBuildSummary_Succeeded.verified.txt
@@ -1,4 +1,4 @@
 ﻿]9;4;3;\[?25l[1F
 [?25h
-Build [32;1msucceeded[m in 5.0s
+Build [32;1msucceeded[m in 0.0s
 ]9;4;0;\


### PR DESCRIPTION
Fixed expected results and culture for decimal separator.
