### PR TITLE
Reduce runtime for and allocations from BaseConsoleLogger.IndentString

### DIFF
--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -1234,7 +1234,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void MultilineFormatMixedLineEndings()
         {
-            string s = "foo" + "\r\n\r\n" + "bar" + "\n" + "baz" + "\n\r\n\n" +
+            string s = "\n" + "foo" + "\r\n\r\n" + "bar" + "\n" + "baz" + "\n\r\n\n" +
                 "jazz" + "\r\n" + "razz" + "\n\n" + "matazz" + "\n" + "end";
 
             SerialConsoleLogger cl = new SerialConsoleLogger();
@@ -1242,7 +1242,7 @@ namespace Microsoft.Build.UnitTests
             string ss = cl.IndentString(s, 0);
 
             // should convert lines to system format
-            ss.ShouldBe($"foo{Environment.NewLine}{Environment.NewLine}bar{Environment.NewLine}baz{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}jazz{Environment.NewLine}razz{Environment.NewLine}{Environment.NewLine}matazz{Environment.NewLine}end{Environment.NewLine}");
+            ss.ShouldBe($"{Environment.NewLine}foo{Environment.NewLine}{Environment.NewLine}bar{Environment.NewLine}baz{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}jazz{Environment.NewLine}razz{Environment.NewLine}{Environment.NewLine}matazz{Environment.NewLine}end{Environment.NewLine}");
         }
 
         [Fact]

--- a/src/Build.UnitTests/ConsoleOutputAlignerTests.cs
+++ b/src/Build.UnitTests/ConsoleOutputAlignerTests.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Build.UnitTests
             output.ShouldBe(expected);
         }
 
-        private sealed class TestStringBuilderProvider : IReusableStringBuilderProvider
+        private sealed class TestStringBuilderProvider : IStringBuilderProvider
         {
             public StringBuilder Acquire(int capacity) => new StringBuilder(capacity);
             public string GetStringAndRelease(StringBuilder builder) => builder.ToString();

--- a/src/Build.UnitTests/ConsoleOutputAlignerTests.cs
+++ b/src/Build.UnitTests/ConsoleOutputAlignerTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Text;
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Framework;
 using Shouldly;
 using Xunit;
 
@@ -18,7 +20,7 @@ namespace Microsoft.Build.UnitTests
         public void IndentBiggerThanBuffer_IndentedAndNotAligned(string input, bool aligned)
         {
             string indent = "    ";
-            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: aligned);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: aligned, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: false, prefixWidth: indent.Length);
 
@@ -30,7 +32,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("12345")]
         public void NoAlignNoIndent_NotAlignedEvenIfBiggerThanBuffer(string input)
         {
-            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: false);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: false, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: false, prefixWidth: 0);
 
@@ -43,7 +45,7 @@ namespace Microsoft.Build.UnitTests
         public void NoBufferWidthNoIndent_NotAligned(int sizeOfMessage)
         {
             string input = new string('.', sizeOfMessage);
-            var aligner = new ConsoleOutputAligner(bufferWidth: -1, alignMessages: false);
+            var aligner = new ConsoleOutputAligner(bufferWidth: -1, alignMessages: false, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: false, prefixWidth: 0);
 
@@ -55,7 +57,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("12345")]
         public void WithoutBufferWidthWithoutIndentWithAlign_NotIndentedAndNotAligned(string input)
         {
-            var aligner = new ConsoleOutputAligner(bufferWidth: -1, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: -1, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: false, prefixWidth: 0);
 
@@ -67,7 +69,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("12345")]
         public void NoAlignPrefixAlreadyWritten_NotChanged(string input)
         {
-            var aligner = new ConsoleOutputAligner(bufferWidth: 10, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 10, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: true, prefixWidth: 0);
 
@@ -80,7 +82,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("  ", "1")]
         public void SmallerThanBuffer_NotAligned(string indent, string input)
         {
-            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: false, prefixWidth: indent.Length);
 
@@ -93,7 +95,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("  ", "12", "  1", "  2")]
         public void BiggerThanBuffer_AlignedWithIndent(string indent, string input, string expected1stLine, string expected2ndLine)
         {
-            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: false, prefixWidth: indent.Length);
 
@@ -114,7 +116,7 @@ namespace Microsoft.Build.UnitTests
                                   "  4\n")]
         public void XTimesBiggerThanBuffer_AlignedToMultipleLines(string indent, string input, string expected)
         {
-            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: false, prefixWidth: indent.Length);
 
@@ -128,7 +130,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("  ", "12", "1", "  2")]
         public void BiggerThanBufferWithPrefixAlreadyWritten_AlignedWithIndentFromSecondLine(string indent, string input, string expected1stLine, string expected2ndLine)
         {
-            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: true, prefixWidth: indent.Length);
 
@@ -142,7 +144,7 @@ namespace Microsoft.Build.UnitTests
         public void MultiLineWithoutAlign_NotChanged(string input)
         {
             input = input.Replace("\n", Environment.NewLine);
-            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: false);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: false, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: true, prefixWidth: 0);
 
@@ -165,7 +167,7 @@ namespace Microsoft.Build.UnitTests
         {
             expected = expected.Replace("\n", Environment.NewLine) + Environment.NewLine;
 
-            var aligner = new ConsoleOutputAligner(bufferWidth: 10, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 10, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: true, prefixWidth: 2);
 
@@ -179,7 +181,7 @@ namespace Microsoft.Build.UnitTests
         public void ShortMultiLineWithAlign_NoChange(string input)
         {
             input = input.Replace("\n", Environment.NewLine);
-            var aligner = new ConsoleOutputAligner(bufferWidth: 10, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 10, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: true, prefixWidth: 0);
 
@@ -202,7 +204,7 @@ namespace Microsoft.Build.UnitTests
         public void ShortMultiLineWithMixedNewLines_NewLinesReplacedByActualEnvironmentNewLines(string input)
         {
             string expected = input.Replace("\r", "").Replace("\n", Environment.NewLine) + Environment.NewLine;
-            var aligner = new ConsoleOutputAligner(bufferWidth: 10, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 10, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: true, prefixWidth: 0);
 
@@ -217,7 +219,7 @@ namespace Microsoft.Build.UnitTests
         {
             input = input.Replace("\n", Environment.NewLine);
             expected = expected.Replace("\n", Environment.NewLine);
-            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: true, prefixWidth: prefix.Length);
 
@@ -231,7 +233,7 @@ namespace Microsoft.Build.UnitTests
         {
             input = input.Replace("\n", Environment.NewLine);
             expected = expected.Replace("\n", Environment.NewLine);
-            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 4, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: false, prefixWidth: prefix.Length);
 
@@ -244,7 +246,7 @@ namespace Microsoft.Build.UnitTests
         public void ShortTextWithTabs_NoChange(string input)
         {
             input = input.Replace("\n", Environment.NewLine);
-            var aligner = new ConsoleOutputAligner(bufferWidth: 50, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: 50, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: true, prefixWidth: 0);
 
@@ -259,7 +261,7 @@ namespace Microsoft.Build.UnitTests
         public void LastTabOverLimit_NoChange(string prefix, string input, int bufferWidthWithoutNewLine, bool prefixAlreadyWritten)
         {
             input = input.Replace("\n", Environment.NewLine);
-            var aligner = new ConsoleOutputAligner(bufferWidth: bufferWidthWithoutNewLine + 1, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: bufferWidthWithoutNewLine + 1, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: prefixAlreadyWritten, prefixWidth: prefix.Length);
 
@@ -274,7 +276,7 @@ namespace Microsoft.Build.UnitTests
         public void LastTabAtLimit_NoChange(string prefix, string input, int bufferWidthWithoutNewLine, bool prefixAlreadyWritten)
         {
             input = input.Replace("\n", Environment.NewLine);
-            var aligner = new ConsoleOutputAligner(bufferWidth: bufferWidthWithoutNewLine + 1, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: bufferWidthWithoutNewLine + 1, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: prefixAlreadyWritten, prefixWidth: prefix.Length);
 
@@ -289,7 +291,7 @@ namespace Microsoft.Build.UnitTests
         public void TabsMakesItJustOverLimit_IndentAndAlign(string prefix, string input, int bufferWidthWithoutNewLine, bool prefixAlreadyWritten)
         {
             input = input.Replace("\n", Environment.NewLine);
-            var aligner = new ConsoleOutputAligner(bufferWidth: bufferWidthWithoutNewLine + 1, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: bufferWidthWithoutNewLine + 1, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input + "x", prefixAlreadyWritten: prefixAlreadyWritten, prefixWidth: prefix.Length);
 
@@ -366,11 +368,17 @@ namespace Microsoft.Build.UnitTests
         {
             input = input.Replace("\n", Environment.NewLine);
             expected = expected.Replace("\n", Environment.NewLine);
-            var aligner = new ConsoleOutputAligner(bufferWidth: bufferWidthWithoutNewLine + 1, alignMessages: true);
+            var aligner = new ConsoleOutputAligner(bufferWidth: bufferWidthWithoutNewLine + 1, alignMessages: true, stringBuilderProvider: new TestStringBuilderProvider());
 
             string output = aligner.AlignConsoleOutput(message: input, prefixAlreadyWritten: prefixAlreadyWritten, prefixWidth: prefix.Length);
 
             output.ShouldBe(expected);
+        }
+
+        private sealed class TestStringBuilderProvider : IReusableStringBuilderProvider
+        {
+            public StringBuilder Acquire(int capacity) => new StringBuilder(capacity);
+            public string GetStringAndRelease(StringBuilder builder) => builder.ToString();
         }
     }
 }

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -8,7 +8,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
@@ -920,85 +922,83 @@ namespace Microsoft.Build.BackEnd.Logging
         /// On net472, benchmarks show that the optimized version runs in about 50-60% of the time
         /// and has about 15% of the memory overhead of the code that it replaces.
         /// <para>
-        /// On net7.0 (which has more optimizations than net472), the optimized version runs in
-        /// about 70-75% of the time and has about 30% of the memory overhead of the code that it
-        /// replaces.
+        /// On net7.0, the optimized version runs in about 45-55% of the time and has about 30%
+        /// of the memory overhead of the code that it replaces.
         /// </para>
         /// </remarks>
         private static class OptimizedStringIndenter
         {
 #nullable enable
-            internal static string IndentString(string? s, int indent)
+#if NET7_0_OR_GREATER
+            [SkipLocalsInit]
+#endif
+            internal static unsafe string IndentString(string? s, int indent)
             {
                 if (s is null)
                 {
                     return string.Empty;
                 }
 
-                string newLine = Environment.NewLine;
+                Span<StringSegment> segments = GetStringSegments(s.AsSpan(), stackalloc StringSegment[128], out StringSegment[]? pooledArray);
 
-                using PooledSpan<StringSegment> segments = GetStringSegments(s);
-                int indentedStringLength = ComputeIndentedStringLength(segments, newLine, indent);
-                string indented = new string('\0', indentedStringLength);
-
-                unsafe
+                int indentedStringLength = segments.Length * (Environment.NewLine.Length + indent);
+                foreach (StringSegment segment in segments)
                 {
-#pragma warning disable SA1519 // Braces should not be omitted from multi-line child statement
-                    fixed (char* pInput = s)
-                    fixed (char* pIndented = indented)
-                    {
-                        char* pSegment = pInput;
-                        char* pOutput = pIndented;
-
-                        foreach (var segment in segments)
-                        {
-                            // append indent
-                            for (int i = 0; i < indent; i++)
-                            {
-                                *pOutput++ = ' ';
-                            }
-
-                            // append string segment
-                            int byteCount = segment.Length * sizeof(char);
-                            Buffer.MemoryCopy(pSegment, pOutput, byteCount, byteCount);
-                            pOutput += segment.Length;
-
-                            // append newLine
-                            for (int i = 0; i < newLine.Length; i++)
-                            {
-                                *pOutput++ = newLine[i];
-                            }
-
-                            // move to next segment
-                            pSegment += segment.TotalLength;
-                        }
-                    }
-#pragma warning restore SA1519 // Braces should not be omitted from multi-line child statement
+                    indentedStringLength += segment.Length;
                 }
 
-                return indented;
-
-                // local method
-                static int ComputeIndentedStringLength(PooledSpan<StringSegment> segments, string newLine, int indent)
+#if NET7_0_OR_GREATER
+#pragma warning disable CS8500
+                string result = string.Create(indentedStringLength, (s, (IntPtr)(&segments), indent), static (output, state) =>
                 {
-                    int indentedLength = segments.Length * (newLine.Length + indent);
-
-                    foreach (var segment in segments)
+                    ReadOnlySpan<char> input = state.s;
+                    foreach (StringSegment segment in *(Span<StringSegment>*)state.Item2)
                     {
-                        indentedLength += segment.Length;
-                    }
+                        // Append indent
+                        output.Slice(0, state.indent).Fill(' ');
+                        output = output.Slice(state.indent);
 
-                    return indentedLength;
+                        // Append string segment
+                        input.Slice(0, segment.Length).CopyTo(output);
+                        input = input.Slice(segment.TotalLength);
+                        output = output.Slice(segment.Length);
+
+                        // Append newline
+                        Environment.NewLine.CopyTo(output);
+                        output = output.Slice(Environment.NewLine.Length);
+                    }
+                });
+#pragma warning restore CS8500
+#else
+                using RentedBuilder rental = RentBuilder(indentedStringLength);
+
+                foreach (StringSegment segment in segments)
+                {
+                    rental.Builder
+                        .Append(' ', indent)
+                        .Append(s, segment.Start, segment.Length)
+                        .AppendLine();
                 }
+
+                string result = rental.Builder.ToString();
+#endif
+
+                if (pooledArray is not null)
+                {
+                    ArrayPool<StringSegment>.Shared.Return(pooledArray);
+                }
+
+                return result;
             }
 
-            private static PooledSpan<StringSegment> GetStringSegments(string input)
+            private static Span<StringSegment> GetStringSegments(ReadOnlySpan<char> input, Span<StringSegment> segments, out StringSegment[]? pooledArray)
             {
-                if (input.Length == 0)
+                if (input.IsEmpty)
                 {
-                    PooledSpan<StringSegment> emptyResult = new(1);
-                    emptyResult.Span[0] = new StringSegment(0, 0);
-                    return emptyResult;
+                    segments = segments.Slice(0, 1);
+                    segments[0] = new StringSegment(0, 0, 0);
+                    pooledArray = null;
+                    return segments;
                 }
 
                 int segmentCount = 1;
@@ -1010,73 +1010,88 @@ namespace Microsoft.Build.BackEnd.Logging
                     }
                 }
 
-                PooledSpan<StringSegment> segments = new(segmentCount);
-                int start = 0;
-                int index = 0;
-
-                for (int i = 0; i < segmentCount; i++)
+                if (segmentCount <= segments.Length)
                 {
-                    while (index < input.Length && input[index] != '\n')
-                    {
-                        index++;
-                    }
+                    pooledArray = null;
+                    segments = segments.Slice(0, segmentCount);
+                }
+                else
+                {
+                    pooledArray = ArrayPool<StringSegment>.Shared.Rent(segmentCount);
+                    segments = pooledArray.AsSpan(0, segmentCount);
+                }
 
-                    // the input string didn't end with a newline
-                    if (index == input.Length)
+                int start = 0;
+                for (int i = 0; i < segments.Length; i++)
+                {
+                    int index = input.IndexOf('\n');
+                    if (index < 0)
                     {
-                        segments[i] = new StringSegment(index - start, 0);
+                        segments[i] = new StringSegment(start, input.Length, 0);
                         break;
                     }
 
                     int newLineLength = 1;
-                    bool endedWithReturnNewline = (index > 0) && (input[index - 1] == '\r');
-
-                    if (endedWithReturnNewline)
+                    if (index > 0 && input[index - 1] == '\r')
                     {
                         newLineLength++;
                         index--;
                     }
 
-                    segments[i] = new StringSegment(index - start, newLineLength);
+                    int totalLength = index + newLineLength;
+                    segments[i] = new StringSegment(start, index, totalLength);
 
-                    start = index += newLineLength;
+                    start += totalLength;
+                    input = input.Slice(totalLength);
                 }
 
                 return segments;
             }
 
-            private readonly record struct StringSegment(int Length, int NewLineLength)
+            private struct StringSegment
             {
-                public int TotalLength => Length + NewLineLength;
+                public StringSegment(int start, int length, int totalLength)
+                {
+                    Start = start;
+                    Length = length;
+                    TotalLength = totalLength;
+                }
+
+                public int Start { get; }
+                public int Length { get; }
+                public int TotalLength { get; }
             }
 
-            private ref struct PooledSpan<T>
-            {
-                private static readonly ArrayPool<T> Pool = ArrayPool<T>.Shared;
-                private readonly T[] _pooledArray;
+#if !NET7_0_OR_GREATER
+            private static RentedBuilder RentBuilder(int capacity) => new RentedBuilder(capacity);
 
-                public PooledSpan(int length)
+            private ref struct RentedBuilder
+            {
+                // The maximum capacity for a StringBuilder that we'll cache.  StringBuilders with
+                // larger capacities will be allowed to be GC'd.
+                private const int MaxStringBuilderCapacity = 512;
+
+                private static StringBuilder? _cachedBuilder;
+
+                public RentedBuilder(int capacity)
                 {
-                    _pooledArray = Pool.Rent(length);
-                    Array.Clear(_pooledArray, 0, length);
-                    Span = _pooledArray.AsSpan(0, length);
+                    Builder = Interlocked.Exchange(ref _cachedBuilder, null) ?? new StringBuilder(capacity);
+                    Builder.EnsureCapacity(capacity);
                 }
 
                 public void Dispose()
                 {
-                    Pool.Return(_pooledArray);
+                    // if builder's capacity is within our limits, return it to the cache
+                    if (Builder.Capacity <= MaxStringBuilderCapacity)
+                    {
+                        Builder.Clear();
+                        Interlocked.Exchange(ref _cachedBuilder, Builder);
+                    }
                 }
 
-                public Span<T> Span { get; }
-                public int Length => Span.Length;
-                public Span<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
-
-                public T this[int index]
-                {
-                    get => Span[index];
-                    set => Span[index] = value;
-                }
+                public StringBuilder Builder { get; }
             }
+#endif
 #nullable restore
         }
 

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -19,6 +19,7 @@ using ColorResetter = Microsoft.Build.Logging.ColorResetter;
 using ColorSetter = Microsoft.Build.Logging.ColorSetter;
 using WriteHandler = Microsoft.Build.Logging.WriteHandler;
 
+// if this is removed, also remove the "#nullable disable" in OptimizedStringIndenter
 #nullable disable
 
 namespace Microsoft.Build.BackEnd.Logging
@@ -1092,7 +1093,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 public StringBuilder Builder { get; }
             }
 #endif
-#nullable restore
+#nullable disable
         }
 
         #region eventHandlers

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.BackEnd.Logging
     internal delegate void WriteLinePrettyFromResourceDelegate(int indentLevel, string resourceString, params object[] args);
     #endregion
 
-    internal abstract class BaseConsoleLogger : INodeLogger, IReusableStringBuilderProvider
+    internal abstract class BaseConsoleLogger : INodeLogger, IStringBuilderProvider
     {
         #region Properties
 
@@ -132,7 +132,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="indent">Depth to indent.</param>
         internal string IndentString(string s, int indent)
         {
-            return OptimizedStringIndenter.IndentString(s, indent, (IReusableStringBuilderProvider)this);
+            return OptimizedStringIndenter.IndentString(s, indent, (IStringBuilderProvider)this);
         }
 
         /// <summary>
@@ -1191,7 +1191,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
         /// <summary>
         /// Since logging messages are processed serially, we can use a single StringBuilder wherever needed.
-        /// It should not be done directly, but rather through the <see cref="IReusableStringBuilderProvider"/> interface methods.
+        /// It should not be done directly, but rather through the <see cref="IStringBuilderProvider"/> interface methods.
         /// </summary>
         private StringBuilder _sharedStringBuilder = new StringBuilder(0x100);
 
@@ -1244,7 +1244,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Since logging messages are processed serially, we can reuse a single StringBuilder wherever needed.
         /// </summary>
-        StringBuilder IReusableStringBuilderProvider.Acquire(int capacity)
+        StringBuilder IStringBuilderProvider.Acquire(int capacity)
         {
             StringBuilder shared = Interlocked.Exchange(ref _sharedStringBuilder, null);
 
@@ -1299,7 +1299,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// Acquired StringBuilder must be returned before next use.
         /// Unbalanced releases are not supported.
         /// </summary>
-        string IReusableStringBuilderProvider.GetStringAndRelease(StringBuilder builder)
+        string IStringBuilderProvider.GetStringAndRelease(StringBuilder builder)
         {
             // This is not supposed to be used concurrently. One method is expected to return it before next acquire.
             // But just for sure if _sharedBuilder was already returned, keep the former.

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -8,7 +8,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+#if NET7_0_OR_GREATER
 using System.Runtime.CompilerServices;
+#endif
 using System.Text;
 using System.Threading;
 using Microsoft.Build.Evaluation;

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -130,28 +131,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="indent">Depth to indent.</param>
         internal string IndentString(string s, int indent)
         {
-            // It's possible the event has a null message
-            if (s == null)
-            {
-                return string.Empty;
-            }
-
-            // This will never return an empty array.  The returned array will always
-            // have at least one non-null element, even if "s" is totally empty.
-            String[] subStrings = SplitStringOnNewLines(s);
-
-            StringBuilder result = new StringBuilder(
-                (subStrings.Length * indent) +
-                (subStrings.Length * Environment.NewLine.Length) +
-                s.Length);
-
-            for (int i = 0; i < subStrings.Length; i++)
-            {
-                result.Append(' ', indent).Append(subStrings[i]);
-                result.AppendLine();
-            }
-
-            return result.ToString();
+            return OptimizedStringIndenter.IndentString(s, indent);
         }
 
         /// <summary>
@@ -909,6 +889,195 @@ namespace Microsoft.Build.BackEnd.Logging
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Helper class to indent all the lines of a potentially multi-line string with
+        /// minimal CPU and memory overhead.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="IndentString"/> is a functional replacement for the following code:
+        /// <code>
+        ///     string IndentString(string s, int indent)
+        ///     {
+        ///         string[] newLines = { "\r\n", "\n" };
+        ///         string[] subStrings = s.Split(newLines, StringSplitOptions.None);
+        ///     
+        ///         StringBuilder result = new StringBuilder(
+        ///             (subStrings.Length * indent) +
+        ///             (subStrings.Length * Environment.NewLine.Length) +
+        ///             s.Length);
+        ///     
+        ///         for (int i = 0; i &lt; subStrings.Length; i++)
+        ///         {
+        ///             result.Append(' ', indent).Append(subStrings[i]);
+        ///             result.AppendLine();
+        ///         }
+        ///     
+        ///         return result.ToString();
+        ///     }
+        /// </code>
+        /// On net472, benchmarks show that the optimized version runs in about 50-60% of the time
+        /// and has about 15% of the memory overhead of the code that it replaces.
+        /// <para>
+        /// On net7.0 (which has more optimizations than net472), the optimized version runs in
+        /// about 70-75% of the time and has about 30% of the memory overhead of the code that it
+        /// replaces.
+        /// </para>
+        /// </remarks>
+        private static class OptimizedStringIndenter
+        {
+#nullable enable
+            internal static string IndentString(string? s, int indent)
+            {
+                if (s is null)
+                {
+                    return string.Empty;
+                }
+
+                string newLine = Environment.NewLine;
+
+                using PooledSpan<StringSegment> segments = GetStringSegments(s);
+                int indentedStringLength = ComputeIndentedStringLength(segments, newLine, indent);
+                string indented = new string('\0', indentedStringLength);
+
+                unsafe
+                {
+#pragma warning disable SA1519 // Braces should not be omitted from multi-line child statement
+                    fixed (char* pInput = s)
+                    fixed (char* pIndented = indented)
+                    {
+                        char* pSegment = pInput;
+                        char* pOutput = pIndented;
+
+                        foreach (var segment in segments)
+                        {
+                            // append indent
+                            for (int i = 0; i < indent; i++)
+                            {
+                                *pOutput++ = ' ';
+                            }
+
+                            // append string segment
+                            int byteCount = segment.Length * sizeof(char);
+                            Buffer.MemoryCopy(pSegment, pOutput, byteCount, byteCount);
+                            pOutput += segment.Length;
+
+                            // append newLine
+                            for (int i = 0; i < newLine.Length; i++)
+                            {
+                                *pOutput++ = newLine[i];
+                            }
+
+                            // move to next segment
+                            pSegment += segment.TotalLength;
+                        }
+                    }
+#pragma warning restore SA1519 // Braces should not be omitted from multi-line child statement
+                }
+
+                return indented;
+
+                // local method
+                static int ComputeIndentedStringLength(PooledSpan<StringSegment> segments, string newLine, int indent)
+                {
+                    int indentedLength = segments.Length * (newLine.Length + indent);
+
+                    foreach (var segment in segments)
+                    {
+                        indentedLength += segment.Length;
+                    }
+
+                    return indentedLength;
+                }
+            }
+
+            private static PooledSpan<StringSegment> GetStringSegments(string input)
+            {
+                if (input.Length == 0)
+                {
+                    PooledSpan<StringSegment> emptyResult = new(1);
+                    emptyResult.Span[0] = new StringSegment(0, 0);
+                    return emptyResult;
+                }
+
+                int segmentCount = 1;
+                for (int i = 0; i < input.Length; i++)
+                {
+                    if (input[i] == '\n')
+                    {
+                        segmentCount++;
+                    }
+                }
+
+                PooledSpan<StringSegment> segments = new(segmentCount);
+                int start = 0;
+                int index = 0;
+
+                for (int i = 0; i < segmentCount; i++)
+                {
+                    while (index < input.Length && input[index] != '\n')
+                    {
+                        index++;
+                    }
+
+                    // the input string didn't end with a newline
+                    if (index == input.Length)
+                    {
+                        segments[i] = new StringSegment(index - start, 0);
+                        break;
+                    }
+
+                    int newLineLength = 1;
+                    bool endedWithReturnNewline = (index > 0) && (input[index - 1] == '\r');
+
+                    if (endedWithReturnNewline)
+                    {
+                        newLineLength++;
+                        index--;
+                    }
+
+                    segments[i] = new StringSegment(index - start, newLineLength);
+
+                    start = index += newLineLength;
+                }
+
+                return segments;
+            }
+
+            private readonly record struct StringSegment(int Length, int NewLineLength)
+            {
+                public int TotalLength => Length + NewLineLength;
+            }
+
+            private ref struct PooledSpan<T>
+            {
+                private static readonly ArrayPool<T> Pool = ArrayPool<T>.Shared;
+                private readonly T[] _pooledArray;
+
+                public PooledSpan(int length)
+                {
+                    _pooledArray = Pool.Rent(length);
+                    Array.Clear(_pooledArray, 0, length);
+                    Span = _pooledArray.AsSpan(0, length);
+                }
+
+                public void Dispose()
+                {
+                    Pool.Return(_pooledArray);
+                }
+
+                public Span<T> Span { get; }
+                public int Length => Span.Length;
+                public Span<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
+
+                public T this[int index]
+                {
+                    get => Span[index];
+                    set => Span[index] = value;
+                }
+            }
+#nullable restore
         }
 
         #region eventHandlers

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
@@ -24,7 +26,7 @@ namespace Microsoft.Build.BackEnd.Logging
     internal delegate void WriteLinePrettyFromResourceDelegate(int indentLevel, string resourceString, params object[] args);
     #endregion
 
-    internal abstract class BaseConsoleLogger : INodeLogger
+    internal abstract class BaseConsoleLogger : INodeLogger, IReusableStringBuilderProvider
     {
         #region Properties
 
@@ -130,7 +132,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="indent">Depth to indent.</param>
         internal string IndentString(string s, int indent)
         {
-            return OptimizedStringIndenter.IndentString(s, indent);
+            return OptimizedStringIndenter.IndentString(s, indent, (IReusableStringBuilderProvider)this);
         }
 
         /// <summary>
@@ -1187,6 +1189,14 @@ namespace Microsoft.Build.BackEnd.Logging
 
         internal bool runningWithCharacterFileType = false;
 
+        /// <summary>
+        /// Since logging messages are processed serially, we can use a single StringBuilder wherever needed.
+        /// It should not be done directly, but rather through the <see cref="IReusableStringBuilderProvider"/> interface methods.
+        /// </summary>
+        private StringBuilder _sharedStringBuilder = new StringBuilder(0x100);
+
+        #endregion
+
         #region Per-build Members
 
         /// <summary>
@@ -1231,6 +1241,72 @@ namespace Microsoft.Build.BackEnd.Logging
 
         #endregion
 
-        #endregion
+        /// <summary>
+        /// Since logging messages are processed serially, we can reuse a single StringBuilder wherever needed.
+        /// </summary>
+        StringBuilder IReusableStringBuilderProvider.Acquire(int capacity)
+        {
+            StringBuilder shared = Interlocked.Exchange(ref _sharedStringBuilder, null);
+
+            Debug.Assert(shared != null, "This is not supposed to be used in multiple threads or multiple time. One method is expected to return it before next acquire. Most probably it was not returned.");
+            if (shared == null)
+            {
+                // This is not supposed to be used concurrently. One method is expected to return it before next acquire.
+                // However to avoid bugs in production, we will create new string builder
+                return StringBuilderCache.Acquire(capacity);
+            }
+
+            if (shared.Capacity < capacity)
+            {
+                const int minimumCapacity = 0x100; // 256 characters, 512 bytes
+                const int maximumBracketedCapacity = 0x80_000; // 512K characters, 1MB
+
+                if (capacity <= minimumCapacity)
+                {
+                    capacity = minimumCapacity;
+                }
+                else if (capacity < maximumBracketedCapacity)
+                {
+                    // GC likes arrays allocated with power of two bytes. Lets make it happy.
+
+                    // Find next power of two http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+                    int v = capacity;
+
+                    v--;
+                    v |= v >> 1;
+                    v |= v >> 2;
+                    v |= v >> 4;
+                    v |= v >> 8;
+                    v |= v >> 16;
+                    v++;
+
+                    capacity = v;
+                }
+                // If capacity is > maximumCapacity we will respect it and use it as is.
+
+                // Lets create new instance with enough capacity.
+                shared = new StringBuilder(capacity);
+            }
+
+            // Prepare for next use.
+            // Equivalent of sb.Clear() that works on .Net 3.5
+            shared.Length = 0; 
+
+            return shared;
+        }
+
+        /// <summary>
+        /// Acquired StringBuilder must be returned before next use.
+        /// Unbalanced releases are not supported.
+        /// </summary>
+        string IReusableStringBuilderProvider.GetStringAndRelease(StringBuilder builder)
+        {
+            // This is not supposed to be used concurrently. One method is expected to return it before next acquire.
+            // But just for sure if _sharedBuilder was already returned, keep the former.
+            StringBuilder previous = Interlocked.CompareExchange(ref _sharedStringBuilder, builder, null);
+            Debug.Assert(previous == null, "This is not supposed to be used in multiple threads or multiple time. One method is expected to return it before next acquire. Most probably it was double returned.");
+
+            return builder.ToString();
+        }
     }
 }

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -2,17 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-#if NET7_0_OR_GREATER
-using System.Runtime.CompilerServices;
-#endif
 using System.Text;
-using System.Threading;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
@@ -21,7 +16,6 @@ using ColorResetter = Microsoft.Build.Logging.ColorResetter;
 using ColorSetter = Microsoft.Build.Logging.ColorSetter;
 using WriteHandler = Microsoft.Build.Logging.WriteHandler;
 
-// if this is removed, also remove the "#nullable disable" in OptimizedStringIndenter
 #nullable disable
 
 namespace Microsoft.Build.BackEnd.Logging
@@ -894,208 +888,6 @@ namespace Microsoft.Build.BackEnd.Logging
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// Helper class to indent all the lines of a potentially multi-line string with
-        /// minimal CPU and memory overhead.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="IndentString"/> is a functional replacement for the following code:
-        /// <code>
-        ///     string IndentString(string s, int indent)
-        ///     {
-        ///         string[] newLines = { "\r\n", "\n" };
-        ///         string[] subStrings = s.Split(newLines, StringSplitOptions.None);
-        ///     
-        ///         StringBuilder result = new StringBuilder(
-        ///             (subStrings.Length * indent) +
-        ///             (subStrings.Length * Environment.NewLine.Length) +
-        ///             s.Length);
-        ///     
-        ///         for (int i = 0; i &lt; subStrings.Length; i++)
-        ///         {
-        ///             result.Append(' ', indent).Append(subStrings[i]);
-        ///             result.AppendLine();
-        ///         }
-        ///     
-        ///         return result.ToString();
-        ///     }
-        /// </code>
-        /// On net472, benchmarks show that the optimized version runs in about 50-60% of the time
-        /// and has about 15% of the memory overhead of the code that it replaces.
-        /// <para>
-        /// On net7.0, the optimized version runs in about 45-55% of the time and has about 30%
-        /// of the memory overhead of the code that it replaces.
-        /// </para>
-        /// </remarks>
-        private static class OptimizedStringIndenter
-        {
-#nullable enable
-#if NET7_0_OR_GREATER
-            [SkipLocalsInit]
-#endif
-            internal static unsafe string IndentString(string? s, int indent)
-            {
-                if (s is null)
-                {
-                    return string.Empty;
-                }
-
-                Span<StringSegment> segments = GetStringSegments(s.AsSpan(), stackalloc StringSegment[128], out StringSegment[]? pooledArray);
-
-                int indentedStringLength = segments.Length * (Environment.NewLine.Length + indent);
-                foreach (StringSegment segment in segments)
-                {
-                    indentedStringLength += segment.Length;
-                }
-
-#if NET7_0_OR_GREATER
-#pragma warning disable CS8500
-                string result = string.Create(indentedStringLength, (s, (IntPtr)(&segments), indent), static (output, state) =>
-                {
-                    ReadOnlySpan<char> input = state.s;
-                    foreach (StringSegment segment in *(Span<StringSegment>*)state.Item2)
-                    {
-                        // Append indent
-                        output.Slice(0, state.indent).Fill(' ');
-                        output = output.Slice(state.indent);
-
-                        // Append string segment
-                        input.Slice(0, segment.Length).CopyTo(output);
-                        input = input.Slice(segment.TotalLength);
-                        output = output.Slice(segment.Length);
-
-                        // Append newline
-                        Environment.NewLine.CopyTo(output);
-                        output = output.Slice(Environment.NewLine.Length);
-                    }
-                });
-#pragma warning restore CS8500
-#else
-                using RentedBuilder rental = RentBuilder(indentedStringLength);
-
-                foreach (StringSegment segment in segments)
-                {
-                    rental.Builder
-                        .Append(' ', indent)
-                        .Append(s, segment.Start, segment.Length)
-                        .AppendLine();
-                }
-
-                string result = rental.Builder.ToString();
-#endif
-
-                if (pooledArray is not null)
-                {
-                    ArrayPool<StringSegment>.Shared.Return(pooledArray);
-                }
-
-                return result;
-            }
-
-            private static Span<StringSegment> GetStringSegments(ReadOnlySpan<char> input, Span<StringSegment> segments, out StringSegment[]? pooledArray)
-            {
-                if (input.IsEmpty)
-                {
-                    segments = segments.Slice(0, 1);
-                    segments[0] = new StringSegment(0, 0, 0);
-                    pooledArray = null;
-                    return segments;
-                }
-
-                int segmentCount = 1;
-                for (int i = 0; i < input.Length; i++)
-                {
-                    if (input[i] == '\n')
-                    {
-                        segmentCount++;
-                    }
-                }
-
-                if (segmentCount <= segments.Length)
-                {
-                    pooledArray = null;
-                    segments = segments.Slice(0, segmentCount);
-                }
-                else
-                {
-                    pooledArray = ArrayPool<StringSegment>.Shared.Rent(segmentCount);
-                    segments = pooledArray.AsSpan(0, segmentCount);
-                }
-
-                int start = 0;
-                for (int i = 0; i < segments.Length; i++)
-                {
-                    int index = input.IndexOf('\n');
-                    if (index < 0)
-                    {
-                        segments[i] = new StringSegment(start, input.Length, 0);
-                        break;
-                    }
-
-                    int newLineLength = 1;
-                    if (index > 0 && input[index - 1] == '\r')
-                    {
-                        newLineLength++;
-                        index--;
-                    }
-
-                    int totalLength = index + newLineLength;
-                    segments[i] = new StringSegment(start, index, totalLength);
-
-                    start += totalLength;
-                    input = input.Slice(totalLength);
-                }
-
-                return segments;
-            }
-
-            private struct StringSegment
-            {
-                public StringSegment(int start, int length, int totalLength)
-                {
-                    Start = start;
-                    Length = length;
-                    TotalLength = totalLength;
-                }
-
-                public int Start { get; }
-                public int Length { get; }
-                public int TotalLength { get; }
-            }
-
-#if !NET7_0_OR_GREATER
-            private static RentedBuilder RentBuilder(int capacity) => new RentedBuilder(capacity);
-
-            private ref struct RentedBuilder
-            {
-                // The maximum capacity for a StringBuilder that we'll cache.  StringBuilders with
-                // larger capacities will be allowed to be GC'd.
-                private const int MaxStringBuilderCapacity = 512;
-
-                private static StringBuilder? _cachedBuilder;
-
-                public RentedBuilder(int capacity)
-                {
-                    Builder = Interlocked.Exchange(ref _cachedBuilder, null) ?? new StringBuilder(capacity);
-                    Builder.EnsureCapacity(capacity);
-                }
-
-                public void Dispose()
-                {
-                    // if builder's capacity is within our limits, return it to the cache
-                    if (Builder.Capacity <= MaxStringBuilderCapacity)
-                    {
-                        Builder.Clear();
-                        Interlocked.Exchange(ref _cachedBuilder, Builder);
-                    }
-                }
-
-                public StringBuilder Builder { get; }
-            }
-#endif
-#nullable disable
         }
 
         #region eventHandlers

--- a/src/Build/Logging/OptimizedStringIndenter.cs
+++ b/src/Build/Logging/OptimizedStringIndenter.cs
@@ -8,8 +8,8 @@ using System.Buffers;
 using System.Runtime.CompilerServices;
 #else
 using System.Text;
-using Microsoft.Build.Framework;
 #endif
+using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.BackEnd.Logging;
 
@@ -52,7 +52,7 @@ internal static class OptimizedStringIndenter
 #if NET7_0_OR_GREATER
     [SkipLocalsInit]
 #endif
-    internal static unsafe string IndentString(string? s, int indent)
+    internal static unsafe string IndentString(string? s, int indent, IReusableStringBuilderProvider stringBuilderProvider)
     {
         if (s is null)
         {
@@ -89,7 +89,7 @@ internal static class OptimizedStringIndenter
         });
 #pragma warning restore CS8500
 #else
-        StringBuilder builder = StringBuilderCache.Acquire(indentedStringLength);
+        StringBuilder builder = stringBuilderProvider.Acquire(indentedStringLength);
 
         foreach (StringSegment segment in segments)
         {
@@ -99,7 +99,7 @@ internal static class OptimizedStringIndenter
                 .AppendLine();
         }
 
-        string result = StringBuilderCache.GetStringAndRelease(builder);
+        string result = stringBuilderProvider.GetStringAndRelease(builder);
 #endif
 
         if (pooledArray is not null)

--- a/src/Build/Logging/OptimizedStringIndenter.cs
+++ b/src/Build/Logging/OptimizedStringIndenter.cs
@@ -3,8 +3,12 @@
 
 using System;
 using System.Buffers;
+
 #if NET7_0_OR_GREATER
 using System.Runtime.CompilerServices;
+#else
+using System.Text;
+using Microsoft.Build.Framework;
 #endif
 
 namespace Microsoft.Build.BackEnd.Logging;

--- a/src/Build/Logging/OptimizedStringIndenter.cs
+++ b/src/Build/Logging/OptimizedStringIndenter.cs
@@ -79,8 +79,7 @@ internal static class OptimizedStringIndenter
                 output = output.Slice(state.indent);
 
                 // Append string segment
-                input.Slice(0, segment.Length).CopyTo(output);
-                input = input.Slice(segment.TotalLength);
+                input.Slice(segment.Start, segment.Length).CopyTo(output);
                 output = output.Slice(segment.Length);
 
                 // Append newline
@@ -116,7 +115,7 @@ internal static class OptimizedStringIndenter
         if (input.IsEmpty)
         {
             segments = segments.Slice(0, 1);
-            segments[0] = new StringSegment(0, 0, 0);
+            segments[0] = new StringSegment(0, 0);
             pooledArray = null;
             return segments;
         }
@@ -147,7 +146,7 @@ internal static class OptimizedStringIndenter
             int index = input.IndexOf('\n');
             if (index < 0)
             {
-                segments[i] = new StringSegment(start, input.Length, 0);
+                segments[i] = new StringSegment(start, input.Length);
                 break;
             }
 
@@ -159,7 +158,7 @@ internal static class OptimizedStringIndenter
             }
 
             int totalLength = index + newLineLength;
-            segments[i] = new StringSegment(start, index, totalLength);
+            segments[i] = new StringSegment(start, index);
 
             start += totalLength;
             input = input.Slice(totalLength);
@@ -170,15 +169,13 @@ internal static class OptimizedStringIndenter
 
     private struct StringSegment
     {
-        public StringSegment(int start, int length, int totalLength)
+        public StringSegment(int start, int length)
         {
             Start = start;
             Length = length;
-            TotalLength = totalLength;
         }
 
         public int Start { get; }
         public int Length { get; }
-        public int TotalLength { get; }
     }
 }

--- a/src/Build/Logging/OptimizedStringIndenter.cs
+++ b/src/Build/Logging/OptimizedStringIndenter.cs
@@ -52,7 +52,7 @@ internal static class OptimizedStringIndenter
 #if NET7_0_OR_GREATER
     [SkipLocalsInit]
 #endif
-    internal static unsafe string IndentString(string? s, int indent, IReusableStringBuilderProvider stringBuilderProvider)
+    internal static unsafe string IndentString(string? s, int indent, IStringBuilderProvider stringBuilderProvider)
     {
         if (s is null)
         {

--- a/src/Build/Logging/OptimizedStringIndenter.cs
+++ b/src/Build/Logging/OptimizedStringIndenter.cs
@@ -1,0 +1,214 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+#if NET7_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#else
+using System.Text;
+using System.Threading;
+#endif
+
+namespace Microsoft.Build.BackEnd.Logging;
+
+/// <summary>
+/// Helper class to indent all the lines of a potentially multi-line string with
+/// minimal CPU and memory overhead.
+/// </summary>
+/// <remarks>
+/// <see cref="IndentString"/> is a functional replacement for the following code:
+/// <code>
+///     string IndentString(string s, int indent)
+///     {
+///         string[] newLines = { "\r\n", "\n" };
+///         string[] subStrings = s.Split(newLines, StringSplitOptions.None);
+///
+///         StringBuilder result = new StringBuilder(
+///             (subStrings.Length * indent) +
+///             (subStrings.Length * Environment.NewLine.Length) +
+///             s.Length);
+///
+///         for (int i = 0; i &lt; subStrings.Length; i++)
+///         {
+///             result.Append(' ', indent).Append(subStrings[i]);
+///             result.AppendLine();
+///         }
+///
+///         return result.ToString();
+///     }
+/// </code>
+/// On net472, benchmarks show that the optimized version runs in about 50-60% of the time
+/// and has about 15% of the memory overhead of the code that it replaces.
+/// <para>
+/// On net7.0, the optimized version runs in about 45-55% of the time and has about 30%
+/// of the memory overhead of the code that it replaces.
+/// </para>
+/// </remarks>
+internal static class OptimizedStringIndenter
+{
+#nullable enable
+#if NET7_0_OR_GREATER
+    [SkipLocalsInit]
+#endif
+    internal static unsafe string IndentString(string? s, int indent)
+    {
+        if (s is null)
+        {
+            return string.Empty;
+        }
+
+        Span<StringSegment> segments = GetStringSegments(s.AsSpan(), stackalloc StringSegment[128], out StringSegment[]? pooledArray);
+
+        int indentedStringLength = segments.Length * (Environment.NewLine.Length + indent);
+        foreach (StringSegment segment in segments)
+        {
+            indentedStringLength += segment.Length;
+        }
+
+#if NET7_0_OR_GREATER
+#pragma warning disable CS8500
+        string result = string.Create(indentedStringLength, (s, (IntPtr)(&segments), indent), static (output, state) =>
+        {
+            ReadOnlySpan<char> input = state.s;
+            foreach (StringSegment segment in *(Span<StringSegment>*)state.Item2)
+            {
+                // Append indent
+                output.Slice(0, state.indent).Fill(' ');
+                output = output.Slice(state.indent);
+
+                // Append string segment
+                input.Slice(0, segment.Length).CopyTo(output);
+                input = input.Slice(segment.TotalLength);
+                output = output.Slice(segment.Length);
+
+                // Append newline
+                Environment.NewLine.CopyTo(output);
+                output = output.Slice(Environment.NewLine.Length);
+            }
+        });
+#pragma warning restore CS8500
+#else
+        using RentedBuilder rental = RentBuilder(indentedStringLength);
+
+        foreach (StringSegment segment in segments)
+        {
+            rental.Builder
+                .Append(' ', indent)
+                .Append(s, segment.Start, segment.Length)
+                .AppendLine();
+        }
+
+        string result = rental.Builder.ToString();
+#endif
+
+        if (pooledArray is not null)
+        {
+            ArrayPool<StringSegment>.Shared.Return(pooledArray);
+        }
+
+        return result;
+    }
+
+    private static Span<StringSegment> GetStringSegments(ReadOnlySpan<char> input, Span<StringSegment> segments, out StringSegment[]? pooledArray)
+    {
+        if (input.IsEmpty)
+        {
+            segments = segments.Slice(0, 1);
+            segments[0] = new StringSegment(0, 0, 0);
+            pooledArray = null;
+            return segments;
+        }
+
+        int segmentCount = 1;
+        for (int i = 0; i < input.Length; i++)
+        {
+            if (input[i] == '\n')
+            {
+                segmentCount++;
+            }
+        }
+
+        if (segmentCount <= segments.Length)
+        {
+            pooledArray = null;
+            segments = segments.Slice(0, segmentCount);
+        }
+        else
+        {
+            pooledArray = ArrayPool<StringSegment>.Shared.Rent(segmentCount);
+            segments = pooledArray.AsSpan(0, segmentCount);
+        }
+
+        int start = 0;
+        for (int i = 0; i < segments.Length; i++)
+        {
+            int index = input.IndexOf('\n');
+            if (index < 0)
+            {
+                segments[i] = new StringSegment(start, input.Length, 0);
+                break;
+            }
+
+            int newLineLength = 1;
+            if (index > 0 && input[index - 1] == '\r')
+            {
+                newLineLength++;
+                index--;
+            }
+
+            int totalLength = index + newLineLength;
+            segments[i] = new StringSegment(start, index, totalLength);
+
+            start += totalLength;
+            input = input.Slice(totalLength);
+        }
+
+        return segments;
+    }
+
+    private struct StringSegment
+    {
+        public StringSegment(int start, int length, int totalLength)
+        {
+            Start = start;
+            Length = length;
+            TotalLength = totalLength;
+        }
+
+        public int Start { get; }
+        public int Length { get; }
+        public int TotalLength { get; }
+    }
+
+#if !NET7_0_OR_GREATER
+    private static RentedBuilder RentBuilder(int capacity) => new RentedBuilder(capacity);
+
+    private ref struct RentedBuilder
+    {
+        // The maximum capacity for a StringBuilder that we'll cache.  StringBuilders with
+        // larger capacities will be allowed to be GC'd.
+        private const int MaxStringBuilderCapacity = 512;
+
+        private static StringBuilder? _cachedBuilder;
+
+        public RentedBuilder(int capacity)
+        {
+            Builder = Interlocked.Exchange(ref _cachedBuilder, null) ?? new StringBuilder(capacity);
+            Builder.EnsureCapacity(capacity);
+        }
+
+        public void Dispose()
+        {
+            // if builder's capacity is within our limits, return it to the cache
+            if (Builder.Capacity <= MaxStringBuilderCapacity)
+            {
+                Builder.Clear();
+                Interlocked.Exchange(ref _cachedBuilder, Builder);
+            }
+        }
+
+        public StringBuilder Builder { get; }
+    }
+#endif
+}

--- a/src/Build/Logging/OptimizedStringIndenter.cs
+++ b/src/Build/Logging/OptimizedStringIndenter.cs
@@ -5,9 +5,6 @@ using System;
 using System.Buffers;
 #if NET7_0_OR_GREATER
 using System.Runtime.CompilerServices;
-#else
-using System.Text;
-using System.Threading;
 #endif
 
 namespace Microsoft.Build.BackEnd.Logging;
@@ -89,17 +86,17 @@ internal static class OptimizedStringIndenter
         });
 #pragma warning restore CS8500
 #else
-        using RentedBuilder rental = RentBuilder(indentedStringLength);
+        StringBuilder builder = StringBuilderCache.Acquire(indentedStringLength);
 
         foreach (StringSegment segment in segments)
         {
-            rental.Builder
+            builder
                 .Append(' ', indent)
                 .Append(s, segment.Start, segment.Length)
                 .AppendLine();
         }
 
-        string result = rental.Builder.ToString();
+        string result = StringBuilderCache.GetStringAndRelease(builder);
 #endif
 
         if (pooledArray is not null)
@@ -180,35 +177,4 @@ internal static class OptimizedStringIndenter
         public int Length { get; }
         public int TotalLength { get; }
     }
-
-#if !NET7_0_OR_GREATER
-    private static RentedBuilder RentBuilder(int capacity) => new RentedBuilder(capacity);
-
-    private ref struct RentedBuilder
-    {
-        // The maximum capacity for a StringBuilder that we'll cache.  StringBuilders with
-        // larger capacities will be allowed to be GC'd.
-        private const int MaxStringBuilderCapacity = 512;
-
-        private static StringBuilder? _cachedBuilder;
-
-        public RentedBuilder(int capacity)
-        {
-            Builder = Interlocked.Exchange(ref _cachedBuilder, null) ?? new StringBuilder(capacity);
-            Builder.EnsureCapacity(capacity);
-        }
-
-        public void Dispose()
-        {
-            // if builder's capacity is within our limits, return it to the cache
-            if (Builder.Capacity <= MaxStringBuilderCapacity)
-            {
-                Builder.Clear();
-                Interlocked.Exchange(ref _cachedBuilder, Builder);
-            }
-        }
-
-        public StringBuilder Builder { get; }
-    }
-#endif
 }

--- a/src/Build/Logging/ParallelLogger/ConsoleOutputAligner.cs
+++ b/src/Build/Logging/ParallelLogger/ConsoleOutputAligner.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
         private readonly int _bufferWidth;
         private readonly bool _alignMessages;
-        private readonly IReusableStringBuilderProvider _stringBuilderProvider;
+        private readonly IStringBuilderProvider _stringBuilderProvider;
 
         /// <summary>
         /// Constructor.
@@ -29,7 +29,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="bufferWidth">Console buffer width. -1 if unknown/unlimited</param>
         /// <param name="alignMessages">Whether messages are aligned/wrapped into console buffer width</param>
         /// <param name="stringBuilderProvider"></param>
-        public ConsoleOutputAligner(int bufferWidth, bool alignMessages, IReusableStringBuilderProvider stringBuilderProvider)
+        public ConsoleOutputAligner(int bufferWidth, bool alignMessages, IStringBuilderProvider stringBuilderProvider)
         {
             _bufferWidth = bufferWidth;
             _alignMessages = alignMessages;

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 }
             }
 
-            _consoleOutputAligner = new ConsoleOutputAligner(_bufferWidth, _alignMessages, (IReusableStringBuilderProvider)this);
+            _consoleOutputAligner = new ConsoleOutputAligner(_bufferWidth, _alignMessages, (IStringBuilderProvider)this);
         }
 
         #endregion

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 }
             }
 
-            _consoleOutputAligner = new ConsoleOutputAligner(_bufferWidth, _alignMessages);
+            _consoleOutputAligner = new ConsoleOutputAligner(_bufferWidth, _alignMessages, (IReusableStringBuilderProvider)this);
         }
 
         #endregion

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -617,6 +617,7 @@
     <Compile Include="Logging\LoggerDescription.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Logging\OptimizedStringIndenter.cs" />
     <Compile Include="Logging\ParallelLogger\ParallelLoggerHelpers.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Framework/IStringBuilderProvider.cs
+++ b/src/Framework/IStringBuilderProvider.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+using System.Text;
+
+namespace Microsoft.Build.Framework;
+
+/// <summary>
+/// Provider of <see cref="StringBuilder"/> instances.
+/// Main design goal is for reusable String Builders and string builder pools.
+/// </summary>
+/// <remarks>
+/// It is up to particular implementations to decide how to handle unbalanced releases.
+/// </remarks>
+internal interface IStringBuilderProvider
+{
+    /// <summary>
+    /// Get a <see cref="StringBuilder"/> of at least the specified capacity.
+    /// </summary>
+    /// <param name="capacity">The suggested starting size of this instance.</param>
+    /// <returns>A <see cref="StringBuilder"/> that may or may not be reused.</returns>
+    /// <remarks>
+    /// It can be called any number of times; if a <see cref="StringBuilder"/> is in the cache then
+    /// it will be returned and the cache emptied. Subsequent calls will return a new <see cref="StringBuilder"/>.
+    /// </remarks>
+    StringBuilder Acquire(int capacity);
+
+    /// <summary>
+    /// Get a string and return its builder to the cache.
+    /// </summary>
+    /// <param name="builder">Builder to cache (if it's not too big).</param>
+    /// <returns>The <see langword="string"/> equivalent to <paramref name="builder"/>'s contents.</returns>
+    /// <remarks>
+    /// The StringBuilder should not be used after it has been released.
+    /// </remarks>
+    string GetStringAndRelease(StringBuilder builder);
+}


### PR DESCRIPTION
Fixes [Bug 1828095](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1828095): [GCPauseWatson] MSBuild: BaseConsoleLogger.IndentString uses String.Split and StringBuilder to create an indented string

GCPauseWatson telemetry showed that `BaseConsoleLogger.IndentString` is responsible for allocating 1.99 GB of memory in VS at the 95th percentile.  This change aims to address that by replacing the multiple allocations of `String.Split` and `StringBuilder` with code that makes a single allocation of a right-sized string and then builds the indented string directly in the new string's buffer.

Benchmarking shows that -- depending on the target framework -- the new algorithm runs in 50-75% of the time of the code it replaces, and allocates 15-30% of the memory.  The optimizations have more of an impact on net472 than on net7.0 due to the `String` and `StringBuilder` optimizations included in net7.0.

<details>
```
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22631.1900)
Intel Core i9-10900 CPU 2.80GHz, 1 CPU, 20 logical and 10 physical cores
  [Host]               : .NET Framework 4.8.1 (4.8.9166.0), X64 RyuJIT VectorSize=256
  .NET 7.0             : .NET 7.0.7 (7.0.723.27404), X64 RyuJIT AVX2
  .NET Framework 4.7.2 : .NET Framework 4.8.1 (4.8.9166.0), X64 RyuJIT VectorSize=256


|    Method |              Runtime | StringCount |         Mean | Ratio |     Gen0 |   Gen1 | Allocated | Alloc Ratio |
|----------:|---------------------:|------------:|-------------:|------:|---------:|-------:|----------:|------------:|
|  Original |             .NET 7.0 |           2 |   1,165.9 ns |  1.00 |   0.3052 |      - |    3192 B |        1.00 |
| Optimized |             .NET 7.0 |           2 |     803.1 ns |  0.69 |   0.0925 |      - |     976 B |        0.31 |
|           |                      |             |              |       |          |        |           |             |
|  Original | .NET Framework 4.7.2 |           2 |   1,832.6 ns |  1.00 |   1.0567 | 0.0038 |    6660 B |        1.00 |
| Optimized | .NET Framework 4.7.2 |           2 |     909.1 ns |  0.50 |   0.1554 |      - |     979 B |        0.15 |
|           |                      |             |              |       |          |        |           |             |
|  Original |             .NET 7.0 |           4 |   1,857.7 ns |  1.00 |   0.5150 |      - |    5400 B |        1.00 |
| Optimized |             .NET 7.0 |           4 |   1,383.5 ns |  0.74 |   0.1545 |      - |    1632 B |        0.30 |
|           |                      |             |              |       |          |        |           |             |
|  Original | .NET Framework 4.7.2 |           4 |   3,119.1 ns |  1.00 |   1.7738 | 0.0038 |   11177 B |        1.00 |
| Optimized | .NET Framework 4.7.2 |           4 |   1,603.1 ns |  0.51 |   0.2613 |      - |    1653 B |        0.15 |
|           |                      |             |              |       |          |        |           |             |
|  Original |             .NET 7.0 |           8 |   3,642.3 ns |  1.00 |   0.9766 |      - |   10232 B |        1.00 |
| Optimized |             .NET 7.0 |           8 |   2,716.4 ns |  0.75 |   0.2937 |      - |    3096 B |        0.30 |
|           |                      |             |              |       |          |        |           |             |
|  Original | .NET Framework 4.7.2 |           8 |   5,984.5 ns |  1.00 |   3.3417 | 0.0076 |   21070 B |        1.00 |
| Optimized | .NET Framework 4.7.2 |           8 |   3,130.6 ns |  0.52 |   0.4997 |      - |    3145 B |        0.15 |
|           |                      |             |              |       |          |        |           |             |
|  Original |             .NET 7.0 |          16 |   6,457.6 ns |  1.00 |   1.7242 |      - |   18096 B |        1.00 |
| Optimized |             .NET 7.0 |          16 |   4,698.2 ns |  0.73 |   0.5188 |      - |    5424 B |        0.30 |
|           |                      |             |              |       |          |        |           |             |
|  Original | .NET Framework 4.7.2 |          16 |  10,747.7 ns |  1.00 |   5.8136 | 0.0153 |   36628 B |        1.00 |
| Optimized | .NET Framework 4.7.2 |          16 |   5,735.8 ns |  0.53 |   0.8698 |      - |    5504 B |        0.15 |
|           |                      |             |              |       |          |        |           |             |
|  Original |             .NET 7.0 |          32 |  12,028.4 ns |  1.00 |   3.1891 |      - |   33360 B |        1.00 |
| Optimized |             .NET 7.0 |          32 |   9,267.4 ns |  0.77 |   0.9460 |      - |    9920 B |        0.30 |
|           |                      |             |              |       |          |        |           |             |
|  Original | .NET Framework 4.7.2 |          32 |  20,126.2 ns |  1.00 |  10.6201 | 0.0305 |   66918 B |        1.00 |
| Optimized | .NET Framework 4.7.2 |          32 |  10,968.9 ns |  0.54 |   1.6022 |      - |   10102 B |        0.15 |
|           |                      |             |              |       |          |        |           |             |
|  Original |             .NET 7.0 |          64 |  24,792.3 ns |  1.00 |   6.3477 |      - |   66552 B |        1.00 |
| Optimized |             .NET 7.0 |          64 |  18,397.9 ns |  0.74 |   1.8921 |      - |   19832 B |        0.30 |
|           |                      |             |              |       |          |        |           |             |
|  Original | .NET Framework 4.7.2 |          64 |  40,532.2 ns |  1.00 |  21.1792 |      - |  133610 B |        1.00 |
| Optimized | .NET Framework 4.7.2 |          64 |  22,522.4 ns |  0.56 |   3.1738 |      - |   20131 B |        0.15 |
|           |                      |             |              |       |          |        |           |             |
|  Original |             .NET 7.0 |         128 |  50,012.8 ns |  1.00 |  12.2681 |      - |  128672 B |        1.00 |
| Optimized |             .NET 7.0 |         128 |  37,066.0 ns |  0.74 |   3.6011 |      - |   38136 B |        0.30 |
|           |                      |             |              |       |          |        |           |             |
|  Original | .NET Framework 4.7.2 |         128 |  78,969.9 ns |  1.00 |  40.7715 |      - |  256999 B |        1.00 |
| Optimized | .NET Framework 4.7.2 |         128 |  44,377.9 ns |  0.56 |   6.1646 |      - |   38827 B |        0.15 |
|           |                      |             |              |       |          |        |           |             |
|  Original |             .NET 7.0 |         256 |  95,493.7 ns |  1.00 |  23.6816 |      - |  248544 B |        1.00 |
| Optimized |             .NET 7.0 |         256 |  71,305.1 ns |  0.75 |   6.9580 |      - |   73360 B |        0.30 |
|           |                      |             |              |       |          |        |           |             |
|  Original | .NET Framework 4.7.2 |         256 | 151,293.4 ns |  1.00 |  78.1250 |      - |  492317 B |        1.00 |
| Optimized | .NET Framework 4.7.2 |         256 |  86,210.2 ns |  0.57 |  11.8408 |      - |   74645 B |        0.15 |
|           |                      |             |              |       |          |        |           |             |
|  Original |             .NET 7.0 |         512 | 190,107.9 ns |  1.00 |  47.1191 |      - |  494032 B |        1.00 |
| Optimized |             .NET 7.0 |         512 | 142,247.7 ns |  0.75 |  13.9160 |      - |  145728 B |        0.29 |
|           |                      |             |              |       |          |        |           |             |
|  Original | .NET Framework 4.7.2 |         512 | 301,655.3 ns |  1.00 | 155.2734 |      - |  978898 B |        1.00 |
| Optimized | .NET Framework 4.7.2 |         512 | 177,835.2 ns |  0.59 |  23.4375 |      - |  148296 B |        0.15 |
```
</details>