### PR TITLE
Expose static methods from System.OperatingSystem

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -2806,6 +2806,38 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Assert.Equal(expectedExpansion, result);
         }
 
+        [WindowsFullFrameworkOnlyTheory]
+        [InlineData("windows")]
+        [InlineData("linux")]
+        [InlineData("macos")]
+        [InlineData("osx")]
+        public void IsOSPlatformFullFramework(string platform)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatform('{platform}'))";
+            string expected = platform.Equals("windows", StringComparison.OrdinalIgnoreCase) ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [DotNetOnlyTheory]
+        [InlineData("windows")]
+        [InlineData("linux")]
+        [InlineData("macos")]
+        [InlineData("osx")]
+        public void IsOSPlatformDotNet(string platform)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatform('{platform}'))";
+            bool result = false;
+#if NET5_0_OR_GREATER
+            result = System.OperatingSystem.IsOSPlatform(platform);
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
         [Theory]
         [InlineData("AString", "x12x456789x11", "$(AString.IndexOf('x', 1))", "3")]
         [InlineData("AString", "x12x456789x11", "$(AString.IndexOf('x45', 1))", "3")]

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -2806,31 +2806,19 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Assert.Equal(expectedExpansion, result);
         }
 
-        [WindowsFullFrameworkOnlyTheory]
+        [Theory]
         [InlineData("windows")]
         [InlineData("linux")]
         [InlineData("macos")]
         [InlineData("osx")]
-        public void IsOSPlatformFullFramework(string platform)
-        {
-            string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatform('{platform}'))";
-            string expected = platform.Equals("windows", StringComparison.OrdinalIgnoreCase) ? "True" : "False";
-            var pg = new PropertyDictionary<ProjectPropertyInstance>();
-            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
-            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
-        }
-
-        [DotNetOnlyTheory]
-        [InlineData("windows")]
-        [InlineData("linux")]
-        [InlineData("macos")]
-        [InlineData("osx")]
-        public void IsOSPlatformDotNet(string platform)
+        public void IsOSPlatform(string platform)
         {
             string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatform('{platform}'))";
             bool result = false;
 #if NET5_0_OR_GREATER
             result = System.OperatingSystem.IsOSPlatform(platform);
+#else
+            result = Microsoft.Build.Framework.OperatingSystem.IsOSPlatform(platform);
 #endif
             string expected = result ? "True" : "False";
             var pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2838,38 +2826,21 @@ namespace Microsoft.Build.UnitTests.Evaluation
             expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
         }
 
-        [WindowsFullFrameworkOnlyTheory]
-        [InlineData("windows", 4)]
-        [InlineData("linux", 0)]
-        [InlineData("macos", 10)]
-        [InlineData("macos", 999)]
-        [InlineData("osx", 0)]
-        public void IsOSPlatformVersionAtLeastFullFramework(string platform, int major)
-        {
-            string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatformVersionAtLeast('{platform}', {major}, 0, 0, 0))";
-            bool result = false;
-#if !NET5_0_OR_GREATER
-            result = Microsoft.Build.Framework.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, 0, 0, 0);
-#endif
-            string expected = result ? "True" : "False";
-            var pg = new PropertyDictionary<ProjectPropertyInstance>();
-            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
-            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
-        }
-
-        [DotNetOnlyTheory]
+        [Theory]
         [InlineData("windows", 4)]
         [InlineData("windows", 999)]
         [InlineData("linux", 0)]
         [InlineData("macos", 10)]
         [InlineData("macos", 999)]
         [InlineData("osx", 0)]
-        public void IsOSPlatformVersionAtLeastDotNet(string platform, int major)
+        public void IsOSPlatformVersionAtLeast(string platform, int major)
         {
             string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatformVersionAtLeast('{platform}', {major}, 0, 0, 0))";
             bool result = false;
 #if NET5_0_OR_GREATER
             result = System.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, 0, 0, 0);
+#else
+            result = Microsoft.Build.Framework.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, 0, 0, 0);
 #endif
             string expected = result ? "True" : "False";
             var pg = new PropertyDictionary<ProjectPropertyInstance>();

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -2816,7 +2816,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatform('{platform}'))";
             bool result = false;
 #if NET5_0_OR_GREATER
-            result = System.OperatingSystem.IsOSPlatform(platform);
+            result = OperatingSystem.IsOSPlatform(platform);
 #else
             result = Microsoft.Build.Framework.OperatingSystem.IsOSPlatform(platform);
 #endif
@@ -2838,7 +2838,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatformVersionAtLeast('{platform}', {major}, {minor}, {build}, {revision}))";
             bool result = false;
 #if NET5_0_OR_GREATER
-            result = System.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, minor, build, revision);
+            result = OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, minor, build, revision);
 #else
             result = Microsoft.Build.Framework.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, minor, build, revision);
 #endif
@@ -2851,10 +2851,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void IsLinux()
         {
-            string propertyFunction = $"$([System.OperatingSystem]::IsLinux())";
+            const string propertyFunction = "$([System.OperatingSystem]::IsLinux())";
             bool result = false;
 #if NET5_0_OR_GREATER
-            result = System.OperatingSystem.IsLinux();
+            result = OperatingSystem.IsLinux();
 #else
             result = Microsoft.Build.Framework.OperatingSystem.IsLinux();
 #endif
@@ -2867,7 +2867,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void IsFreeBSD()
         {
-            string propertyFunction = $"$([System.OperatingSystem]::IsFreeBSD())";
+            const string propertyFunction = "$([System.OperatingSystem]::IsFreeBSD())";
             bool result = false;
 #if NET5_0_OR_GREATER
             result = System.OperatingSystem.IsFreeBSD();
@@ -2888,7 +2888,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string propertyFunction = $"$([System.OperatingSystem]::IsFreeBSDVersionAtLeast({major}, {minor}, {build}, {revision}))";
             bool result = false;
 #if NET5_0_OR_GREATER
-            result = System.OperatingSystem.IsFreeBSDVersionAtLeast(major, minor, build, revision);
+            result = OperatingSystem.IsFreeBSDVersionAtLeast(major, minor, build, revision);
 #else
             result = Microsoft.Build.Framework.OperatingSystem.IsFreeBSDVersionAtLeast(major, minor, build, revision);
 #endif
@@ -2901,10 +2901,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void IsMacOS()
         {
-            string propertyFunction = $"$([System.OperatingSystem]::IsMacOS())";
+            const string propertyFunction = "$([System.OperatingSystem]::IsMacOS())";
             bool result = false;
 #if NET5_0_OR_GREATER
-            result = System.OperatingSystem.IsMacOS();
+            result = OperatingSystem.IsMacOS();
 #else
             result = Microsoft.Build.Framework.OperatingSystem.IsMacOS();
 #endif
@@ -2923,7 +2923,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string propertyFunction = $"$([System.OperatingSystem]::IsMacOSVersionAtLeast({major}, {minor}, {build}))";
             bool result = false;
 #if NET5_0_OR_GREATER
-            result = System.OperatingSystem.IsMacOSVersionAtLeast(major, minor, build);
+            result = OperatingSystem.IsMacOSVersionAtLeast(major, minor, build);
 #else
             result = Microsoft.Build.Framework.OperatingSystem.IsMacOSVersionAtLeast(major, minor, build);
 #endif
@@ -2936,10 +2936,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void IsWindows()
         {
-            string propertyFunction = $"$([System.OperatingSystem]::IsWindows())";
+            const string propertyFunction = "$([System.OperatingSystem]::IsWindows())";
             bool result = false;
 #if NET5_0_OR_GREATER
-            result = System.OperatingSystem.IsWindows();
+            result = OperatingSystem.IsWindows();
 #else
             result = Microsoft.Build.Framework.OperatingSystem.IsWindows();
 #endif
@@ -2958,7 +2958,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string propertyFunction = $"$([System.OperatingSystem]::IsWindowsVersionAtLeast({major}, {minor}, {build}, {revision}))";
             bool result = false;
 #if NET5_0_OR_GREATER
-            result = System.OperatingSystem.IsWindowsVersionAtLeast(major, minor, build, revision);
+            result = OperatingSystem.IsWindowsVersionAtLeast(major, minor, build, revision);
 #else
             result = Microsoft.Build.Framework.OperatingSystem.IsWindowsVersionAtLeast(major, minor, build, revision);
 #endif
@@ -2967,6 +2967,128 @@ namespace Microsoft.Build.UnitTests.Evaluation
             var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
             expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
         }
+
+#if NET5_0_OR_GREATER
+
+        [Fact]
+        public void IsAndroid()
+        {
+            const string propertyFunction = "$([System.OperatingSystem]::IsAndroid())";
+
+            string expected = OperatingSystem.IsAndroid() ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(999, 0, 0, 0)]
+        public void IsAndroidVersionAtLeast(int major, int minor, int build, int revision)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsAndroidVersionAtLeast({major}, {minor}, {build}, {revision}))";
+            string expected = OperatingSystem.IsAndroidVersionAtLeast(major, minor, build, revision) ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsIOS()
+        {
+            const string propertyFunction = "$([System.OperatingSystem]::IsIOS())";
+
+            string expected = OperatingSystem.IsIOS() ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(16, 5, 1)]
+        [InlineData(999, 0, 0)]
+        public void IsIOSVersionAtLeast(int major, int minor, int build)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsIOSVersionAtLeast({major}, {minor}, {build}))";
+            string expected = OperatingSystem.IsIOSVersionAtLeast(major, minor, build) ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsMacCatalyst()
+        {
+            const string propertyFunction = "$([System.OperatingSystem]::IsMacCatalyst())";
+
+            string expected = OperatingSystem.IsMacCatalyst() ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(999, 0, 0)]
+        public void IsMacCatalystVersionAtLeast(int major, int minor, int build)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsMacCatalystVersionAtLeast({major}, {minor}, {build}))";
+            string expected = OperatingSystem.IsMacCatalystVersionAtLeast(major, minor, build) ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsTvOS()
+        {
+            const string propertyFunction = "$([System.OperatingSystem]::IsTvOS())";
+
+            string expected = OperatingSystem.IsTvOS() ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(16, 5, 0)]
+        [InlineData(999, 0, 0)]
+        public void IsTvOSVersionAtLeast(int major, int minor, int build)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsTvOSVersionAtLeast({major}, {minor}, {build}))";
+            string expected = OperatingSystem.IsTvOSVersionAtLeast(major, minor, build) ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsWatchOS()
+        {
+            const string propertyFunction = "$([System.OperatingSystem]::IsWatchOS())";
+
+            string expected = OperatingSystem.IsWatchOS() ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(9, 5, 2)]
+        [InlineData(999, 0, 0)]
+        public void IsWatchOSVersionAtLeast(int major, int minor, int build)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsWatchOSVersionAtLeast({major}, {minor}, {build}))";
+            string expected = OperatingSystem.IsWatchOSVersionAtLeast(major, minor, build) ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+#endif
 
         [Theory]
         [InlineData("AString", "x12x456789x11", "$(AString.IndexOf('x', 1))", "3")]

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -2827,20 +2827,140 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Theory]
-        [InlineData("windows", 4)]
-        [InlineData("windows", 999)]
-        [InlineData("linux", 0)]
-        [InlineData("macos", 10)]
-        [InlineData("macos", 999)]
-        [InlineData("osx", 0)]
-        public void IsOSPlatformVersionAtLeast(string platform, int major)
+        [InlineData("windows", 4, 0, 0, 0)]
+        [InlineData("windows", 999, 0, 0, 0)]
+        [InlineData("linux", 0, 0, 0, 0)]
+        [InlineData("macos", 10, 15, 0, 0)]
+        [InlineData("macos", 999, 0, 0, 0)]
+        [InlineData("osx", 0, 0, 0, 0)]
+        public void IsOSPlatformVersionAtLeast(string platform, int major, int minor, int build, int revision)
         {
-            string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatformVersionAtLeast('{platform}', {major}, 0, 0, 0))";
+            string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatformVersionAtLeast('{platform}', {major}, {minor}, {build}, {revision}))";
             bool result = false;
 #if NET5_0_OR_GREATER
-            result = System.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, 0, 0, 0);
+            result = System.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, minor, build, revision);
 #else
-            result = Microsoft.Build.Framework.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, 0, 0, 0);
+            result = Microsoft.Build.Framework.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, minor, build, revision);
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsLinux()
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsLinux())";
+            bool result = false;
+#if NET5_0_OR_GREATER
+            result = System.OperatingSystem.IsLinux();
+#else
+            result = Microsoft.Build.Framework.OperatingSystem.IsLinux();
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsFreeBSD()
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsFreeBSD())";
+            bool result = false;
+#if NET5_0_OR_GREATER
+            result = System.OperatingSystem.IsFreeBSD();
+#else
+            result = Microsoft.Build.Framework.OperatingSystem.IsFreeBSD();
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(999, 0, 0, 0)]
+        public void IsFreeBSDVersionAtLeast(int major, int minor, int build, int revision)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsFreeBSDVersionAtLeast({major}, {minor}, {build}, {revision}))";
+            bool result = false;
+#if NET5_0_OR_GREATER
+            result = System.OperatingSystem.IsFreeBSDVersionAtLeast(major, minor, build, revision);
+#else
+            result = Microsoft.Build.Framework.OperatingSystem.IsFreeBSDVersionAtLeast(major, minor, build, revision);
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsMacOS()
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsMacOS())";
+            bool result = false;
+#if NET5_0_OR_GREATER
+            result = System.OperatingSystem.IsMacOS();
+#else
+            result = Microsoft.Build.Framework.OperatingSystem.IsMacOS();
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(10, 15, 0)]
+        [InlineData(999, 0, 0)]
+        public void IsMacOSVersionAtLeast(int major, int minor, int build)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsMacOSVersionAtLeast({major}, {minor}, {build}))";
+            bool result = false;
+#if NET5_0_OR_GREATER
+            result = System.OperatingSystem.IsMacOSVersionAtLeast(major, minor, build);
+#else
+            result = Microsoft.Build.Framework.OperatingSystem.IsMacOSVersionAtLeast(major, minor, build);
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsWindows()
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsWindows())";
+            bool result = false;
+#if NET5_0_OR_GREATER
+            result = System.OperatingSystem.IsWindows();
+#else
+            result = Microsoft.Build.Framework.OperatingSystem.IsWindows();
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(4, 0, 0, 0)]
+        [InlineData(999, 0, 0, 0)]
+        public void IsWindowsVersionAtLeast(int major, int minor, int build, int revision)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsWindowsVersionAtLeast({major}, {minor}, {build}, {revision}))";
+            bool result = false;
+#if NET5_0_OR_GREATER
+            result = System.OperatingSystem.IsWindowsVersionAtLeast(major, minor, build, revision);
+#else
+            result = Microsoft.Build.Framework.OperatingSystem.IsWindowsVersionAtLeast(major, minor, build, revision);
 #endif
             string expected = result ? "True" : "False";
             var pg = new PropertyDictionary<ProjectPropertyInstance>();

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -2838,6 +2838,45 @@ namespace Microsoft.Build.UnitTests.Evaluation
             expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
         }
 
+        [WindowsFullFrameworkOnlyTheory]
+        [InlineData("windows", 4)]
+        [InlineData("linux", 0)]
+        [InlineData("macos", 10)]
+        [InlineData("macos", 999)]
+        [InlineData("osx", 0)]
+        public void IsOSPlatformVersionAtLeastFullFramework(string platform, int major)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatformVersionAtLeast('{platform}', {major}, 0, 0, 0))";
+            bool result = false;
+#if !NET5_0_OR_GREATER
+            result = Microsoft.Build.Framework.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, 0, 0, 0);
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
+        [DotNetOnlyTheory]
+        [InlineData("windows", 4)]
+        [InlineData("windows", 999)]
+        [InlineData("linux", 0)]
+        [InlineData("macos", 10)]
+        [InlineData("macos", 999)]
+        [InlineData("osx", 0)]
+        public void IsOSPlatformVersionAtLeastDotNet(string platform, int major)
+        {
+            string propertyFunction = $"$([System.OperatingSystem]::IsOSPlatformVersionAtLeast('{platform}', {major}, 0, 0, 0))";
+            bool result = false;
+#if NET5_0_OR_GREATER
+            result = System.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major, 0, 0, 0);
+#endif
+            string expected = result ? "True" : "False";
+            var pg = new PropertyDictionary<ProjectPropertyInstance>();
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expected);
+        }
+
         [Theory]
         [InlineData("AString", "x12x456789x11", "$(AString.IndexOf('x', 1))", "3")]
         [InlineData("AString", "x12x456789x11", "$(AString.IndexOf('x45', 1))", "3")]

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -365,6 +365,14 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("Microsoft.Build.Utilities.ToolLocationHelper", new Tuple<string, Type>("Microsoft.Build.Utilities.ToolLocationHelper, Microsoft.Build.Utilities.Core, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null));
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.RuntimeInformation", runtimeInformationType);
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.OSPlatform", osPlatformType);
+#if !NET5_0_OR_GREATER
+                        // Add alternate type for System.OperatingSystem static methods.
+                        var operatingSystemType = new Tuple<string, Type>("Microsoft.Build.Framework.OperatingSystem, Microsoft.Build.Framework, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null);
+                        availableStaticMethods.TryAdd("System.OperatingSystem", operatingSystemType);
+                        availableStaticMethods.TryAdd("Microsoft.Build.Framework.OperatingSystem", operatingSystemType);
+#else
+                        availableStaticMethods.TryAdd("System.OperatingSystem", new Tuple<string, Type>(null, typeof(OperatingSystem)));
+#endif
 
                         s_availableStaticMethods = availableStaticMethods;
                     }

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -366,7 +366,16 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.RuntimeInformation", runtimeInformationType);
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.OSPlatform", osPlatformType);
 #if NET5_0_OR_GREATER
-                        availableStaticMethods.TryAdd("System.OperatingSystem", new Tuple<string, Type>(null, typeof(OperatingSystem)));
+                        var operatingSystemType = new Tuple<string, Type>(null, typeof(OperatingSystem));
+                        availableStaticMethods.TryAdd("System.OperatingSystem::IsOSPlatform", operatingSystemType);
+                        availableStaticMethods.TryAdd("System.OperatingSystem::IsOSPlatformVersionAtLeast", operatingSystemType);
+                        availableStaticMethods.TryAdd("System.OperatingSystem::IsLinux", operatingSystemType);
+                        availableStaticMethods.TryAdd("System.OperatingSystem::IsFreeBSD", operatingSystemType);
+                        availableStaticMethods.TryAdd("System.OperatingSystem::IsFreeBSDVersionAtLeast", operatingSystemType);
+                        availableStaticMethods.TryAdd("System.OperatingSystem::IsMacOS", operatingSystemType);
+                        availableStaticMethods.TryAdd("System.OperatingSystem::IsMacOSVersionAtLeast", operatingSystemType);
+                        availableStaticMethods.TryAdd("System.OperatingSystem::IsWindows", operatingSystemType);
+                        availableStaticMethods.TryAdd("System.OperatingSystem::IsWindowsVersionAtLeast", operatingSystemType);
 #else
                         // Add alternate type for System.OperatingSystem static methods which aren't available on .NET Framework.
                         var operatingSystemType = new Tuple<string, Type>("Microsoft.Build.Framework.OperatingSystem, Microsoft.Build.Framework, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null);

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -367,15 +367,7 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.OSPlatform", osPlatformType);
 #if NET5_0_OR_GREATER
                         var operatingSystemType = new Tuple<string, Type>(null, typeof(OperatingSystem));
-                        availableStaticMethods.TryAdd("System.OperatingSystem::IsOSPlatform", operatingSystemType);
-                        availableStaticMethods.TryAdd("System.OperatingSystem::IsOSPlatformVersionAtLeast", operatingSystemType);
-                        availableStaticMethods.TryAdd("System.OperatingSystem::IsLinux", operatingSystemType);
-                        availableStaticMethods.TryAdd("System.OperatingSystem::IsFreeBSD", operatingSystemType);
-                        availableStaticMethods.TryAdd("System.OperatingSystem::IsFreeBSDVersionAtLeast", operatingSystemType);
-                        availableStaticMethods.TryAdd("System.OperatingSystem::IsMacOS", operatingSystemType);
-                        availableStaticMethods.TryAdd("System.OperatingSystem::IsMacOSVersionAtLeast", operatingSystemType);
-                        availableStaticMethods.TryAdd("System.OperatingSystem::IsWindows", operatingSystemType);
-                        availableStaticMethods.TryAdd("System.OperatingSystem::IsWindowsVersionAtLeast", operatingSystemType);
+                        availableStaticMethods.TryAdd("System.OperatingSystem", operatingSystemType);
 #else
                         // Add alternate type for System.OperatingSystem static methods which aren't available on .NET Framework.
                         var operatingSystemType = new Tuple<string, Type>("Microsoft.Build.Framework.OperatingSystem, Microsoft.Build.Framework, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null);

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.RuntimeInformation", runtimeInformationType);
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.OSPlatform", osPlatformType);
 #if !NET5_0_OR_GREATER
-                        // Add alternate type for System.OperatingSystem static methods.
+                        // Add alternate type for System.OperatingSystem static methods which aren't available on .NET Framework.
                         var operatingSystemType = new Tuple<string, Type>("Microsoft.Build.Framework.OperatingSystem, Microsoft.Build.Framework, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null);
                         availableStaticMethods.TryAdd("System.OperatingSystem", operatingSystemType);
                         availableStaticMethods.TryAdd("Microsoft.Build.Framework.OperatingSystem", operatingSystemType);

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -365,13 +365,13 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("Microsoft.Build.Utilities.ToolLocationHelper", new Tuple<string, Type>("Microsoft.Build.Utilities.ToolLocationHelper, Microsoft.Build.Utilities.Core, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null));
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.RuntimeInformation", runtimeInformationType);
                         availableStaticMethods.TryAdd("System.Runtime.InteropServices.OSPlatform", osPlatformType);
-#if !NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
+                        availableStaticMethods.TryAdd("System.OperatingSystem", new Tuple<string, Type>(null, typeof(OperatingSystem)));
+#else
                         // Add alternate type for System.OperatingSystem static methods which aren't available on .NET Framework.
                         var operatingSystemType = new Tuple<string, Type>("Microsoft.Build.Framework.OperatingSystem, Microsoft.Build.Framework, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null);
                         availableStaticMethods.TryAdd("System.OperatingSystem", operatingSystemType);
                         availableStaticMethods.TryAdd("Microsoft.Build.Framework.OperatingSystem", operatingSystemType);
-#else
-                        availableStaticMethods.TryAdd("System.OperatingSystem", new Tuple<string, Type>(null, typeof(OperatingSystem)));
 #endif
 
                         s_availableStaticMethods = availableStaticMethods;

--- a/src/Framework.UnitTests/OperatingSystem_Tests.cs
+++ b/src/Framework.UnitTests/OperatingSystem_Tests.cs
@@ -10,57 +10,48 @@ namespace Microsoft.Build.Framework.UnitTests
 {
     public class OperatingSystem_Tests
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters", Justification = "Don't complain when test body is empty")]
+#if !NET5_0_OR_GREATER
         [WindowsFullFrameworkOnlyTheory]
         [InlineData("windows", true)]
         [InlineData("linux", false)]
         [InlineData("macOS", false)]
         public void IsOSPlatform(string platform, bool expected)
         {
-#if !NET5_0_OR_GREATER
             Microsoft.Build.Framework.OperatingSystem.IsOSPlatform(platform).ShouldBe(expected);
-#endif
+        }
+
+        [WindowsFullFrameworkOnlyTheory]
+        [InlineData("windows", 4, true)]
+        [InlineData("windows", 999, false)]
+        [InlineData("linux", 0, false)]
+        [InlineData("macOS", 0, false)]
+        public void IsOSPlatformVersionAtLeast(string platform, int major, bool expected)
+        {
+            Microsoft.Build.Framework.OperatingSystem.IsOSPlatformVersionAtLeast(platform, major).ShouldBe(expected);
         }
 
         [WindowsFullFrameworkOnlyFact]
         public void IsWindows()
         {
-#if !NET5_0_OR_GREATER
             Microsoft.Build.Framework.OperatingSystem.IsWindows().ShouldBeTrue();
-#endif
         }
 
         [WindowsFullFrameworkOnlyFact]
         public void IsWindowsVersionAtLeast()
         {
-#if !NET5_0_OR_GREATER
             Microsoft.Build.Framework.OperatingSystem.IsWindowsVersionAtLeast(4).ShouldBeTrue();
-#endif
         }
 
         [WindowsFullFrameworkOnlyFact]
         public void IsOtherThanWindows()
         {
-#if !NET5_0_OR_GREATER
-            Microsoft.Build.Framework.OperatingSystem.IsAndroid().ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsAndroidVersionAtLeast(0).ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsBrowser().ShouldBeFalse();
             Microsoft.Build.Framework.OperatingSystem.IsFreeBSD().ShouldBeFalse();
             Microsoft.Build.Framework.OperatingSystem.IsFreeBSDVersionAtLeast(0).ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsIOS().ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsIOSVersionAtLeast(0).ShouldBeFalse();
             Microsoft.Build.Framework.OperatingSystem.IsLinux().ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsMacCatalyst().ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsMacCatalystVersionAtLeast(0).ShouldBeFalse();
             Microsoft.Build.Framework.OperatingSystem.IsMacOS().ShouldBeFalse();
             Microsoft.Build.Framework.OperatingSystem.IsMacOSVersionAtLeast(0).ShouldBeFalse();
             Microsoft.Build.Framework.OperatingSystem.IsOSXLike().ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsTvOS().ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsTvOSVersionAtLeast(0).ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsWasi().ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsWatchOS().ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsWatchOSVersionAtLeast(0).ShouldBeFalse();
-#endif
         }
+#endif
     }
 }

--- a/src/Framework.UnitTests/OperatingSystem_Tests.cs
+++ b/src/Framework.UnitTests/OperatingSystem_Tests.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Shouldly;
+
+using Xunit;
+using Xunit.NetCore.Extensions;
+
+namespace Microsoft.Build.Framework.UnitTests
+{
+    public class OperatingSystem_Tests
+    {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters", Justification = "Don't complain when test body is empty")]
+        [WindowsFullFrameworkOnlyTheory]
+        [InlineData("windows", true)]
+        [InlineData("linux", false)]
+        [InlineData("macOS", false)]
+        public void IsOSPlatform(string platform, bool expected)
+        {
+#if !NET5_0_OR_GREATER
+            Microsoft.Build.Framework.OperatingSystem.IsOSPlatform(platform).ShouldBe(expected);
+#endif
+        }
+
+        [WindowsFullFrameworkOnlyFact]
+        public void IsWindows()
+        {
+#if !NET5_0_OR_GREATER
+            Microsoft.Build.Framework.OperatingSystem.IsWindows().ShouldBeTrue();
+#endif
+        }
+
+        [WindowsFullFrameworkOnlyFact]
+        public void IsWindowsVersionAtLeast()
+        {
+#if !NET5_0_OR_GREATER
+            Microsoft.Build.Framework.OperatingSystem.IsWindowsVersionAtLeast(4).ShouldBeTrue();
+#endif
+        }
+
+        [WindowsFullFrameworkOnlyFact]
+        public void IsOtherThanWindows()
+        {
+#if !NET5_0_OR_GREATER
+            Microsoft.Build.Framework.OperatingSystem.IsAndroid().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsAndroidVersionAtLeast(0).ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsBrowser().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsFreeBSD().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsFreeBSDVersionAtLeast(0).ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsIOS().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsIOSVersionAtLeast(0).ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsLinux().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsMacCatalyst().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsMacCatalystVersionAtLeast(0).ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsMacOS().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsMacOSVersionAtLeast(0).ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsOSXLike().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsTvOS().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsTvOSVersionAtLeast(0).ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsWasi().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsWatchOS().ShouldBeFalse();
+            Microsoft.Build.Framework.OperatingSystem.IsWatchOSVersionAtLeast(0).ShouldBeFalse();
+#endif
+        }
+    }
+}

--- a/src/Framework.UnitTests/OperatingSystem_Tests.cs
+++ b/src/Framework.UnitTests/OperatingSystem_Tests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Build.Framework.UnitTests
         public void IsWindowsVersionAtLeast()
         {
             Microsoft.Build.Framework.OperatingSystem.IsWindowsVersionAtLeast(4).ShouldBeTrue();
+            Microsoft.Build.Framework.OperatingSystem.IsWindowsVersionAtLeast(999).ShouldBeFalse();
         }
 
         [WindowsFullFrameworkOnlyFact]

--- a/src/Framework.UnitTests/OperatingSystem_Tests.cs
+++ b/src/Framework.UnitTests/OperatingSystem_Tests.cs
@@ -51,7 +51,6 @@ namespace Microsoft.Build.Framework.UnitTests
             Microsoft.Build.Framework.OperatingSystem.IsLinux().ShouldBeFalse();
             Microsoft.Build.Framework.OperatingSystem.IsMacOS().ShouldBeFalse();
             Microsoft.Build.Framework.OperatingSystem.IsMacOSVersionAtLeast(0).ShouldBeFalse();
-            Microsoft.Build.Framework.OperatingSystem.IsOSXLike().ShouldBeFalse();
         }
 #endif
     }

--- a/src/Framework/OperatingSystem.cs
+++ b/src/Framework/OperatingSystem.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET5_0_OR_GREATER
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// System.OperatingSystem static methods were added in .Net 5.0.
+    /// This class create stand-in methods for net472 builds.
+    /// Assumes only Windows is supported.
+    /// </summary>
+    public static class OperatingSystem
+    {
+        public static bool IsOSPlatform(string platform)
+        {
+            return platform?.Equals("WINDOWS", StringComparison.OrdinalIgnoreCase) ?? throw new ArgumentNullException(nameof(platform));
+        }
+
+        public static bool IsOSPlatformVersionAtLeast(string platform, int major, int minor = 0, int build = 0, int revision = 0)
+            => IsOSPlatform(platform) && IsOSVersionAtLeast(major, minor, build, revision);
+
+        public static bool IsBrowser() => false;
+
+        public static bool IsWasi() => false;
+
+        public static bool IsLinux() => false;
+
+        public static bool IsFreeBSD() => false;
+
+        public static bool IsFreeBSDVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) => false;
+
+        public static bool IsAndroid() => false;
+
+        public static bool IsAndroidVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) => false;
+
+        public static bool IsIOS() => false;
+
+        public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
+
+        public static bool IsMacOS() => false;
+
+        public static bool IsOSXLike() => false;
+
+        public static bool IsMacOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
+
+        public static bool IsMacCatalyst() => false;
+
+        public static bool IsMacCatalystVersionAtLeast(int major, int minor = 0, int build = 0) => false;
+
+        public static bool IsTvOS() => false;
+
+        public static bool IsTvOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
+
+        public static bool IsWatchOS() => false;
+
+        public static bool IsWatchOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
+
+        public static bool IsWindows() => true;
+
+        public static bool IsWindowsVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0)
+            => IsWindows() && IsOSVersionAtLeast(major, minor, build, revision);
+
+        private static bool IsOSVersionAtLeast(int major, int minor, int build, int revision)
+        {
+            Version current = Environment.OSVersion.Version;
+
+            if (current.Major != major)
+            {
+                return current.Major > major;
+            }
+
+            if (current.Minor != minor)
+            {
+                return current.Minor > minor;
+            }
+
+            if (current.Build != build)
+            {
+                return current.Build > build;
+            }
+
+            return current.Revision >= revision;
+        }
+    }
+}
+#endif
+

--- a/src/Framework/OperatingSystem.cs
+++ b/src/Framework/OperatingSystem.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Framework
 {
     /// <summary>
     /// System.OperatingSystem static methods were added in net5.0.
-    /// This class create stand-in methods for net472 builds.
+    /// This class creates stand-in methods for net472 builds.
     /// Assumes only Windows is supported.
     /// </summary>
     internal static class OperatingSystem

--- a/src/Framework/OperatingSystem.cs
+++ b/src/Framework/OperatingSystem.cs
@@ -30,8 +30,6 @@ namespace Microsoft.Build.Framework
 
         public static bool IsMacOS() => false;
 
-        public static bool IsOSXLike() => false;
-
         public static bool IsMacOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
 
         public static bool IsWindows() => true;

--- a/src/Framework/OperatingSystem.cs
+++ b/src/Framework/OperatingSystem.cs
@@ -8,7 +8,7 @@ using System;
 namespace Microsoft.Build.Framework
 {
     /// <summary>
-    /// System.OperatingSystem static methods were added in .Net 5.0.
+    /// System.OperatingSystem static methods were added in net5.0.
     /// This class create stand-in methods for net472 builds.
     /// Assumes only Windows is supported.
     /// </summary>

--- a/src/Framework/OperatingSystem.cs
+++ b/src/Framework/OperatingSystem.cs
@@ -22,41 +22,17 @@ namespace Microsoft.Build.Framework
         public static bool IsOSPlatformVersionAtLeast(string platform, int major, int minor = 0, int build = 0, int revision = 0)
             => IsOSPlatform(platform) && IsOSVersionAtLeast(major, minor, build, revision);
 
-        public static bool IsBrowser() => false;
-
-        public static bool IsWasi() => false;
-
         public static bool IsLinux() => false;
 
         public static bool IsFreeBSD() => false;
 
         public static bool IsFreeBSDVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) => false;
 
-        public static bool IsAndroid() => false;
-
-        public static bool IsAndroidVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) => false;
-
-        public static bool IsIOS() => false;
-
-        public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
-
         public static bool IsMacOS() => false;
 
         public static bool IsOSXLike() => false;
 
         public static bool IsMacOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
-
-        public static bool IsMacCatalyst() => false;
-
-        public static bool IsMacCatalystVersionAtLeast(int major, int minor = 0, int build = 0) => false;
-
-        public static bool IsTvOS() => false;
-
-        public static bool IsTvOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
-
-        public static bool IsWatchOS() => false;
-
-        public static bool IsWatchOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
 
         public static bool IsWindows() => true;
 

--- a/src/Framework/OperatingSystem.cs
+++ b/src/Framework/OperatingSystem.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.Framework
     /// This class create stand-in methods for net472 builds.
     /// Assumes only Windows is supported.
     /// </summary>
-    public static class OperatingSystem
+    internal static class OperatingSystem
     {
         public static bool IsOSPlatform(string platform)
         {

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2369,7 +2369,6 @@ $@"<Project>
             success.ShouldBe(expectedSuccess);
         }
 
-        // Test failed due to timeout. Windows-on-Core Full Framework.
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
         [Fact]

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2369,6 +2369,7 @@ $@"<Project>
             success.ShouldBe(expectedSuccess);
         }
 
+        // Test failed due to timeout. Windows-on-Core Full Framework.
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
         [Fact]


### PR DESCRIPTION
Fixes #5982

### Context
Expose methods added in .Net 5.0. Create alternate stand-in for net471.

### Changes Made
- Add `Microsoft.Build.Framework.OperatingSystem` as stand-in substitute for net471. The class assumes that only Windows is supported.
- Add unit tests for `Microsoft.Build.Framework.OperatingSystem`.
- Modify Constants.cs to static methods either from `System.OperatingSystem` or from `Microsoft.Build.Framework.OperatingSystem`.
- Add unit tests for `IsOSPlatform` property function

### Testing
Tested on windows 11 and macOS 12. tested by running full suite of unit test.

### Notes
