### PR TITLE
Fix AssemblyLoadBuildEventArgs transfering

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -228,12 +228,24 @@ namespace Microsoft.Build.UnitTests
                 BinaryLogger logger = new();
                 logger.Parameters = _logFile;
                 env.SetEnvironmentVariable("MSBUILDNOINPROCNODE", "1");
-                RunnerUtilities.ExecMSBuild($"{projectFile.Path} -nr:False -bl:{logger.Parameters}", out bool success);
+                RunnerUtilities.ExecMSBuild($"{projectFile.Path} -nr:False -bl:{logger.Parameters} -flp1:logfile={Path.Combine(logFolder.Path, "logFile.log")};verbosity=diagnostic -flp2:logfile={Path.Combine(logFolder.Path, "logFile2.log")};verbosity=normal", out bool success);
                 success.ShouldBeTrue();
-                RunnerUtilities.ExecMSBuild($"{logger.Parameters} -flp:logfile={Path.Combine(logFolder.Path, "logFile.log")};verbosity=diagnostic", out success);
-                success.ShouldBeTrue();
+
+                string assemblyLoadedEventText =
+                    "Assembly loaded during TaskRun (InlineCode.HelloWorld): System.Diagnostics.Debug";
                 string text = File.ReadAllText(Path.Combine(logFolder.Path, "logFile.log"));
-                text.ShouldContain("Assembly loaded during TaskRun (InlineCode.HelloWorld): System.Diagnostics.Debug");
+                text.ShouldContain(assemblyLoadedEventText);
+                // events should not be in logger with verbosity normal
+                string text2 = File.ReadAllText(Path.Combine(logFolder.Path, "logFile2.log"));
+                text2.ShouldNotContain(assemblyLoadedEventText);
+
+                RunnerUtilities.ExecMSBuild($"{logger.Parameters} -flp1:logfile={Path.Combine(logFolder.Path, "logFile3.log")};verbosity=diagnostic -flp2:logfile={Path.Combine(logFolder.Path, "logFile4.log")};verbosity=normal", out success);
+                success.ShouldBeTrue();
+                text = File.ReadAllText(Path.Combine(logFolder.Path, "logFile3.log"));
+                text.ShouldContain(assemblyLoadedEventText);
+                // events should not be in logger with verbosity normal
+                text2 = File.ReadAllText(Path.Combine(logFolder.Path, "logFile4.log"));
+                text2.ShouldNotContain(assemblyLoadedEventText);
             }
         }
 

--- a/src/Framework.UnitTests/AssemblyLoadBuildEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/AssemblyLoadBuildEventArgs_Tests.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Build.Framework.UnitTests
             stream.Position = 0;
             using BinaryReader br = new BinaryReader(stream);
             AssemblyLoadBuildEventArgs argDeserialized = new();
-            argDeserialized.CreateFromStream(br, 0);
+            int packetVersion = (Environment.Version.Major * 10) + Environment.Version.Minor;
+            argDeserialized.CreateFromStream(br, packetVersion);
 
             argDeserialized.LoadingInitiator.ShouldBe(loadingInitiator);
             argDeserialized.AssemblyName.ShouldBe(assemblyName);
@@ -37,6 +38,7 @@ namespace Microsoft.Build.Framework.UnitTests
             argDeserialized.MVID.ShouldBe(mvid);
             argDeserialized.AppDomainDescriptor.ShouldBe(appDomainName);
             argDeserialized.LoadingContext.ShouldBe(context);
+            argDeserialized.Importance.ShouldBe(arg.Importance);
         }
     }
 }

--- a/src/Framework/AssemblyLoadBuildEventArgs.cs
+++ b/src/Framework/AssemblyLoadBuildEventArgs.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Build.Framework
 
         internal override void WriteToStream(BinaryWriter writer)
         {
+            base.WriteToStream(writer);
+
             writer.Write7BitEncodedInt((int)LoadingContext);
             writer.WriteTimestamp(RawTimestamp);
             writer.WriteOptionalBuildEventContext(BuildEventContext);
@@ -56,6 +58,8 @@ namespace Microsoft.Build.Framework
 
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
+            base.CreateFromStream(reader, version);
+
             LoadingContext = (AssemblyLoadingContext)reader.Read7BitEncodedInt();
             RawTimestamp = reader.ReadTimestamp();
             BuildEventContext = reader.ReadOptionalBuildEventContext();

--- a/src/Framework/AssemblyLoadBuildEventArgs.cs
+++ b/src/Framework/AssemblyLoadBuildEventArgs.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Build.Framework
             Guid mvid,
             string? customAppDomainDescriptor,
             MessageImportance importance = MessageImportance.Low)
-            : base(null, null, null, importance, DateTime.UtcNow, assemblyName, assemblyPath, mvid)
+            : base(null, null, null, importance, DateTime.UtcNow, null)
         {
             LoadingContext = loadingContext;
             LoadingInitiator = loadingInitiator;


### PR DESCRIPTION
Fixes #8784

Credit for finding the issue with serialization: @rokonec 

### Context
AssemblyLoad log messages were appearing in the VS output window based on file logger verbosity

### Changes Made
AssemblyLoadBuildEventArgs  were not de/serializing it's `Importance`. The default value is `High`. So if another logger was consuming LowImportnace messages - including AssemblyLoadBuildEventArgs , then those were in multiprocess build transfered to main node, where their `Importance` jumped to `High` - and hence they got consumed by other loggers with lower verbosity (including VS output).