### PR TITLE
Add more packages to Version.Details for source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,8 +6,9 @@
       <Sha>525b6c35cc5c5c9b80b47044be2e4e77858d505a</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
-      and flow in as dependencies of the packages produced by msbuild. -->
+    <!-- Necessary for source-build due to being a transitive dependency of System.Reflection.MetadataLoadContext.
+      This allows the package to be retrieved from previously-source-built artifacts and flow in as dependencies
+      of the packages produced by msbuild. -->
     <Dependency Name="System.Collections.Immutable" Version="7.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,12 +6,32 @@
       <Sha>525b6c35cc5c5c9b80b47044be2e4e77858d505a</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <!-- Necessary for source-build. This allows the packages to be retrieved from previously-source-built artifacts
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+      and flow in as dependencies of the packages produced by msbuild. -->
+    <Dependency Name="System.Collections.Immutable" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
       and flow in as dependencies of the packages produced by msbuild. -->
     <Dependency Name="System.Configuration.ConfigurationManager" Version="7.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+      and flow in as dependencies of the packages produced by msbuild. -->
+    <Dependency Name="System.Reflection.Metadata" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+      and flow in as dependencies of the packages produced by msbuild. -->
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+      and flow in as dependencies of the packages produced by msbuild. -->
     <Dependency Name="System.Security.Cryptography.Pkcs" Version="7.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>


### PR DESCRIPTION
Contributes to dotnet/source-build#3528

### Context

When attempting to run an MSBuild command from an SDK that was source-built using the Mono runtime, the following exception occurs:

```
MSBUILD : error MSB1021: Cannot create an instance of the logger. Microsoft.Build.BackEnd.Logging.CentralForwardingLogger Could not load type of field 'Microsoft.Build.Shared.TypeLoader:_context' (4) due to: Could not load file or assembly 'System.Reflection.MetadataLoadContext, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies.
```

This is a regression caused by the change in https://github.com/dotnet/installer/pull/16637. That change allowed the msbuild repo to compile against the package versions that it defines rather than source-build overriding the package version with the current source-built version. For example, the msbuild repo will target System.Reflection.MetadataLoadContext.7.0.0: https://github.com/dotnet/msbuild/blob/83ac8d91e92a16f33823ac2b8cb4cd5a14dc62a0/eng/Versions.props#L38 

Prior to the change in https://github.com/dotnet/installer/pull/16637, source-build would have overridden that version and forced the msbuild repo to use the version of `System.Reflection.MetadataLoadContext` that was just produced during its build. But after the change, the 7.0.0 version is being referenced. The referencing of a 7.0.0 version doesn't cause prebuilts because that version is defined in [SBRP](https://github.com/dotnet/source-build-reference-packages).

Referencing a 7.0.0 version is fine as long as it's only a build-time dependency and not runtime. A runtime dependency will cause an attempt to load that 7.0.0 version which will not exist for an 8.0 source-built SDK. That's exactly what happens here with this error. There must be some code path specific to Mono that causes a code path which depends on `System.Reflection.MetadataLoadContext`.

### Changes Made

Added the following packages to Version.Details.xml:

* `System.Collections.Immutable.7.0.0`
* `System.Reflection.Metadata.7.0.0`
* `System.Reflection.MetadataLoadContext.7.0.0`

Their presence in this file will cause source-build to override the corresponding `Version` property (e.g. `SystemReflectionMetadataLoadContextVersion`) so that it uses the "live" version (the version just produced by source-build in the current build). Even though the dependency only exists on `System.Reflection.MetadataLoadContext`, the other two packages need to be listed as well since those are transitive dependencies. Not listing them would cause package downgrade errors since a newer version of `System.Reflection.MetadataLoadContext` would be referenced with older versions of the other assemblies.

I've also updated the comments in this file so that they are applied to each package. This avoids ambiguity as to which packages the original comment applied to.