### PR TITLE
Send AssemblyLoadBuildEventArgs only for valid LoggingContext

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
@@ -157,11 +157,14 @@ namespace Microsoft.Build.BackEnd.Components.RequestBuilder
                 : $"{_appDomain.Id}|{_appDomain.FriendlyName}";
 
 
-            AssemblyLoadBuildEventArgs buildArgs = new(_context, _initiator, assemblyName, assemblyPath, mvid, appDomainDescriptor)
+            AssemblyLoadBuildEventArgs buildArgs = new(_context, _initiator, assemblyName, assemblyPath, mvid, appDomainDescriptor);
+
+            // Fix #8816 - when LoggingContext does not have BuildEventContext it is unable to log anything
+            if (_loggingContext?.BuildEventContext != null)
             {
-                BuildEventContext = _loggingContext?.BuildEventContext ?? BuildEventContext.Invalid
-            };
-            _loggingContext?.LogBuildEvent(buildArgs);
+                buildArgs.BuildEventContext = _loggingContext.BuildEventContext;
+                _loggingContext.LogBuildEvent(buildArgs);
+            }
             _loggingService?.LogBuildEvent(buildArgs);
         }
 


### PR DESCRIPTION
Fixes #8816

### Context
As discussed in #8816 we are trying the simplest solution, i.e. do not fail when LoggingContext is not yet properly initialized.

### Changes Made
Simple IF

### Testing
Local.

### Notes
@KirillOsenkov Can you please test if this PR addresses #8816 issue properly?
