### PR TITLE
Fix copy cancelation

### DIFF
--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -422,9 +422,18 @@ namespace Microsoft.Build.Tasks
 
             // Use single-threaded code path when requested or when there is only copy to make
             // (no need to create all the parallel infrastructure for that case).
-            bool success = parallelism == 1 || DestinationFiles.Length == 1
-                ? CopySingleThreaded(copyFile, out destinationFilesSuccessfullyCopied)
-                : CopyParallel(copyFile, parallelism, out destinationFilesSuccessfullyCopied);
+            bool success = false;
+
+            try
+            {
+                success = parallelism == 1 || DestinationFiles.Length == 1
+                    ? CopySingleThreaded(copyFile, out destinationFilesSuccessfullyCopied)
+                    : CopyParallel(copyFile, parallelism, out destinationFilesSuccessfullyCopied);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
 
             // copiedFiles contains only the copies that were successful.
             CopiedFiles = destinationFilesSuccessfullyCopied.ToArray();


### PR DESCRIPTION
Fix https://github.com/dotnet/msbuild/issues/3891

Ctrl-C calls Cancel() on the task. That signals the cancelation token we [pass into the ActionBlock](https://github.com/dotnet/msbuild/blob/92f3600820b5d5da87e4a0dcf141c709d0817a03/src/Tasks/Copy.cs#L561) which throws an exception that we do not catch.

Note: the exception is caught in two other places; those are still required as they would otherwise be caught in the generic catch there and log and error.

No unit test here is really feasible without exceptional efforts.