### PR TITLE
Fix /warnaserror false positive overall success

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2466,7 +2466,6 @@ namespace Microsoft.Build.Execution
                     // shut down.
                     submission.CompleteLogging();
 
-                    _overallBuildSuccess = _overallBuildSuccess && (submission.BuildResult.OverallResult == BuildResultCode.Success);
                     CheckSubmissionCompletenessAndRemove(submission);
                 }
 
@@ -2480,7 +2479,6 @@ namespace Microsoft.Build.Execution
 
                     submission.CompleteResults(new GraphBuildResult(submission.SubmissionId, new BuildAbortedException()));
 
-                    _overallBuildSuccess &= submission.BuildResult.OverallResult == BuildResultCode.Success;
                     CheckSubmissionCompletenessAndRemove(submission);
                 }
 
@@ -2592,8 +2590,6 @@ namespace Microsoft.Build.Execution
 
                     submission.CompleteResults(result);
 
-                    _overallBuildSuccess = _overallBuildSuccess && (_buildSubmissions[result.SubmissionId].BuildResult.OverallResult == BuildResultCode.Success);
-
                     CheckSubmissionCompletenessAndRemove(submission);
                 }
             }
@@ -2611,8 +2607,6 @@ namespace Microsoft.Build.Execution
                 {
                     submission.CompleteResults(result);
 
-                    _overallBuildSuccess &= submission.BuildResult.OverallResult == BuildResultCode.Success;
-
                     CheckSubmissionCompletenessAndRemove(submission);
                 }
             }
@@ -2628,6 +2622,7 @@ namespace Microsoft.Build.Execution
                 // If the submission has completed or never started, remove it.
                 if (submission.IsCompleted || submission.BuildRequest == null)
                 {
+                    _overallBuildSuccess &= (submission.BuildResult?.OverallResult == BuildResultCode.Success);
                     _buildSubmissions.Remove(submission.SubmissionId);
 
                     // Clear all cached SDKs for the submission
@@ -2648,6 +2643,7 @@ namespace Microsoft.Build.Execution
                 // If the submission has completed or never started, remove it.
                 if (submission.IsCompleted || !submission.IsStarted)
                 {
+                    _overallBuildSuccess &= submission.BuildResult?.OverallResult == BuildResultCode.Success;
                     _graphBuildSubmissions.Remove(submission.SubmissionId);
 
                     // Clear all cached SDKs for the submission


### PR DESCRIPTION
Fixes #8735, possibly #5689, #2845

### Context
There were race condition when `ProjectFinished` log message has been processed after `BuildResult` event. Even though `ProjectFinished` log message event is always send before `BuildResult` event from Node, because `ProjectFinished` is asyncronously routed by `LoggingService` reversing order can and do often happen.

### Changes Made
Updating `_overallBuildSuccess` in one place when submission is considered to be done and assumed its final state.

### Testing
Can't local repro.