### PR TITLE
Issue 8963

### DIFF
--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -192,15 +192,14 @@ namespace Microsoft.Build.Construction
         public IReadOnlyDictionary<string, ProjectInSolution> ProjectsByGuid => new ReadOnlyDictionary<string, ProjectInSolution>(_projects);
 
         /// <summary>
-        /// This is the read/write accessor for the solution file which we will parse.  This
-        /// must be set before calling any other methods on this class.
+        /// Gets a <see cref="T:System.String" /> value that contains the fully-qualified pathname of the Solution file that has been parsed.
         /// </summary>
-        /// <value></value>
-        internal string FullPath
+        // NOTE: This is the read/write accessor that is used internally for the Solution file which we will parse.  This must be set before calling any other methods on this class.
+        public string FullPath
         {
             get => _solutionFile;
 
-            set
+            internal set
             {
                 // Should already be canonicalized to a full path
                 ErrorUtilities.VerifyThrowInternalRooted(value);
@@ -223,11 +222,13 @@ namespace Microsoft.Build.Construction
             }
         }
 
-        internal string SolutionFileDirectory
+        /// <summary>
+        /// Gets a <see cref="T:System.String" /> containing the fully-qualified
+        /// pathname of the folder in which this Solution's file resides.
+        /// </summary
+        public string SolutionFileDirectory
         {
-            get;
-            // This setter is only used by the unit tests
-            set;
+            get; internal set; // The setter is only used by unit tests.
         }
 
         /// <summary>

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -218,13 +218,15 @@ namespace Microsoft.Build.Construction
                     _solutionFilter = null;
 
                     // Only set the value of the SolutionFileDirectory property
-                    // if, and only if, the _solutionFile field is non blank and the 
+                    // if, and only if, the _solutionFile field is non-blank and the 
                     // _solutionFile field contains the fully-qualified pathname of
                     // a file that actually exists on the disk.
                     if (!string.IsNullOrWhiteSpace(_solutionFile)
                         && File.Exists(_solutionFile)
                         && IsExtensionValid(_solutionFile))
+                    {
                       SolutionFileDirectory = Path.GetDirectoryName(_solutionFile);
+                    }
                 }
             }
         }
@@ -251,8 +253,8 @@ namespace Microsoft.Build.Construction
         }
   
         /// <summary>
-        /// Gets a <see cref="T:System.String" /> containing the fully-qualified
-        /// pathname of the folder in which this Solution's file resides.
+        /// Gets a <see cref="System.String" /> containing the fully-qualified
+        /// pathname of the folder in which this Solution file resides.
         /// </summary
         public string SolutionFileDirectory
         {

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Build.Construction
         public IReadOnlyDictionary<string, ProjectInSolution> ProjectsByGuid => new ReadOnlyDictionary<string, ProjectInSolution>(_projects);
 
         /// <summary>
-        /// Gets a <see cref="T:System.String" /> value that contains the fully-qualified pathname of the Solution file that has been parsed.
+        /// Gets a <see cref="System.String" /> value that contains the fully-qualified pathname of the Solution file that has been parsed.
         /// </summary>
         // NOTE: This is the read/write accessor that is used internally for the Solution file which we will parse.  This must be set before calling any other methods on this class.
         public string FullPath

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -217,11 +217,39 @@ namespace Microsoft.Build.Construction
                     _solutionFile = value;
                     _solutionFilter = null;
 
-                    SolutionFileDirectory = Path.GetDirectoryName(_solutionFile);
+                    // Only set the value of the SolutionFileDirectory property
+                    // if, and only if, the _solutionFile field is non blank and the 
+                    // _solutionFile field contains the fully-qualified pathname of
+                    // a file that actually exists on the disk.
+                    if (!string.IsNullOrWhiteSpace(_solutionFile)
+                        && File.Exists(_solutionFile)
+                        && IsExtensionValid(_solutionFile))
+                      SolutionFileDirectory = Path.GetDirectoryName(_solutionFile);
                 }
             }
         }
 
+        private static bool IsExtensionValid(string pathname)
+        {
+           var result = false;
+           
+           try
+           {
+             if (string.IsNullOrWhiteSpace(pathname)) return result;
+                          
+             result = ".sln".Equals(Path.GetExtension(pathname))
+                      || ".slnf".Equals(Path.GetExtension(pathname));
+           }
+           catch(Exception ex)
+           {
+              Console.WriteLine(ex);
+              
+              result = false;
+           }
+           
+           return result;
+        }
+  
         /// <summary>
         /// Gets a <see cref="T:System.String" /> containing the fully-qualified
         /// pathname of the folder in which this Solution's file resides.


### PR DESCRIPTION
Updated `SolutionFile.cs`

Updated the `SolutionFile.FullPath` property to have a `public` getter and an `internal` setter.  Since, now the property is part of a publicly-exposed API, reworked the XML documentation for the property as well.  Suggest updating the Microsoft Learn docs accordingly.

Updated the `SolutionFile.SolutionFileDirectory` property to have a `public` getter and an `internal` setter.  I also added XML documentation configuration for the property, since, now, it is part of a publicly-exposed API.  Suggest updating the Microsoft Learn docs accordingly.

This was done because it is a best practice to expose the fully-qualified pathname of a Solution file after it's been parsed.  In my mind, there is no risk of programs reading the value of the property 