### PR TITLE
Fix of OutOfMemoryException when embedding large amount of files to binlog

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -218,6 +218,17 @@ namespace Microsoft.Build.Logging
             Write(bytes);
         }
 
+        public void WriteBlob(BinaryLogRecordKind kind, Stream stream)
+        {
+            // write the blob directly to the underlying writer,
+            // bypassing the memory stream
+            using var redirection = RedirectWritesToOriginalWriter();
+
+            Write(kind);
+            Write(stream.Length);
+            Write(stream);
+        }
+
         /// <summary>
         /// Switches the binaryWriter used by the Write* methods to the direct underlying stream writer
         /// until the disposable is disposed. Useful to bypass the currentRecordWriter to write a string,
@@ -1089,6 +1100,11 @@ namespace Microsoft.Build.Logging
         private void Write(byte[] bytes)
         {
             binaryWriter.Write(bytes);
+        }
+
+        private void Write(Stream stream)
+        {
+            stream.CopyTo(binaryWriter.BaseStream);
         }
 
         private void Write(byte b)

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Build.Shared;
 
 #nullable disable
 
@@ -20,30 +21,10 @@ namespace Microsoft.Build.Logging
     /// </summary>
     internal class ProjectImportsCollector
     {
-        private Stream _stream;
-        public byte[] GetAllBytes()
-        {
-            if (_stream == null)
-            {
-                return Array.Empty<byte>();
-            }
-            else if (ArchiveFilePath == null)
-            {
-                var stream = _stream as MemoryStream;
-                // Before we can use the zip archive, it must be closed.
-                Close(false);
-                return stream.ToArray();
-            }
-            else
-            {
-                Close();
-                return File.ReadAllBytes(ArchiveFilePath);
-            }
-        }
-
+        private Stream _fileStream;
         private ZipArchive _zipArchive;
 
-        private string ArchiveFilePath { get; set; }
+        public string ArchiveFilePath { get; }
 
         /// <summary>
         /// Avoid visiting each file more than once.
@@ -55,33 +36,46 @@ namespace Microsoft.Build.Logging
 
         public ProjectImportsCollector(string logFilePath, bool createFile, string sourcesArchiveExtension = ".ProjectImports.zip")
         {
+            if (createFile)
+            {
+                // Archive file will be stored alongside the binlog
+                ArchiveFilePath = Path.ChangeExtension(logFilePath, sourcesArchiveExtension);
+            }
+            else
+            {
+                string cacheDirectory = FileUtilities.GetCacheDirectory();
+                if (!Directory.Exists(cacheDirectory))
+                {
+                    Directory.CreateDirectory(cacheDirectory);
+                }
+
+                // Archive file will be temporarily stored in MSBuild cache folder and deleted when no longer needed
+                ArchiveFilePath = Path.Combine(
+                    cacheDirectory,
+                    Path.ChangeExtension(
+                        Path.GetFileName(logFilePath),
+                        sourcesArchiveExtension));
+            }
+
             try
             {
-                if (createFile)
-                {
-                    ArchiveFilePath = Path.ChangeExtension(logFilePath, sourcesArchiveExtension);
-                    _stream = new FileStream(ArchiveFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Delete);
-                }
-                else
-                {
-                    _stream = new MemoryStream();
-                }
-                _zipArchive = new ZipArchive(_stream, ZipArchiveMode.Create, true);
+                _fileStream = new FileStream(ArchiveFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Delete);
+                _zipArchive = new ZipArchive(_fileStream, ZipArchiveMode.Create);
             }
             catch
             {
                 // For some reason we weren't able to create a file for the archive.
                 // Disable the file collector.
-                _stream = null;
+                _fileStream = null;
                 _zipArchive = null;
             }
         }
 
         public void AddFile(string filePath)
         {
-            if (filePath != null && _stream != null)
+            if (filePath != null && _fileStream != null)
             {
-                lock (_stream)
+                lock (_fileStream)
                 {
                     // enqueue the task to add a file and return quickly
                     // to avoid holding up the current thread
@@ -101,9 +95,9 @@ namespace Microsoft.Build.Logging
 
         public void AddFileFromMemory(string filePath, string data)
         {
-            if (filePath != null && data != null && _stream != null)
+            if (filePath != null && data != null && _fileStream != null)
             {
-                lock (_stream)
+                lock (_fileStream)
                 {
                     // enqueue the task to add a file and return quickly
                     // to avoid holding up the current thread
@@ -197,7 +191,7 @@ namespace Microsoft.Build.Logging
             return archivePath;
         }
 
-        public void Close(bool closeStream = true)
+        public void Close()
         {
             // wait for all pending file writes to complete
             _currentTask.Wait();
@@ -208,10 +202,10 @@ namespace Microsoft.Build.Logging
                 _zipArchive = null;
             }
 
-            if (closeStream && (_stream != null))
+            if (_fileStream != null)
             {
-                _stream.Dispose();
-                _stream = null;
+                _fileStream.Dispose();
+                _fileStream = null;
             }
         }
     }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1498,8 +1498,8 @@ namespace Microsoft.Build.CommandLine
             }
             finally
             {
-                FileUtilities.ClearCacheDirectory();
                 projectCollection?.Dispose();
+                FileUtilities.ClearCacheDirectory();
 
                 // Build manager shall be reused for all build sessions.
                 // If, for one reason or another, this behavior needs to change in future


### PR DESCRIPTION
Fixes #8595

### Summary

Embedding of large amount of files to binlog can lead to OutOfMemoryException due to memory pressure. It also causes LOH fragmentation and Gen2 collections. 

### Customer Impact

Large builds cannot use the binary logger due to an OOM crash.

### Regression?

Yes, in 16.8 (#5718).

### Testing

Before:
![Screenshot 2023-06-28 102953](https://github.com/dotnet/msbuild/assets/12775388/fecb5266-497b-4a2e-866a-1f7e95b62c66)

After:
![Screenshot 2023-06-29 102337](https://github.com/dotnet/msbuild/assets/12775388/83b580ac-08f5-4288-886f-3eff8ba80359)

### Risk

Medium--adds new filesystem dependencies which could fail, but is similar to the pre-16.8 mechanism and tries to be tolerant of failures.

### Changes Made
This change reverts in-memory operations and uses temp file for embedded files. The file is now stored in temporary directory (instead of binlog target directory) to avoid problems with file watchers. There might be possible another optimizations, but goal of this PR is to unblock our partners. We can optimize further in separate PR. 
