### PR TITLE
Deep clone TaskRegistry and Toolset

### DIFF
--- a/src/Build.UnitTests/Definition/Toolset_Tests.cs
+++ b/src/Build.UnitTests/Definition/Toolset_Tests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
+using Microsoft.Build.Engine.UnitTests.TestComparers;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Internal;
@@ -13,6 +14,7 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests.BackEnd;
 using Xunit;
 using Xunit.NetCore.Extensions;
+using static Microsoft.Build.Engine.UnitTests.TestComparers.TaskRegistryComparers;
 
 #nullable disable
 
@@ -123,45 +125,7 @@ namespace Microsoft.Build.UnitTests.Definition
             ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
             Toolset t2 = Toolset.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
 
-            Assert.Equal(t.ToolsVersion, t2.ToolsVersion);
-            Assert.Equal(t.ToolsPath, t2.ToolsPath);
-            Assert.Equal(t.OverrideTasksPath, t2.OverrideTasksPath);
-            Assert.Equal(t.Properties.Count, t2.Properties.Count);
-
-            foreach (string key in t.Properties.Values.Select(p => p.Name))
-            {
-                Assert.Equal(t.Properties[key].Name, t2.Properties[key].Name);
-                Assert.Equal(t.Properties[key].EvaluatedValue, t2.Properties[key].EvaluatedValue);
-            }
-
-            Assert.Equal(t.SubToolsets.Count, t2.SubToolsets.Count);
-
-            foreach (string key in t.SubToolsets.Keys)
-            {
-                SubToolset subToolset1 = t.SubToolsets[key];
-                SubToolset subToolset2 = null;
-
-                if (t2.SubToolsets.TryGetValue(key, out subToolset2))
-                {
-                    Assert.Equal(subToolset1.SubToolsetVersion, subToolset2.SubToolsetVersion);
-                    Assert.Equal(subToolset1.Properties.Count, subToolset2.Properties.Count);
-
-                    foreach (string subToolsetPropertyKey in subToolset1.Properties.Values.Select(p => p.Name))
-                    {
-                        Assert.Equal(subToolset1.Properties[subToolsetPropertyKey].Name, subToolset2.Properties[subToolsetPropertyKey].Name);
-                        Assert.Equal(subToolset1.Properties[subToolsetPropertyKey].EvaluatedValue, subToolset2.Properties[subToolsetPropertyKey].EvaluatedValue);
-                    }
-                }
-                else
-                {
-                    Assert.True(false, $"Sub-toolset {key} was lost in translation.");
-                }
-            }
-
-            Assert.Equal(t.DefaultOverrideToolsVersion, t2.DefaultOverrideToolsVersion);
-
-            Assert.NotNull(t2.ImportPropertySearchPathsTable);
-            Assert.Single(t2.ImportPropertySearchPathsTable);
+            Assert.Equal(t, t2, new ToolsetComparer());
             Assert.Equal(@"c:\foo", t2.ImportPropertySearchPathsTable["MSBuildExtensionsPath"].SearchPaths[0]);
         }
 

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -9,6 +9,7 @@ using System.Xml;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Definition;
+using Microsoft.Build.Engine.UnitTests.TestComparers;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
@@ -480,8 +481,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance first = GetSampleProjectInstance();
             ProjectInstance second = first.DeepCopy();
 
-            // Task registry object should be immutable
-            first.TaskRegistry.ShouldBeSameAs(second.TaskRegistry);
+            // Task registry object should be cloned
+            Assert.Equal(first.TaskRegistry, second.TaskRegistry, new TaskRegistryComparers.TaskRegistryComparer());
         }
 
         /// <summary>
@@ -530,7 +531,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance first = GetSampleProjectInstance();
             ProjectInstance second = first.DeepCopy();
 
-            second.Toolset.ShouldBe(first.Toolset);
+            Assert.Equal(first.Toolset, second.Toolset, new TaskRegistryComparers.ToolsetComparer());
         }
 
         /// <summary>

--- a/src/Build.UnitTests/TestComparers/TaskRegistryComparers.cs
+++ b/src/Build.UnitTests/TestComparers/TaskRegistryComparers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
@@ -136,6 +137,26 @@ namespace Microsoft.Build.Engine.UnitTests.TestComparers
                         Assert.Equal(xp.Value.Name, yp.Value.Name);
                         Assert.Equal(xp.Value.EvaluatedValue, yp.Value.EvaluatedValue);
                     });
+
+                Helpers.AssertDictionariesEqual(
+                    x.SubToolsets,
+                    y.SubToolsets,
+                    (xp, yp) =>
+                    {
+                        Assert.Equal(xp.Key, yp.Key);
+                        SubToolset subToolset1 = xp.Value;
+                        SubToolset subToolset2 = yp.Value;
+                        Assert.Equal(subToolset1.SubToolsetVersion, subToolset2.SubToolsetVersion);
+                        Assert.Equal(subToolset1.Properties.Count, subToolset2.Properties.Count);
+
+                        foreach (string subToolsetPropertyKey in subToolset1.Properties.Values.Select(p => p.Name))
+                        {
+                            Assert.Equal(subToolset1.Properties[subToolsetPropertyKey].Name, subToolset2.Properties[subToolsetPropertyKey].Name);
+                            Assert.Equal(subToolset1.Properties[subToolsetPropertyKey].EvaluatedValue, subToolset2.Properties[subToolsetPropertyKey].EvaluatedValue);
+                        }
+                    });
+
+                Assert.Equal(x.DefaultOverrideToolsVersion, y.DefaultOverrideToolsVersion);
 
                 return true;
             }

--- a/src/Build/BackEnd/Components/Communications/CloningExtensions.cs
+++ b/src/Build/BackEnd/Components/Communications/CloningExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.Build.BackEnd;
+
+internal static class CloningExtensions
+{
+    public static PropertyDictionary<ProjectPropertyInstance> DeepClone(
+        this PropertyDictionary<ProjectPropertyInstance> properties)
+        => new(properties.Select<ProjectPropertyInstance, ProjectPropertyInstance>(p => p.DeepClone()));
+
+    public static Dictionary<TKey, TValue> DeepClone<TKey, TValue>(
+        this IDictionary<TKey, TValue> dictionary,
+        Func<TValue, TValue> valueClone,
+        IEqualityComparer<TKey> comparer) where TKey : notnull
+        => dictionary.DeepClone(null, valueClone, comparer);
+
+    public static Dictionary<TKey, TValue> DeepClone<TKey, TValue>(
+        this IDictionary<TKey, TValue> dictionary,
+        Func<TKey, TKey> keyClone,
+        IEqualityComparer<TKey> comparer) where TKey : notnull
+        => dictionary.DeepClone(keyClone, null, comparer);
+
+    public static Dictionary<TKey, TValue> DeepClone<TKey, TValue>(
+        this IDictionary<TKey, TValue> dictionary,
+        Func<TKey, TKey>? keyClone,
+        Func<TValue, TValue>? valueClone,
+        IEqualityComparer<TKey> comparer) where TKey : notnull
+        => dictionary.ToDictionary(
+        p => (keyClone ?? Identity)(p.Key),
+        p => (valueClone ?? Identity)(p.Value),
+        comparer);
+
+    private static T Identity<T>(T value) => value;
+}
+

--- a/src/Build/BackEnd/Components/Communications/CloningExtensions.cs
+++ b/src/Build/BackEnd/Components/Communications/CloningExtensions.cs
@@ -17,6 +17,11 @@ internal static class CloningExtensions
 
     public static Dictionary<TKey, TValue>? DeepClone<TKey, TValue>(
         this IDictionary<TKey, TValue>? dictionary,
+        IEqualityComparer<TKey> comparer) where TKey : notnull
+        => dictionary.DeepClone(null, null, comparer);
+
+    public static Dictionary<TKey, TValue>? DeepClone<TKey, TValue>(
+        this IDictionary<TKey, TValue>? dictionary,
         Func<TValue, TValue> valueClone,
         IEqualityComparer<TKey> comparer) where TKey : notnull
         => dictionary.DeepClone(null, valueClone, comparer);

--- a/src/Build/BackEnd/Components/Communications/CloningExtensions.cs
+++ b/src/Build/BackEnd/Components/Communications/CloningExtensions.cs
@@ -11,28 +11,28 @@ namespace Microsoft.Build.BackEnd;
 
 internal static class CloningExtensions
 {
-    public static PropertyDictionary<ProjectPropertyInstance> DeepClone(
-        this PropertyDictionary<ProjectPropertyInstance> properties)
-        => new(properties.Select<ProjectPropertyInstance, ProjectPropertyInstance>(p => p.DeepClone()));
+    public static PropertyDictionary<ProjectPropertyInstance>? DeepClone(
+        this PropertyDictionary<ProjectPropertyInstance>? properties)
+        => properties == null ? null : new(properties.Select<ProjectPropertyInstance, ProjectPropertyInstance>(p => p.DeepClone()));
 
-    public static Dictionary<TKey, TValue> DeepClone<TKey, TValue>(
-        this IDictionary<TKey, TValue> dictionary,
+    public static Dictionary<TKey, TValue>? DeepClone<TKey, TValue>(
+        this IDictionary<TKey, TValue>? dictionary,
         Func<TValue, TValue> valueClone,
         IEqualityComparer<TKey> comparer) where TKey : notnull
         => dictionary.DeepClone(null, valueClone, comparer);
 
-    public static Dictionary<TKey, TValue> DeepClone<TKey, TValue>(
-        this IDictionary<TKey, TValue> dictionary,
+    public static Dictionary<TKey, TValue>? DeepClone<TKey, TValue>(
+        this IDictionary<TKey, TValue>? dictionary,
         Func<TKey, TKey> keyClone,
         IEqualityComparer<TKey> comparer) where TKey : notnull
         => dictionary.DeepClone(keyClone, null, comparer);
 
-    public static Dictionary<TKey, TValue> DeepClone<TKey, TValue>(
-        this IDictionary<TKey, TValue> dictionary,
+    public static Dictionary<TKey, TValue>? DeepClone<TKey, TValue>(
+        this IDictionary<TKey, TValue>? dictionary,
         Func<TKey, TKey>? keyClone,
         Func<TValue, TValue>? valueClone,
         IEqualityComparer<TKey> comparer) where TKey : notnull
-        => dictionary.ToDictionary(
+        => dictionary?.ToDictionary(
         p => (keyClone ?? Identity)(p.Key),
         p => (valueClone ?? Identity)(p.Value),
         comparer);

--- a/src/Build/Definition/ProjectImportPathMatch.cs
+++ b/src/Build/Definition/ProjectImportPathMatch.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Build.Evaluation
     /// </summary>
     internal class ProjectImportPathMatch : ITranslatable
     {
+        private string _propertyName;
+        private string _msBuildPropertyFormat;
+        private List<string> _searchPaths;
+
         /// <summary>
         /// ProjectImportPathMatch instance representing no fall-back
         /// </summary>
@@ -24,9 +28,9 @@ namespace Microsoft.Build.Evaluation
             ErrorUtilities.VerifyThrowArgumentNull(propertyName, nameof(propertyName));
             ErrorUtilities.VerifyThrowArgumentNull(searchPaths, nameof(searchPaths));
 
-            PropertyName = propertyName;
-            SearchPaths = searchPaths;
-            MsBuildPropertyFormat = $"$({PropertyName})";
+            _propertyName = propertyName;
+            _searchPaths = searchPaths;
+            _msBuildPropertyFormat = $"$({PropertyName})";
         }
 
         public ProjectImportPathMatch(ITranslator translator)
@@ -34,26 +38,29 @@ namespace Microsoft.Build.Evaluation
             ((ITranslatable)this).Translate(translator);
         }
 
+        internal ProjectImportPathMatch DeepClone()
+            => new ProjectImportPathMatch(_propertyName, new List<string>(_searchPaths));
+
         /// <summary>
         /// String representation of the property reference - eg. "MSBuildExtensionsPath32"
         /// </summary>
-        public string PropertyName;
+        public string PropertyName => _propertyName;
 
         /// <summary>
         /// Returns the corresponding property name - eg. "$(MSBuildExtensionsPath32)"
         /// </summary>
-        public string MsBuildPropertyFormat;
+        public string MsBuildPropertyFormat => _msBuildPropertyFormat;
 
         /// <summary>
         /// Enumeration of the search paths for the property.
         /// </summary>
-        public List<string> SearchPaths;
+        public List<string> SearchPaths => _searchPaths;
 
         public void Translate(ITranslator translator)
         {
-            translator.Translate(ref PropertyName);
-            translator.Translate(ref MsBuildPropertyFormat);
-            translator.Translate(ref SearchPaths);
+            translator.Translate(ref _propertyName);
+            translator.Translate(ref _msBuildPropertyFormat);
+            translator.Translate(ref _searchPaths);
         }
 
         /// <summary>

--- a/src/Build/Definition/ProjectImportPathMatch.cs
+++ b/src/Build/Definition/ProjectImportPathMatch.cs
@@ -11,9 +11,13 @@ namespace Microsoft.Build.Evaluation
 {
     /// <summary>
     /// Class representing a reference to a project import path with property fall-back
+    /// This class is immutable.
+    /// If mutability would be needed in the future, it should be implemented via copy-on-write or
+    ///  a DeepClone would need to be added (and called from DeepClone methods of owning types)
     /// </summary>
     internal class ProjectImportPathMatch : ITranslatable
     {
+        // Those are effectively readonly and should stay so. Cannot be marked readonly due to ITranslatable
         private string _propertyName;
         private string _msBuildPropertyFormat;
         private List<string> _searchPaths;

--- a/src/Build/Definition/ProjectImportPathMatch.cs
+++ b/src/Build/Definition/ProjectImportPathMatch.cs
@@ -42,9 +42,6 @@ namespace Microsoft.Build.Evaluation
             ((ITranslatable)this).Translate(translator);
         }
 
-        internal ProjectImportPathMatch DeepClone()
-            => new ProjectImportPathMatch(_propertyName, new List<string>(_searchPaths));
-
         /// <summary>
         /// String representation of the property reference - eg. "MSBuildExtensionsPath32"
         /// </summary>
@@ -58,7 +55,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Enumeration of the search paths for the property.
         /// </summary>
-        public List<string> SearchPaths => _searchPaths;
+        public IReadOnlyList<string> SearchPaths => _searchPaths;
 
         public void Translate(ITranslator translator)
         {

--- a/src/Build/Definition/SubToolset.cs
+++ b/src/Build/Definition/SubToolset.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Build.Evaluation
             ((ITranslatable)this).Translate(translator);
         }
 
+        internal SubToolset DeepClone()
+            => new SubToolset(_subToolsetVersion, _properties.DeepClone());
+
         /// <summary>
         /// VisualStudioVersion that corresponds to this subtoolset
         /// </summary>

--- a/src/Build/Definition/SubToolset.cs
+++ b/src/Build/Definition/SubToolset.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Build.Evaluation
         }
 
         internal SubToolset DeepClone()
-            => new SubToolset(_subToolsetVersion, _properties.DeepClone());
+            => new SubToolset(_subToolsetVersion, _properties?.DeepClone());
 
         /// <summary>
         /// VisualStudioVersion that corresponds to this subtoolset

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -620,8 +620,9 @@ namespace Microsoft.Build.Evaluation
                 _subToolsets = _subToolsets.DeepClone(v => v.DeepClone(), StringComparer.OrdinalIgnoreCase),
                 _overrideTasksPath = _overrideTasksPath,
                 _defaultOverrideToolsVersion = _defaultOverrideToolsVersion,
+                // ProjectImportPathMatch is immutable
                 _propertySearchPathsTable =
-                    _propertySearchPathsTable.DeepClone(v => v.DeepClone(), StringComparer.OrdinalIgnoreCase),
+                    _propertySearchPathsTable.DeepClone(StringComparer.OrdinalIgnoreCase),
                 _defaultTasksRegistrationAttempted = _defaultTasksRegistrationAttempted,
                 _overrideTasksRegistrationAttempted = _overrideTasksRegistrationAttempted,
                 _defaultTaskRegistry = _defaultTaskRegistry?.DeepClone(),

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -953,7 +953,7 @@ namespace Microsoft.Build.Evaluation
 
                 // GenerateSubToolsetVersion checks the environment and global properties, so it's safe to go ahead and gather the
                 // subtoolset properties here without fearing that we'll have somehow come up with the wrong subtoolset version.
-                string subToolsetVersion = this.GenerateSubToolsetVersion();
+                string subToolsetVersion = GenerateSubToolsetVersion();
                 SubToolset subToolset;
                 ICollection<ProjectPropertyInstance> subToolsetProperties = null;
 

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -566,7 +566,7 @@ namespace Microsoft.Build.Execution
             // If the task registry uses toolset identical to the one in data instance - deep clone it just once.
             this.Toolset = data.TaskRegistry?.Toolset == data.Toolset
                 ? this.TaskRegistry?.Toolset
-                : data.Toolset.DeepClone();
+                : data.Toolset?.DeepClone();
 
             this.ProjectRootElementCache = data.Project.ProjectCollection.ProjectRootElementCache;
 
@@ -649,7 +649,7 @@ namespace Microsoft.Build.Execution
                 // If the task registry uses toolset identical to the one in project instance - deep clone it just once.
                 this.Toolset = that.TaskRegistry?.Toolset == that.Toolset
                     ? this.TaskRegistry?.Toolset
-                    : that.Toolset.DeepClone();
+                    : that.Toolset?.DeepClone();
                 this.SubToolsetVersion = that.SubToolsetVersion;
                 _targets = that._targets;
                 _itemDefinitions = that._itemDefinitions;

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -563,18 +563,12 @@ namespace Microsoft.Build.Execution
 
             this.SubToolsetVersion = data.SubToolsetVersion;
             this.TaskRegistry = data.TaskRegistry?.DeepClone();
-            // todo: temporary hack - should we actually clone? BUT - below we just copy as well
-            if (TaskRegistry != null)
-            {
-                this.TaskRegistry.RootElementCache = data.Project.ProjectCollection.ProjectRootElementCache;
-            }
 
             // If the task registry uses toolset identical to the one in data instance - deep clone it just once.
             this.Toolset = data.TaskRegistry?.Toolset == data.Toolset
                 ? this.TaskRegistry?.Toolset
                 : data.Toolset?.DeepClone();
 
-            // ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk, loadProjectsReadOnly);
             this.ProjectRootElementCache = data.Project.ProjectCollection.ProjectRootElementCache;
 
             this.EvaluatedItemElements = new List<ProjectItemElement>(data.EvaluatedItemElements);
@@ -653,11 +647,6 @@ namespace Microsoft.Build.Execution
                         ProjectItemDefinitionInstance>)that).AfterTargets, StringComparer.OrdinalIgnoreCase);
 
                 this.TaskRegistry = that.TaskRegistry.DeepClone();
-                // todo: temporary hack - should we actually clone? BUT - below we just copy as well
-                if (TaskRegistry != null)
-                {
-                    this.TaskRegistry.RootElementCache = that.ProjectRootElementCache;
-                }
                 // If the task registry uses toolset identical to the one in project instance - deep clone it just once.
                 this.Toolset = that.TaskRegistry?.Toolset == that.Toolset
                     ? this.TaskRegistry?.Toolset
@@ -671,7 +660,6 @@ namespace Microsoft.Build.Execution
                 _importPathsIncludingDuplicates = that._importPathsIncludingDuplicates;
                 ImportPathsIncludingDuplicates = _importPathsIncludingDuplicates.AsReadOnly();
 
-                // todo: is the reference copy fine here?? 
                 this.EvaluatedItemElements = that.EvaluatedItemElements;
 
                 this.ProjectRootElementCache = that.ProjectRootElementCache;

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -564,7 +564,8 @@ namespace Microsoft.Build.Execution
             this.SubToolsetVersion = data.SubToolsetVersion;
             this.TaskRegistry = data.TaskRegistry?.DeepClone();
 
-            // If the task registry uses toolset identical to the one in data instance - deep clone it just once.
+            // If the task registry uses toolset identical to the one in data instance - deep clone it just once,
+            // by reusing the already cloned Toolset member of TaskRegistry.
             this.Toolset = data.TaskRegistry?.Toolset == data.Toolset
                 ? this.TaskRegistry?.Toolset
                 : data.Toolset?.DeepClone();
@@ -647,7 +648,8 @@ namespace Microsoft.Build.Execution
                         ProjectItemDefinitionInstance>)that).AfterTargets, StringComparer.OrdinalIgnoreCase);
 
                 this.TaskRegistry = that.TaskRegistry.DeepClone();
-                // If the task registry uses toolset identical to the one in project instance - deep clone it just once.
+                // If the task registry uses toolset identical to the one in data instance - deep clone it just once,
+                // by reusing the already cloned Toolset member of TaskRegistry.
                 this.Toolset = that.TaskRegistry?.Toolset == that.Toolset
                     ? this.TaskRegistry?.Toolset
                     : that.Toolset?.DeepClone();

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -563,11 +563,18 @@ namespace Microsoft.Build.Execution
 
             this.SubToolsetVersion = data.SubToolsetVersion;
             this.TaskRegistry = data.TaskRegistry?.DeepClone();
+            // todo: temporary hack - should we actually clone? BUT - below we just copy as well
+            if (TaskRegistry != null)
+            {
+                this.TaskRegistry.RootElementCache = data.Project.ProjectCollection.ProjectRootElementCache;
+            }
+
             // If the task registry uses toolset identical to the one in data instance - deep clone it just once.
             this.Toolset = data.TaskRegistry?.Toolset == data.Toolset
                 ? this.TaskRegistry?.Toolset
                 : data.Toolset?.DeepClone();
 
+            // ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk, loadProjectsReadOnly);
             this.ProjectRootElementCache = data.Project.ProjectCollection.ProjectRootElementCache;
 
             this.EvaluatedItemElements = new List<ProjectItemElement>(data.EvaluatedItemElements);
@@ -646,6 +653,11 @@ namespace Microsoft.Build.Execution
                         ProjectItemDefinitionInstance>)that).AfterTargets, StringComparer.OrdinalIgnoreCase);
 
                 this.TaskRegistry = that.TaskRegistry.DeepClone();
+                // todo: temporary hack - should we actually clone? BUT - below we just copy as well
+                if (TaskRegistry != null)
+                {
+                    this.TaskRegistry.RootElementCache = that.ProjectRootElementCache;
+                }
                 // If the task registry uses toolset identical to the one in project instance - deep clone it just once.
                 this.Toolset = that.TaskRegistry?.Toolset == that.Toolset
                     ? this.TaskRegistry?.Toolset
@@ -659,6 +671,7 @@ namespace Microsoft.Build.Execution
                 _importPathsIncludingDuplicates = that._importPathsIncludingDuplicates;
                 ImportPathsIncludingDuplicates = _importPathsIncludingDuplicates.AsReadOnly();
 
+                // todo: is the reference copy fine here?? 
                 this.EvaluatedItemElements = that.EvaluatedItemElements;
 
                 this.ProjectRootElementCache = that.ProjectRootElementCache;

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1779,8 +1779,8 @@ namespace Microsoft.Build.Execution
                     // AssemblyLoadInfo is immutable, so we can just copy the reference
                     _taskFactoryAssemblyLoadInfo = _taskFactoryAssemblyLoadInfo,
                     _taskFactory = _taskFactory,
-                    _parameterGroupAndTaskBody = _parameterGroupAndTaskBody.DeepClone(),
-                    _taskFactoryParameters = new Dictionary<string, string>(_taskFactoryParameters)
+                    _parameterGroupAndTaskBody = _parameterGroupAndTaskBody?.DeepClone(),
+                    _taskFactoryParameters = _taskFactoryParameters == null ? null : new Dictionary<string, string>(_taskFactoryParameters)
                 };
 
             public void Translate(ITranslator translator)
@@ -1812,9 +1812,9 @@ namespace Microsoft.Build.Execution
         public TaskRegistry DeepClone()
             => new()
             {
-                _toolset = _toolset.DeepClone(),
-                _taskRegistrations = this._taskRegistrations?.DeepClone(
-                    v => v.Select(i => i.DeepClone()).ToList(),
+                _toolset = _toolset?.DeepClone(),
+                _taskRegistrations = this._taskRegistrations.DeepClone(
+                    v => v?.Select(i => i.DeepClone())?.ToList(),
                     RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact)
             };
 

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -760,24 +760,24 @@ namespace Microsoft.Build.Execution
                 _name = name;
 
                 // The ReadOnlyDictionary is a *wrapper*, the Dictionary is the copy.
-                _taskIdentityParameters = taskIdentityParameters == null ? null : CreateTaskIdentityParametersDictionary(taskIdentityParameters);
+                _taskIdentityParameters = taskIdentityParameters == null ? null : new ReadOnlyDictionary<string, string>(CreateTaskIdentityParametersDictionary(taskIdentityParameters));
             }
 
-            private static ReadOnlyDictionary<string, string> CreateTaskIdentityParametersDictionary(IDictionary<string, string> initialState = null, int? initialCount = null)
+            private static IDictionary<string, string> CreateTaskIdentityParametersDictionary(IDictionary<string, string> initialState = null, int? initialCount = null)
             {
                 ErrorUtilities.VerifyThrowInvalidOperation(initialState == null || initialCount == null, "at most one can be non-null");
 
                 if (initialState != null)
                 {
-                    return new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(initialState, StringComparer.OrdinalIgnoreCase));
+                    return new Dictionary<string, string>(initialState, StringComparer.OrdinalIgnoreCase);
                 }
 
                 if (initialCount != null)
                 {
-                    return new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(initialCount.Value, StringComparer.OrdinalIgnoreCase));
+                    return new Dictionary<string, string>(initialCount.Value, StringComparer.OrdinalIgnoreCase);
                 }
 
-                return new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
 
             public RegisteredTaskIdentity()

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1815,7 +1815,10 @@ namespace Microsoft.Build.Execution
                 _toolset = _toolset?.DeepClone(),
                 _taskRegistrations = this._taskRegistrations.DeepClone(
                     v => v?.Select(i => i.DeepClone())?.ToList(),
-                    RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact)
+                    RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact),
+                // this is not a deep clone, but it should be ok to share (effectively immutable) -
+                // it's done so even for ProjectInstance DeepClone
+                RootElementCache = this.RootElementCache
             };
 
         public void Translate(ITranslator translator)

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -160,6 +160,7 @@
     <Compile Include="BackEnd\Components\SdkResolution\TranslationHelpers.cs" />
     <Compile Include="FileSystem\*.cs" />
     <Compile Include="Evaluation\IItemTypeDefinition.cs" />
+    <Compile Include="Utilities\EnumerableExtensions.cs" />
     <Compile Include="Utilities\ReaderWriterLockSlimExtensions.cs" />
     <Compile Include="BackEnd\Node\ConsoleOutput.cs" />
     <Compile Include="BackEnd\Node\PartialBuildTelemetry.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -151,6 +151,7 @@
     <Compile Include="BackEnd\Components\Caching\ConfigCacheWithOverride.cs" />
     <Compile Include="BackEnd\Components\Caching\ResultsCacheWithOverride.cs" />
     <Compile Include="BackEnd\Components\ProjectCache\*.cs" />
+    <Compile Include="BackEnd\Components\Communications\CloningExtensions.cs" />
     <Compile Include="BackEnd\Components\Communications\CurrentHost.cs" />
     <Compile Include="BackEnd\Components\Communications\SerializationContractInitializer.cs" />
     <Compile Include="BackEnd\Components\Communications\ServerNodeEndpointOutOfProc.cs" />

--- a/src/Build/Utilities/EnumerableExtensions.cs
+++ b/src/Build/Utilities/EnumerableExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Internal;
+
+internal static class EnumerableExtensions
+{
+    public static void CopyTo<T>(this IReadOnlyList<T> list, T[] array, int startIndex)
+    {
+        for (int i = 0, count = list.Count; i < count; i++)
+        {
+            array[startIndex + i] = list[i];
+        }
+    }
+}

--- a/src/Framework/TaskPropertyInfo.cs
+++ b/src/Framework/TaskPropertyInfo.cs
@@ -32,25 +32,34 @@ namespace Microsoft.Build.Framework
             IsAssignableToITask = typeof(ITaskItem).IsAssignableFrom(elementType);
         }
 
+        internal TaskPropertyInfo DeepClone()
+        {
+            return new TaskPropertyInfo(Name, PropertyType, Output, Required)
+            {
+                IsAssignableToITask = IsAssignableToITask,
+                // do not set Initialized - so that Log and LogItemMetadata can be initialized as appropriate
+            };
+        }
+
         /// <summary>
         /// The type of the property
         /// </summary>
-        public Type PropertyType { get; private set; }
+        public Type PropertyType { get; private init; }
 
         /// <summary>
         /// Name of the property
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; private init; }
 
         /// <summary>
         /// This task parameter is an output parameter (analogous to [Output] attribute)
         /// </summary>
-        public bool Output { get; private set; }
+        public bool Output { get; private init; }
 
         /// <summary>
         /// This task parameter is required (analogous to the [Required] attribute)
         /// </summary>
-        public bool Required { get; private set; }
+        public bool Required { get; private init; }
 
         /// <summary>
         /// This task parameter should be logged when LogTaskInputs is set. Defaults to true.
@@ -67,7 +76,7 @@ namespace Microsoft.Build.Framework
         /// </summary>
         internal bool Initialized = false;
 
-        internal bool IsValueTypeOutputParameter { get; private set; }
-        internal bool IsAssignableToITask { get; set; }
+        internal bool IsValueTypeOutputParameter { get; private init; }
+        protected internal bool IsAssignableToITask { get; protected init; }
     }
 }


### PR DESCRIPTION
Fixes [ADO#1801351](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1801351) and [ADO#1801341](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1801341) and possibly [ADO#1824802](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824802)

Credit for rootcausing: @rokonec 

### Context
`TaskRegistry` (and as `Toolset` as well) were not properly clonned during clonning `ProjectInstance` data - that could cause unintended sharing of `TaskRegistry` data between multiple independent evaluation/build threads - allowing concurrent access to `TaskRegistry` and its objects, while such concurency is not supported.

### Changes Made
Made `TaskRegistry` and `Toolset` classes DeepClonable and properly cloning them during `ProjectInstance` clonning

### Testing - Perf

No observable impact.

 * OrchardCore and Console, build command: `msbuild.exe /nodeReuse:false /bl`

| Scenario | Mean Duration |
| --- | --- |
| Orchard, MSBuild main, clean build, /bl | 00:01:54.28 |
| Orchard, MSBuild curr branch, clean build, /bl | 00:02:01.36 |
|  |  |
| Orchard, MSBuild main, rebuild, /bl | 00:01:44.46 |
| Orchard, MSBuild curr branch, rebuild, /bl | 00:01:41.81 |
|  |  |
| Orchard, MSBuild main, rebuild | 00:01:36.55 |
| Orchard, MSBuild curr branch, rebuild | 00:01:39.83 |
| --- | --- |
| Console, MSBuild main, clean build | 00:00:01.75 |
| Console, MSBuild curr branch, clean build | 00:00:01.71 |
|  |  |
| Console, MSBuild main, rebuild | 00:00:01.34 |
| Console, MSBuild curr branch, rebuild | 00:00:01.31 |

