### PR TITLE
Update System.Security.Cryptography.Pkcs

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="System.Runtime" Version="4.3.1" />
     <PackageVersion Update="System.Runtime" Condition="'$(SystemRuntimeVersion)' != ''" Version="$(SystemRuntimeVersion)" />
 
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="7.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
     <PackageVersion Update="System.Security.Cryptography.Pkcs" Condition="'$(SystemSecurityCryptographyPkcsVersion)' != ''" Version="$(SystemSecurityCryptographyPkcsVersion)" />
 
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.1" />


### PR DESCRIPTION
Fixes CVE-2023-29331

### Context
[CVE-2023-29331](https://github.com/advisories/GHSA-555c-2p6r-68mm)

### Changes Made
Version bump - adopted from https://github.com/dotnet/msbuild/pull/8903
