### PR TITLE
Change to faster modulo

### DIFF
--- a/THIRDPARTYNOTICES.txt
+++ b/THIRDPARTYNOTICES.txt
@@ -44,3 +44,20 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 language governing permissions and limitations under the License.
 -------------------------------
+
+License for fastmod (https://github.com/lemire/fastmod), ibm-fpgen (https://github.com/nigeltao/parse-number-fxx-test-data) and fastrange (https://github.com/lemire/fastrange)
+--------------------------------------
+
+   Copyright 2018 Daniel Lemire
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/Build/Collections/RetrievableEntryHashSet/HashHelpers.cs
+++ b/src/Build/Collections/RetrievableEntryHashSet/HashHelpers.cs
@@ -3,11 +3,7 @@
 
 using System;
 using System.Diagnostics;
-#if !SILVERLIGHT
-#if FEATURE_CONSTRAINED_EXECUTION
-using System.Runtime.ConstrainedExecution;
-#endif
-#endif
+using System.Runtime.CompilerServices;
 
 #nullable disable
 
@@ -18,23 +14,34 @@ namespace Microsoft.Build.Collections
     /// </summary>
     internal static class HashHelpers
     {
-        // Table of prime numbers to use as hash table sizes. 
-        // The entry used for capacity is the smallest prime number in this array
-        // that is larger than twice the previous capacity. 
+        // This is the maximum prime smaller than Array.MaxLength.
+        public const int MaxPrimeArrayLength = 0x7FFFFFC3;
 
-        internal static readonly int[] primes = {
+        public const int HashPrime = 101;
+
+        // Table of prime numbers to use as hash table sizes.
+        // A typical resize algorithm would pick the smallest prime number in this array
+        // that is larger than twice the previous capacity.
+        // Suppose our Hashtable currently has capacity x and enough elements are added
+        // such that a resize needs to occur. Resizing first computes 2x then finds the
+        // first prime in the table greater than 2x, i.e. if primes are ordered
+        // p_1, p_2, ..., p_i, ..., it finds p_n such that p_n-1 < 2x < p_n.
+        // Doubling is important for preserving the asymptotic complexity of the
+        // hashtable operations such as add.  Having a prime guarantees that double
+        // hashing does not lead to infinite loops.  IE, your hash function will be
+        // h1(key) + i*h2(key), 0 <= i < size.  h2 and the size must be relatively prime.
+        // We prefer the low computation costs of higher prime numbers over the increased
+        // memory allocation of a fixed prime number i.e. when right sizing a HashSet.
+        internal static ReadOnlySpan<int> Primes => new int[]
+        {
             3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197, 239, 293, 353, 431, 521, 631, 761, 919,
             1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
             17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
             187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
-            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369};
+            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369
+        };
 
-#if !SILVERLIGHT
-#if FEATURE_CONSTRAINED_EXECUTION
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
-#endif
-        internal static bool IsPrime(int candidate)
+        public static bool IsPrime(int candidate)
         {
             if ((candidate & 1) != 0)
             {
@@ -51,28 +58,20 @@ namespace Microsoft.Build.Collections
             return candidate == 2;
         }
 
-#if !SILVERLIGHT
-#if FEATURE_CONSTRAINED_EXECUTION
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
-#endif
-        internal static int GetPrime(int min)
+        public static int GetPrime(int min)
         {
-            Debug.Assert(min >= 0, "min less than zero; handle overflow checking before calling HashHelpers");
-
-            for (int i = 0; i < primes.Length; i++)
+            foreach (int prime in Primes)
             {
-                int prime = primes[i];
                 if (prime >= min)
                 {
                     return prime;
                 }
             }
 
-            // Outside of our predefined table. Compute the hard way. 
-            for (int i = (min | 1); i < Int32.MaxValue; i += 2)
+            // Outside of our predefined table. Compute the hard way.
+            for (int i = (min | 1); i < int.MaxValue; i += 2)
             {
-                if (IsPrime(i))
+                if (IsPrime(i) && ((i - 1) % HashPrime != 0))
                 {
                     return i;
                 }
@@ -82,25 +81,45 @@ namespace Microsoft.Build.Collections
 
         internal static int GetMinPrime()
         {
-            return primes[0];
+            return Primes[0];
         }
 
         // Returns size of hashtable to grow to.
-        internal static int ExpandPrime(int oldSize)
+        public static int ExpandPrime(int oldSize)
         {
             int newSize = 2 * oldSize;
 
-            // Allow the hashtables to grow to maximum possible size (~2G elements) before encoutering capacity overflow.
+            // Allow the hashtables to grow to maximum possible size (~2G elements) before encountering capacity overflow.
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-            if ((uint)newSize > MaxPrimeArrayLength)
+            if ((uint)newSize > MaxPrimeArrayLength && MaxPrimeArrayLength > oldSize)
             {
+                Debug.Assert(MaxPrimeArrayLength == GetPrime(MaxPrimeArrayLength), "Invalid MaxPrimeArrayLength");
                 return MaxPrimeArrayLength;
             }
 
             return GetPrime(newSize);
         }
 
-        // This is the maximum prime smaller than Array.MaxArrayLength
-        internal const int MaxPrimeArrayLength = 0x7FEFFFFD;
+        /// <summary>Returns approximate reciprocal of the divisor: ceil(2**64 / divisor).</summary>
+        /// <remarks>This should only be used on 64-bit.</remarks>
+        public static ulong GetFastModMultiplier(uint divisor) =>
+            ulong.MaxValue / divisor + 1;
+
+        /// <summary>Performs a mod operation using the multiplier pre-computed with <see cref="GetFastModMultiplier"/>.</summary>
+        /// <remarks>This should only be used on 64-bit.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint FastMod(uint value, uint divisor, ulong multiplier)
+        {
+            // We use modified Daniel Lemire's fastmod algorithm
+            // which allows to avoid the long multiplication if the divisor is less than 2**31.
+            Debug.Assert(divisor <= int.MaxValue);
+
+            // This is equivalent of (uint)Math.BigMul(multiplier * value, divisor, out _). This version
+            // is faster than BigMul currently because we only need the high bits.
+            uint highbits = (uint)(((((multiplier * value) >> 32) + 1) * divisor) >> 32);
+
+            Debug.Assert(highbits == value % divisor);
+            return highbits;
+        }
     }
 }


### PR DESCRIPTION
RetrievableEntryHashset is basically a modified subset of Hashset in the core libraries.

And that version is using the fastmod trick from Daniel Lemire https://lemire.me/blog/2019/02/08/faster-remainders-when-the-divisor-is-a-constant-beating-compilers-and-libdivide/ see https://github.com/dotnet/runtime/pull/406

Copy HashHelpers.cs from https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs to pick up that improvement. Note: no perf testing would have happened with the .NET Framework JIT. It's conceivable that this is somehow a deoptimization there (but I have no reason to believe it would be). I don't know how to measure perf but it's hard to imagine that this kind of change would show up there.