### PR TITLE
improve TaskItem hashcode

### DIFF
--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1495,7 +1495,12 @@ namespace Microsoft.Build.Execution
                 // This is ignore case to ensure that task items whose item specs differ only by
                 // casing still have the same hash code, since this is used to determine if we have duplicates when
                 // we do duplicate removal.
-                return StringComparer.OrdinalIgnoreCase.GetHashCode(ItemSpec);
+                // Hash in direct metadata count as it's cheap.
+#if NET7_0_OR_GREATER
+                return HashCode.Combine(StringComparer.OrdinalIgnoreCase.GetHashCode(_includeEscaped), DirectMetadataCount);
+#else
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(_includeEscaped) ^ DirectMetadataCount;
+#endif
             }
 
             /// <summary>

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1495,12 +1495,11 @@ namespace Microsoft.Build.Execution
                 // This is ignore case to ensure that task items whose item specs differ only by
                 // casing still have the same hash code, since this is used to determine if we have duplicates when
                 // we do duplicate removal.
-                // Hash in direct metadata count as it's cheap.
-#if NET7_0_OR_GREATER
-                return HashCode.Combine(StringComparer.OrdinalIgnoreCase.GetHashCode(_includeEscaped), DirectMetadataCount);
-#else
-                return StringComparer.OrdinalIgnoreCase.GetHashCode(_includeEscaped) ^ DirectMetadataCount;
-#endif
+                //
+                // Ideally this would also hash in something like the metadata count. However this requires calculation,
+                // because local and inherited metadata are equally considered during equality comparison, and the
+                // former may mask some of the latter.
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(_includeEscaped);
             }
 
             /// <summary>


### PR DESCRIPTION
Tiny improvement to the hash code calculation perf - ItemSpec is just EscapingUtilities.UnescapeAll(_includeEscaped), which is a simple deterministic transform so we can just use the string.

Added a comment to explain why we can't easily hash in something about the metadata. This means that all items with the same item spec continue to have the same hash code, which can cause degenerate performance.