### PR TITLE
cleanup ErrorUtilities

### DIFF
--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1322,9 +1322,9 @@ namespace Microsoft.Build.BackEnd
         /// <param name="config">The configuration to be mapped.</param>
         private void IssueConfigurationRequest(BuildRequestConfiguration config)
         {
-            ErrorUtilities.VerifyThrowArgument(config.WasGeneratedByNode, "InvalidConfigurationId");
+            ErrorUtilities.VerifyThrow(config.WasGeneratedByNode, "InvalidConfigurationId");
             ErrorUtilities.VerifyThrowArgumentNull(config, nameof(config));
-            ErrorUtilities.VerifyThrowInvalidOperation(_unresolvedConfigurations.HasConfiguration(config.ConfigurationId), "NoUnresolvedConfiguration");
+            ErrorUtilities.VerifyThrow(_unresolvedConfigurations.HasConfiguration(config.ConfigurationId), "NoUnresolvedConfiguration");
             TraceEngine("Issuing configuration request for node config {0}", config.ConfigurationId);
             RaiseNewConfigurationRequest(config);
         }

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>The build results for the specified request.</returns>
         public BuildResult GetResultForRequest(BuildRequest request)
         {
-            ErrorUtilities.VerifyThrowArgument(request.IsConfigurationResolved, "UnresolvedConfigurationInRequest");
+            ErrorUtilities.VerifyThrow(request.IsConfigurationResolved, "UnresolvedConfigurationInRequest");
 
             lock (_resultsByConfiguration)
             {
@@ -155,7 +155,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>A response indicating the results, if any, and the targets needing to be built, if any.</returns>
         public ResultsCacheResponse SatisfyRequest(BuildRequest request, List<string> configInitialTargets, List<string> configDefaultTargets, bool skippedResultsDoNotCauseCacheMiss)
         {
-            ErrorUtilities.VerifyThrowArgument(request.IsConfigurationResolved, "UnresolvedConfigurationInRequest");
+            ErrorUtilities.VerifyThrow(request.IsConfigurationResolved, "UnresolvedConfigurationInRequest");
             ResultsCacheResponse response = new ResultsCacheResponse(ResultsCacheResponseType.NotSatisfied);
 
             lock (_resultsByConfiguration)

--- a/src/Build/BackEnd/Components/Communications/TranslatorExtensions.cs
+++ b/src/Build/BackEnd/Components/Communications/TranslatorExtensions.cs
@@ -71,11 +71,11 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref typeName);
 
             var type = Type.GetType(typeName);
-            ErrorUtilities.VerifyThrowInvalidOperation(type != null, "type cannot be null");
-            ErrorUtilities.VerifyThrowInvalidOperation(
+            ErrorUtilities.VerifyThrow(type != null, "type cannot be null");
+            ErrorUtilities.VerifyThrow(
                 typeof(T).IsAssignableFrom(type),
                 $"{typeName} must be a {typeof(T).FullName}");
-            ErrorUtilities.VerifyThrowInvalidOperation(
+            ErrorUtilities.VerifyThrow(
                 typeof(ITranslatable).IsAssignableFrom(type),
                 $"{typeName} must be a {nameof(ITranslatable)}");
 
@@ -85,9 +85,9 @@ namespace Microsoft.Build.BackEnd
                 {
                     ConstructorInfo constructor = null;
                     constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, Type.EmptyTypes, null);
-                    ErrorUtilities.VerifyThrowInvalidOperation(
+                    ErrorUtilities.VerifyThrow(
                         constructor != null,
-                        $"{typeName} must have a private parameterless constructor");
+                        "{0} must have a private parameterless constructor", typeName);
                     return constructor;
                 });
 

--- a/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
         public static CacheResult IndicateNonCacheHit(CacheResultType resultType)
         {
-            ErrorUtilities.VerifyThrowInvalidOperation(resultType != CacheResultType.CacheHit, "CantBeCacheHit");
+            ErrorUtilities.VerifyThrow(resultType != CacheResultType.CacheHit, "CantBeCacheHit");
             return new CacheResult(resultType);
         }
 

--- a/src/Build/Construction/ProjectElement.cs
+++ b/src/Build/Construction/ProjectElement.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Build.Construction
         public virtual void CopyFrom(ProjectElement element)
         {
             ErrorUtilities.VerifyThrowArgumentNull(element, nameof(element));
-            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), nameof(element));
+            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "UnrecognizedElement");
 
             if (this == element)
             {

--- a/src/Build/Construction/ProjectElement.cs
+++ b/src/Build/Construction/ProjectElement.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Build.Construction
         public virtual void CopyFrom(ProjectElement element)
         {
             ErrorUtilities.VerifyThrowArgumentNull(element, nameof(element));
-            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "UnrecognizedElement");
+            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "CannotCopyFromElementOfThatType");
 
             if (this == element)
             {

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Build.Construction
         public virtual void DeepCopyFrom(ProjectElementContainer element)
         {
             ErrorUtilities.VerifyThrowArgumentNull(element, nameof(element));
-            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "UnrecognizedElement");
+            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "CannotCopyFromElementOfThatType");
 
             if (this == element)
             {

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Build.Construction
         public virtual void DeepCopyFrom(ProjectElementContainer element)
         {
             ErrorUtilities.VerifyThrowArgumentNull(element, nameof(element));
-            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), nameof(element));
+            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "UnrecognizedElement");
 
             if (this == element)
             {

--- a/src/Build/Construction/ProjectExtensionsElement.cs
+++ b/src/Build/Construction/ProjectExtensionsElement.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Build.Construction
         public override void CopyFrom(ProjectElement element)
         {
             ErrorUtilities.VerifyThrowArgumentNull(element, nameof(element));
-            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), nameof(element));
+            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "UnrecognizedElement");
 
             if (this == element)
             {

--- a/src/Build/Construction/ProjectExtensionsElement.cs
+++ b/src/Build/Construction/ProjectExtensionsElement.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Build.Construction
         public override void CopyFrom(ProjectElement element)
         {
             ErrorUtilities.VerifyThrowArgumentNull(element, nameof(element));
-            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "UnrecognizedElement");
+            ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "CannotCopyFromElementOfThatType");
 
             if (this == element)
             {

--- a/src/Build/Errors/InvalidToolsetDefinitionException.cs
+++ b/src/Build/Errors/InvalidToolsetDefinitionException.cs
@@ -160,9 +160,7 @@ namespace Microsoft.Build.Exceptions
             string resourceName,
             params string[] args)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             string errorCode;
             string helpKeyword;
             string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out errorCode, out helpKeyword, resourceName, (object[])args);

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -762,7 +762,7 @@ namespace Microsoft.Build.Execution
 
             private static IDictionary<string, string> CreateTaskIdentityParametersDictionary(IDictionary<string, string> initialState = null, int? initialCount = null)
             {
-                ErrorUtilities.VerifyThrowInvalidOperation(initialState == null || initialCount == null, "at most one can be non-null");
+                ErrorUtilities.VerifyThrow(initialState == null || initialCount == null, "at most one can be non-null");
 
                 if (initialState != null)
                 {

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1996,7 +1996,14 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <comment>{StrBegin="MSB4120: "}</comment>
   </data>
   <data name="CannotCopyFromElementOfThatType" xml:space="preserve">
-    <value>MSB4276: Cannot copy from object of that type.</value>
-    <comment>{StrBegin="MSB4276: "}</comment>
+    <value>MSB4277: Cannot copy from object of that type.</value>
+    <comment>{StrBegin="MSB4277: "}</comment>
   </data>
+  <!--
+        The Build message bucket is: MSB4000 - MSB4999
+
+        Next message code should be MSB4278
+
+        Don't forget to update this comment after using a new code.
+  -->
 </root>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -463,10 +463,6 @@
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</comment>
   </data>
-  <data name="LoggingBeforeTaskInitialization" UESanitized="false" Visibility="Public">
-    <value>MSB6005: Task attempted to log before it was initialized. Message was: {0}</value>
-    <comment>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</comment>
-  </data>
   <data name="General.TwoVectorsMustHaveSameLength">
     <value>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</value>
     <comment>{StrBegin="MSB3094: "}</comment>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1995,4 +1995,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>MSB4120: Item '{0}' definition within target references itself via (qualified or unqualified) metadatum '{1}'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref</value>
     <comment>{StrBegin="MSB4120: "}</comment>
   </data>
+  <data name="CannotCopyFromElementOfThatType" xml:space="preserve">
+    <value>MSB4276: Cannot copy from object of that type.</value>
+    <comment>{StrBegin="MSB4276: "}</comment>
+  </data>
 </root>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -463,6 +463,14 @@
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</comment>
   </data>
+  <data name="LoggingBeforeTaskInitialization" UESanitized="false" Visibility="Public">
+    <value>MSB6005: Task attempted to log before it was initialized. Message was: {0}</value>
+    <comment>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</comment>
+  </data>
+  <data name="General.TwoVectorsMustHaveSameLength">
+    <value>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</value>
+    <comment>{StrBegin="MSB3094: "}</comment>
+  </data>
   <data name="FatalTaskError" xml:space="preserve">
     <value>MSB4018: The "{0}" task failed unexpectedly.</value>
     <comment>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -191,11 +191,6 @@
         <target state="translated">Od tohoto místa dále jsou parametry zkrácené. Pokud si chcete zobrazit všechny parametry, vymažte proměnnou prostředí MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Metaprojekt {0} byl vygenerován.</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Na pozici {1} podmínky {0} je neočekávaná mezera. Nezapomněli jste ji odebrat?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">Od tohoto místa dále jsou parametry zkrácené. Pokud si chcete zobrazit všechny parametry, vymažte proměnnou prostředí MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Nejde rozbalit metadata ve výrazu {0}. {1}</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Unerwartetes Leerzeichen an Position "{1}" der Bedingung "{0}". Haben Sie vergessen, ein Leerzeichen zu entfernen?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">Die Parameter wurden über diesen Punkt hinaus abgeschnitten. Um alle Parameter anzuzeigen, löschen Sie die Umgebungsvariable MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Metadaten können im Ausdruck "{0}" nicht erweitert werden. {1}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -191,11 +191,6 @@
         <target state="translated">Die Parameter wurden über diesen Punkt hinaus abgeschnitten. Um alle Parameter anzuzeigen, löschen Sie die Umgebungsvariable MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Das Metaprojekt "{0}" wurde generiert.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -191,11 +191,6 @@
         <target state="translated">Los parámetros se han truncado a partir de este punto. Para ver todos los parámetros, borre la variable de entorno MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Se generó el metaproyecto "{0}".</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Espacio inesperado en la posición "{1}" de la condición "{0}". ¿Olvidó quitar un espacio?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">Los parámetros se han truncado a partir de este punto. Para ver todos los parámetros, borre la variable de entorno MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: No se pueden expandir los metadatos en la expresión "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: espace inattendu à la position "{1}" de la condition "{0}". Avez-vous oublié de supprimer un espace ?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">Les paramètres ont été tronqués au-delà de ce point. Pour voir tous les paramètres, désactivez la variable d'environnement MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -191,11 +191,6 @@
         <target state="translated">Les paramètres ont été tronqués au-delà de ce point. Pour voir tous les paramètres, désactivez la variable d'environnement MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Le métaprojet "{0}" a été généré.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Impossible d'étendre les métadonnées dans l'expression "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: spazio imprevisto alla posizione "{1}" della condizione "{0}". Si è dimenticato di rimuovere uno spazio?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">I parametri oltre questo punto sono stati troncati. Per visualizzare tutti i parametri, cancellare la variabile di ambiente MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -191,11 +191,6 @@
         <target state="translated">I parametri oltre questo punto sono stati troncati. Per visualizzare tutti i parametri, cancellare la variabile di ambiente MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Il metaprogetto "{0}" è stato generato.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: non è possibile espandere i metadati nell'espressione "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -191,11 +191,6 @@
         <target state="translated">このポイントを超えるパラメーターは切り詰められています。すべてのパラメーターを表示するには、MSBUILDTRUNCATETASKINPUTLOGGING 環境変数をクリアします。</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">メタプロジェクト "{0}" が生成されました。</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: 条件 "{0}" の位置 "{1}" に予期しないスペースがあります。スペースを削除したか確認してください。</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">このポイントを超えるパラメーターは切り詰められています。すべてのパラメーターを表示するには、MSBUILDTRUNCATETASKINPUTLOGGING 環境変数をクリアします。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: 式 "{0}" の中のメタデータを展開できません。 {1}</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: "{0}" 조건의 "{1}" 위치에 예기치 않은 공백이 있습니다. 공백을 제거했는지 확인하세요.</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">이 지점 이후의 매개 변수가 잘렸습니다. 모든 매개 변수를 보려면 MSBUILDTRUNCATETASKINPUTLOGGING 환경 변수를 지우세요.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: "{0}" 식에서 메타데이터를 확장할 수 없습니다. {1}</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -191,11 +191,6 @@
         <target state="translated">이 지점 이후의 매개 변수가 잘렸습니다. 모든 매개 변수를 보려면 MSBUILDTRUNCATETASKINPUTLOGGING 환경 변수를 지우세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">메타프로젝트 "{0}"이(가) 생성되었습니다.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Nie można rozwinąć metadanych w wyrażeniu „{0}”. {1}</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -191,11 +191,6 @@
         <target state="translated">Parametry zostały obcięte za tym punktem. Aby wyświetlić wszystkie parametry, wyczyść zmienną środowiskową MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Wygenerowano metaprojekt „{0}”.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Nieoczekiwana spacja na pozycji „{1}” warunku „{0}”. Czy zapomniano o usunięciu spacji?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">Parametry zostały obcięte za tym punktem. Aby wyświetlić wszystkie parametry, wyczyść zmienną środowiskową MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: espaço inesperado na posição "{1}" da condição "{0}". Você esqueceu de remover um espaço?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">Os parâmetros foram truncados além deste ponto. Para exibir todos os parâmetros, limpe a variável de ambiente MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Não é possível expandir os metadados na expressão "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -191,11 +191,6 @@
         <target state="translated">Os parâmetros foram truncados além deste ponto. Para exibir todos os parâmetros, limpe a variável de ambiente MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Metaprojeto "{0}" gerado.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: невозможно развернуть метаданные в выражении "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: неожиданный пробел в позиции "{1}" условия "{0}". Вы забыли удалить пробел?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">Далее параметры были усечены. Чтобы просмотреть все параметры, очистите переменную среды MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -191,11 +191,6 @@
         <target state="translated">Далее параметры были усечены. Чтобы просмотреть все параметры, очистите переменную среды MSBUILDTRUNCATETASKINPUTLOGGING.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Создан метапроект "{0}".</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: "{0}" koşulunun "{1}" konumunda beklenmeyen boşluk var. Boşluğu kaldırmayı unutmuş olabilirsiniz.</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">Parametreler bu noktanın ötesinde kısaltıldı. Tüm parametreleri görüntülemek için MSBUILDTRUNCATETASKINPUTLOGGING ortam değişkenini temizleyin.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: "{0}" ifadesindeki meta veriler genişletilemiyor. {1}</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -191,11 +191,6 @@
         <target state="translated">Parametreler bu noktanın ötesinde kısaltıldı. Tüm parametreleri görüntülemek için MSBUILDTRUNCATETASKINPUTLOGGING ortam değişkenini temizleyin.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">"{0}" meta projesi oluşturuldu.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: 在条件“{0}”的位置“{1}”处出现意外空格。是否忘记了删除空格?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">这些参数在此点之前已被截断。若要查看所有参数，请清除 MSBUILDTRUNCATETASKINPUTLOGGING 环境变量。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -191,11 +191,6 @@
         <target state="translated">这些参数在此点之前已被截断。若要查看所有参数，请清除 MSBUILDTRUNCATETASKINPUTLOGGING 环境变量。</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">已生成元项目“{0}”。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: 无法在表达式“{0}”中展开元数据。{1}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -191,11 +191,6 @@
         <target state="translated">參數已在此點之後截斷。若要檢視所有參數，請清除 MSBUILDTRUNCATETASKINPUTLOGGING 環境變數。</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">已產生中繼專案 "{0}"。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -55,6 +55,11 @@
       LOCALIZATION: Do not localize the following words: ProjectReference, ProjectReferenceTargets
     </note>
       </trans-unit>
+      <trans-unit id="CannotCopyFromElementOfThatType">
+        <source>MSB4276: Cannot copy from object of that type.</source>
+        <target state="new">MSB4276: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4276: "}</note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: 無法在運算式 "{0}" 中展開中繼資料。{1}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -134,6 +134,11 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: 條件 "{0}" 的位置 "{1}" 出現非預期的空格。忘記移除空格了嗎?</target>
@@ -180,6 +185,11 @@
         <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
         <target state="translated">參數已在此點之後截斷。若要檢視所有參數，請清除 MSBUILDTRUNCATETASKINPUTLOGGING 環境變數。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -56,9 +56,9 @@
     </note>
       </trans-unit>
       <trans-unit id="CannotCopyFromElementOfThatType">
-        <source>MSB4276: Cannot copy from object of that type.</source>
-        <target state="new">MSB4276: Cannot copy from object of that type.</target>
-        <note>{StrBegin="MSB4276: "}</note>
+        <source>MSB4277: Cannot copy from object of that type.</source>
+        <target state="new">MSB4277: Cannot copy from object of that type.</target>
+        <note>{StrBegin="MSB4277: "}</note>
       </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>

--- a/src/Framework/ErrorUtilities.cs
+++ b/src/Framework/ErrorUtilities.cs
@@ -55,10 +55,7 @@ namespace Microsoft.Build.Framework
         /// </summary>
         internal static void ThrowInternalError(string message, Exception innerException, params object[] args)
         {
-            if (s_throwExceptions)
-            {
-                throw new InternalErrorException(string.Format(message, args), innerException);
-            }
+            throw new InternalErrorException(string.Format(message, args), innerException);
         }
     }
 }

--- a/src/Framework/ErrorUtilities.cs
+++ b/src/Framework/ErrorUtilities.cs
@@ -14,13 +14,6 @@ namespace Microsoft.Build.Framework
     internal class FrameworkErrorUtilities
     {
         /// <summary>
-        /// Emergency escape hatch. If a customer hits a bug in the shipped product causing an internal exception,
-        /// and fortuitously it happens that ignoring the VerifyThrow allows execution to continue in a reasonable way,
-        /// then we can give them this undocumented environment variable as an immediate workaround.
-        /// </summary>
-        private static readonly bool s_throwExceptions = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDONOTTHROWINTERNAL"));
-
-        /// <summary>
         /// This method should be used in places where one would normally put
         /// an "assert". It should be used to validate that our assumptions are
         /// true, where false would indicate that there must be a bug in our
@@ -47,7 +40,7 @@ namespace Microsoft.Build.Framework
         /// anything caused by user action.
         /// </summary>
         /// <param name="parameter">The value of the argument.</param>
-        /// <param name="parameterName">Parameter that should not be null</param>
+        /// <param name="parameterName">Parameter that should not be null.</param>
         internal static void VerifyThrowInternalNull(object parameter, string parameterName)
         {
             if (parameter == null)

--- a/src/Framework/ErrorUtilities.cs
+++ b/src/Framework/ErrorUtilities.cs
@@ -22,14 +22,10 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="condition"></param>
         /// <param name="unformattedMessage"></param>
-        internal static void VerifyThrow(
-            bool condition,
-            string unformattedMessage)
+        internal static void VerifyThrow(bool condition, string unformattedMessage)
         {
             if (!condition)
             {
-                // PERF NOTE: explicitly passing null for the arguments array
-                // prevents memory allocation
                 ThrowInternalError(unformattedMessage, null, null);
             }
         }

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -470,16 +470,6 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
-        /// Emergency escape hatch. If a customer hits a bug in the shipped product causing an internal exception,
-        /// and fortuitously it happens that ignoring the VerifyThrow allows execution to continue in a reasonable way,
-        /// then we can give them this undocumented environment variable as an immediate workaround.
-        /// </summary>
-        /// <remarks>
-        /// Clone from ErrorUtilities which isn't available in Framework.
-        /// </remarks>
-        private static readonly bool s_throwExceptions = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDONOTTHROWINTERNAL"));
-
-        /// <summary>
         /// Throws InternalErrorException.
         /// </summary>
         /// <remarks>

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -477,10 +477,7 @@ namespace Microsoft.Build.Framework
         /// </remarks>
         internal static void ThrowInternalError(string message)
         {
-            if (s_throwExceptions)
-            {
-                throw new InternalErrorException(message);
-            }
+            throw new InternalErrorException(message);
         }
 
         /// <summary>
@@ -492,10 +489,7 @@ namespace Microsoft.Build.Framework
         /// </remarks>
         internal static void ThrowInternalError(string message, params object[] args)
         {
-            if (s_throwExceptions)
-            {
-                throw new InternalErrorException(FormatString(message, args));
-            }
+            throw new InternalErrorException(FormatString(message, args));
         }
 
         /// <summary>

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -335,9 +335,7 @@ namespace Microsoft.Build.Shared
             bool condition,
             string resourceName)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             if (!condition)
             {
                 // PERF NOTE: explicitly passing null for the arguments array
@@ -357,9 +355,7 @@ namespace Microsoft.Build.Shared
             string resourceName,
             object arg0)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowInvalidOperation() method, because that method always
             // allocates memory for its variable array of arguments
@@ -382,9 +378,7 @@ namespace Microsoft.Build.Shared
             object arg0,
             object arg1)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowInvalidOperation() method, because that method always
             // allocates memory for its variable array of arguments
@@ -409,9 +403,7 @@ namespace Microsoft.Build.Shared
             object arg1,
             object arg2)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowInvalidOperation() method, because that method always
             // allocates memory for its variable array of arguments
@@ -438,9 +430,7 @@ namespace Microsoft.Build.Shared
             object arg2,
             object arg3)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowInvalidOperation() method, because that method always
             // allocates memory for its variable array of arguments
@@ -579,9 +569,7 @@ namespace Microsoft.Build.Shared
             Exception innerException,
             string resourceName)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             if (!condition)
             {
                 // PERF NOTE: explicitly passing null for the arguments array
@@ -604,9 +592,7 @@ namespace Microsoft.Build.Shared
             string resourceName,
             object arg0)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowArgument() method, because that method always allocates
             // memory for its variable array of arguments
@@ -632,9 +618,7 @@ namespace Microsoft.Build.Shared
             object arg0,
             object arg1)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowArgument() method, because that method always allocates
             // memory for its variable array of arguments
@@ -656,9 +640,7 @@ namespace Microsoft.Build.Shared
             object arg1,
             object arg2)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowArgument() method, because that method always allocates
             // memory for its variable array of arguments
@@ -681,9 +663,7 @@ namespace Microsoft.Build.Shared
             object arg2,
             object arg3)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowArgument() method, because that method always allocates
             // memory for its variable array of arguments
@@ -819,9 +799,7 @@ namespace Microsoft.Build.Shared
         /// <remarks>This method is thread-safe.</remarks>
         internal static void VerifyThrowArgumentNull(object parameter, string parameterName, string resourceName)
         {
-#if DEBUG
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             if (parameter == null)
             {
                 ThrowArgumentNull(parameterName, resourceName);

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -58,10 +58,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static void ThrowInternalError(string message, params object[] args)
         {
-            if (s_throwExceptions)
-            {
-                throw new InternalErrorException(ResourceUtilities.FormatString(message, args));
-            }
+            throw new InternalErrorException(ResourceUtilities.FormatString(message, args));
         }
 
         /// <summary>
@@ -70,10 +67,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static void ThrowInternalError(string message, Exception innerException, params object[] args)
         {
-            if (s_throwExceptions)
-            {
-                throw new InternalErrorException(ResourceUtilities.FormatString(message, args), innerException);
-            }
+            throw new InternalErrorException(ResourceUtilities.FormatString(message, args), innerException);
         }
 
         /// <summary>
@@ -83,10 +77,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static void ThrowInternalErrorUnreachable()
         {
-            if (s_throwExceptions)
-            {
-                throw new InternalErrorException("Unreachable?");
-            }
+            throw new InternalErrorException("Unreachable?");
         }
 
         /// <summary>
@@ -197,8 +188,6 @@ namespace Microsoft.Build.Shared
         /// code somewhere. This should not be used to throw errors based on bad
         /// user input or anything that the user did wrong.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
         internal static void VerifyThrow(
             bool condition,
             string unformattedMessage)
@@ -214,9 +203,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
-        /// <param name="arg0"></param>
         internal static void VerifyThrow(
             bool condition,
             string unformattedMessage,
@@ -234,10 +220,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
         internal static void VerifyThrow(
             bool condition,
             string unformattedMessage,
@@ -256,11 +238,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        /// <param name="arg2"></param>
         internal static void VerifyThrow(
             bool condition,
             string unformattedMessage,
@@ -280,12 +257,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        /// <param name="arg2"></param>
-        /// <param name="arg3"></param>
         internal static void VerifyThrow(
             bool condition,
             string unformattedMessage,
@@ -314,17 +285,12 @@ namespace Microsoft.Build.Shared
         /// <param name="args">Formatting args.</param>
         internal static void ThrowInvalidOperation(string resourceName, params object[] args)
         {
-            if (s_throwExceptions)
-            {
-                throw new InvalidOperationException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, args));
-            }
+            throw new InvalidOperationException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, args));
         }
 
         /// <summary>
         /// Throws an InvalidOperationException if the given condition is false.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
         internal static void VerifyThrowInvalidOperation(
             bool condition,
             string resourceName)
@@ -341,9 +307,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
         internal static void VerifyThrowInvalidOperation(
             bool condition,
             string resourceName,
@@ -362,10 +325,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
         internal static void VerifyThrowInvalidOperation(
             bool condition,
             string resourceName,
@@ -385,11 +344,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        /// <param name="arg2"></param>
         internal static void VerifyThrowInvalidOperation(
             bool condition,
             string resourceName,
@@ -410,12 +364,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        /// <param name="arg2"></param>
-        /// <param name="arg3"></param>
         internal static void VerifyThrowInvalidOperation(
             bool condition,
             string resourceName,
@@ -471,18 +419,13 @@ namespace Microsoft.Build.Shared
             string resourceName,
             params object[] args)
         {
-            if (s_throwExceptions)
-            {
-                throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, args), innerException);
-            }
+            throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, args), innerException);
         }
 
         /// <summary>
         /// Throws an ArgumentException if the given condition is false.
         /// </summary>
         /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
         internal static void VerifyThrowArgument(
             bool condition,
             string resourceName)
@@ -494,9 +437,6 @@ namespace Microsoft.Build.Shared
         /// Overload for one string format argument.
         /// </summary>
         /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
         internal static void VerifyThrowArgument(
             bool condition,
             string resourceName,
@@ -509,10 +449,6 @@ namespace Microsoft.Build.Shared
         /// Overload for two string format arguments.
         /// </summary>
         /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
         internal static void VerifyThrowArgument(
             bool condition,
             string resourceName,
@@ -577,10 +513,6 @@ namespace Microsoft.Build.Shared
         /// Overload for one string format argument.
         /// </summary>
         /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="innerException"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
         internal static void VerifyThrowArgument(
             bool condition,
             Exception innerException,
@@ -601,11 +533,6 @@ namespace Microsoft.Build.Shared
         /// Overload for two string format arguments.
         /// </summary>
         /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="innerException"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
         internal static void VerifyThrowArgument(
             bool condition,
             Exception innerException,
@@ -677,10 +604,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static void ThrowArgumentOutOfRange(string parameterName)
         {
-            if (s_throwExceptions)
-            {
-                throw new ArgumentOutOfRangeException(parameterName);
-            }
+            throw new ArgumentOutOfRangeException(parameterName);
         }
 
         /// <summary>
@@ -699,8 +623,6 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentNullException if the given string parameter is null
         /// and ArgumentException if it has zero length.
         /// </summary>
-        /// <param name="parameter"></param>
-        /// <param name="parameterName"></param>
         internal static void VerifyThrowArgumentLength(string parameter, string parameterName)
         {
             VerifyThrowArgumentNull(parameter, parameterName);
@@ -716,8 +638,6 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentNullException if the given collection is null
         /// and ArgumentException if it has zero length.
         /// </summary>
-        /// <param name="parameter"></param>
-        /// <param name="parameterName"></param>
         internal static void VerifyThrowArgumentLength<T>(IReadOnlyCollection<T> parameter, string parameterName)
         {
             VerifyThrowArgumentNull(parameter, parameterName);
@@ -731,8 +651,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentException if the given collection is not null but of zero length.
         /// </summary>
-        /// <param name="parameter"></param>
-        /// <param name="parameterName"></param>
         internal static void VerifyThrowArgumentLengthIfNotNull<T>(IReadOnlyCollection<T> parameter, string parameterName)
         {
             if (parameter?.Count == 0)
@@ -743,25 +661,20 @@ namespace Microsoft.Build.Shared
 #endif
         private static void ThrowArgumentLength(string parameterName)
         {
-            if (s_throwExceptions)
-            {
-                throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParameterCannotHaveZeroLength", parameterName));
-            }
+            throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParameterCannotHaveZeroLength", parameterName));
         }
 
         /// <summary>
         /// Throws an ArgumentNullException if the given string parameter is null
         /// and ArgumentException if it has zero length.
         /// </summary>
-        /// <param name="parameter"></param>
-        /// <param name="parameterName"></param>
         internal static void VerifyThrowArgumentInvalidPath(string parameter, string parameterName)
         {
             VerifyThrowArgumentNull(parameter, parameterName);
 
-            if (FileUtilities.PathIsInvalid(parameter) && s_throwExceptions)
+            if (FileUtilities.PathIsInvalid(parameter))
             {
-                throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParameterCannotHaveInvalidPathChars", parameterName, parameter));
+                ThrowArgument("Shared.ParameterCannotHaveInvalidPathChars", parameterName, parameter);
             }
         }
 
@@ -781,8 +694,6 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentNullException if the given parameter is null.
         /// </summary>
         /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="parameter"></param>
-        /// <param name="parameterName"></param>
         internal static void VerifyThrowArgumentNull(object parameter, string parameterName)
         {
             VerifyThrowArgumentNull(parameter, parameterName, "Shared.ParameterCannotBeNull");
@@ -803,31 +714,24 @@ namespace Microsoft.Build.Shared
 
         internal static void ThrowArgumentNull(string parameterName, string resourceName)
         {
-            if (s_throwExceptions)
-            {
-                // Most ArgumentNullException overloads append its own rather clunky multi-line message.
-                // So use the one overload that doesn't.
-                throw new ArgumentNullException(
-                    ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, parameterName),
-                    (Exception)null);
-            }
+            // Most ArgumentNullException overloads append its own rather clunky multi-line message.
+            // So use the one overload that doesn't.
+            throw new ArgumentNullException(
+                ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, parameterName),
+                (Exception)null);
         }
 
         /// <summary>
         /// Verifies the given arrays are not null and have the same length
         /// </summary>
-        /// <param name="parameter1"></param>
-        /// <param name="parameter2"></param>
-        /// <param name="parameter1Name"></param>
-        /// <param name="parameter2Name"></param>
         internal static void VerifyThrowArgumentArraysSameLength(Array parameter1, Array parameter2, string parameter1Name, string parameter2Name)
         {
             VerifyThrowArgumentNull(parameter1, parameter1Name);
             VerifyThrowArgumentNull(parameter2, parameter2Name);
 
-            if (parameter1.Length != parameter2.Length && s_throwExceptions)
+            if (parameter1.Length != parameter2.Length)
             {
-                throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParametersMustHaveTheSameLength", parameter1Name, parameter2Name));
+                ThrowArgument("Shared.ParametersMustHaveTheSameLength", parameter1Name, parameter2Name);
             }
         }
 
@@ -845,10 +749,7 @@ namespace Microsoft.Build.Shared
 
         internal static void ThrowObjectDisposed(string objectName)
         {
-            if (s_throwExceptions)
-            {
-                throw new ObjectDisposedException(objectName);
-            }
+            throw new ObjectDisposedException(objectName);
         }
 
         #endregion

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -22,12 +22,6 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal static class ErrorUtilities
     {
-        /// <summary>
-        /// Emergency escape hatch. If a customer hits a bug in the shipped product causing an internal exception,
-        /// and fortuitously it happens that ignoring the VerifyThrow allows execution to continue in a reasonable way,
-        /// then we can give them this undocumented environment variable as an immediate workaround.
-        /// </summary>
-        private static readonly bool s_throwExceptions = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDONOTTHROWINTERNAL"));
         private static readonly bool s_enableMSBuildDebugTracing = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDENABLEDEBUGTRACING"));
 
         #region DebugTracing
@@ -119,7 +113,7 @@ namespace Microsoft.Build.Shared
             // Check it has a real implementation of ToString()
             if (String.Equals(param.GetType().ToString(), param.ToString(), StringComparison.Ordinal))
             {
-                ErrorUtilities.ThrowInternalError("This type does not implement ToString() properly {0}", param.GetType().FullName);
+                ThrowInternalError("This type does not implement ToString() properly {0}", param.GetType().FullName);
             }
 #endif
         }
@@ -187,7 +181,7 @@ namespace Microsoft.Build.Shared
         /// This should be used ONLY if this would indicate a bug in MSBuild rather than
         /// anything caused by user action.
         /// </summary>
-        /// <param name="value">Parameter that should be a rooted path</param>
+        /// <param name="value">Parameter that should be a rooted path.</param>
         internal static void VerifyThrowInternalRooted(string value)
         {
             if (!Path.IsPathRooted(value))
@@ -431,6 +425,7 @@ namespace Microsoft.Build.Shared
             object arg3)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
+
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowInvalidOperation() method, because that method always
             // allocates memory for its variable array of arguments

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -52,9 +52,9 @@ namespace Microsoft.Build.Shared
 
         internal static void VerifyThrowInternalError(bool condition, string message, params object[] args)
         {
-            if (s_throwExceptions && !condition)
+            if (!condition)
             {
-                throw new InternalErrorException(ResourceUtilities.FormatString(message, args));
+                ThrowInternalError(message, args);
             }
         }
 
@@ -102,9 +102,9 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static void VerifyThrowInternalErrorUnreachable(bool condition)
         {
-            if (s_throwExceptions && !condition)
+            if (!condition)
             {
-                throw new InternalErrorException("Unreachable?");
+                ThrowInternalErrorUnreachable();
             }
         }
 
@@ -320,9 +320,6 @@ namespace Microsoft.Build.Shared
         /// <param name="args">Formatting args.</param>
         internal static void ThrowInvalidOperation(string resourceName, params object[] args)
         {
-#if DEBUG
-            ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             if (s_throwExceptions)
             {
                 throw new InvalidOperationException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, args));
@@ -338,6 +335,9 @@ namespace Microsoft.Build.Shared
             bool condition,
             string resourceName)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             if (!condition)
             {
                 // PERF NOTE: explicitly passing null for the arguments array
@@ -357,6 +357,9 @@ namespace Microsoft.Build.Shared
             string resourceName,
             object arg0)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowInvalidOperation() method, because that method always
             // allocates memory for its variable array of arguments
@@ -379,6 +382,9 @@ namespace Microsoft.Build.Shared
             object arg0,
             object arg1)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowInvalidOperation() method, because that method always
             // allocates memory for its variable array of arguments
@@ -403,6 +409,9 @@ namespace Microsoft.Build.Shared
             object arg1,
             object arg2)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowInvalidOperation() method, because that method always
             // allocates memory for its variable array of arguments
@@ -429,6 +438,9 @@ namespace Microsoft.Build.Shared
             object arg2,
             object arg3)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowInvalidOperation() method, because that method always
             // allocates memory for its variable array of arguments
@@ -474,9 +486,6 @@ namespace Microsoft.Build.Shared
             string resourceName,
             params object[] args)
         {
-#if DEBUG
-            ResourceUtilities.VerifyResourceStringExists(resourceName);
-#endif
             if (s_throwExceptions)
             {
                 throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, args), innerException);
@@ -570,6 +579,9 @@ namespace Microsoft.Build.Shared
             Exception innerException,
             string resourceName)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             if (!condition)
             {
                 // PERF NOTE: explicitly passing null for the arguments array
@@ -592,6 +604,9 @@ namespace Microsoft.Build.Shared
             string resourceName,
             object arg0)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowArgument() method, because that method always allocates
             // memory for its variable array of arguments
@@ -617,6 +632,9 @@ namespace Microsoft.Build.Shared
             object arg0,
             object arg1)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowArgument() method, because that method always allocates
             // memory for its variable array of arguments
@@ -638,6 +656,9 @@ namespace Microsoft.Build.Shared
             object arg1,
             object arg2)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowArgument() method, because that method always allocates
             // memory for its variable array of arguments
@@ -660,6 +681,9 @@ namespace Microsoft.Build.Shared
             object arg2,
             object arg3)
         {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
             // PERF NOTE: check the condition here instead of pushing it into
             // the ThrowArgument() method, because that method always allocates
             // memory for its variable array of arguments
@@ -706,9 +730,9 @@ namespace Microsoft.Build.Shared
         {
             VerifyThrowArgumentNull(parameter, parameterName);
 
-            if (parameter.Length == 0 && s_throwExceptions)
+            if (parameter.Length == 0)
             {
-                throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParameterCannotHaveZeroLength", parameterName));
+                ThrowArgumentLength(parameterName);
             }
         }
 
@@ -723,9 +747,9 @@ namespace Microsoft.Build.Shared
         {
             VerifyThrowArgumentNull(parameter, parameterName);
 
-            if (parameter.Count == 0 && s_throwExceptions)
+            if (parameter.Count == 0)
             {
-                throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParameterCannotHaveZeroLength", parameterName));
+                ThrowArgumentLength(parameterName);
             }
         }
 
@@ -736,12 +760,19 @@ namespace Microsoft.Build.Shared
         /// <param name="parameterName"></param>
         internal static void VerifyThrowArgumentLengthIfNotNull<T>(IReadOnlyCollection<T> parameter, string parameterName)
         {
-            if (parameter?.Count == 0 && s_throwExceptions)
+            if (parameter?.Count == 0)
+            {
+                ThrowArgumentLength(parameterName);
+            }
+        }
+#endif
+        private static void ThrowArgumentLength(string parameterName)
+        {
+            if (s_throwExceptions)
             {
                 throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParameterCannotHaveZeroLength", parameterName));
             }
         }
-#endif
 
         /// <summary>
         /// Throws an ArgumentNullException if the given string parameter is null
@@ -765,9 +796,9 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static void VerifyThrowArgumentLengthIfNotNull(string parameter, string parameterName)
         {
-            if (parameter?.Length == 0 && s_throwExceptions)
+            if (parameter?.Length == 0)
             {
-                throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParameterCannotHaveZeroLength", parameterName));
+                ThrowArgumentLength(parameterName);
             }
         }
 
@@ -788,7 +819,18 @@ namespace Microsoft.Build.Shared
         /// <remarks>This method is thread-safe.</remarks>
         internal static void VerifyThrowArgumentNull(object parameter, string parameterName, string resourceName)
         {
-            if (parameter == null && s_throwExceptions)
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
+            if (parameter == null)
+            {
+                ThrowArgumentNull(parameterName, resourceName);
+            }
+        }
+
+        internal static void ThrowArgumentNull(string parameterName, string resourceName)
+        {
+            if (s_throwExceptions)
             {
                 // Most ArgumentNullException overloads append its own rather clunky multi-line message.
                 // So use the one overload that doesn't.
@@ -822,11 +864,17 @@ namespace Microsoft.Build.Shared
 
         internal static void VerifyThrowObjectDisposed(bool condition, string objectName)
         {
+            if (!condition)
             {
-                if (s_throwExceptions && !condition)
-                {
-                    throw new ObjectDisposedException(objectName);
-                }
+                ThrowObjectDisposed(objectName);
+            }
+        }
+
+        internal static void ThrowObjectDisposed(string objectName)
+        {
+            if (s_throwExceptions)
+            {
+                throw new ObjectDisposedException(objectName);
             }
         }
 

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Build.Shared
     {
         private static readonly bool s_enableMSBuildDebugTracing = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDENABLEDEBUGTRACING"));
 
-        #region DebugTracing
         public static void DebugTraceMessage(string category, string formatstring, params object[] parameters)
         {
             if (s_enableMSBuildDebugTracing)
@@ -39,10 +38,8 @@ namespace Microsoft.Build.Shared
                 }
             }
         }
-        #endregion
 
 #if !BUILDINGAPPXTASKS
-        #region VerifyThrow -- for internal errors
 
         internal static void VerifyThrowInternalError(bool condition, string message, params object[] args)
         {
@@ -188,14 +185,10 @@ namespace Microsoft.Build.Shared
         /// code somewhere. This should not be used to throw errors based on bad
         /// user input or anything that the user did wrong.
         /// </summary>
-        internal static void VerifyThrow(
-            bool condition,
-            string unformattedMessage)
+        internal static void VerifyThrow(bool condition, string unformattedMessage)
         {
             if (!condition)
             {
-                // PERF NOTE: explicitly passing null for the arguments array
-                // prevents memory allocation
                 ThrowInternalError(unformattedMessage, null, null);
             }
         }
@@ -203,14 +196,8 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        internal static void VerifyThrow(
-            bool condition,
-            string unformattedMessage,
-            object arg0)
+        internal static void VerifyThrow(bool condition, string unformattedMessage, object arg0)
         {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInternalError() method, because that method always
-            // allocates memory for its variable array of arguments
             if (!condition)
             {
                 ThrowInternalError(unformattedMessage, arg0);
@@ -220,15 +207,8 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        internal static void VerifyThrow(
-            bool condition,
-            string unformattedMessage,
-            object arg0,
-            object arg1)
+        internal static void VerifyThrow(bool condition, string unformattedMessage, object arg0, object arg1)
         {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInternalError() method, because that method always
-            // allocates memory for its variable array of arguments
             if (!condition)
             {
                 ThrowInternalError(unformattedMessage, arg0, arg1);
@@ -238,16 +218,8 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        internal static void VerifyThrow(
-            bool condition,
-            string unformattedMessage,
-            object arg0,
-            object arg1,
-            object arg2)
+        internal static void VerifyThrow(bool condition, string unformattedMessage, object arg0, object arg1, object arg2)
         {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInternalError() method, because that method always
-            // allocates memory for its variable array of arguments
             if (!condition)
             {
                 ThrowInternalError(unformattedMessage, arg0, arg1, arg2);
@@ -257,26 +229,13 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        internal static void VerifyThrow(
-            bool condition,
-            string unformattedMessage,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3)
+        internal static void VerifyThrow(bool condition, string unformattedMessage, object arg0, object arg1, object arg2, object arg3)
         {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInternalError() method, because that method always
-            // allocates memory for its variable array of arguments
             if (!condition)
             {
                 ThrowInternalError(unformattedMessage, arg0, arg1, arg2, arg3);
             }
         }
-
-        #endregion
-
-        #region VerifyThrowInvalidOperation
 
         /// <summary>
         /// Throws an InvalidOperationException with the specified resource string
@@ -291,15 +250,11 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an InvalidOperationException if the given condition is false.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(
-            bool condition,
-            string resourceName)
+        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             if (!condition)
             {
-                // PERF NOTE: explicitly passing null for the arguments array
-                // prevents memory allocation
                 ThrowInvalidOperation(resourceName, null);
             }
         }
@@ -307,10 +262,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(
-            bool condition,
-            string resourceName,
-            object arg0)
+        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName, object arg0)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             // PERF NOTE: check the condition here instead of pushing it into
@@ -325,11 +277,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1)
+        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName, object arg0, object arg1)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             // PERF NOTE: check the condition here instead of pushing it into
@@ -344,12 +292,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2)
+        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName, object arg0, object arg1, object arg2)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             // PERF NOTE: check the condition here instead of pushing it into
@@ -364,13 +307,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3)
+        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName, object arg0, object arg1, object arg2, object arg3)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
 
@@ -383,10 +320,6 @@ namespace Microsoft.Build.Shared
             }
         }
 
-        #endregion
-
-        #region VerifyThrowArgument
-
         /// <summary>
         /// Throws an ArgumentException that can include an inner exception.
         ///
@@ -394,9 +327,7 @@ namespace Microsoft.Build.Shared
         /// is expensive, because memory is allocated for the array of arguments -- do
         /// not call this method repeatedly in performance-critical scenarios
         /// </summary>
-        internal static void ThrowArgument(
-            string resourceName,
-            params object[] args)
+        internal static void ThrowArgument(string resourceName, params object[] args)
         {
             ThrowArgument(null, resourceName, args);
         }
@@ -414,10 +345,7 @@ namespace Microsoft.Build.Shared
         /// <param name="innerException">Can be null.</param>
         /// <param name="resourceName"></param>
         /// <param name="args"></param>
-        internal static void ThrowArgument(
-            Exception innerException,
-            string resourceName,
-            params object[] args)
+        internal static void ThrowArgument(Exception innerException, string resourceName, params object[] args)
         {
             throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, args), innerException);
         }
@@ -425,10 +353,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentException if the given condition is false.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            string resourceName)
+        internal static void VerifyThrowArgument(bool condition, string resourceName)
         {
             VerifyThrowArgument(condition, null, resourceName);
         }
@@ -436,11 +361,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            string resourceName,
-            object arg0)
+        internal static void VerifyThrowArgument(bool condition, string resourceName, object arg0)
         {
             VerifyThrowArgument(condition, null, resourceName, arg0);
         }
@@ -448,12 +369,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1)
+        internal static void VerifyThrowArgument(bool condition, string resourceName, object arg0, object arg1)
         {
             VerifyThrowArgument(condition, null, resourceName, arg0, arg1);
         }
@@ -461,13 +377,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2)
+        internal static void VerifyThrowArgument(bool condition, string resourceName, object arg0, object arg1, object arg2)
         {
             VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2);
         }
@@ -475,14 +385,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3)
+        internal static void VerifyThrowArgument(bool condition, string resourceName, object arg0, object arg1, object arg2, object arg3)
         {
             VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2, arg3);
         }
@@ -491,20 +394,14 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentException that includes an inner exception, if
         /// the given condition is false.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
         /// <param name="condition"></param>
         /// <param name="innerException">Can be null.</param>
         /// <param name="resourceName"></param>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            Exception innerException,
-            string resourceName)
+        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             if (!condition)
             {
-                // PERF NOTE: explicitly passing null for the arguments array
-                // prevents memory allocation
                 ThrowArgument(innerException, resourceName, null);
             }
         }
@@ -512,17 +409,10 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            Exception innerException,
-            string resourceName,
-            object arg0)
+        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName, object arg0)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowArgument() method, because that method always allocates
-            // memory for its variable array of arguments
+
             if (!condition)
             {
                 ThrowArgument(innerException, resourceName, arg0);
@@ -532,18 +422,10 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            Exception innerException,
-            string resourceName,
-            object arg0,
-            object arg1)
+        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName, object arg0, object arg1)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowArgument() method, because that method always allocates
-            // memory for its variable array of arguments
+
             if (!condition)
             {
                 ThrowArgument(innerException, resourceName, arg0, arg1);
@@ -553,19 +435,10 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            Exception innerException,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2)
+        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName, object arg0, object arg1, object arg2)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowArgument() method, because that method always allocates
-            // memory for its variable array of arguments
+
             if (!condition)
             {
                 ThrowArgument(innerException, resourceName, arg0, arg1, arg2);
@@ -575,29 +448,15 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument(
-            bool condition,
-            Exception innerException,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3)
+        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName, object arg0, object arg1, object arg2, object arg3)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowArgument() method, because that method always allocates
-            // memory for its variable array of arguments
+
             if (!condition)
             {
                 ThrowArgument(innerException, resourceName, arg0, arg1, arg2, arg3);
             }
         }
-
-        #endregion
-
-        #region VerifyThrowArgumentXXX
 
         /// <summary>
         /// Throws an argument out of range exception.
@@ -693,7 +552,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentNullException if the given parameter is null.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
         internal static void VerifyThrowArgumentNull(object parameter, string parameterName)
         {
             VerifyThrowArgumentNull(parameter, parameterName, "Shared.ParameterCannotBeNull");
@@ -702,7 +560,6 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentNullException if the given parameter is null.
         /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
         internal static void VerifyThrowArgumentNull(object parameter, string parameterName, string resourceName)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
@@ -714,11 +571,8 @@ namespace Microsoft.Build.Shared
 
         internal static void ThrowArgumentNull(string parameterName, string resourceName)
         {
-            // Most ArgumentNullException overloads append its own rather clunky multi-line message.
-            // So use the one overload that doesn't.
-            throw new ArgumentNullException(
-                ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, parameterName),
-                (Exception)null);
+            // Most ArgumentNullException overloads append its own rather clunky multi-line message. So use the one overload that doesn't.
+            throw new ArgumentNullException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, parameterName), (Exception)null);
         }
 
         /// <summary>
@@ -735,10 +589,6 @@ namespace Microsoft.Build.Shared
             }
         }
 
-        #endregion
-
-        #region VerifyThrowObjectDisposed
-
         internal static void VerifyThrowObjectDisposed(bool condition, string objectName)
         {
             if (!condition)
@@ -751,8 +601,6 @@ namespace Microsoft.Build.Shared
         {
             throw new ObjectDisposedException(objectName);
         }
-
-        #endregion
 #endif
     }
 }

--- a/src/Shared/ProjectErrorUtilities.cs
+++ b/src/Shared/ProjectErrorUtilities.cs
@@ -1,17 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-/******************************************************************************
- * 
- *                              !! WARNING !!
- * 
- * This class depends on the build engine assembly! Do not share this class
- * into any assembly that is not supposed to take a dependency on the build
- * engine assembly!
- * 
- * 
- ******************************************************************************/
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 
 #nullable disable
@@ -36,10 +25,7 @@ namespace Microsoft.Build.Shared
         /// <param name="condition">The condition to check.</param>
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
-        internal static void VerifyThrowInvalidProject(
-            bool condition,
-            IElementLocation elementLocation,
-            string resourceName)
+        internal static void VerifyThrowInvalidProject(bool condition, IElementLocation elementLocation, string resourceName)
         {
             VerifyThrowInvalidProject(condition, null, elementLocation, resourceName);
         }
@@ -50,10 +36,7 @@ namespace Microsoft.Build.Shared
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
-        internal static void ThrowInvalidProject<T1>(
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0)
+        internal static void ThrowInvalidProject<T1>(IElementLocation elementLocation, string resourceName, T1 arg0)
         {
             ThrowInvalidProject(null, elementLocation, resourceName, arg0);
         }
@@ -65,11 +48,7 @@ namespace Microsoft.Build.Shared
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
-        internal static void VerifyThrowInvalidProject<T1>(
-            bool condition,
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0)
+        internal static void VerifyThrowInvalidProject<T1>(bool condition, IElementLocation elementLocation, string resourceName, T1 arg0)
         {
             VerifyThrowInvalidProject(condition, null, elementLocation, resourceName, arg0);
         }
@@ -81,11 +60,7 @@ namespace Microsoft.Build.Shared
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
-        internal static void ThrowInvalidProject<T1, T2>(
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0,
-            T2 arg1)
+        internal static void ThrowInvalidProject<T1, T2>(IElementLocation elementLocation, string resourceName, T1 arg0, T2 arg1)
         {
             ThrowInvalidProject(null, elementLocation, resourceName, arg0, arg1);
         }
@@ -98,12 +73,7 @@ namespace Microsoft.Build.Shared
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
-        internal static void ThrowInvalidProject<T1, T2, T3>(
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0,
-            T2 arg1,
-            T3 arg2)
+        internal static void ThrowInvalidProject<T1, T2, T3>(IElementLocation elementLocation, string resourceName, T1 arg0, T2 arg1, T3 arg2)
         {
             ThrowInvalidProject(null, elementLocation, resourceName, arg0, arg1, arg2);
         }
@@ -117,13 +87,7 @@ namespace Microsoft.Build.Shared
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
         /// <param name="arg3"></param>
-        internal static void ThrowInvalidProject<T1, T2, T3, T4>(
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0,
-            T2 arg1,
-            T3 arg2,
-            T4 arg3)
+        internal static void ThrowInvalidProject<T1, T2, T3, T4>(IElementLocation elementLocation, string resourceName, T1 arg0, T2 arg1, T3 arg2, T4 arg3)
         {
             ThrowInvalidProject(null, elementLocation, resourceName, arg0, arg1, arg2, arg3);
         }
@@ -134,10 +98,7 @@ namespace Microsoft.Build.Shared
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="args"></param>
-        internal static void ThrowInvalidProject(
-            IElementLocation elementLocation,
-            string resourceName,
-            params object[] args)
+        internal static void ThrowInvalidProject(IElementLocation elementLocation, string resourceName, params object[] args)
         {
             ThrowInvalidProject(null, elementLocation, resourceName, args);
         }
@@ -150,12 +111,7 @@ namespace Microsoft.Build.Shared
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
-        internal static void VerifyThrowInvalidProject<T1, T2>(
-            bool condition,
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0,
-            T2 arg1)
+        internal static void VerifyThrowInvalidProject<T1, T2>(bool condition, IElementLocation elementLocation, string resourceName, T1 arg0, T2 arg1)
         {
             VerifyThrowInvalidProject(condition, null, elementLocation, resourceName, arg0, arg1);
         }
@@ -169,13 +125,7 @@ namespace Microsoft.Build.Shared
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
-        internal static void VerifyThrowInvalidProject<T1, T2, T3>(
-            bool condition,
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0,
-            T2 arg1,
-            T3 arg2)
+        internal static void VerifyThrowInvalidProject<T1, T2, T3>(bool condition, IElementLocation elementLocation, string resourceName, T1 arg0, T2 arg1, T3 arg2)
         {
             VerifyThrowInvalidProject(condition, null, elementLocation, resourceName, arg0, arg1, arg2);
         }
@@ -190,14 +140,7 @@ namespace Microsoft.Build.Shared
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
         /// <param name="arg3"></param>
-        internal static void VerifyThrowInvalidProject<T1, T2, T3, T4>(
-            bool condition,
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0,
-            T2 arg1,
-            T3 arg2,
-            T4 arg3)
+        internal static void VerifyThrowInvalidProject<T1, T2, T3, T4>(bool condition, IElementLocation elementLocation, string resourceName, T1 arg0, T2 arg1, T3 arg2, T4 arg3)
         {
             VerifyThrowInvalidProject(condition, null, elementLocation, resourceName, arg0, arg1, arg2, arg3);
         }
@@ -212,16 +155,10 @@ namespace Microsoft.Build.Shared
         /// error sub-category (can be null).</param>
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
-        internal static void VerifyThrowInvalidProject(
-            bool condition,
-            string errorSubCategoryResourceName,
-            IElementLocation elementLocation,
-            string resourceName)
+        internal static void VerifyThrowInvalidProject(bool condition, string errorSubCategoryResourceName, IElementLocation elementLocation, string resourceName)
         {
             if (!condition)
             {
-                // PERF NOTE: explicitly passing null for the arguments array
-                // prevents memory allocation
                 ThrowInvalidProject(errorSubCategoryResourceName, elementLocation, resourceName, null);
             }
         }
@@ -235,16 +172,8 @@ namespace Microsoft.Build.Shared
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
-        internal static void VerifyThrowInvalidProject<T1>(
-            bool condition,
-            string errorSubCategoryResourceName,
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0)
+        internal static void VerifyThrowInvalidProject<T1>(bool condition, string errorSubCategoryResourceName, IElementLocation elementLocation, string resourceName, T1 arg0)
         {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInvalidProject() method, because that method always
-            // allocates memory for its variable array of arguments
             if (!condition)
             {
                 ThrowInvalidProject(errorSubCategoryResourceName, elementLocation, resourceName, arg0);
@@ -261,17 +190,8 @@ namespace Microsoft.Build.Shared
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
-        internal static void VerifyThrowInvalidProject<T1, T2>(
-            bool condition,
-            string errorSubCategoryResourceName,
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0,
-            T2 arg1)
+        internal static void VerifyThrowInvalidProject<T1, T2>(bool condition, string errorSubCategoryResourceName, IElementLocation elementLocation, string resourceName, T1 arg0, T2 arg1)
         {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInvalidProject() method, because that method always
-            // allocates memory for its variable array of arguments
             if (!condition)
             {
                 ThrowInvalidProject(errorSubCategoryResourceName, elementLocation, resourceName, arg0, arg1);
@@ -289,18 +209,8 @@ namespace Microsoft.Build.Shared
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
-        internal static void VerifyThrowInvalidProject<T1, T2, T3>(
-            bool condition,
-            string errorSubCategoryResourceName,
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0,
-            T2 arg1,
-            T3 arg2)
+        internal static void VerifyThrowInvalidProject<T1, T2, T3>(bool condition, string errorSubCategoryResourceName, IElementLocation elementLocation, string resourceName, T1 arg0, T2 arg1, T3 arg2)
         {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInvalidProject() method, because that method always
-            // allocates memory for its variable array of arguments
             if (!condition)
             {
                 ThrowInvalidProject(errorSubCategoryResourceName, elementLocation, resourceName, arg0, arg1, arg2);
@@ -319,19 +229,8 @@ namespace Microsoft.Build.Shared
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
         /// <param name="arg3"></param>
-        internal static void VerifyThrowInvalidProject<T1, T2, T3, T4>(
-            bool condition,
-            string errorSubCategoryResourceName,
-            IElementLocation elementLocation,
-            string resourceName,
-            T1 arg0,
-            T2 arg1,
-            T3 arg2,
-            T4 arg3)
+        internal static void VerifyThrowInvalidProject<T1, T2, T3, T4>(bool condition, string errorSubCategoryResourceName, IElementLocation elementLocation, string resourceName, T1 arg0, T2 arg1, T3 arg2, T4 arg3)
         {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInvalidProject() method, because that method always
-            // allocates memory for its variable array of arguments
             if (!condition)
             {
                 ThrowInvalidProject(errorSubCategoryResourceName, elementLocation, resourceName, arg0, arg1, arg2, arg3);
@@ -351,11 +250,7 @@ namespace Microsoft.Build.Shared
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="args">Extra arguments for formatting the error message.</param>
-        private static void ThrowInvalidProject(
-            string errorSubCategoryResourceName,
-            IElementLocation elementLocation,
-            string resourceName,
-            params object[] args)
+        private static void ThrowInvalidProject(string errorSubCategoryResourceName, IElementLocation elementLocation, string resourceName, params object[] args)
         {
             ErrorUtilities.VerifyThrowInternalNull(elementLocation, nameof(elementLocation));
 #if DEBUG

--- a/src/Shared/ResourceUtilities.cs
+++ b/src/Shared/ResourceUtilities.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-#if !BUILDINGAPPXTASKS && DEBUG
+#if !BUILDINGAPPXTASKS
 using System.Resources;
 using System.Diagnostics;
 #endif
@@ -261,9 +261,9 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <remarks>This method is thread-safe.</remarks>
         /// <param name="resourceName">Resource string to check.</param>
+        [Conditional("DEBUG")]
         internal static void VerifyResourceStringExists(string resourceName)
         {
-#if DEBUG
             try
             {
                 // Look up the resource string in the engine's string table.
@@ -298,6 +298,5 @@ namespace Microsoft.Build.Shared
             }
 #endif
         }
-#endif
     }
 }

--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -283,6 +283,10 @@
     <comment>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</comment>
   </data>
+  <data name="LoggingBeforeTaskInitialization" UESanitized="false" Visibility="Public">
+    <value>MSB6005: Task attempted to log before it was initialized. Message was: {0}</value>
+    <comment>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</comment>
+  </data>
   <!--
         The shared message bucket is: MSB5001 - MSB5999
 

--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">Předtím, než bude pro hostitele úlohy použito prostředí přijaté z nadřazeného uzlu, budou provedeny jeho následující úpravy:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">Es werden folgende vom übergeordneten Knoten empfangene Änderungen an der Umgebung vorgenommen, bevor sie auf den Aufgabenhost angewendet wird:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">Se están realizando las siguientes modificaciones en el entorno recibido del nodo primario antes de aplicarlo al host de tareas:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">Modifications suivantes en cours sur l'environnement reçu du nœud parent avant son application à l'hôte de tâche :</target>

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">Le modifiche seguenti verranno apportate all'ambiente ricevuto dal nodo padre prima dell'applicazione all'host attività:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">親ノードから受け取った環境をタスク ホストに適用する前に、次の変更を行っています:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0}({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">작업 호스트에 적용하기 전에 부모 노드로부터 받은 환경을 다음과 같이 수정하고 있습니다.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">Wymienione zmiany otrzymane z węzła nadrzędnego zostaną wprowadzone w środowisku, a po sprawdzeniu działania zastosowane do hosta zadań:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">Fazendo as seguintes modificações no ambiente recebido do nó pai antes de aplicá-lo ao host de tarefas:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">Перед применением окружения, полученного от родительского узла, к серверу задач в нем выполняются следующие изменения:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">Üst düğümden alınan ortam görev ana bilgisayarına uygulanmadan önce ortamda aşağıdaki değişiklikler yapılıyor:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">先对从父节点收到的环境进行以下修改，然后再将其应用于任务宿主:</target>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">{0} ({1},{2})</target>
         <note>A file location to be embedded in a string.</note>
       </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
       <trans-unit id="ModifyingTaskHostEnvironmentHeader">
         <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
         <target state="translated">在套用到工作主機之前，對從父節點接收的環境進行下列修改:</target>

--- a/src/Utilities/Resources/Strings.resx
+++ b/src/Utilities/Resources/Strings.resx
@@ -120,10 +120,6 @@
     <data name="General.ToolCommandFailedNoErrorCode">
         <value>The command exited with code {0}.</value>
     </data>
-    <data name="LoggingBeforeTaskInitialization" UESanitized="false" Visibility="Public">
-        <value>MSB6005: Task attempted to log before it was initialized. Message was: {0}</value>
-        <comment>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</comment>
-    </data>
     <data name="PlatformManifest.MissingPlatformXml" UESanitized="false" Visibility="Private_OM">
         <value>MSB6010: Could not find platform manifest file at "{0}".</value>
         <comment>{StrBegin="MSB6010: "}</comment>

--- a/src/Utilities/Resources/xlf/Strings.cs.xlf
+++ b/src/Utilities/Resources/xlf/Strings.cs.xlf
@@ -27,11 +27,6 @@
         <target state="translated">Příkaz byl ukončen s kódem {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: Úloha se pokusila přihlásit před tím, než byla inicializována. Zpráva: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: Nepovedlo se najít soubor manifestu platformy v umístění {0}.</target>

--- a/src/Utilities/Resources/xlf/Strings.de.xlf
+++ b/src/Utilities/Resources/xlf/Strings.de.xlf
@@ -27,11 +27,6 @@
         <target state="translated">Der Befehl wurde mit dem Code {0} beendet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: Die Aufgabe hat versucht, eine Protokollierung durchzuführen, bevor sie initialisiert wurde. Meldung: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: Plattform-Manifestdatei in "{0}" nicht gefunden.</target>

--- a/src/Utilities/Resources/xlf/Strings.es.xlf
+++ b/src/Utilities/Resources/xlf/Strings.es.xlf
@@ -27,11 +27,6 @@
         <target state="translated">El comando salió con el código {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: La tarea intentó registrarse antes de inicializarse. El mensaje era: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: No se ha podido encontrar el archivo de manifiesto de plataforma en "{0}".</target>

--- a/src/Utilities/Resources/xlf/Strings.fr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.fr.xlf
@@ -27,11 +27,6 @@
         <target state="translated">La commande s'est arrêtée avec le code {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: La tâche a tenté d'ouvrir une session avant d'être initialisée. Le message était le suivant : {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: Impossible de trouver le fichier manifeste de la plateforme dans "{0}".</target>

--- a/src/Utilities/Resources/xlf/Strings.it.xlf
+++ b/src/Utilities/Resources/xlf/Strings.it.xlf
@@ -27,11 +27,6 @@
         <target state="translated">Uscita dal comando con codice {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: tentativo di registrazione prima dell'inizializzazione dell'attività. Messaggio: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: il file manifesto della piattaforma non è stato trovato in "{0}".</target>

--- a/src/Utilities/Resources/xlf/Strings.ja.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ja.xlf
@@ -27,11 +27,6 @@
         <target state="translated">コマンドはコード {0} で終了しました。</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: タスクは、初期化される前にログを記録しようとしました。メッセージ: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: "{0}" にプラットフォームのマニフェスト ファイルが見つかりませんでした。</target>

--- a/src/Utilities/Resources/xlf/Strings.ko.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ko.xlf
@@ -27,11 +27,6 @@
         <target state="translated">명령이 종료되었습니다(코드: {0}).</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: 작업을 초기화하기 전에 로깅하려고 했습니다. 메시지: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: "{0}"에서 플랫폼 매니페스트 파일을 찾을 수 없습니다.</target>

--- a/src/Utilities/Resources/xlf/Strings.pl.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pl.xlf
@@ -27,11 +27,6 @@
         <target state="translated">Polecenie zostało zakończone z kodem {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: Zadanie podjęło próbę zarejestrowania przed zainicjowaniem. Pojawił się komunikat: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: nie można odnaleźć pliku manifestu platformy w lokalizacji „{0}”.</target>

--- a/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
@@ -27,11 +27,6 @@
         <target state="translated">O comando foi encerrado com o código {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: A tarefa tentou fazer o registro antes de ser inicializada. A mensagem era: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: não foi possível encontrar o arquivo de manifesto da plataforma em "{0}".</target>

--- a/src/Utilities/Resources/xlf/Strings.ru.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ru.xlf
@@ -27,11 +27,6 @@
         <target state="translated">Выход из команды с кодом "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: задачей предпринята попытка вести журнал до своей инициализации. Сообщение: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: не удалось найти файл манифеста платформы по адресу "{0}".</target>

--- a/src/Utilities/Resources/xlf/Strings.tr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.tr.xlf
@@ -27,11 +27,6 @@
         <target state="translated">Komuttan {0} koduyla çıkıldı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: Görev başlatılmadan önce günlüğe yazmaya çalıştı. İleti: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: Platform bildirim dosyası, "{0}" konumunda bulunamadı.</target>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
@@ -27,11 +27,6 @@
         <target state="translated">命令已退出，代码为 {0}。</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: 任务尚未初始化就尝试进行日志记录。消息为: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: 找不到“{0}”中的平台清单文件。</target>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
@@ -27,11 +27,6 @@
         <target state="translated">命令以返回碼 {0} 結束。</target>
         <note />
       </trans-unit>
-      <trans-unit id="LoggingBeforeTaskInitialization">
-        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
-        <target state="translated">MSB6005: 工作在初始化之前就嘗試記錄。訊息為: {0}</target>
-        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
-      </trans-unit>
       <trans-unit id="PlatformManifest.MissingPlatformXml">
         <source>MSB6010: Could not find platform manifest file at "{0}".</source>
         <target state="translated">MSB6010: 在 "{0}" 找不到平台資訊清單檔案。</target>


### PR DESCRIPTION
1. Moved resource string existence check (in debug) consistently outside of the condition. This detected cases where we were using an invalid resource string, but the condition was never false. Fixed these. Note, it doesn't need to be localized message or even probably the same exception type because almost by definition, these conditions have never been true, and possibly can never be true (otherwise they'd have hit the missing resource already). Also, change method to be debug-only so as to remove the #if.

2. Moved s_throwExceptions consistently inside the condition check as cleaner.

3. Move exception construction consistently out of the VerifyThrowXX methods so this cold path doesn't prevent them inlining.

4. Remove string formatting inside the condition in one place where string interpolation was happening.