### PR TITLE
Add BaseOutputPath to XSD

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1933,6 +1933,11 @@ elementFormDefault="qualified">
         </xs:annotation>
     </xs:element>
     <xs:element name="OSVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="BaseOutputPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="BaseOutputPath" _locComment="" -->Base path of output folder, to which configurations may be appended, with trailing slash</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="OutputPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
         <xs:annotation>
             <xs:documentation><!-- _locID_text="OutputPath" _locComment="" -->Path to output folder, with trailing slash</xs:documentation>


### PR DESCRIPTION
VS completion doesn't offer `BaseOutputPath` in MSBuild files. This change adds the property to the XSD to enable that.
