### PR TITLE
Avoid boxing enum

### DIFF
--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2522,7 +2522,7 @@ namespace Microsoft.Build.Evaluation
 
         private void RecordEvaluatedItemElement(ProjectItemElement itemElement)
         {
-            if (_loadSettings.HasFlag(ProjectLoadSettings.RecordEvaluatedItemElements))
+            if ((_loadSettings & ProjectLoadSettings.RecordEvaluatedItemElements) == ProjectLoadSettings.RecordEvaluatedItemElements)
             {
                 _data.EvaluatedItemElements.Add(itemElement);
             }


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1848255

### Context
On .NET Framework this boxes an enum, and allocated 600 MB in a trace I was looking at.

<img width="552" alt="image" src="https://github.com/dotnet/msbuild/assets/1103906/6a0baa9c-a2b4-4c11-b2b2-4c8400b41662">