### PR TITLE
Improving the log of CombineTargetFrameworkInfoProperties fails with not valid RootElementName

### DIFF
--- a/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
+++ b/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
@@ -17,20 +17,22 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void RootElementNameNotValid()
         {
+            MockEngine e = new MockEngine();
             var task = new CombineTargetFrameworkInfoProperties();
+            task.BuildEngine = e;
             var items = new ITaskItem[]
             {
                 new TaskItemData("ItemSpec1", null)
             };
             task.PropertiesAndValues = items;
             task.UseAttributeForTargetFrameworkInfoPropertyNames = true;
-            var exp = Assert.Throws<ArgumentNullException>(() => task.Execute());
-            exp.Message.ShouldContain("RootElementName");
+            task.Execute().ShouldBe(false);
+            e.AssertLogContains("MSB3992");
 
             task.RootElementName = string.Empty;
             task.UseAttributeForTargetFrameworkInfoPropertyNames = false;
-            var exp1 = Assert.Throws<ArgumentException>(() => task.Execute());
-            exp1.Message.ShouldContain("RootElementName");
+            task.Execute().ShouldBe(false);
+            e.AssertLogContains("MSB3991");
         }
     }
 }

--- a/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
+++ b/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests
+{
+    public sealed class CombineTargetFrameworkInfoProperties_Tests
+    {
+        /// <summary>
+        /// https://github.com/dotnet/msbuild/issues/8320
+        /// </summary>
+        [Fact]
+        public void RootElementNameNotValid()
+        {
+            var task = new CombineTargetFrameworkInfoProperties();
+            var items = new ITaskItem[]
+            {
+                new TaskItemData("ItemSpec1", null)
+            };
+            task.PropertiesAndValues = items;
+            task.UseAttributeForTargetFrameworkInfoPropertyNames = true;
+            var exp = Assert.Throws<ArgumentNullException>(() => task.Execute());
+            exp.Message.ShouldContain("RootElementName");
+
+            task.RootElementName = string.Empty;
+            task.UseAttributeForTargetFrameworkInfoPropertyNames = false;
+            var exp1 = Assert.Throws<ArgumentException>(() => task.Execute());
+            exp1.Message.ShouldContain("RootElementName");
+        }
+    }
+}

--- a/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
+++ b/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
@@ -14,8 +14,11 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// https://github.com/dotnet/msbuild/issues/8320
         /// </summary>
-        [Fact]
-        public void RootElementNameNotValid()
+        [Theory]
+        [InlineData(null, false, "MSB3991")]
+        [InlineData("", false, "MSB3991")]
+        [InlineData(null, true, "MSB3992")]
+        public void RootElementNameNotValid(string rootElementName, bool UseAttributeForTargetFrameworkInfoPropertyNames, string errorCode)
         {
             MockEngine e = new MockEngine();
             var task = new CombineTargetFrameworkInfoProperties();
@@ -24,15 +27,11 @@ namespace Microsoft.Build.UnitTests
             {
                 new TaskItemData("ItemSpec1", null)
             };
+            task.RootElementName = rootElementName;
             task.PropertiesAndValues = items;
-            task.UseAttributeForTargetFrameworkInfoPropertyNames = true;
+            task.UseAttributeForTargetFrameworkInfoPropertyNames = UseAttributeForTargetFrameworkInfoPropertyNames;
             task.Execute().ShouldBe(false);
-            e.AssertLogContains("MSB3992");
-
-            task.RootElementName = string.Empty;
-            task.UseAttributeForTargetFrameworkInfoPropertyNames = false;
-            task.Execute().ShouldBe(false);
-            e.AssertLogContains("MSB3991");
+            e.AssertLogContains(errorCode);
         }
     }
 }

--- a/src/Tasks/CombineTargetFrameworkInfoProperties.cs
+++ b/src/Tasks/CombineTargetFrameworkInfoProperties.cs
@@ -17,7 +17,28 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The root element name to use for the generated XML string
         /// </summary>
-        public string RootElementName { get; set; }
+        private string _rootElementName;
+
+        /// <summary>
+        /// Gets or sets the root element name to use for the generated XML string
+        /// </summary>
+        public string RootElementName
+        {
+            get
+            {
+                if (!UseAttributeForTargetFrameworkInfoPropertyNames)
+                {
+                    ErrorUtilities.VerifyThrowArgumentLength(_rootElementName, nameof(RootElementName));
+                }
+                else
+                {
+                    ErrorUtilities.VerifyThrowArgumentNull(_rootElementName, nameof(RootElementName));
+                }
+                return _rootElementName;
+            }
+
+            set => _rootElementName = value;
+        }
 
         /// <summary>
         /// Items to include in the XML.  The ItemSpec should be the property name, and it should have Value metadata for its value.
@@ -39,9 +60,17 @@ namespace Microsoft.Build.Tasks
         {
             if (PropertiesAndValues != null)
             {
+                if (!UseAttributeForTargetFrameworkInfoPropertyNames)
+                {
+                    ErrorUtilities.VerifyThrowArgumentLength(_rootElementName, nameof(RootElementName));
+                }
+                else
+                {
+                    ErrorUtilities.VerifyThrowArgumentNull(_rootElementName, nameof(RootElementName));
+                }
                 XElement root = UseAttributeForTargetFrameworkInfoPropertyNames ?
-                    new("TargetFramework", new XAttribute("Name", EscapingUtilities.Escape(RootElementName))) :
-                    new(RootElementName);
+                    new("TargetFramework", new XAttribute("Name", EscapingUtilities.Escape(_rootElementName))) :
+                    new(_rootElementName);
 
                 foreach (ITaskItem item in PropertiesAndValues)
                 {

--- a/src/Tasks/CombineTargetFrameworkInfoProperties.cs
+++ b/src/Tasks/CombineTargetFrameworkInfoProperties.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.Tasks
                 if ((!UseAttributeForTargetFrameworkInfoPropertyNames && string.IsNullOrEmpty(RootElementName)) || (UseAttributeForTargetFrameworkInfoPropertyNames && RootElementName == null))
                 {
                     string resource = UseAttributeForTargetFrameworkInfoPropertyNames ? "CombineTargetFrameworkInfoProperties.NotNullRootElementName" : "CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName";
-                    Log.LogErrorWithCodeFromResources(resource, "RootElementName");
+                    Log.LogErrorWithCodeFromResources(resource, nameof(RootElementName), nameof(UseAttributeForTargetFrameworkInfoPropertyNames));
                 }
                 else
                 {

--- a/src/Tasks/CombineTargetFrameworkInfoProperties.cs
+++ b/src/Tasks/CombineTargetFrameworkInfoProperties.cs
@@ -17,29 +17,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The root element name to use for the generated XML string
         /// </summary>
-        private string _rootElementName;
-
-        /// <summary>
-        /// Gets or sets the root element name to use for the generated XML string
-        /// </summary>
-        public string RootElementName
-        {
-            get
-            {
-                if (!UseAttributeForTargetFrameworkInfoPropertyNames)
-                {
-                    ErrorUtilities.VerifyThrowArgumentLength(_rootElementName, nameof(RootElementName));
-                }
-                else
-                {
-                    ErrorUtilities.VerifyThrowArgumentNull(_rootElementName, nameof(RootElementName));
-                }
-                return _rootElementName;
-            }
-
-            set => _rootElementName = value;
-        }
-
+        public string RootElementName { get; set; }
         /// <summary>
         /// Items to include in the XML.  The ItemSpec should be the property name, and it should have Value metadata for its value.
         /// </summary>
@@ -60,24 +38,24 @@ namespace Microsoft.Build.Tasks
         {
             if (PropertiesAndValues != null)
             {
-                if (!UseAttributeForTargetFrameworkInfoPropertyNames)
+                if ((!UseAttributeForTargetFrameworkInfoPropertyNames && string.IsNullOrEmpty(RootElementName)) || (UseAttributeForTargetFrameworkInfoPropertyNames && RootElementName == null))
                 {
-                    ErrorUtilities.VerifyThrowArgumentLength(_rootElementName, nameof(RootElementName));
+                    string resource = UseAttributeForTargetFrameworkInfoPropertyNames ? "CombineTargetFrameworkInfoProperties.NotNullRootElementName" : "CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName";
+                    Log.LogErrorWithCodeFromResources(resource, "RootElementName");
                 }
                 else
                 {
-                    ErrorUtilities.VerifyThrowArgumentNull(_rootElementName, nameof(RootElementName));
-                }
-                XElement root = UseAttributeForTargetFrameworkInfoPropertyNames ?
-                    new("TargetFramework", new XAttribute("Name", EscapingUtilities.Escape(_rootElementName))) :
-                    new(_rootElementName);
+                    XElement root = UseAttributeForTargetFrameworkInfoPropertyNames ?
+                        new("TargetFramework", new XAttribute("Name", EscapingUtilities.Escape(RootElementName))) :
+                        new(RootElementName);
 
-                foreach (ITaskItem item in PropertiesAndValues)
-                {
-                    root.Add(new XElement(item.ItemSpec, item.GetMetadata("Value")));
-                }
+                    foreach (ITaskItem item in PropertiesAndValues)
+                    {
+                        root.Add(new XElement(item.ItemSpec, item.GetMetadata("Value")));
+                    }
 
-                Result = root.ToString();
+                    Result = root.ToString();
+                }
             }
             return !Log.HasLoggedErrors;
         }

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2990,11 +2990,11 @@
         MSB3991 - MSB3999   Task: CombineTargetFrameworkInfoProperties
   -->
   <data name="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-    <value>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</value>
+    <value>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</value>
     <comment>{StrBegin="MSB3991: "}</comment>
   </data>
   <data name="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-    <value>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</value>
+    <value>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</value>
     <comment>{StrBegin="MSB3992: "}</comment>
   </data>
   <!--

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2985,6 +2985,18 @@
   <data name="ResolveKeySource.PfxUnsupported" xml:space="preserve">
     <value>PFX signing not supported on .NET Core.</value>
   </data>
+
+  <!--
+        MSB3991 - MSB3999   Task: CombineTargetFrameworkInfoProperties
+  -->
+  <data name="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+    <value>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</value>
+    <comment>{StrBegin="MSB3991: "}</comment>
+  </data>
+  <data name="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+    <value>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</value>
+    <comment>{StrBegin="MSB3992: "}</comment>
+  </data>
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 
@@ -3071,6 +3083,7 @@
             MSB3961 - MSB3970   Task: GenerateLauncher
             MSB3971 - MSB3980   Task: GetReferenceAssemblyPaths overflow
             MSB3981 - MSB3990   Task: GetCompatiblePlatform
+            MSB3991 - MSB3999   Task: CombineTargetFrameworkInfoProperties
 
             MSB4000 - MSB4200   Portable targets & tasks (vsproject\flavors\portable\msbuild)
             MSB9000 - MSB9900   MSBuild targets files (C++)

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: Pozdržené podepisování požaduje, aby byl určen alespoň veřejný klíč.  Zadejte veřejný klíč pomocí vlastnosti KeyFile nebo KeyContainer, nebo zakažte pozdržené podepisování.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Závažná chyba: víc než {0} argumentů příkazového řádku</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: Für verzögertes Signieren muss mindestens ein öffentlicher Schlüssel angegeben werden.  Geben Sie entweder einen öffentlichen Schlüssel mithilfe der KeyFile- oder KeyContainer-Eigenschaft an, oder deaktivieren Sie verzögertes Signieren.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Schwerwiegender Fehler: mehr als {0} Befehlszeilenargumente.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: La firma retrasada requiere que se especifique al menos una clave pública.  Proporcione una clave pública mediante las propiedades KeyFile o KeyContainer, o deshabilite la firma retrasada.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Error irrecuperable: más de {0} argumentos de línea de comandos.</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: La signature différée nécessite qu'au moins une clé publique soit spécifiée.  Indiquez une clé publique à l'aide des propriétés KeyFile ou KeyContainer, ou désactivez la signature différée.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Erreur fatale : plus de {0} arguments de ligne de commande.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: la firma ritardata richiede che sia specificata almeno una chiave pubblica. Fornire una chiave pubblica usando le proprietà KeyFile o KeyContainer oppure disabilitare la firma ritardata.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Errore irreversibile: più di {0} argomenti della riga di comando.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: 遅延署名には、最低でも 1 つの公開キーを指定する必要があります。KeyFile または KeyContainer プロパティを使用して公開キーを提供するか、遅延署名を無効にしてください。</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: 致命的なエラー: コマンド ライン引数が {0} を超えています。</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: 서명을 연기하려면 적어도 공개 키를 지정해야 합니다.  KeyFile 또는 KeyContainer 속성을 사용하여 공개 키를 제공하거나 서명 연기를 비활성화하세요.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: 심각한 오류: 명령줄 인수가 {0}개를 넘었습니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: Podpisywanie opóźnione wymaga określenia przynajmniej klucza publicznego.  Podaj klucz publiczny przy użyciu właściwości KeyFile lub KeyContainer albo wyłącz podpisywanie opóźnione.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Błąd krytyczny: liczba argumentów wiersza polecenia większa niż {0}.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: A assinatura atrasada requer que pelo menos uma chave pública seja especificada.  Forneça uma chave pública usando as propriedades KeyFile ou KeyContainer ou desabilite a assinatura atrasada.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Erro Fatal: mais de {0} argumentos de linha de comando.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: для отложенного подписывания необходимо указать хотя бы один открытый ключ.  Укажите открытый ключ с помощью свойства KeyFile или KeyContainer либо отключите отложенное подписывание.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: неустранимая ошибка: число аргументов командной строки превышает {0}.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: Gecikmeli imzalama, en azından bir ortak anahtar belirtilmesini gerektirir.  Lütfen KeyFile veya KeyContainer özelliklerini kullanarak bir ortak anahtar sağlayın veya gecikmeli imzalamayı devre dışı bırakın.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Kritik Hata: Komut satırı bağımsız değişkenleri şu sayıdan fazla: {0}.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: 延迟签名要求至少指定一个公钥。请使用 KeyFile 或 KeyContainer 属性提供一个公钥，或者禁用延迟签名。</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: 严重错误: 超出 {0} 个命令行参数。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -121,6 +121,16 @@
         <target state="translated">MSB3654: 延遲簽署需要至少指定一個公開金鑰。請使用 KeyFile 或 KeyContainer 屬性提供公開金鑰，或停用延遲簽署。</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
+        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <note>{StrBegin="MSB3991: "}</note>
+      </trans-unit>
+      <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
+        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <note>{StrBegin="MSB3992: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: 嚴重錯誤: 命令列引數的數目超過 {0} 個。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -122,13 +122,13 @@
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
-        <source>MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</source>
-        <target state="new">MSB3991: '{0}' is not set or empty. When UseAttributeForTargetFrameworkInfoPropertyNames is false, make sure to set a non-empty value for '{0}'.</target>
+        <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
+        <target state="new">MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</target>
         <note>{StrBegin="MSB3991: "}</note>
       </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullRootElementName">
-        <source>MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</source>
-        <target state="new">MSB3992: '{0}' is not set. When UseAttributeForTargetFrameworkInfoPropertyNames is true, make sure to set a value for '{0}'.</target>
+        <source>MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</source>
+        <target state="new">MSB3992: '{0}' is not set. When {1} is true, make sure to set a value for '{0}'.</target>
         <note>{StrBegin="MSB3992: "}</note>
       </trans-unit>
       <trans-unit id="Compiler.FatalArguments">


### PR DESCRIPTION
Fixes [#8320](https://github.com/dotnet/msbuild/issues/8320)

### Context
[CombineTargetFrameworkInfoProperties](https://github.com/dotnet/msbuild/blob/3c3b3c52a142f75532de216eb7a9b9c832d99da6/src/Tasks/CombineTargetFrameworkInfoProperties.cs#L42C16-L45)) is not handling null case of RootElementName. And empty RootElementName when UseAttributeForTargetFrameworkInfoPropertyNames is false.

### Changes Made
Add the verification with the name of the parameter.

### Testing
RootElementNameNotValid()

### Notes
