### PR TITLE
Switch TaskItemData exceptions

### DIFF
--- a/src/Framework/TaskItemData.cs
+++ b/src/Framework/TaskItemData.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.Framework
         IEnumerable<KeyValuePair<string, string>> IMetadataContainer.EnumerateMetadata() => Metadata;
 
         void IMetadataContainer.ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
-            => throw new NotImplementedException();
+            => throw new InvalidOperationException($"{nameof(TaskItemData)} does not support write operations");
 
         public int MetadataCount => Metadata.Count;
 
@@ -66,7 +66,7 @@ namespace Microsoft.Build.Framework
 
         public void CopyMetadataTo(ITaskItem destinationItem)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException($"{nameof(TaskItemData)} does not support write operations");
         }
 
         public string GetMetadata(string metadataName)
@@ -77,12 +77,12 @@ namespace Microsoft.Build.Framework
 
         public void RemoveMetadata(string metadataName)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException($"{nameof(TaskItemData)} does not support write operations");
         }
 
         public void SetMetadata(string metadataName, string metadataValue)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException($"{nameof(TaskItemData)} does not support write operations");
         }
 
         public override string ToString()


### PR DESCRIPTION
They were NotImplementedExceptions, but that wasn't an accurate representation of why they threw, which is that write operations aren't supported on this type.
