### PR TITLE
Add StringIntern for Item and Property Functions.

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3315,7 +3315,7 @@ namespace Microsoft.Build.Evaluation
                         ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "InvalidFunctionStaticMethodSyntax", expressionFunction, String.Empty);
                     }
 
-                    var typeName = expressionRoot.Slice(1, typeEndIndex - 1).ToString();
+                    var typeName = Strings.WeakIntern(expressionRoot.Slice(1, typeEndIndex - 1));
                     var methodStartIndex = typeEndIndex + 1;
 
                     if (expressionRoot.Length > methodStartIndex + 2 && expressionRoot[methodStartIndex] == ':' && expressionRoot[methodStartIndex + 1] == ':')
@@ -3373,7 +3373,7 @@ namespace Microsoft.Build.Evaluation
                     var rootEndIndex = expressionRoot.IndexOf('.');
 
                     // If this is an instance function rather than a static, then we'll capture the name of the property referenced
-                    var functionReceiver = expressionRoot.Slice(0, rootEndIndex).Trim().ToString();
+                    var functionReceiver = Strings.WeakIntern(expressionRoot.Slice(0, rootEndIndex).Trim());
 
                     // If propertyValue is null (we're not recursing), then we're expecting a valid property name
                     if (propertyValue == null && !IsValidPropertyName(functionReceiver))

--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -156,10 +156,7 @@ namespace Microsoft.Build.Evaluation
 
                     // Grab the name, but continue to verify it's a well-formed expression
                     // before we store it.
-                    string name = expression.Substring(startOfName, i - startOfName);
-
-                    // return the item that we're working with
-                    string itemName = name;
+                    string itemName = Microsoft.NET.StringTools.Strings.WeakIntern(expression.AsSpan(startOfName, i - startOfName));
 
                     SinkWhitespace(expression, ref i);
                     bool transformOrFunctionFound = true;
@@ -251,10 +248,10 @@ namespace Microsoft.Build.Evaluation
                         subExpressions = new List<ItemExpressionCapture>();
                     }
 
-                    // Create an expression capture that encompases the entire expression between the @( and the )
+                    // Create an expression capture that encompasses the entire expression between the @( and the )
                     // with the item name and any separator contained within it
                     // and each transform expression contained within it (i.e. each ->XYZ)
-                    ItemExpressionCapture expressionCapture = new ItemExpressionCapture(startPoint, endPoint - startPoint, expression.Substring(startPoint, endPoint - startPoint), itemName, separator, separatorStart, transformExpressions);
+                    ItemExpressionCapture expressionCapture = new ItemExpressionCapture(startPoint, endPoint - startPoint, Microsoft.NET.StringTools.Strings.WeakIntern(expression.AsSpan(startPoint, endPoint - startPoint)), itemName, separator, separatorStart, transformExpressions);
                     subExpressions.Add(expressionCapture);
 
                     continue;
@@ -601,7 +598,7 @@ namespace Microsoft.Build.Evaluation
 
                     if (endFunctionArguments > startFunctionArguments)
                     {
-                        capture.FunctionArguments = expression.Substring(startFunctionArguments, endFunctionArguments - startFunctionArguments);
+                        capture.FunctionArguments = Microsoft.NET.StringTools.Strings.WeakIntern(expression.AsSpan(startFunctionArguments, endFunctionArguments - startFunctionArguments));
                     }
 
                     return capture;


### PR DESCRIPTION
Remove duplicated strings from Item and Property Function.  Intern these strings to reduce memory usage.

### Context
Strings used parsing Item and Property Function are duplicated many times, common offenders are "Contains", "Strings", and "true".  

### Changes Made
Use the  Strings.WeakIntern() tool to cache the strings.  Since these are common strings which are shared among projects, use the global String store instead of the project specific store.

### Testing
Profiled with the Visual Studio Memory Inspector.  This reduced 5-6mb of strings saved in our internal Repro of 200 projects.

### Notes
There are still other places here duplicate string exists, this PR focus only on these locations.