### PR TITLE
adjust XmlReader.Create to passed path with potentially invalid character

### DIFF
--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -299,10 +299,11 @@ namespace Microsoft.Build.Construction
             try
             {
                 // Read project thru a XmlReader with proper setting to avoid DTD processing
-                var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+                var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
                 var projectDocument = new XmlDocument();
 
-                using (XmlReader xmlReader = XmlReader.Create(AbsolutePath, xrSettings))
+                FileStream fs = File.OpenRead(AbsolutePath);
+                using (XmlReader xmlReader = XmlReader.Create(fs, xrSettings))
                 {
                     // Load the project file and get the first node    
                     projectDocument.Load(xmlReader);

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -888,10 +888,11 @@ namespace Microsoft.Build.Construction
                 *</EFPROJECT>
                 **********************************************************************************/
                 // Make sure the XML reader ignores DTD processing
-                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
 
                 // Load the .etp project file thru the XML reader
-                using (XmlReader xmlReader = XmlReader.Create(fullPathToEtpProj, readerSettings))
+                FileStream fs = File.OpenRead(fullPathToEtpProj);
+                using (XmlReader xmlReader = XmlReader.Create(fs, readerSettings))
                 {
                     etpProjectDocument.Load(xmlReader);
                 }

--- a/src/Tasks/AppConfig/AppConfig.cs
+++ b/src/Tasks/AppConfig/AppConfig.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Read the .config from a file.
         /// </summary>
-        /// <param name="appConfigFile"></param>
-        internal void Load(string appConfigFile)
+        /// <param name="appConfigFilePath"></param>
+        internal void Load(string appConfigFilePath)
         {
             XmlReader reader = null;
             try
@@ -29,11 +29,11 @@ namespace Microsoft.Build.Tasks
 
                 // it's important to normalize the path as it may contain two slashes
                 // see https://github.com/dotnet/msbuild/issues/4335 for details.
-                appConfigFile = FileUtilities.NormalizePath(appConfigFile);
+                appConfigFilePath = FileUtilities.NormalizePath(appConfigFilePath);
 
                 // Need a filestream as the XmlReader doesn't support nonstandard unicode characters in path.
                 // No need to dispose - as 'CloseInput' was passed to XmlReaderSettings
-                FileStream fs = File.OpenRead(appConfigFile);
+                FileStream fs = File.OpenRead(appConfigFilePath);
                 reader = XmlReader.Create(fs, readerSettings);
                 Read(reader);
             }
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Tasks
                     linePosition = info.LinePosition;
                 }
 
-                throw new AppConfigException(e.Message, appConfigFile, lineNumber, linePosition, e);
+                throw new AppConfigException(e.Message, appConfigFilePath, lineNumber, linePosition, e);
             }
             catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
             {
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Tasks
                     linePosition = info.LinePosition;
                 }
 
-                throw new AppConfigException(e.Message, appConfigFile, lineNumber, linePosition, e);
+                throw new AppConfigException(e.Message, appConfigFilePath, lineNumber, linePosition, e);
             }
             finally
             {

--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -532,14 +532,15 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 foreach (string subDirectory in Directory.GetDirectories(startDirectory))
                 {
                     string resourceDirectory = System.IO.Path.Combine(startDirectory, subDirectory);
-                    string resourceFile = System.IO.Path.Combine(resourceDirectory, SETUP_RESOURCES_FILE);
-                    if (FileSystems.Default.FileExists(resourceFile))
+                    string resourceFilePath = System.IO.Path.Combine(resourceDirectory, SETUP_RESOURCES_FILE);
+                    if (FileSystems.Default.FileExists(resourceFilePath))
                     {
                         var resourceDoc = new XmlDocument();
                         try
                         {
-                            var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                            using (var xr = XmlReader.Create(resourceFile, xrs))
+                            var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                            FileStream fs = File.OpenRead(resourceFilePath);
+                            using (var xr = XmlReader.Create(fs, xrs))
                             {
                                 resourceDoc.Load(xr);
                             }
@@ -836,8 +837,9 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
 #pragma warning disable 618 // Using XmlValidatingReader. TODO: We need to switch to using XmlReader.Create() with validation.
                         var validatingReader = new XmlValidatingReader(xmlReader);
 #pragma warning restore 618
-                        var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                        using (XmlReader xr = XmlReader.Create(schemaPath, xrSettings))
+                        var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                        FileStream fs = File.OpenRead(schemaPath);
+                        using (XmlReader xr = XmlReader.Create(fs, xrSettings))
                         {
                             try
                             {

--- a/src/Tasks/ManifestUtil/ApplicationManifest.cs
+++ b/src/Tasks/ManifestUtil/ApplicationManifest.cs
@@ -527,8 +527,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             if (!TrustInfo.IsFullTrust)
             {
                 var document = new XmlDocument();
-                var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                using (XmlReader xr = XmlReader.Create(configFile.ResolvedPath, xrs))
+                var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                FileStream fs = File.OpenRead(configFile.ResolvedPath);
+                using (XmlReader xr = XmlReader.Create(fs, xrs))
                 {
                     document.Load(xr);
                 }

--- a/src/Tasks/ManifestUtil/AssemblyIdentity.cs
+++ b/src/Tasks/ManifestUtil/AssemblyIdentity.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private static AssemblyIdentity FromManifest(Stream s)
         {
             var document = new XmlDocument();
-            var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+            var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
             try
             {
                 using (XmlReader xr = XmlReader.Create(s, xrSettings))

--- a/src/Tasks/ManifestUtil/AssemblyIdentity.cs
+++ b/src/Tasks/ManifestUtil/AssemblyIdentity.cs
@@ -193,8 +193,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             var document = new XmlDocument();
             try
             {
-                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                using (XmlReader xmlReader = XmlReader.Create(path, readerSettings))
+                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                FileStream fs = File.OpenRead(path);
+                using (XmlReader xmlReader = XmlReader.Create(fs, readerSettings))
                 {
                     document.Load(xmlReader);
                 }
@@ -210,7 +211,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private static AssemblyIdentity FromManifest(Stream s)
         {
             var document = new XmlDocument();
-            var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+            var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
             try
             {
                 using (XmlReader xr = XmlReader.Create(s, xrSettings))

--- a/src/Tasks/ManifestUtil/DeployManifest.cs
+++ b/src/Tasks/ManifestUtil/DeployManifest.cs
@@ -213,8 +213,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             try
             {
                 var doc = new XmlDocument();
-                var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                using (XmlReader xr = XmlReader.Create(redistListFilePath, xrSettings))
+                var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                FileStream fs = File.OpenRead(redistListFilePath);
+                using (XmlReader xr = XmlReader.Create(fs, xrSettings))
                 {
                     doc.Load(xr);
                     XmlNode fileListNode = doc.DocumentElement;

--- a/src/Tasks/ManifestUtil/Manifest.cs
+++ b/src/Tasks/ManifestUtil/Manifest.cs
@@ -376,8 +376,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         internal static void UpdateEntryPoint(string inputPath, string outputPath, string updatedApplicationPath, string applicationManifestPath, string targetFrameworkVersion)
         {
             var document = new XmlDocument();
-            var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-            using (XmlReader xr = XmlReader.Create(inputPath, xrSettings))
+            var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+            FileStream fs = File.OpenRead(inputPath);
+            using (XmlReader xr = XmlReader.Create(fs, xrSettings))
             {
                 document.Load(xr);
             }

--- a/src/Tasks/ManifestUtil/ManifestReader.cs
+++ b/src/Tasks/ManifestUtil/ManifestReader.cs
@@ -61,15 +61,17 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 // if first two bytes are "MZ" then we're looking at an .exe or a .dll not a .manifest
                 if ((buffer[0] == 0x4D) && (buffer[1] == 0x5A))
                 {
-                    Stream m = EmbeddedManifestReader.Read(path);
-                    if (m == null)
+                    using (Stream m = EmbeddedManifestReader.Read(path))
                     {
-                        throw new BadImageFormatException(null, path);
-                    }
+                        if (m == null)
+                        {
+                            throw new BadImageFormatException(null, path);
+                        }
 
-                    using (XmlReader xr = XmlReader.Create(m, xrSettings))
-                    {
-                        document.Load(xr);
+                        using (XmlReader xr = XmlReader.Create(m, xrSettings))
+                        {
+                            document.Load(xr);
+                        }
                     }
                 }
                 else

--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -694,8 +694,10 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     try
                     {
                         var doc = new XmlDocument { PreserveWhitespace = true };
-                        var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                        using (XmlReader xr = XmlReader.Create(path, xrSettings))
+                        var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                        FileStream fs = File.OpenRead(path);
+
+                        using (XmlReader xr = XmlReader.Create(fs, xrSettings))
                         {
                             doc.Load(xr);
                         }

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -659,8 +659,10 @@ namespace Microsoft.Build.Tasks
 
             try
             {
-                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                reader = XmlReader.Create(path, readerSettings);
+                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                FileStream fs = File.OpenRead(path);
+
+                reader = XmlReader.Create(fs, readerSettings);
 
                 while (reader.Read())
                 {

--- a/src/Utilities/PlatformManifest.cs
+++ b/src/Utilities/PlatformManifest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Build.Utilities
                     XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
 
                     FileStream fs = File.OpenRead(platformManifestPath);
-                    using (XmlReader xmlReader = XmlReader.Create(platformManifestPath, readerSettings))
+                    using (XmlReader xmlReader = XmlReader.Create(fs, readerSettings))
                     {
                         doc.Load(xmlReader);
                     }

--- a/src/Utilities/PlatformManifest.cs
+++ b/src/Utilities/PlatformManifest.cs
@@ -96,8 +96,9 @@ namespace Microsoft.Build.Utilities
                 if (FileSystems.Default.FileExists(platformManifestPath))
                 {
                     XmlDocument doc = new XmlDocument();
-                    XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+                    XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
 
+                    FileStream fs = File.OpenRead(platformManifestPath);
                     using (XmlReader xmlReader = XmlReader.Create(platformManifestPath, readerSettings))
                     {
                         doc.Load(xmlReader);

--- a/src/Utilities/SDKManifest.cs
+++ b/src/Utilities/SDKManifest.cs
@@ -315,8 +315,9 @@ namespace Microsoft.Build.Utilities
                 if (FileSystems.Default.FileExists(sdkManifestPath))
                 {
                     XmlDocument doc = new XmlDocument();
-                    XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+                    XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
 
+                    FileStream fs = File.OpenRead(sdkManifestPath);
                     using (XmlReader xmlReader = XmlReader.Create(sdkManifestPath, readerSettings))
                     {
                         doc.Load(xmlReader);

--- a/src/Utilities/SDKManifest.cs
+++ b/src/Utilities/SDKManifest.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Build.Utilities
                     XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
 
                     FileStream fs = File.OpenRead(sdkManifestPath);
-                    using (XmlReader xmlReader = XmlReader.Create(sdkManifestPath, readerSettings))
+                    using (XmlReader xmlReader = XmlReader.Create(fs, readerSettings))
                     {
                         doc.Load(xmlReader);
                     }

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -3116,10 +3116,10 @@ namespace Microsoft.Build.Utilities
 
             // Make sure we have a directory with a redist list folder and a FrameworkList.xml file in there as this is what we will use for chaining.
             string redistListFolder = Path.Combine(path, "RedistList");
-            string redistFile = Path.Combine(redistListFolder, "FrameworkList.xml");
+            string redistFilePath = Path.Combine(redistListFolder, "FrameworkList.xml");
 
             // If the redist list does not exist then the entire chain is incorrect.
-            if (!FileSystems.Default.FileExists(redistFile))
+            if (!FileSystems.Default.FileExists(redistFilePath))
             {
                 // Under MONO a directory may chain to one that has no redist list
                 var chainReference = NativeMethodsShared.IsMono ? string.Empty : null;
@@ -3139,10 +3139,9 @@ namespace Microsoft.Build.Utilities
             try
             {
                 // Read in the xml file looking for the includeFramework inorder to chain.
-                XmlReaderSettings readerSettings = new XmlReaderSettings();
-                readerSettings.DtdProcessing = DtdProcessing.Ignore;
-
-                using (XmlReader reader = XmlReader.Create(redistFile, readerSettings))
+                XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                FileStream fs = File.OpenRead(redistFilePath);
+                using (XmlReader reader = XmlReader.Create(fs, readerSettings))
                 {
                     while (reader.Read())
                     {
@@ -3182,11 +3181,11 @@ namespace Microsoft.Build.Utilities
             }
             catch (XmlException ex)
             {
-                ErrorUtilities.ThrowInvalidOperation("ToolsLocationHelper.InvalidRedistFile", redistFile, ex.Message);
+                ErrorUtilities.ThrowInvalidOperation("ToolsLocationHelper.InvalidRedistFile", redistFilePath, ex.Message);
             }
             catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
             {
-                ErrorUtilities.ThrowInvalidOperation("ToolsLocationHelper.InvalidRedistFile", redistFile, ex.Message);
+                ErrorUtilities.ThrowInvalidOperation("ToolsLocationHelper.InvalidRedistFile", redistFilePath, ex.Message);
             }
 
             // Cache the display name if we have one


### PR DESCRIPTION
Fixes #8972

### Context
https://github.com/dotnet/msbuild/pull/8931 fixed one instance of the issue with build issues caused by localized characters in OS paths.
This PR attempts to address the rest of the same unintended string -> uri conversion

### Changes Made
Passing Stream to XmlReader.Create instead of path in order to prevent unintended string -> uri conversion

### Testing
N/A
