### PR TITLE
TerminalLogger: Store output writer after setting it to UTF-8

### DIFF
--- a/src/MSBuild/LiveLogger/Terminal.cs
+++ b/src/MSBuild/LiveLogger/Terminal.cs
@@ -30,7 +30,7 @@ internal sealed class Terminal : ITerminal
     /// </summary>
     private bool _isBuffering = false;
 
-    internal TextWriter Output { private get; set; } = Console.Out;
+    internal TextWriter Output { private get; set; }
 
     private const int BigUnknownDimension = 2 << 23;
 
@@ -66,6 +66,8 @@ internal sealed class Terminal : ITerminal
     {
         _originalOutputEncoding = Console.OutputEncoding;
         Console.OutputEncoding = Encoding.UTF8;
+
+        Output = Console.Out;
     }
 
     internal Terminal(TextWriter output)


### PR DESCRIPTION
Fixes #9030 by capturing the stdout writer only _after_ setting the console encoding to support Unicode. The Console encoding setter works by [discarding its internal writer and creating a new one with the new encoding](https://github.com/dotnet/runtime/blob/ddbce91b241bcf0d7f33d04d33520659addd6dd7/src/libraries/System.Console/src/System/Console.cs#L140-L151).
