### PR TITLE
Optimize exclude computation on ItemGroupIntrinsicTask target call

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -427,10 +427,10 @@ namespace Microsoft.Build.BackEnd
                     itemFactory,
                     ExpanderOptions.ExpandItems,
                     false /* do not include null expansion results */,
-                    out bool isTransformExpression,
+                    out _,
                     originalItem.IncludeLocation);
 
-                if (isTransformExpression)
+                if (itemsFromSplit != null)
                 {
                     // Expression is in form "@(X)", so add these items directly.
                     items.AddRange(itemsFromSplit);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -413,27 +413,28 @@ namespace Microsoft.Build.BackEnd
 
             // Split Include on any semicolons, and take each split in turn
             var includeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedInclude);
-            ProjectItemInstanceFactory itemFactory = new ProjectItemInstanceFactory(this.Project, originalItem.ItemType);
+            ProjectItemInstanceFactory itemFactory = new ProjectItemInstanceFactory(Project, originalItem.ItemType);
+
+            // EngineFileUtilities.GetFileListEscaped api invocation evaluates excludes by default.
+            // If the code process any expression like "@(x)", we need to handle excludes explicitly using EvaluateExcludePaths().
+            bool anyTransformExprProceeded = false;
 
             foreach (string includeSplit in includeSplits)
             {
                 // If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
-                bool throwaway;
-
-                IList<ProjectItemInstance> itemsFromSplit = expander.ExpandSingleItemVectorExpressionIntoItems(includeSplit,
+                IList<ProjectItemInstance> itemsFromSplit = expander.ExpandSingleItemVectorExpressionIntoItems(
+                    includeSplit,
                     itemFactory,
                     ExpanderOptions.ExpandItems,
                     false /* do not include null expansion results */,
-                    out throwaway,
+                    out bool isTransformExpression,
                     originalItem.IncludeLocation);
 
-                if (itemsFromSplit != null)
+                if (isTransformExpression)
                 {
                     // Expression is in form "@(X)", so add these items directly.
-                    foreach (ProjectItemInstance item in itemsFromSplit)
-                    {
-                        items.Add(item);
-                    }
+                    items.AddRange(itemsFromSplit);
+                    anyTransformExprProceeded = true;
                 }
                 else
                 {
@@ -463,34 +464,17 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
-            // Evaluate, split, expand and subtract any Exclude
-            HashSet<string> excludesUnescapedForComparison = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (string excludeSplit in excludes)
+            // There is a need to Evaluate Exclude part explicitly because of of the expressions had the form "@(X)".
+            if (anyTransformExprProceeded)
             {
-                string[] excludeSplitFiles = EngineFileUtilities.GetFileListUnescaped(
-                    Project.Directory,
-                    excludeSplit,
-                    loggingMechanism: LoggingContext,
-                    excludeLocation: originalItem.ExcludeLocation);
+                // Calculate all Exclude
+                var excludesUnescapedForComparison = EvaluateExcludePaths(excludes, originalItem.ExcludeLocation);
 
-                foreach (string excludeSplitFile in excludeSplitFiles)
-                {
-                    excludesUnescapedForComparison.Add(excludeSplitFile.NormalizeForPathComparison());
-                }
+                //// Subtract any Exclude
+                items = items
+                    .Where(i => !excludesUnescapedForComparison.Contains(((IItem)i).EvaluatedInclude.NormalizeForPathComparison()))
+                    .ToList();
             }
-
-            List<ProjectItemInstance> remainingItems = new List<ProjectItemInstance>();
-
-            for (int i = 0; i < items.Count; i++)
-            {
-                if (!excludesUnescapedForComparison.Contains(((IItem)items[i]).EvaluatedInclude.NormalizeForPathComparison()))
-                {
-                    remainingItems.Add(items[i]);
-                }
-            }
-
-            items = remainingItems;
 
             // Filter the metadata as appropriate
             if (keepMetadata != null)
@@ -517,6 +501,32 @@ namespace Microsoft.Build.BackEnd
             }
 
             return items;
+        }
+
+        /// <summary>
+        /// Returns a list of all items specified in Exclude parameter.
+        /// If no items match, returns empty list.
+        /// </summary>
+        /// <param name="excludes">The items to match</param>
+        /// <param name="excludeLocation">The specification to match against the items.</param>
+        /// <returns>A list of matching items</returns>
+        private HashSet<string> EvaluateExcludePaths(IReadOnlyList<string> excludes, ElementLocation excludeLocation)
+        {
+            HashSet<string> excludesUnescapedForComparison = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string excludeSplit in excludes)
+            {
+                string[] excludeSplitFiles = EngineFileUtilities.GetFileListUnescaped(
+                    Project.Directory,
+                    excludeSplit,
+                    loggingMechanism: LoggingContext,
+                    excludeLocation: excludeLocation);
+                foreach (string excludeSplitFile in excludeSplitFiles)
+                {
+                    excludesUnescapedForComparison.Add(excludeSplitFile.NormalizeForPathComparison());
+                }
+            }
+
+            return excludesUnescapedForComparison;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Build.BackEnd
                 // Calculate all Exclude
                 var excludesUnescapedForComparison = EvaluateExcludePaths(excludes, originalItem.ExcludeLocation);
 
-                //// Subtract any Exclude
+                // Subtract any Exclude
                 items = items
                     .Where(i => !excludesUnescapedForComparison.Contains(((IItem)i).EvaluatedInclude.NormalizeForPathComparison()))
                     .ToList();

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -192,8 +192,9 @@ namespace Microsoft.Build.Internal
             string excludeFileSpec = string.Empty;
 
             var noWildcards = !FilespecHasWildcards(filespecEscaped) || FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
+            var noExcludeSpecs = excludeSpecsEscaped == null || !excludeSpecsEscaped.Any();
             // It is possible to return original string if no entries in Exclude set and no wildcard matches. 
-            if (noWildcards && !excludeSpecsEscaped.Any())
+            if (noWildcards && noExcludeSpecs)
             {
                 fileList = new string[] { returnEscaped ? filespecEscaped : EscapingUtilities.UnescapeAll(filespecEscaped) };
             }

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Internal
             var noWildcards = !FilespecHasWildcards(filespecEscaped) || FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
 
             // It is possible to return original string if no wildcard matches and no entries in Exclude set. 
-            if (noWildcards && excludeSpecsEscaped?.Any() == false)
+            if (noWildcards && excludeSpecsEscaped?.Any() != true)
             {
                 // Just return the original string.
                 fileList = new string[] { returnEscaped ? filespecEscaped : EscapingUtilities.UnescapeAll(filespecEscaped) };

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -191,10 +191,9 @@ namespace Microsoft.Build.Internal
             FileMatcher.SearchAction action = FileMatcher.SearchAction.None;
             string excludeFileSpec = string.Empty;
 
-            var noWildcards = !FilespecHasWildcards(filespecEscaped) || FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
-            var noExcludeSpecs = excludeSpecsEscaped == null || !excludeSpecsEscaped.Any();
-            // It is possible to return original string if no entries in Exclude set and no wildcard matches. 
-            if (noWildcards && noExcludeSpecs)
+            var hasWildcards = !FilespecHasWildcards(filespecEscaped) || FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
+            // It is possible to return original string if no wildcard matches and no entries in Exclude set . 
+            if (!(hasWildcards || excludeSpecsEscaped?.Any() == true))
             {
                 fileList = new string[] { returnEscaped ? filespecEscaped : EscapingUtilities.UnescapeAll(filespecEscaped) };
             }

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -191,10 +191,12 @@ namespace Microsoft.Build.Internal
             FileMatcher.SearchAction action = FileMatcher.SearchAction.None;
             string excludeFileSpec = string.Empty;
 
-            var hasWildcards = !FilespecHasWildcards(filespecEscaped) || FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
-            // It is possible to return original string if no wildcard matches and no entries in Exclude set . 
-            if (!(hasWildcards || excludeSpecsEscaped?.Any() == true))
+            var noWildcards = !FilespecHasWildcards(filespecEscaped) || FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
+
+            // It is possible to return original string if no wildcard matches and no entries in Exclude set. 
+            if (noWildcards && excludeSpecsEscaped?.Any() == false)
             {
+                // Just return the original string.
                 fileList = new string[] { returnEscaped ? filespecEscaped : EscapingUtilities.UnescapeAll(filespecEscaped) };
             }
             else

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -191,10 +191,10 @@ namespace Microsoft.Build.Internal
             FileMatcher.SearchAction action = FileMatcher.SearchAction.None;
             string excludeFileSpec = string.Empty;
 
-            if (!FilespecHasWildcards(filespecEscaped) ||
-                FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards))
+            var noWildcards = !FilespecHasWildcards(filespecEscaped) || FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
+            // It is possible to return original string if no entries in Exclude set and no wildcard matches. 
+            if (noWildcards && !excludeSpecsEscaped.Any())
             {
-                // Just return the original string.
                 fileList = new string[] { returnEscaped ? filespecEscaped : EscapingUtilities.UnescapeAll(filespecEscaped) };
             }
             else


### PR DESCRIPTION
Fixes #8984

### Context
When glob expansion runs in a target via ItemGroupIntrinsicTask, it implicitly invokes `EngineFileUtilities.GetFileListEscaped` for Excludes evaluation.

### Changes Made
Traverse Exclude only if EngineFileUtilities.GetFileListEscaped wasn't called in order to avoid double traversal.

### Testing
Existing cases cover this change.