### PR TITLE
Fix binlog corruption with incorrectly serialized blob size.

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -220,13 +220,16 @@ namespace Microsoft.Build.Logging
 
         public void WriteBlob(BinaryLogRecordKind kind, Stream stream)
         {
-            // write the blob directly to the underlying writer,
-            // bypassing the memory stream
-            using var redirection = RedirectWritesToOriginalWriter();
+            if (stream.Length <= int.MaxValue)
+            {
+                // write the blob directly to the underlying writer,
+                // bypassing the memory stream
+                using var redirection = RedirectWritesToOriginalWriter();
 
-            Write(kind);
-            Write(stream.Length);
-            Write(stream);
+                Write(kind);
+                Write((int)stream.Length);
+                Write(stream);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Contributes to fixing https://github.com/xamarin/xamarin-macios/issues/18568

### Context

PR #9022 introduced a bug which started incorrectly serializing blobs in .binlog format due to overlooked `long` vs. `int` bug (https://github.com/dotnet/msbuild/pull/9022/files#r1271468212).

### Changes Made

Added a missing `int` cast to preserve the original .binlog file format.

### Testing

Manually tested that the .binlog is fixed and readable by MSBuildLog viewer after this change.

### Notes
