### PR TITLE
[ClickOnce] Fix for GB18030 character issues in ClickOnce publishing

### DIFF
--- a/src/Tasks/ManifestUtil/ApplicationManifest.cs
+++ b/src/Tasks/ManifestUtil/ApplicationManifest.cs
@@ -527,9 +527,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             if (!TrustInfo.IsFullTrust)
             {
                 var document = new XmlDocument();
-                var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
-                FileStream fs = File.OpenRead(configFile.ResolvedPath);
-                using (XmlReader xr = XmlReader.Create(fs, xrs))
+                var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+                //
+                // XmlReader.Create(string, ...) treats the first parameter as a Uri and escapes GB18030 chars in PUA block.
+                // In order to open such files, we use StreamReader and pass that to pass that to XmlReader.Create
+                //
+                using (StreamReader sr = new StreamReader(configFile.ResolvedPath))
+                using (XmlReader xr = XmlReader.Create(sr, xrs))
                 {
                     document.Load(xr);
                 }

--- a/src/Tasks/ManifestUtil/AssemblyIdentity.cs
+++ b/src/Tasks/ManifestUtil/AssemblyIdentity.cs
@@ -193,9 +193,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             var document = new XmlDocument();
             try
             {
-                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
-                FileStream fs = File.OpenRead(path);
-                using (XmlReader xmlReader = XmlReader.Create(fs, readerSettings))
+                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+                //
+                // XmlReader.Create(string, ...) treats the first parameter as a Uri and escapes GB18030 chars in PUA block.
+                // In order to open such files, we use StreamReader and pass that to pass that to XmlReader.Create
+                //
+                using (StreamReader sr = new StreamReader(path))
+                using (XmlReader xmlReader = XmlReader.Create(sr, readerSettings))
                 {
                     document.Load(xmlReader);
                 }

--- a/src/Tasks/ManifestUtil/DeployManifest.cs
+++ b/src/Tasks/ManifestUtil/DeployManifest.cs
@@ -213,9 +213,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             try
             {
                 var doc = new XmlDocument();
-                var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
-                FileStream fs = File.OpenRead(redistListFilePath);
-                using (XmlReader xr = XmlReader.Create(fs, xrSettings))
+                var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+                //
+                // XmlReader.Create(string, ...) treats the first parameter as a Uri and escapes GB18030 chars in PUA block.
+                // In order to open such files, we use StreamReader and pass that to pass that to XmlReader.Create
+                //
+                using (StreamReader sr = new StreamReader(redistListFilePath))
+                using (XmlReader xr = XmlReader.Create(sr, xrSettings))
                 {
                     doc.Load(xr);
                     XmlNode fileListNode = doc.DocumentElement;

--- a/src/Tasks/ManifestUtil/Manifest.cs
+++ b/src/Tasks/ManifestUtil/Manifest.cs
@@ -376,9 +376,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         internal static void UpdateEntryPoint(string inputPath, string outputPath, string updatedApplicationPath, string applicationManifestPath, string targetFrameworkVersion)
         {
             var document = new XmlDocument();
-            var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
-            FileStream fs = File.OpenRead(inputPath);
-            using (XmlReader xr = XmlReader.Create(fs, xrSettings))
+            var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+            //
+            // XmlReader.Create(string, ...) treats the first parameter as a Uri and escapes GB18030 chars in PUA block.
+            // In order to open such files, we use StreamReader and pass that to pass that to XmlReader.Create
+            //
+            using (StreamReader sr = new StreamReader(inputPath))
+            using (XmlReader xr = XmlReader.Create(sr, xrSettings))
             {
                 document.Load(xr);
             }

--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -694,10 +694,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     try
                     {
                         var doc = new XmlDocument { PreserveWhitespace = true };
-                        var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
-                        FileStream fs = File.OpenRead(path);
-
-                        using (XmlReader xr = XmlReader.Create(fs, xrSettings))
+                        var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+                        //
+                        // XmlReader.Create(string, ...) treats the first parameter as a Uri and escapes GB18030 chars in PUA block.
+                        // In order to open such files, we use StreamReader and pass that to pass that to XmlReader.Create
+                        //
+                        using (StreamReader sr = new StreamReader(path))
+                        using (XmlReader xr = XmlReader.Create(sr, xrSettings))
                         {
                             doc.Load(xr);
                         }


### PR DESCRIPTION
Fixes #
[AB#1852036](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1852036)
[AB#1852046](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1852046)

### Context
Projects with GB18030 characters fail during ClickOnce publishing of .NET FX and VSTO Addin-in projects.

### Changes Made
GB1830 characters in PUA block get escaped by XmlReader.Create(string, ...) because it treats the string argument as a URI. This can cause publishing failure b/c the paths become invalid. We now use StreamReader to load the file and pass that to XmlReader.Create.

### Testing
Stepped through code to confirm the fixes made.
CTI team is validating the fixes.

### Notes
