### PR TITLE
Skip TerminalLogger in context of dotnet test

### DIFF
--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1482,13 +1482,13 @@
     </comment>
   </data>
   <data name="TerminalLoggerNotUsedDisabled" xml:space="preserve">
-    <value>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</value>
+    <value>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</value>
   </data>
   <data name="TerminalLoggerNotUsedNotSupported" xml:space="preserve">
-    <value>TerminalLogger was not used because the output is not supported.</value>
+    <value>Terminal Logger was not used because the output is not supported.</value>
   </data>
   <data name="TerminalLoggerNotUsedRedirected" xml:space="preserve">
-    <value>TerminalLogger was not used because the output is being redirected to a file.</value>
+    <value>Terminal Logger was not used because the output is being redirected to a file.</value>
   </data>
   <!-- **** TerminalLogger strings end **** -->
 

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1481,6 +1481,15 @@
       {4}: duration in seconds with 1 decimal point
     </comment>
   </data>
+  <data name="TerminalLoggerNotUsedDisabled" xml:space="preserve">
+    <value>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</value>
+  </data>
+  <data name="TerminalLoggerNotUsedNotSupported" xml:space="preserve">
+    <value>TerminalLogger was not used because the output is not supported.</value>
+  </data>
+  <data name="TerminalLoggerNotUsedRedirected" xml:space="preserve">
+    <value>TerminalLogger was not used because the output is being redirected to a file.</value>
+  </data>
   <!-- **** TerminalLogger strings end **** -->
 
     <!--

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1554,18 +1554,18 @@ Když se nastaví na MessageUponIsolationViolation (nebo jeho krátký
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1553,6 +1553,21 @@ Když se nastaví na MessageUponIsolationViolation (nebo jeho krátký
         <target state="translated">MSBUILD : error MSB1059: Cíle se nepovedlo vypsat. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: Pro tento přepínač se nepoužívají žádné parametry.</target>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1547,18 +1547,18 @@ Dieses Protokollierungsformat ist standardmäßig aktiviert.
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1546,6 +1546,21 @@ Dieses Protokollierungsformat ist standardmäßig aktiviert.
         <target state="translated">MSBUILD : error MSB1059: Ziele konnten nicht ausgegeben werden. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: Der Schalter erlaubt keine Parameter.</target>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1554,18 +1554,18 @@
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1553,6 +1553,21 @@
         <target state="translated">MSBUILD : error MSB1059: No se pudieron imprimir los destinos. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: Este modificador no tiene ningún parámetro.</target>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1547,18 +1547,18 @@ Remarque : verbosité des enregistreurs d’événements de fichiers
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1546,6 +1546,21 @@ Remarque : verbosité des enregistreurs d’événements de fichiers
         <target state="translated">MSBUILD : error MSB1059: les cibles n'ont pas pu être imprimées. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: Ce commutateur n'accepte aucun paramètre.</target>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1556,6 +1556,21 @@ Nota: livello di dettaglio dei logger di file
         <target state="translated">MSBUILD : error MSB1059: non è stato possibile stampare le destinazioni. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: questa opzione non accetta parametri.</target>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1557,18 +1557,18 @@ Nota: livello di dettaglio dei logger di file
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1547,18 +1547,18 @@
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1546,6 +1546,21 @@
         <target state="translated">MSBUILD : error MSB1059: ターゲットを出力できませんでした。{0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: このスイッチにはパラメーターを指定できません。</target>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1546,6 +1546,21 @@
         <target state="translated">MSBUILD : error MSB1059: 대상을 출력할 수 없습니다. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: 이 스위치에는 매개 변수를 지정할 수 없습니다.</target>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1547,18 +1547,18 @@
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1553,18 +1553,18 @@
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1552,6 +1552,21 @@
         <target state="translated">MSBUILD : error MSB1059: Nie można wydrukować elementów docelowych. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: ten przełącznik nie ma żadnych parametrów.</target>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1548,18 +1548,18 @@ arquivo de resposta.
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1547,6 +1547,21 @@ arquivo de resposta.
         <target state="translated">MSBUILD : error MSB1059: não foi possível imprimir destinos. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: Esta opção não aceita parâmetros.</target>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1545,6 +1545,21 @@
         <target state="translated">MSBUILD : error MSB1059: не удалось вывести целевые объекты. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: у этого ключа нет параметров.</target>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1546,18 +1546,18 @@
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1547,18 +1547,18 @@
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1546,6 +1546,21 @@
         <target state="translated">MSBUILD : error MSB1059: Hedefler yazdırılamadı. {0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: Bu anahtar parametreyle kullanılmaz.</target>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1547,18 +1547,18 @@
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1546,6 +1546,21 @@
         <target state="translated">MSBUILD : error MSB1059: 无法打印目标。{0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: 此开关不采用任何参数。</target>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1547,18 +1547,18 @@
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedDisabled">
-        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
-        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <source>Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">Terminal Logger was not used because build is run in context of a process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedNotSupported">
-        <source>TerminalLogger was not used because the output is not supported.</source>
-        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <source>Terminal Logger was not used because the output is not supported.</source>
+        <target state="new">Terminal Logger was not used because the output is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalLoggerNotUsedRedirected">
-        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
-        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <source>Terminal Logger was not used because the output is being redirected to a file.</source>
+        <target state="new">Terminal Logger was not used because the output is being redirected to a file.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedParametersError">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1546,6 +1546,21 @@
         <target state="translated">MSBUILD : error MSB1059: 無法列印目標。{0}</target>
         <note>{StrBegin="MSBUILD : error MSB1059: "}</note>
       </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedDisabled">
+        <source>TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</source>
+        <target state="new">TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedNotSupported">
+        <source>TerminalLogger was not used because the output is not supported.</source>
+        <target state="new">TerminalLogger was not used because the output is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalLoggerNotUsedRedirected">
+        <source>TerminalLogger was not used because the output is being redirected to a file.</source>
+        <target state="new">TerminalLogger was not used because the output is being redirected to a file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedParametersError">
         <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
         <target state="translated">MSBUILD : error MSB1002: 這個參數不使用任何參數。</target>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2586,6 +2586,14 @@ namespace Microsoft.Build.CommandLine
                         new BuildManager.DeferredBuildMessage("TerminalLogger was not used because the output is not supported.", MessageImportance.Low));
                     return false;
                 }
+
+                if (Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout)
+                {
+                    s_globalMessagesToLogInBuildLoggers.Add(
+                        new BuildManager.DeferredBuildMessage("TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.", MessageImportance.Low));
+                    return false;
+                }
+
                 return true;
             }
         }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2575,7 +2575,7 @@ namespace Microsoft.Build.CommandLine
                 if (!outputIsScreen)
                 {
                     s_globalMessagesToLogInBuildLoggers.Add(
-                        new BuildManager.DeferredBuildMessage("TerminalLogger was not used because the output is being redirected to a file.", MessageImportance.Low));
+                        new BuildManager.DeferredBuildMessage(ResourceUtilities.GetResourceString("TerminalLoggerNotUsedRedirected"), MessageImportance.Low));
                     return false;
                 }
 
@@ -2583,14 +2583,14 @@ namespace Microsoft.Build.CommandLine
                 if (!acceptAnsiColorCodes)
                 {
                     s_globalMessagesToLogInBuildLoggers.Add(
-                        new BuildManager.DeferredBuildMessage("TerminalLogger was not used because the output is not supported.", MessageImportance.Low));
+                        new BuildManager.DeferredBuildMessage(ResourceUtilities.GetResourceString("TerminalLoggerNotUsedNotSupported"), MessageImportance.Low));
                     return false;
                 }
 
                 if (Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout)
                 {
                     s_globalMessagesToLogInBuildLoggers.Add(
-                        new BuildManager.DeferredBuildMessage("TerminalLogger was not used because build is run in context of process (e.g. 'dotnet test') that requests direct access to stdout stream.", MessageImportance.Low));
+                        new BuildManager.DeferredBuildMessage(ResourceUtilities.GetResourceString("TerminalLoggerNotUsedDisabled"), MessageImportance.Low));
                     return false;
                 }
 


### PR DESCRIPTION
Fixes #9061

### Context
#9061
This is the proposal of option a) (disabling `TerminalLogger` entirely for `dotnet test`)

### UX

![TL-dotnetTests-skip](https://github.com/dotnet/msbuild/assets/3809076/c2395259-5fe0-4014-a247-4114f5aec5fb)


### Note

The approach b) (disabling `TerminalLogger` only for the test part of the `dotnet test`) turns out to be not 'hardenable' enough for multi-project solutions due to the fact that MSTest and MSBuild race with writing to a single console and MSBuild might not be quick enough to teporarily pause it's updates.
It looks workable for simple solutions - sample just for reference:

![TL-dotnetTests-skip-after-target](https://github.com/dotnet/msbuild/assets/3809076/7de45c4b-9063-4b54-8951-d08d43d9697c)
