### PR TITLE
Fix typo in ProjectCacheService.IsDesignTimeBuild leading to the value of BuildingProject not being checked

### DIFF
--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
             string? designTimeBuild = buildRequestConfiguration.GlobalProperties[DesignTimeProperties.DesignTimeBuild]?.EvaluatedValue;
             string? buildingProject = buildRequestConfiguration.GlobalProperties[DesignTimeProperties.BuildingProject]?.EvaluatedValue;
             return ConversionUtilities.ConvertStringToBool(designTimeBuild, nullOrWhitespaceIsFalse: true)
-                || (buildingProject != null && !ConversionUtilities.ConvertStringToBool(designTimeBuild, nullOrWhitespaceIsFalse: true));
+                || (buildingProject != null && !ConversionUtilities.ConvertStringToBool(buildingProject, nullOrWhitespaceIsFalse: true));
         }
 
         public void PostCacheRequest(CacheRequest cacheRequest, CancellationToken cancellationToken)


### PR DESCRIPTION
Fix typo in ProjectCacheService.IsDesignTimeBuild leading to the value of BuildingProject not being checked.

This is a regression in #7833, probably due to bad copy/paste while refactoring.

Thanks @davkean for spotting this bug!