### PR TITLE
Terminal logger: Remove emojis and tweak warning/error colors

### DIFF
--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Linux.verified.txt
@@ -1,5 +1,5 @@
 ﻿]9;4;3;\  project [31;1mfailed with errors[m (0.0s)
-    directory/[37;1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
 Build [31;1mfailed with errors[m in 0.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Linux.verified.txt
@@ -1,5 +1,5 @@
 ﻿]9;4;3;\  project [31;1mfailed with errors[m (0.0s)
-[31;1m    ❌︎[7D[6C MSBUILD : error : Error![m
+    directory/[37;1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
 Build [31;1mfailed with errors[m in 0.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.OSX.verified.txt
@@ -1,5 +1,5 @@
 ﻿  project [31;1mfailed with errors[m (0.0s)
-[31;1m    ❌︎[7D[6C MSBUILD : error : Error![m
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
 Build [31;1mfailed with errors[m in 0.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Windows.verified.txt
@@ -1,5 +1,5 @@
 ﻿]9;4;3;\  project [31;1mfailed with errors[m (0.0s)
-[31;1m    ❌︎[7D[6C MSBUILD : error : Error![m
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
 Build [31;1mfailed with errors[m in 0.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
@@ -1,5 +1,5 @@
 ﻿]9;4;3;\  project [33;1msucceeded with warnings[m (0.0s)
-    directory/[37;1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
 [?25l[1F
 [?25h
 Build [33;1msucceeded with warnings[m in 0.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
@@ -1,5 +1,5 @@
 ﻿]9;4;3;\  project [33;1msucceeded with warnings[m (0.0s)
-[33;1m    ⚠︎[7D[6C MSBUILD : warning : Warning![m
+    directory/[37;1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
 [?25l[1F
 [?25h
 Build [33;1msucceeded with warnings[m in 0.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.OSX.verified.txt
@@ -1,5 +1,5 @@
 ﻿  project [33;1msucceeded with warnings[m (0.0s)
-[33;1m    ⚠︎[7D[6C MSBUILD : warning : Warning![m
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
 [?25l[1F
 [?25h
 Build [33;1msucceeded with warnings[m in 0.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Windows.verified.txt
@@ -1,5 +1,5 @@
 ﻿]9;4;3;\  project [33;1msucceeded with warnings[m (0.0s)
-[33;1m    ⚠︎[7D[6C MSBUILD : warning : Warning![m
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
 [?25l[1F
 [?25h
 Build [33;1msucceeded with warnings[m in 0.0s

--- a/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Build.UnitTests
 
         private BuildWarningEventArgs MakeWarningEventArgs(string warning)
         {
-            return new BuildWarningEventArgs("", "", "", 0, 0, 0, 0, warning, null, null)
+            return new BuildWarningEventArgs("", "AA0000", "directory/file", 1, 2, 3, 4, warning, null, null)
             {
                 BuildEventContext = MakeBuildEventContext(),
             };
@@ -178,7 +178,7 @@ namespace Microsoft.Build.UnitTests
 
         private BuildErrorEventArgs MakeErrorEventArgs(string error)
         {
-            return new BuildErrorEventArgs("", "", "", 0, 0, 0, 0, error, null, null)
+            return new BuildErrorEventArgs("", "AA0000", "directory/file", 1, 2, 3, 4, error, null, null)
             {
                 BuildEventContext = MakeBuildEventContext(),
             };

--- a/src/MSBuild/TerminalLogger/AnsiCodes.cs
+++ b/src/MSBuild/TerminalLogger/AnsiCodes.cs
@@ -16,10 +16,18 @@ internal static class AnsiCodes
     /// <summary>
     /// Select graphic rendition.
     /// </summary>
-    /// <remarks>\
+    /// <remarks>
     /// Print <see cref="CSI"/>color-code<see cref="SetColor"/> to change text color.
     /// </remarks>
     public const string SetColor = ";1m";
+
+    /// <summary>
+    /// Select graphic rendition - set bold mode.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="CSI"/><see cref="SetBold"/> to change text to bold.
+    /// </remarks>
+    public const string SetBold = "1m";
 
     /// <summary>
     /// A shortcut to reset color back to normal.
@@ -122,5 +130,15 @@ internal static class AnsiCodes
         }
 
         return $"{CSI}{(int)color}{SetColor}{s}{SetDefaultColor}";
+    }
+
+    public static string MakeBold(string? s)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return s ?? "";
+        }
+
+        return $"{CSI}{SetBold}{s}{SetDefaultColor}";
     }
 }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -861,7 +861,7 @@ internal sealed class TerminalLogger : INodeLogger
 
         int index = path.LastIndexOfAny(PathSeparators);
         return index >= 0
-            ? $"{path.Substring(0, index + 1)}{AnsiCodes.Colorize(path.Substring(index + 1), TerminalColor.White)}"
+            ? $"{path.Substring(0, index + 1)}{AnsiCodes.MakeBold(path.Substring(index + 1))}"
             : path;
     }
 

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -165,6 +165,11 @@ internal sealed class TerminalLogger : INodeLogger
     };
 
     /// <summary>
+    /// The two directory separator characters to be passed to methods like <see cref="String.IndexOfAny(char[])"/>.
+    /// </summary>
+    private static readonly char[] PathSeparators = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+    /// <summary>
     /// Default constructor, used by the MSBuild logger infra.
     /// </summary>
     public TerminalLogger()
@@ -456,14 +461,7 @@ internal sealed class TerminalLogger : INodeLogger
                     {
                         foreach (BuildMessage buildMessage in project.BuildMessages)
                         {
-                            TerminalColor color = buildMessage.Severity switch
-                            {
-                                MessageSeverity.Warning => TerminalColor.Yellow,
-                                MessageSeverity.Error => TerminalColor.Red,
-                                _ => TerminalColor.Default,
-                            };
-
-                            Terminal.WriteColorLine(color, $"{Indentation}{Indentation}{buildMessage.Message}");
+                            Terminal.WriteLine($"{Indentation}{Indentation}{buildMessage.Message}");
                         }
                     }
 
@@ -566,7 +564,20 @@ internal sealed class TerminalLogger : INodeLogger
         var buildEventContext = e.BuildEventContext;
         if (buildEventContext is not null && _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project))
         {
-            string message = EventArgsFormatting.FormatEventMessage(e, false);
+            string message = EventArgsFormatting.FormatEventMessage(
+                category: AnsiCodes.Colorize("warning", TerminalColor.Yellow),
+                subcategory: e.Subcategory,
+                message: e.Message,
+                code: AnsiCodes.Colorize(e.Code, TerminalColor.Yellow),
+                file: HighlightFileName(e.File),
+                projectFile: null,
+                lineNumber: e.LineNumber,
+                endLineNumber: e.EndLineNumber,
+                columnNumber: e.ColumnNumber,
+                endColumnNumber: e.EndColumnNumber,
+                threadId: e.ThreadId,
+                logOutputProperties: null);
+
             project.AddBuildMessage(MessageSeverity.Warning, message);
         }
     }
@@ -579,7 +590,20 @@ internal sealed class TerminalLogger : INodeLogger
         var buildEventContext = e.BuildEventContext;
         if (buildEventContext is not null && _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project))
         {
-            string message = EventArgsFormatting.FormatEventMessage(e, false);
+            string message = EventArgsFormatting.FormatEventMessage(
+                category: AnsiCodes.Colorize("error", TerminalColor.Red),
+                subcategory: e.Subcategory,
+                message: e.Message,
+                code: AnsiCodes.Colorize(e.Code, TerminalColor.Red),
+                file: HighlightFileName(e.File),
+                projectFile: null,
+                lineNumber: e.LineNumber,
+                endLineNumber: e.EndLineNumber,
+                columnNumber: e.ColumnNumber,
+                endColumnNumber: e.EndColumnNumber,
+                threadId: e.ThreadId,
+                logOutputProperties: null);
+
             project.AddBuildMessage(MessageSeverity.Error, message);
         }
     }
@@ -823,6 +847,22 @@ internal sealed class TerminalLogger : INodeLogger
     {
         // Node IDs reported by the build are 1-based.
         return context.NodeId - 1;
+    }
+
+    /// <summary>
+    /// Colorizes the filename part of the given path.
+    /// </summary>
+    private string? HighlightFileName(string? path)
+    {
+        if (path == null)
+        {
+            return null;
+        }
+
+        int index = path.LastIndexOfAny(PathSeparators);
+        return index >= 0
+            ? $"{path.Substring(0, index + 1)}{AnsiCodes.Colorize(path.Substring(index + 1), TerminalColor.White)}"
+            : path;
     }
 
     #endregion

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -462,20 +462,8 @@ internal sealed class TerminalLogger : INodeLogger
                                 MessageSeverity.Error => TerminalColor.Red,
                                 _ => TerminalColor.Default,
                             };
-                            char symbol = buildMessage.Severity switch
-                            {
-                                MessageSeverity.Warning => '⚠',
-                                MessageSeverity.Error => '❌',
-                                _ => ' ',
-                            };
 
-                            // The error and warning symbols may be rendered with different width on some terminals. To make sure that the message text
-                            // is always aligned, we print the symbol, move back to the start of the line, then move forward to the desired column, and
-                            // finally print the message text.
-                            int maxSymbolWidth = 2;
-                            int messageStartColumn = Indentation.Length + Indentation.Length + maxSymbolWidth;
-                            Terminal.WriteColorLine(color, $"{Indentation}{Indentation}{symbol}\uFE0E{AnsiCodes.CSI}{messageStartColumn + 1}{AnsiCodes.MoveBackward}" +
-                                $"{AnsiCodes.CSI}{messageStartColumn}{AnsiCodes.MoveForward} {buildMessage.Message}");
+                            Terminal.WriteColorLine(color, $"{Indentation}{Indentation}{buildMessage.Message}");
                         }
                     }
 

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -852,7 +852,7 @@ internal sealed class TerminalLogger : INodeLogger
     /// <summary>
     /// Colorizes the filename part of the given path.
     /// </summary>
-    private string? HighlightFileName(string? path)
+    private static string? HighlightFileName(string? path)
     {
         if (path == null)
         {


### PR DESCRIPTION
### Context

We would like to adjust the warning and error output to make it easier on the eye and draw attention to the most important parts.

### Changes Made

- Removed the ❌ and ⚠ symbols
- Made the lines use multiple colors: red/yellow for the text `error`/`warning` and the code, bold for file name, and default for everything else

Before (Windows "Campbell"):
![image](https://github.com/dotnet/msbuild/assets/12206368/c8ad2eac-123c-4ea9-b0dd-f37f73ccd4d6)

Before (Windows "Solarized Dark"):
![image](https://github.com/dotnet/msbuild/assets/12206368/484d28ed-b56e-43ca-ad17-54654f3896f2)

After (Windows "Campbell"):
![image](https://github.com/dotnet/msbuild/assets/12206368/222f6e09-b5a7-4bb6-ad2a-6fb3672b399e)

After (Windows "Solarized Dark"):
![image](https://github.com/dotnet/msbuild/assets/12206368/58e5bac9-f253-4e65-b5fd-bf091c9f5f67)

### Testing

Existing unit tests.