### PR TITLE
Ban XmlReader overloads that take string

### DIFF
--- a/src/BannedSymbols.txt
+++ b/src/BannedSymbols.txt
@@ -1,2 +1,5 @@
 M:System.Globalization.CompareInfo.IndexOf(System.String,System.Char);CompareInfo.IndexOf can unexpectedly allocate strings--use string.IndexOf
 P:Microsoft.Build.Construction.ProjectElementContainer.Children;Use ChildrenEnumerable instead to avoid boxing
+M:System.Xml.XmlReader.Create(System.String);Do not pass paths to XmlReader.Create--use the Stream overload
+M:System.Xml.XmlReader.Create(System.String,System.Xml.XmlReaderSettings);Do not pass paths to XmlReader.Create--use the Stream overload
+M:System.Xml.XmlReader.Create(System.String,System.Xml.XmlReaderSettings,System.Xml.XmlParserContext);Do not pass paths to XmlReader.Create--use the Stream overload


### PR DESCRIPTION
These overloads create a URI from the string and can cause problems with
GB18030 certification, because that URI gets normalized in a way that
doesn't work with all characters. We should instead pass a stream
created from the file, as in #8931 and #9028.

Formalize that rule for the whole repo.
