### PR TITLE
Reduce memory usage in static graph build by snapshotting the project instance

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 buildParameters,
                 new BuildRequestData(
                     graph.GraphRoots.FirstOrDefault()
-                        .ProjectInstance.FullPath,
+                        .ProjectInstanceSnapshot.FullPath,
                     new Dictionary<string, string>(),
                     MSBuildConstants.CurrentToolsVersion,
                     Array.Empty<string>(),
@@ -4197,11 +4197,11 @@ $@"<Project InitialTargets=`Sleep`>
             GraphBuildResult result = _buildManager.Build(_parameters, data);
             result.OverallResult.ShouldBe(BuildResultCode.Success);
 
-            var node1 = graph.ProjectNodes.First(node => node.ProjectInstance.FullPath.Equals(project1, StringComparison.OrdinalIgnoreCase));
+            var node1 = graph.ProjectNodes.First(node => node.ProjectInstanceSnapshot.FullPath.Equals(project1, StringComparison.OrdinalIgnoreCase));
             result.ResultsByNode.ContainsKey(node1).ShouldBeTrue();
             result.ResultsByNode[node1].OverallResult.ShouldBe(BuildResultCode.Success);
 
-            var node2 = graph.ProjectNodes.First(node => node.ProjectInstance.FullPath.Equals(project2, StringComparison.OrdinalIgnoreCase));
+            var node2 = graph.ProjectNodes.First(node => node.ProjectInstanceSnapshot.FullPath.Equals(project2, StringComparison.OrdinalIgnoreCase));
             result.ResultsByNode.ContainsKey(node2).ShouldBeTrue();
             result.ResultsByNode[node2].OverallResult.ShouldBe(BuildResultCode.Success);
         }
@@ -4282,11 +4282,11 @@ $@"<Project InitialTargets=`Sleep`>
             GraphBuildResult result = _buildManager.Build(_parameters, data);
             result.OverallResult.ShouldBe(BuildResultCode.Failure);
 
-            var node1 = graph.ProjectNodes.First(node => node.ProjectInstance.FullPath.Equals(project1, StringComparison.OrdinalIgnoreCase));
+            var node1 = graph.ProjectNodes.First(node => node.ProjectInstanceSnapshot.FullPath.Equals(project1, StringComparison.OrdinalIgnoreCase));
             result.ResultsByNode.ContainsKey(node1).ShouldBeTrue();
             result.ResultsByNode[node1].OverallResult.ShouldBe(BuildResultCode.Failure);
 
-            var node2 = graph.ProjectNodes.First(node => node.ProjectInstance.FullPath.Equals(project2, StringComparison.OrdinalIgnoreCase));
+            var node2 = graph.ProjectNodes.First(node => node.ProjectInstanceSnapshot.FullPath.Equals(project2, StringComparison.OrdinalIgnoreCase));
             result.ResultsByNode.ContainsKey(node2).ShouldBeTrue();
             result.ResultsByNode[node2].OverallResult.ShouldBe(BuildResultCode.Failure);
         }
@@ -4339,7 +4339,7 @@ $@"<Project InitialTargets=`Sleep`>
             {
                 var graphResult = buildSession.BuildGraphSubmission(
                     new GraphBuildRequestData(
-                        projectGraphEntryPoints: new[] { new ProjectGraphEntryPoint(graph.GraphRoots.First().ProjectInstance.FullPath) },
+                        projectGraphEntryPoints: new[] { new ProjectGraphEntryPoint(graph.GraphRoots.First().ProjectInstanceSnapshot.FullPath) },
                         targetsToBuild: Array.Empty<string>(),
                         hostServices: null,
                         flags: BuildRequestDataFlags.None,

--- a/src/Build.UnitTests/Construction/SolutionFilter_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFilter_Tests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Build.Engine.UnitTests.Construction
                     ProjectGraph graphFromSolution = new(entryPoint, projectCollection);
                     logger.AssertNoErrors();
                     graphFromSolution.ProjectNodes.ShouldHaveSingleItem();
-                    graphFromSolution.ProjectNodes.Single().ProjectInstance.ProjectFileLocation.LocationString.ShouldBe(simpleProject.Path);
+                    graphFromSolution.ProjectNodes.Single().ProjectInstanceSnapshot.ProjectFileLocation.LocationString.ShouldBe(simpleProject.Path);
                 }
                 else
                 {

--- a/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Graph.UnitTests
                                                     </Project>");
 
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
-                GetFirstNodeWithProjectNumber(graph, 1).ProjectInstance.GlobalProperties.ContainsKey("Platform").ShouldBeFalse();
+                GetFirstNodeWithProjectNumber(graph, 1).ProjectInstanceSnapshot.GlobalProperties.ContainsKey("Platform").ShouldBeFalse();
             }
         }
 
@@ -97,8 +97,8 @@ namespace Microsoft.Build.Graph.UnitTests
 
 
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties["Platform"].ShouldBe("x86");
-                GetFirstNodeWithProjectNumber(graph, 3).ProjectInstance.GlobalProperties["Platform"].ShouldBe("x86");
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstanceSnapshot.GlobalProperties["Platform"].ShouldBe("x86");
+                GetFirstNodeWithProjectNumber(graph, 3).ProjectInstanceSnapshot.GlobalProperties["Platform"].ShouldBe("x86");
             }
         }
 
@@ -139,8 +139,8 @@ namespace Microsoft.Build.Graph.UnitTests
 
 
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties.ContainsKey("Platform").ShouldBeFalse();
-                GetFirstNodeWithProjectNumber(graph, 3).ProjectInstance.GlobalProperties["Platform"].ShouldBe("x86");
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstanceSnapshot.GlobalProperties.ContainsKey("Platform").ShouldBeFalse();
+                GetFirstNodeWithProjectNumber(graph, 3).ProjectInstanceSnapshot.GlobalProperties["Platform"].ShouldBe("x86");
             }
         }
 
@@ -179,8 +179,8 @@ namespace Microsoft.Build.Graph.UnitTests
 
 
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties["Platform"].ShouldBe("AnyCPU");
-                GetFirstNodeWithProjectNumber(graph, 3).ProjectInstance.GlobalProperties["Platform"].ShouldBe("AnyCPU");
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstanceSnapshot.GlobalProperties["Platform"].ShouldBe("AnyCPU");
+                GetFirstNodeWithProjectNumber(graph, 3).ProjectInstanceSnapshot.GlobalProperties["Platform"].ShouldBe("AnyCPU");
                 graph.ProjectNodes.Count.ShouldBe(3);
             }
         }
@@ -208,7 +208,7 @@ namespace Microsoft.Build.Graph.UnitTests
                                                     </Project>");
 
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties["Platform"].ShouldBe("x64");
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstanceSnapshot.GlobalProperties["Platform"].ShouldBe("x64");
             }
         }
 
@@ -236,7 +236,7 @@ namespace Microsoft.Build.Graph.UnitTests
                                                     </Project>");
 
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties["Platform"].ShouldBe("x86");
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstanceSnapshot.GlobalProperties["Platform"].ShouldBe("x86");
             }
         }
 
@@ -263,7 +263,7 @@ namespace Microsoft.Build.Graph.UnitTests
                                                     </Project>");
 
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties["Platform"].ShouldBe("AnyCPU");
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstanceSnapshot.GlobalProperties["Platform"].ShouldBe("AnyCPU");
             }
         }
 
@@ -291,7 +291,7 @@ namespace Microsoft.Build.Graph.UnitTests
                                                     </Project>");
 
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties["Platform"].ShouldBe("x86");
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstanceSnapshot.GlobalProperties["Platform"].ShouldBe("x86");
             }
         }
 
@@ -321,7 +321,7 @@ namespace Microsoft.Build.Graph.UnitTests
                 // Here we are checking if platform is defined. in this case it should not be since Platorm would be set to the value this project defaults as
                 // in order to avoid dual build errors we remove platform in order to avoid the edge case where a project has global platform set and does not have global platform set
                 // yet still default to the same platform.
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GlobalProperties.ContainsKey("Platform").ShouldBeFalse();
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstanceSnapshot.GlobalProperties.ContainsKey("Platform").ShouldBeFalse();
             }
         }
 
@@ -348,7 +348,7 @@ namespace Microsoft.Build.Graph.UnitTests
                                                     </Project>");
 
                 ProjectGraph graph = new ProjectGraph(entryProject.Path);
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstance.GetPropertyValue("Platform").ShouldBe(GetFirstNodeWithProjectNumber(graph, 1).ProjectInstance.GetPropertyValue("Platform"));
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectInstanceSnapshot.GetPropertyValue("Platform").ShouldBe(GetFirstNodeWithProjectNumber(graph, 1).ProjectInstanceSnapshot.GetPropertyValue("Platform"));
             }
         }
 
@@ -444,8 +444,8 @@ namespace Microsoft.Build.Graph.UnitTests
                 // We want to make sure negotiation respects configuration if defined but negotiates if not.
                 ProjectGraph graphFromSolution = new(entryPoint, projectCollection);
                 logger.AssertNoErrors();
-                GetFirstNodeWithProjectNumber(graphFromSolution, 2).ProjectInstance.GetPropertyValue("Platform").ShouldBe("AnyCPU", "Project2 should have followed the sln config to AnyCPU");
-                GetFirstNodeWithProjectNumber(graphFromSolution, 3).ProjectInstance.GetPropertyValue("Platform").ShouldBe("x64", "Project3 isn't in the solution so it should have negotiated to x64 to match Project1");
+                GetFirstNodeWithProjectNumber(graphFromSolution, 2).ProjectInstanceSnapshot.GetPropertyValue("Platform").ShouldBe("AnyCPU", "Project2 should have followed the sln config to AnyCPU");
+                GetFirstNodeWithProjectNumber(graphFromSolution, 3).ProjectInstanceSnapshot.GetPropertyValue("Platform").ShouldBe("x64", "Project3 isn't in the solution so it should have negotiated to x64 to match Project1");
             }
         }
     }

--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -635,12 +635,12 @@ namespace Microsoft.Build.Graph.UnitTests
             GetInnerBuilds(graph, 3).SelectMany(n => GetIncomingEdgeItemsToNode(n, edges)).ShouldAllBe(edgeItem => !IsSolutionItemReference(edgeItem));
             GetInnerBuilds(graph, 3).SelectMany(n => GetOutgoingEdgeItemsFromNode(n, edges)).ShouldAllBe(edgeItem => !IsSolutionItemReference(edgeItem));
 
-            IEnumerable<ProjectItemInstance> GetOutgoingEdgeItemsFromNode(ProjectGraphNode node, IReadOnlyDictionary<(ConfigurationMetadata, ConfigurationMetadata), ProjectItemInstance> edgeInfos)
+            IEnumerable<ProjectItemInstanceSnapshot> GetOutgoingEdgeItemsFromNode(ProjectGraphNode node, IReadOnlyDictionary<(ConfigurationMetadata, ConfigurationMetadata), ProjectItemInstanceSnapshot> edgeInfos)
             {
                 return edgeInfos.Where(e => e.Key.Item1.Equals(node.ToConfigurationMetadata())).Select(e => e.Value);
             }
 
-            IEnumerable<ProjectItemInstance> GetIncomingEdgeItemsToNode(ProjectGraphNode node, IReadOnlyDictionary<(ConfigurationMetadata, ConfigurationMetadata), ProjectItemInstance> edgeInfos)
+            IEnumerable<ProjectItemInstanceSnapshot> GetIncomingEdgeItemsToNode(ProjectGraphNode node, IReadOnlyDictionary<(ConfigurationMetadata, ConfigurationMetadata), ProjectItemInstanceSnapshot> edgeInfos)
             {
                 return edgeInfos.Where(e => e.Key.Item2.Equals(node.ToConfigurationMetadata())).Select(e => e.Value);
             }
@@ -668,7 +668,7 @@ namespace Microsoft.Build.Graph.UnitTests
             exception.Message.ShouldContain("but a project with this GUID was not found in the .SLN file");
         }
 
-        private static bool IsSolutionItemReference(ProjectItemInstance edgeItem)
+        private static bool IsSolutionItemReference(ProjectItemInstanceSnapshot edgeItem)
         {
             return edgeItem.ItemType == GraphBuilder.SolutionItemReference;
         }
@@ -736,12 +736,12 @@ namespace Microsoft.Build.Graph.UnitTests
 
         private static string GetConfiguration(ProjectGraphNode node)
         {
-            return node.ProjectInstance.GlobalProperties["Configuration"];
+            return node.ProjectInstanceSnapshot.GlobalProperties["Configuration"];
         }
 
         private static string GetPlatform(ProjectGraphNode node)
         {
-            return node.ProjectInstance.GlobalProperties["Platform"];
+            return node.ProjectInstanceSnapshot.GlobalProperties["Platform"];
         }
 
         public void Dispose()

--- a/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
+++ b/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Build.Graph.UnitTests
             foreach (var node in topoSortedNodes)
             {
                 var project = Project.FromFile(
-                    node.ProjectInstance.FullPath,
+                    node.ProjectInstanceSnapshot.FullPath,
                     new ProjectOptions
                     {
                         ProjectCollection = collection
@@ -347,7 +347,7 @@ namespace Microsoft.Build.Graph.UnitTests
 
             BuildUsingCaches(_env, topoSortedNodes, expectedOutput, outputCaches, generateCacheFiles: true);
 
-            var rootNode = topoSortedNodes.First(n => Path.GetFileNameWithoutExtension(n.ProjectInstance.FullPath) == "1");
+            var rootNode = topoSortedNodes.First(n => Path.GetFileNameWithoutExtension(n.ProjectInstanceSnapshot.FullPath) == "1");
             var outputCache = outputCaches[rootNode];
 
             outputCache.ShouldNotBeNull();
@@ -468,10 +468,10 @@ namespace Microsoft.Build.Graph.UnitTests
                 buildParameters.Loggers = new[] { logger };
 
                 var result = BuildProjectFileUsingBuildManager(
-                    node.ProjectInstance.FullPath,
+                    node.ProjectInstanceSnapshot.FullPath,
                     null,
                     buildParameters,
-                    targetListsPerNode?[node] != null ? targetListsPerNode?[node] : node.ProjectInstance.DefaultTargets);
+                    targetListsPerNode?[node] != null ? targetListsPerNode?[node] : node.ProjectInstanceSnapshot.DefaultTargets);
 
                 results[ProjectNumber(node)] = (result, logger);
 
@@ -507,7 +507,7 @@ namespace Microsoft.Build.Graph.UnitTests
             }
         }
 
-        private static string ProjectNumber(ProjectGraphNode node) => Path.GetFileNameWithoutExtension(node.ProjectInstance.FullPath);
+        private static string ProjectNumber(ProjectGraphNode node) => Path.GetFileNameWithoutExtension(node.ProjectInstanceSnapshot.FullPath);
 
         private static TransientTestFile CreateProjectFileWrapper(TestEnvironment env, int projectNumber, int[] projectReferences, Dictionary<string, string[]> projectReferenceTargets, string defaultTargets, string extraContent)
         {

--- a/src/Build.UnitTests/SolutionFileBuilder.cs
+++ b/src/Build.UnitTests/SolutionFileBuilder.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Build.Engine.UnitTests
             {
                 Projects = graph.ProjectNodes.ToDictionary(
                     n => GraphTestingUtilities.GetProjectNumber((ProjectGraphNode)n).ToString(),
-                    n => n.ProjectInstance.FullPath),
+                    n => n.ProjectInstanceSnapshot.FullPath),
                 ProjectConfigurations = projectConfigurations,
                 SolutionDependencies = solutionDependencies,
                 SolutionDependenciesProjectNameToGuids = solutionDependenciesProjectNameToGuids

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1878,7 +1878,8 @@ namespace Microsoft.Build.Execution
                             SdkResolverService,
                             submission.SubmissionId,
                             projectLoadSettings);
-                    });
+                    },
+                    keepProjectInstance: false);
             }
 
             LogMessage(
@@ -1887,6 +1888,9 @@ namespace Microsoft.Build.Execution
                     Math.Round(projectGraph.ConstructionMetrics.ConstructionTime.TotalSeconds, 3),
                     projectGraph.ConstructionMetrics.NodeCount,
                     projectGraph.ConstructionMetrics.EdgeCount));
+
+            GC.Collect();
+            LogMessage($"GraphBuild GC: {GC.GetTotalMemory(false)} bytes *new*");
 
             Dictionary<ProjectGraphNode, BuildResult> resultsPerNode = null;
 
@@ -1973,7 +1977,9 @@ namespace Microsoft.Build.Execution
                         }
 
                         var request = new BuildRequestData(
-                            node.ProjectInstance,
+                            node.ProjectInstanceSnapshot.FullPath,
+                            node.ProjectInstanceSnapshot.GlobalProperties,
+                            node.ProjectInstanceSnapshot.ToolsVersion,
                             targetList.ToArray(),
                             graphBuildRequestData.HostServices,
                             graphBuildRequestData.Flags);

--- a/src/Build/Graph/GraphBuildSubmission.cs
+++ b/src/Build/Graph/GraphBuildSubmission.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Graph
     /// A callback used to receive notification that a build has completed.
     /// </summary>
     /// <remarks>
-    /// When this delegate is invoked, the WaitHandle on the BuildSubmission will have been be signalled and the OverallBuildResult will be valid.
+    /// When this delegate is invoked, the WaitHandle on the BuildSubmission will have been be signaled and the OverallBuildResult will be valid.
     /// </remarks>
     public delegate void GraphBuildSubmissionCompleteCallback(GraphBuildSubmission submission);
 
@@ -74,7 +74,7 @@ namespace Microsoft.Build.Graph
         public Object AsyncContext { get; private set; }
 
         /// <summary>
-        /// A <see cref="System.Threading.WaitHandle"/> which will be signalled when the build is complete.  Valid after <see cref="BuildSubmission.Execute()"/> or <see cref="BuildSubmission.ExecuteAsync(BuildSubmissionCompleteCallback, object)"/> returns, otherwise null.
+        /// A <see cref="System.Threading.WaitHandle"/> which will be signaled when the build is complete.  Valid after <see cref="BuildSubmission.Execute()"/> or <see cref="BuildSubmission.ExecuteAsync(BuildSubmissionCompleteCallback, object)"/> returns, otherwise null.
         /// </summary>
         public WaitHandle WaitHandle => _completionEvent;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Build.Graph
         public bool IsCompleted => WaitHandle.WaitOne(new TimeSpan(0));
 
         /// <summary>
-        /// The results of the build per graph node.  Valid only after WaitHandle has become signalled.
+        /// The results of the build per graph node.  Valid only after WaitHandle has become signaled.
         /// </summary>
         public GraphBuildResult BuildResult { get; internal set; }
 

--- a/src/Build/Graph/ProjectGraphNode.cs
+++ b/src/Build/Graph/ProjectGraphNode.cs
@@ -3,14 +3,201 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Experimental.ProjectCache;
 using Microsoft.Build.Shared;
+using static Microsoft.Build.Graph.ProjectInterpretation;
 
 #nullable disable
 
 namespace Microsoft.Build.Graph
 {
+    internal class ProjectItemInstanceSnapshot
+    {
+        public string FullPath = string.Empty;
+        public string EvaluatedInclude = string.Empty;
+        public string ItemType = string.Empty;
+
+        private List<(string Name, string Value)> Metadata;
+
+        public ProjectItemInstanceSnapshot(List<(string Name, string Value)> metadata)
+        {
+            Metadata = metadata;
+        }
+
+        public ProjectItemInstanceSnapshot(ProjectItemInstance projectItemInstance)
+        {
+            Metadata = new(projectItemInstance.MetadataCount);
+            foreach (var metadata in projectItemInstance.Metadata)
+            {
+                Metadata.Add((metadata.Name, metadata.EvaluatedValue));
+            }
+
+            FullPath = projectItemInstance.GetMetadataValue(FullPathMetadataName);
+        }
+
+        public string GetMetadataValue(string metadataName)
+        {
+            // Note: FullPath is a special metadata that doesn't count towards the DirectMetadataCount.
+            if (FullPathMetadataName == metadataName)
+            {
+                return FullPath;
+            }
+
+            // Note: caller expect empty string instead of null.
+            var result = Metadata.FirstOrDefault((k) => k.Name == metadataName);
+            return string.IsNullOrEmpty(result.Value) ? string.Empty : result.Value;
+        }
+
+        public void SetMetadata(string metadataName, string value)
+        {
+            RemoveMetadata(metadataName);
+            Metadata.Add((metadataName, value));
+        }
+
+        public void RemoveMetadata(string metadataName)
+        {
+            int count = Metadata.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (Metadata[i].Name == metadataName)
+                {
+                    Metadata.RemoveAt(i);
+                    break;
+                }
+            }
+        }
+
+        public bool HasMetadata(string metadataName)
+        {
+            return Metadata.Any( (kv) => kv.Name == metadataName);
+        }
+
+        public int DirectMetadataCount => Metadata.Count;
+    }
+
+    internal class ProjectInstanceSnapshot
+    {
+        public ProjectInstanceSnapshot(ProjectInstance instance)
+        {
+            FullPath = instance.FullPath;
+            DefaultTargets = instance.DefaultTargets;
+            ProjectFileLocation = instance.ProjectFileLocation;
+            GlobalPropertiesDictionary = instance.GlobalPropertiesDictionary;
+            GlobalProperties = instance.GlobalProperties;
+            ToolsVersion = instance.ToolsVersion;
+
+            var innerBuildPropName = instance.GetPropertyValue(PropertyNames.InnerBuildProperty);
+            var innerBuildPropValue = instance.GetPropertyValue(innerBuildPropName);
+
+            var innerBuildPropValues = instance.GetPropertyValue(PropertyNames.InnerBuildPropertyValues);
+            var innerBuildPropValuesValue = instance.GetPropertyValue(innerBuildPropValues);
+
+            var isOuterBuild = string.IsNullOrWhiteSpace(innerBuildPropValue) && !string.IsNullOrWhiteSpace(innerBuildPropValuesValue);
+            var isInnerBuild = !string.IsNullOrWhiteSpace(innerBuildPropValue);
+
+            ProjectType = isOuterBuild
+                ? ProjectType.OuterBuild
+                : isInnerBuild
+                    ? ProjectType.InnerBuild
+                    : ProjectType.NonMultitargeting;
+
+            Targets = instance.Targets.Keys.ToList();
+            Properties = new()
+                {
+                    { AddTransitiveProjectReferencesInStaticGraphPropertyName, instance.GetPropertyValue(AddTransitiveProjectReferencesInStaticGraphPropertyName) },
+                    { EnableDynamicPlatformResolutionPropertyName, instance.GetPropertyValue(EnableDynamicPlatformResolutionPropertyName) },
+                    { "TargetFrameworks", instance.GetPropertyValue("TargetFrameworks") },
+                    { BuildProjectInSolutionPropertyName, instance.GetPropertyValue(BuildProjectInSolutionPropertyName) },
+                    { PropertyNames.InnerBuildProperty, innerBuildPropName },
+                    { PropertyNames.InnerBuildPropertyValues, innerBuildPropValues },
+                    { UsingMicrosoftNETSdkPropertyName, instance.GetPropertyValue(UsingMicrosoftNETSdkPropertyName) },
+                    { DisableTransitiveProjectReferencesPropertyName, instance.GetPropertyValue(DisableTransitiveProjectReferencesPropertyName) },
+                    { SolutionProjectGenerator.CurrentSolutionConfigurationContents, instance.GetPropertyValue(SolutionProjectGenerator.CurrentSolutionConfigurationContents) },
+                    { PlatformMetadataName, instance.GetPropertyValue(PlatformMetadataName) },
+                    { ConfigurationMetadataName, instance.GetPropertyValue(ConfigurationMetadataName) },
+                    { PlatformLookupTableMetadataName, instance.GetPropertyValue(PlatformLookupTableMetadataName) },
+                    { ShouldUnsetParentConfigurationAndPlatformPropertyName, instance.GetPropertyValue(ShouldUnsetParentConfigurationAndPlatformPropertyName) },
+                };
+
+            if (!string.IsNullOrEmpty(innerBuildPropName))
+            {
+                Properties[innerBuildPropName] = innerBuildPropValue;
+            }
+
+            if (!string.IsNullOrEmpty(innerBuildPropValues))
+            {
+                Properties[innerBuildPropValues] = innerBuildPropValuesValue;
+            }
+
+            var projectReferenceTargets = instance.GetItems(ItemTypeNames.ProjectReferenceTargets);
+            ProjectReferenceByTargets = new(projectReferenceTargets.Count) { };
+            foreach (ProjectItemInstance projectReferenceTarget in projectReferenceTargets)
+            {
+                ProjectReferenceByTargets.Add(new ProjectItemInstanceSnapshot(projectReferenceTarget)
+                {
+                    ItemType = projectReferenceTarget.ItemType,
+                    EvaluatedInclude = projectReferenceTarget.EvaluatedInclude,
+                });
+            }
+
+            var projectReferences = instance.GetItems(ItemTypeNames.ProjectReference);
+            ProjectReference = new(projectReferences.Count) { };
+            foreach (ProjectItemInstance projectReference in projectReferences)
+            {
+                ProjectReference.Add(new ProjectItemInstanceSnapshot(projectReference)
+                {
+                    ItemType = projectReference.ItemType,
+                    EvaluatedInclude = projectReference.EvaluatedInclude,
+                });
+            }
+
+            var items = instance.GetItems(ItemTypeNames.ProjectCachePlugin);
+            ProjectCacheDescriptors = new(items.Count);
+            foreach (ProjectItemInstance item in items)
+            {
+                string pluginPath = FileUtilities.NormalizePath(System.IO.Path.Combine(item.Project.Directory, item.EvaluatedInclude));
+
+                var pluginSettings = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
+                foreach (ProjectMetadataInstance metadatum in item.Metadata)
+                {
+                    pluginSettings.Add(metadatum.Name, metadatum.EvaluatedValue);
+                }
+
+                ProjectCacheDescriptors.Add(ProjectCacheDescriptor.FromAssemblyPath(pluginPath, pluginSettings));
+            }
+        }
+
+        public string FullPath;
+        public string ToolsVersion;
+        public List<string> Targets;
+        internal ProjectType ProjectType;
+        public List<string> DefaultTargets;
+        public ElementLocation ProjectFileLocation;
+        internal Collections.PropertyDictionary<ProjectPropertyInstance> GlobalPropertiesDictionary;
+
+        public int PropertiesCount => Properties.Count;
+        public IDictionary<string, string> GlobalProperties;
+        public List<ProjectItemInstanceSnapshot> ProjectReferenceByTargets;
+        public List<ProjectItemInstanceSnapshot> ProjectReference;
+        public List<ProjectCacheDescriptor> ProjectCacheDescriptors;
+
+        private Dictionary<string, string> Properties;
+
+        public string GetPropertyValue(string propertyName)
+        {
+            if (Properties.TryGetValue(propertyName, out string result))
+            {
+                return result;
+            }
+
+            return string.Empty;
+        }
+    }
+
     /// <summary>
     /// Represents the node for a particular project in a project graph.
     /// A node is defined by (ProjectPath, ToolsVersion, GlobalProperties).
@@ -22,10 +209,16 @@ namespace Microsoft.Build.Graph
         private readonly HashSet<ProjectGraphNode> _referencingProjects = new HashSet<ProjectGraphNode>();
 
         // No public creation.
-        internal ProjectGraphNode(ProjectInstance projectInstance)
+        internal ProjectGraphNode(ProjectInstance projectInstance, bool keepProjectInstance)
         {
             ErrorUtilities.VerifyThrowInternalNull(projectInstance, nameof(projectInstance));
-            ProjectInstance = projectInstance;
+            ProjectInstanceSnapshot = new(projectInstance);
+
+            // Keep ProjectInstance for API compatibility
+            if (keepProjectInstance)
+            {
+                ProjectInstance = projectInstance;
+            }
         }
 
         /// <summary>
@@ -43,15 +236,20 @@ namespace Microsoft.Build.Graph
         /// </summary>
         public ProjectInstance ProjectInstance { get; }
 
+        /// <summary>
+        /// Gets the evaluated project instance represented by this node in the graph.
+        /// </summary>
+        internal ProjectInstanceSnapshot ProjectInstanceSnapshot { get; }
+
         private string DebugString()
         {
-            var truncatedProjectFile = FileUtilities.TruncatePathToTrailingSegments(ProjectInstance.FullPath, 2);
+            var truncatedProjectFile = FileUtilities.TruncatePathToTrailingSegments(ProjectInstanceSnapshot.FullPath, 2);
 
             return
-                $"{truncatedProjectFile}, #GlobalProps={ProjectInstance.GlobalProperties.Count}, #Props={ProjectInstance.Properties.Count}, #Items={ProjectInstance.Items.Count}, #in={ReferencingProjects.Count}, #out={ProjectReferences.Count}";
+                $"{truncatedProjectFile}, #GlobalProps={ProjectInstanceSnapshot.GlobalProperties.Count}, #Props={ProjectInstanceSnapshot.PropertiesCount}, #in={ReferencingProjects.Count}, #out={ProjectReferences.Count}";
         }
 
-        internal void AddProjectReference(ProjectGraphNode reference, ProjectItemInstance projectReferenceItem, GraphBuilder.GraphEdges edges)
+        internal void AddProjectReference(ProjectGraphNode reference, ProjectItemInstanceSnapshot projectReferenceItem, GraphBuilder.GraphEdges edges)
         {
             _projectReferences.Add(reference);
             reference._referencingProjects.Add(this);
@@ -82,7 +280,7 @@ namespace Microsoft.Build.Graph
 
         internal ConfigurationMetadata ToConfigurationMetadata()
         {
-            return new ConfigurationMetadata(ProjectInstance.FullPath, ProjectInstance.GlobalPropertiesDictionary);
+            return new ConfigurationMetadata(ProjectInstanceSnapshot.FullPath, ProjectInstanceSnapshot.GlobalPropertiesDictionary);
         }
     }
 }


### PR DESCRIPTION
### Context
When building with Static Graph, it evaluates the entire solution space to computes the most optimal path for parallelization.  However, it keeps those evaluated instances in memory in hope they might be reused.  From my testing, these are not reused because new instances are created with different properties from platform negotiation. 

### Changes Made
Create a snapshot of the data that Static Graph would use then "free" those instances.

### Testing
Add after printing `Static graph loaded` message.
```
GC.Collect();
LogMessage($"GraphBuild GC: {GC.GetTotalMemory(false)} bytes");
```
**Solution 1:**
*baseline:*
Static graph loaded in 37.884 seconds: 166 nodes, 1628 edges
GraphBuild GC: **185,411,136** bytes

*new:*
Static graph loaded in 37.024 seconds: 166 nodes, 1628 edges
GraphBuild GC: **24,743,840** bytes


**Solution 2:**
*baseline*
Static graph loaded in 498.914 seconds: 913 nodes, 12862 edges
GraphBuild GC: **1,141,466,552** bytes 

*new*
Static graph loaded in 425.508 seconds: 913 nodes, 12862 edges
GraphBuild GC: **62,436,160** bytes 

### Notes
I was hoping there would be more performance uplift from reducing GC pressure.  Static graph performance would need further investigation.
The Snapshot class is mimicking the ProjectInstance API to reduce code churn.  There might be further data structure optimization without that limitation.