### PR TITLE
Update invalid localized string

### DIFF
--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1389,9 +1389,9 @@
     <value>The '{0}' switch is not supported for solution files.</value>
   </data>
   <data name="NameInvalid" Visibility="Public">
-    <value>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</value>
+    <value>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</value>
     <comment>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </comment>
   </data>
   <!-- **** TerminalLogger strings begin **** -->

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1391,7 +1391,7 @@
   <data name="NameInvalid" Visibility="Public">
     <value>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</value>
     <comment>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </comment>
   </data>
   <!-- **** TerminalLogger strings begin **** -->

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1378,10 +1378,10 @@ Když se nastaví na MessageUponIsolationViolation (nebo jeho krátký
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1381,7 +1381,7 @@ Když se nastaví na MessageUponIsolationViolation (nebo jeho krátký
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1371,10 +1371,10 @@ Dieses Protokollierungsformat ist standardmäßig aktiviert.
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1374,7 +1374,7 @@ Dieses Protokollierungsformat ist standardmäßig aktiviert.
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1381,7 +1381,7 @@
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1378,10 +1378,10 @@
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1371,10 +1371,10 @@ Remarque : verbosité des enregistreurs d’événements de fichiers
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1374,7 +1374,7 @@ Remarque : verbosité des enregistreurs d’événements de fichiers
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1384,7 +1384,7 @@ Nota: livello di dettaglio dei logger di file
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1381,10 +1381,10 @@ Nota: livello di dettaglio dei logger di file
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1374,7 +1374,7 @@
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1371,10 +1371,10 @@
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1374,7 +1374,7 @@
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1371,10 +1371,10 @@
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1380,7 +1380,7 @@
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1377,10 +1377,10 @@
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1372,10 +1372,10 @@ arquivo de resposta.
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1375,7 +1375,7 @@ arquivo de resposta.
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1373,7 +1373,7 @@
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1370,10 +1370,10 @@
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1374,7 +1374,7 @@
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1371,10 +1371,10 @@
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1374,7 +1374,7 @@
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1371,10 +1371,10 @@
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1374,7 +1374,7 @@
         <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
         <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD : error MSB5016: "}
+      {StrBegin="MSBUILD: error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1371,10 +1371,10 @@
     </note>
       </trans-unit>
       <trans-unit id="NameInvalid">
-        <source>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
-        <target state="new">MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <source>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</target>
         <note>
-      {StrBegin="MSBUILD: error MSB5016: "}
+      {StrBegin="MSBUILD : error MSB5016: "}
     </note>
       </trans-unit>
       <trans-unit id="NotWarnAsErrorWithoutWarnAsError">


### PR DESCRIPTION
the dev rule is incorrect.
The addition was:

```
<data name="NameInvalid" Visibility="Public">
    <value>MSBUILD: error MSB5016: The name "{0}" contains an invalid character "{1}".</value>
    <comment>
      {StrBegin="MSBUILD : error MSB5016: "}
    </comment>
  </data>
```


The source string does not have the same spaces as the rule asks for.
It should be like this:

```
<data name="NameInvalid" Visibility="Public">
    <value>MSBUILD : error MSB5016: The name "{0}" contains an invalid character "{1}".</value>
    <comment>
      {StrBegin=" MSBUILD : error MSB5016: "}
    </comment>
  </data>
```
