### PR TITLE
Do not register typelib in ComReferenceInfo

### DIFF
--- a/src/Tasks/ComReferenceInfo.cs
+++ b/src/Tasks/ComReferenceInfo.cs
@@ -153,10 +153,10 @@ namespace Microsoft.Build.Tasks
             {
                 case ProcessorArchitecture.AMD64:
                 case ProcessorArchitecture.IA64:
-                    this.typeLibPointer = (ITypeLib)NativeMethods.LoadTypeLibEx(path, (int)NativeMethods.REGKIND.REGKIND_LOAD_TLB_AS_64BIT);
+                    this.typeLibPointer = (ITypeLib)NativeMethods.LoadTypeLibEx(path, (int)NativeMethods.REGKIND.REGKIND_NONE | (int)NativeMethods.REGKIND.REGKIND_LOAD_TLB_AS_64BIT);
                     break;
                 case ProcessorArchitecture.X86:
-                    this.typeLibPointer = (ITypeLib)NativeMethods.LoadTypeLibEx(path, (int)NativeMethods.REGKIND.REGKIND_LOAD_TLB_AS_32BIT);
+                    this.typeLibPointer = (ITypeLib)NativeMethods.LoadTypeLibEx(path, (int)NativeMethods.REGKIND.REGKIND_NONE | (int)NativeMethods.REGKIND.REGKIND_LOAD_TLB_AS_32BIT);
                     break;
                 case ProcessorArchitecture.ARM:
                 case ProcessorArchitecture.MSIL:


### PR DESCRIPTION
Fixes #8980

### Context
Analysis in #8980 seems to be correct. Have not found any evidence otherwise.

### Changes Made
As recommended.

### Testing
Unit tests coverage.

### Notes
In theory something might be dependent on this erroneous  typelib registration, but I deem it very improbable, and if it still would be an bug on their side.