### PR TITLE
upgrade NuGet.CommandLine to 6.6.1 for mitigating CG issue

### DIFF
--- a/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <!-- Managed manually since PackageDownload is not supported by dependabot https://github.com/dependabot/dependabot-core/issues/2920 -->
-    <NuGetCommandLinePackageVersion>4.9.6</NuGetCommandLinePackageVersion>
+    <NuGetCommandLinePackageVersion>6.6.1</NuGetCommandLinePackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes # CG issue generated by pipeline (e.g. https://dev.azure.com/dnceng-public/public/_build/results?buildId=359010&view=results
It's related to NuGet.CommandLine version
