### PR TITLE
Remove unneeded supressions

### DIFF
--- a/src/Build/CompatibilitySuppressions.xml
+++ b/src/Build/CompatibilitySuppressions.xml
@@ -1,42 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <!-- Need to suppress due to AppCompat limitation https://github.com/dotnet/sdk/issues/32922 -->
-  <Suppression>
-    <DiagnosticId>CP0007</DiagnosticId>
-    <Target>T:Microsoft.Build.BackEnd.SdkResolution.SdkResolverException</Target>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0007</DiagnosticId>
-    <Target>T:Microsoft.Build.Exceptions.BuildAbortedException</Target>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0007</DiagnosticId>
-    <Target>T:Microsoft.Build.Exceptions.CircularDependencyException</Target>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0007</DiagnosticId>
-    <Target>T:Microsoft.Build.Exceptions.InternalLoggerException</Target>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0007</DiagnosticId>
-    <Target>T:Microsoft.Build.Exceptions.InvalidProjectFileException</Target>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0007</DiagnosticId>
-    <Target>T:Microsoft.Build.Exceptions.InvalidToolsetDefinitionException</Target>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0007</DiagnosticId>
-    <Target>T:Microsoft.Build.Experimental.ProjectCache.ProjectCacheException</Target>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
   <!-- For updating target framework from net 7.0 to net 8.0 in MSBuild 17.8 suppress baseline package validation error PKV006 on net 7.0 -->
   <Suppression>
     <DiagnosticId>PKV006</DiagnosticId>


### PR DESCRIPTION
### Context
Suppressions were added due to APICompat limitation https://github.com/dotnet/sdk/issues/32922
That limitation was fixed - so suppressions are not needed anymore
