### PR TITLE
Bump up dotnet version to fix CG alerts

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.7.2</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.7.3</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.6.3</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "7.0.304",
+    "dotnet": "7.0.306",
     "vs": {
       "version": "17.4.1"
     },


### PR DESCRIPTION
Fixes #
N/A

### Context
CG alerts for vs17.7 recommends the following upgrade from 7.0.7 to 7.0.9.
- Microsoft.AspNetCore.App.Runtime.win-x64
- Microsoft.AspNetCore.App.Runtime.win-x86
- Microsoft.WindowsDesktop.App.Runtime.win-x64
- Microsoft.WindowsDesktop.App.Runtime.win-x86


### Changes Made
Bump up dotnet version to 7.0.306 that has runtime 7.0.9.

### Testing


### Notes
