### PR TITLE
Fix project configuration case-mismatch issue for solution-based graph builds

### DIFF
--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Build.Graph.UnitTests
             }
         }
 
-        [Theory(Skip = "hangs in CI, can't repro locally: https://github.com/dotnet/msbuild/issues/5453")]
+        [Theory]
         [MemberData(nameof(GraphsWithUniformSolutionConfigurations))]
         public void GraphConstructionCanLoadEntryPointsFromSolution(
             Dictionary<int, int[]> edges,
@@ -199,7 +199,7 @@ namespace Microsoft.Build.Graph.UnitTests
             AssertSolutionBasedGraph(edges, currentSolutionConfiguration, solutionConfigurations);
         }
 
-        [Theory(Skip = "hangs in CI, can't repro locally: https://github.com/dotnet/msbuild/issues/5453")]
+        [Theory]
         [MemberData(nameof(GraphsWithUniformSolutionConfigurations))]
         public void SolutionBasedGraphCanMatchProjectSpecificConfigurations(
             Dictionary<int, int[]> edges,
@@ -706,6 +706,9 @@ namespace Microsoft.Build.Graph.UnitTests
                     solutionPath,
                     globalProperties),
                 _env.CreateProjectCollection().Collection);
+
+            // Exactly 1 node per project
+            graph.ProjectNodes.Count.ShouldBe(graph.ProjectNodes.Select(GetProjectPath).Distinct().Count());
 
             // in the solution, all nodes are entry points
             graphFromSolution.EntryPointNodes.Select(GetProjectPath)

--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Build.Graph.UnitTests
             }
         }
 
-        [Theory]
+        [Theory(Skip = "hangs in CI, can't repro locally: https://github.com/dotnet/msbuild/issues/5453")]
         [MemberData(nameof(GraphsWithUniformSolutionConfigurations))]
         public void GraphConstructionCanLoadEntryPointsFromSolution(
             Dictionary<int, int[]> edges,
@@ -199,7 +199,7 @@ namespace Microsoft.Build.Graph.UnitTests
             AssertSolutionBasedGraph(edges, currentSolutionConfiguration, solutionConfigurations);
         }
 
-        [Theory]
+        [Theory(Skip = "hangs in CI, can't repro locally: https://github.com/dotnet/msbuild/issues/5453")]
         [MemberData(nameof(GraphsWithUniformSolutionConfigurations))]
         public void SolutionBasedGraphCanMatchProjectSpecificConfigurations(
             Dictionary<int, int[]> edges,

--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -695,8 +695,9 @@ namespace Microsoft.Build.Graph.UnitTests
             var globalProperties = currentSolutionConfiguration != null
                 ? new Dictionary<string, string>
                 {
-                    ["Configuration"] = currentSolutionConfiguration.ConfigurationName,
-                    ["Platform"] = currentSolutionConfiguration.PlatformName
+                    // Intentionally use mismatched casing to ensure it's properly normalized.
+                    ["Configuration"] = currentSolutionConfiguration.ConfigurationName.ToUpperInvariant(),
+                    ["Platform"] = currentSolutionConfiguration.PlatformName.ToUpperInvariant()
                 }
                 : new Dictionary<string, string>();
 
@@ -724,19 +725,9 @@ namespace Microsoft.Build.Graph.UnitTests
 
             foreach (var node in graphFromSolution.ProjectNodes)
             {
-                // Project references get duplicated, once as entry points from the solution (handled in the if block) and once as nodes
-                // produced by ProjectReference items (handled in the else block).
-                if (node.ReferencingProjects.Count == 0)
-                {
-                    var expectedProjectConfiguration = actualProjectConfigurations[GetProjectNumber(node).ToString()][expectedCurrentConfiguration];
-                    GetConfiguration(node).ShouldBe(expectedProjectConfiguration.ConfigurationName);
-                    GetPlatform(node).ShouldBe(expectedProjectConfiguration.PlatformName);
-                }
-                else
-                {
-                    GetConfiguration(node).ShouldBe(GetConfiguration(node.ReferencingProjects.First()));
-                    GetPlatform(node).ShouldBe(GetPlatform(node.ReferencingProjects.First()));
-                }
+                var expectedProjectConfiguration = actualProjectConfigurations[GetProjectNumber(node).ToString()][expectedCurrentConfiguration];
+                GetConfiguration(node).ShouldBe(expectedProjectConfiguration.ConfigurationName);
+                GetPlatform(node).ShouldBe(expectedProjectConfiguration.PlatformName);
             }
         }
 

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Build.Graph
             ProjectGraphEntryPoint solutionEntryPoint = entryPoints.Single();
             ImmutableDictionary<string, string>.Builder solutionGlobalPropertiesBuilder = ImmutableDictionary.CreateBuilder(
                 keyComparer: StringComparer.OrdinalIgnoreCase,
-                valueComparer: StringComparer.OrdinalIgnoreCase);
+                valueComparer: StringComparer.Ordinal);
 
             if (solutionEntryPoint.GlobalProperties != null)
             {
@@ -279,9 +279,11 @@ namespace Microsoft.Build.Graph
 
             IReadOnlyCollection<ProjectInSolution> projectsInSolution = GetBuildableProjects(solution);
 
-            SolutionConfigurationInSolution currentSolutionConfiguration = SelectSolutionConfiguration(solution, solutionEntryPoint.GlobalProperties);
-
             // Mimic behavior of SolutionProjectGenerator
+            SolutionConfigurationInSolution currentSolutionConfiguration = SelectSolutionConfiguration(solution, solutionEntryPoint.GlobalProperties);
+            solutionGlobalPropertiesBuilder["Configuration"] = currentSolutionConfiguration.ConfigurationName;
+            solutionGlobalPropertiesBuilder["Platform"] = currentSolutionConfiguration.PlatformName;
+
             string solutionConfigurationXml = SolutionProjectGenerator.GetSolutionConfiguration(solution, currentSolutionConfiguration);
             solutionGlobalPropertiesBuilder["CurrentSolutionConfigurationContents"] = solutionConfigurationXml;
             solutionGlobalPropertiesBuilder["BuildingSolutionFile"] = "true";


### PR DESCRIPTION
Fixes #9103

Tested using repro from linked bug.

Only single build for Project2:
![image](https://github.com/dotnet/msbuild/assets/6445614/3a256d35-3c5f-499f-a50a-b38d32900000)

And it uses the normalized platform value:
![image](https://github.com/dotnet/msbuild/assets/6445614/979543eb-9af6-4512-a1f6-c87dcdf63a9b)
