### PR TITLE
Terminal logger enablement by /tlp:default and related telemetry

### DIFF
--- a/src/Build.UnitTests/BackEnd/LoggingConfigurationTelemetry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingConfigurationTelemetry_Tests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Build.Framework.Telemetry;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.Telemetry;
+
+public class LoggingConfigurationTelemetry_Tests
+{
+    [Fact]
+    public void LoggingConfigurationTelemetryIsThere()
+    {
+        KnownTelemetry.LoggingConfigurationTelemetry.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void BuildTelemetryConstructedHasNoProperties()
+    {
+        LoggingConfigurationTelemetry telemetry = new();
+
+        telemetry.EventName.ShouldBe("loggingConfiguration");
+        telemetry.TerminalLogger.ShouldBe(false);
+        telemetry.TerminalLoggerUserIntent.ShouldBeNull();
+        telemetry.TerminalLoggerUserIntentSource.ShouldBeNull();
+        telemetry.TerminalLoggerDefault.ShouldBeNull();
+        telemetry.TerminalLoggerDefaultSource.ShouldBeNull();
+        telemetry.ConsoleLogger.ShouldBe(false);
+        telemetry.ConsoleLoggerType.ShouldBeNull();
+        telemetry.ConsoleLoggerVerbosity.ShouldBeNull();
+        telemetry.FileLogger.ShouldBe(false);
+        telemetry.FileLoggerVerbosity.ShouldBeNull();
+        telemetry.FileLoggersCount.ShouldBe(0);
+        telemetry.FileLoggerVerbosity.ShouldBeNull();
+        telemetry.BinaryLogger.ShouldBe(false);
+        telemetry.BinaryLoggerUsedDefaultName.ShouldBe(false);
+
+        telemetry.UpdateEventProperties();
+        telemetry.Properties.Where(kv => kv.Value != bool.FalseString).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void BuildTelemetryCreateProperProperties()
+    {
+        LoggingConfigurationTelemetry telemetry = new()
+        {
+            TerminalLogger = true,
+            TerminalLoggerUserIntent = "on",
+            TerminalLoggerUserIntentSource = "arg",
+            TerminalLoggerDefault = "auto",
+            TerminalLoggerDefaultSource = "sdk",
+            ConsoleLogger = true,
+            ConsoleLoggerType = "serial",
+            ConsoleLoggerVerbosity = "minimal",
+            FileLogger = true,
+            FileLoggerType = "serial",
+            FileLoggersCount = 2,
+            FileLoggerVerbosity = "normal",
+            BinaryLogger = true,
+            BinaryLoggerUsedDefaultName = true
+        };
+
+        telemetry.UpdateEventProperties();
+
+        telemetry.Properties["TerminalLogger"].ShouldBe(bool.TrueString);
+        telemetry.Properties["TerminalLoggerUserIntent"].ShouldBe("on");
+        telemetry.Properties["TerminalLoggerUserIntentSource"].ShouldBe("arg");
+        telemetry.Properties["TerminalLoggerDefault"].ShouldBe("auto");
+        telemetry.Properties["TerminalLoggerDefaultSource"].ShouldBe("sdk");
+        telemetry.Properties["ConsoleLogger"].ShouldBe(bool.TrueString);
+        telemetry.Properties["ConsoleLoggerType"].ShouldBe("serial");
+        telemetry.Properties["ConsoleLoggerVerbosity"].ShouldBe("minimal");
+        telemetry.Properties["FileLogger"].ShouldBe(bool.TrueString);
+        telemetry.Properties["FileLoggerType"].ShouldBe("serial");
+        telemetry.Properties["FileLoggersCount"].ShouldBe("2");
+        telemetry.Properties["FileLoggerVerbosity"].ShouldBe("normal");
+        telemetry.Properties["BinaryLogger"].ShouldBe(bool.TrueString);
+        telemetry.Properties["BinaryLoggerUsedDefaultName"].ShouldBe(bool.TrueString);
+    }
+}

--- a/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
+++ b/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
@@ -113,7 +113,7 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
     [Fact]
     public void TerminalLoggerDefaultByEnv()
     {
-        _env.SetEnvironmentVariable("DOTNET_CLI_BUILD_TERMINAL_LOGGER", bool.TrueString);
+        _env.SetEnvironmentVariable("DOTNET_CLI_CONFIGURE_MSBUILD_TERMINAL_LOGGER", bool.TrueString);
         string output = RunnerUtilities.ExecMSBuild($"{_cmd} -tlp:default={bool.TrueString}", out bool success);
         success.ShouldBeTrue();
 
@@ -121,7 +121,7 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         {
             TerminalLogger = true,
             TerminalLoggerDefault = bool.TrueString,
-            TerminalLoggerDefaultSource = "DOTNET_CLI_BUILD_TERMINAL_LOGGER",
+            TerminalLoggerDefaultSource = "DOTNET_CLI_CONFIGURE_MSBUILD_TERMINAL_LOGGER",
             TerminalLoggerUserIntent = null,
             TerminalLoggerUserIntentSource = null,
             ConsoleLogger = false,

--- a/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
+++ b/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
@@ -164,9 +164,6 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
             output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
         }
 
-        // TODO: delete, this is for troubleshooting unit tests on macos
-        _output.WriteLine(output);
-
         // Test if there is ANSI clear screen sequence, which shall only occur when the terminal logger was enabled.
         ShouldBeTerminalLog(output);
     }
@@ -231,6 +228,8 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         ShouldNotBeTerminalLog(output);
     }
 
-    private static void ShouldBeTerminalLog(string output) => output.ShouldContain($"\x1b[J");
-    private static void ShouldNotBeTerminalLog(string output) => output.ShouldNotContain($"\x1b[J");
+    // TODO: remove custom message
+    private static void ShouldBeTerminalLog(string output) => output.ShouldContain($"\x1b[J", output);
+    // TODO: remove custom message
+    private static void ShouldNotBeTerminalLog(string output) => output.ShouldNotContain($"\x1b[J", output);
 }

--- a/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
+++ b/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
@@ -1,0 +1,231 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework.Telemetry;
+using Microsoft.Build.UnitTests.Shared;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Build.UnitTests;
+
+/// <summary>
+/// End to end tests for the terminal logger configuration.
+/// We need to execute msbuild process as tested code path is also in XMake.cs.
+/// Also verifies that the telemetry is logged correctly.
+/// Because we need to test the telemetry for the terminal logger, we need to use the MockLogger which outputs all telemetry properties.
+/// </summary>
+public class TerminalLoggerConfiguration_Tests : IDisposable
+{
+    private readonly TestEnvironment _env;
+
+    private readonly string _cmd;
+
+    public TerminalLoggerConfiguration_Tests(ITestOutputHelper output)
+    {
+        _env = TestEnvironment.Create(output);
+
+        TransientTestFolder logFolder = _env.CreateFolder(createFolder: true);
+        TransientTestFile projectFile = _env.CreateFile(logFolder, "myProj.proj", $"""
+            <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Hello">
+                <Target Name="Hello">
+                  <Message Text="Hello, world!" />
+                </Target>
+            </Project>
+            """);
+        _cmd = $"{projectFile.Path} -target:Hello -logger:{typeof(MockLogger).FullName},{typeof(MockLogger).Assembly.Location};ReportTelemetry";
+    }
+
+    /// <summary>
+    /// TearDown
+    /// </summary>
+    public void Dispose()
+    {
+        _env.Dispose();
+    }
+
+    [Theory]
+    [InlineData("on")]
+    [InlineData("true")]
+    public void TerminalLoggerOn(string tlValue)
+    {
+        string output = RunnerUtilities.ExecMSBuild($"{_cmd} -tl:{tlValue}", out bool success);
+        success.ShouldBeTrue();
+
+        LoggingConfigurationTelemetry expectedTelemetry = new LoggingConfigurationTelemetry
+        {
+            TerminalLogger = true,
+            TerminalLoggerDefault = bool.FalseString,
+            TerminalLoggerDefaultSource = "msbuild",
+            TerminalLoggerUserIntent = tlValue,
+            TerminalLoggerUserIntentSource = "arg",
+            ConsoleLogger = false,
+            FileLogger = false,
+        };
+
+        expectedTelemetry.UpdateEventProperties();
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        {
+            output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
+        }
+
+        // Test if there is ANSI clear screen sequence, which shall only occur when the terminal logger was enabled.
+        ShouldBeTerminalLog(output);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("auto")]
+    public void TerminalLoggerWithTlAutoIsOff(string tlValue)
+    {
+        string output = RunnerUtilities.ExecMSBuild($"{_cmd} -tl:{tlValue}", out bool success);
+        success.ShouldBeTrue();
+
+        LoggingConfigurationTelemetry expectedTelemetry = new LoggingConfigurationTelemetry
+        {
+            TerminalLogger = false,
+            TerminalLoggerDefault = bool.FalseString,
+            TerminalLoggerDefaultSource = "msbuild",
+            TerminalLoggerUserIntent = tlValue,
+            TerminalLoggerUserIntentSource = "arg",
+            ConsoleLogger = true,
+            ConsoleLoggerType = "parallel",
+            ConsoleLoggerVerbosity = "normal",
+            FileLogger = false,
+        };
+
+        expectedTelemetry.UpdateEventProperties();
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        {
+            output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
+        }
+
+        // Test if there is ANSI clear screen sequence, which shall only occur when the terminal logger was enabled.
+        ShouldNotBeTerminalLog(output);
+    }
+
+
+    [Fact]
+    public void TerminalLoggerDefaultByEnv()
+    {
+        _env.SetEnvironmentVariable("DOTNET_CLI_BUILD_TERMINAL_LOGGER", bool.TrueString);
+        string output = RunnerUtilities.ExecMSBuild($"{_cmd} -tlp:default={bool.TrueString}", out bool success);
+        success.ShouldBeTrue();
+
+        LoggingConfigurationTelemetry expectedTelemetry = new LoggingConfigurationTelemetry
+        {
+            TerminalLogger = true,
+            TerminalLoggerDefault = bool.TrueString,
+            TerminalLoggerDefaultSource = "DOTNET_CLI_BUILD_TERMINAL_LOGGER",
+            TerminalLoggerUserIntent = null,
+            TerminalLoggerUserIntentSource = null,
+            ConsoleLogger = false,
+            FileLogger = false,
+        };
+
+        expectedTelemetry.UpdateEventProperties();
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        {
+            output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
+        }
+
+        // Test if there is ANSI clear screen sequence, which shall only occur when the terminal logger was enabled.
+        ShouldBeTerminalLog(output);
+    }
+
+    [Theory]
+    [InlineData("MSBUILDLIVELOGGER")]
+    [InlineData("MSBUILDTERMINALLOGGER")]
+    public void TerminalLoggerOnByEnv(string envVarSource)
+    {
+        _env.SetEnvironmentVariable(envVarSource, bool.TrueString);
+        string output = RunnerUtilities.ExecMSBuild($"{_cmd}", out bool success);
+        success.ShouldBeTrue();
+
+        LoggingConfigurationTelemetry expectedTelemetry = new LoggingConfigurationTelemetry
+        {
+            TerminalLogger = true,
+            TerminalLoggerDefault = bool.FalseString,
+            TerminalLoggerDefaultSource = "msbuild",
+            TerminalLoggerUserIntent = bool.TrueString,
+            TerminalLoggerUserIntentSource = envVarSource,
+            ConsoleLogger = false,
+            FileLogger = false,
+        };
+
+        expectedTelemetry.UpdateEventProperties();
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        {
+            output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
+        }
+
+        // Test if there is ANSI clear screen sequence, which shall only occur when the terminal logger was enabled.
+        ShouldBeTerminalLog(output);
+    }
+
+    [Theory]
+    [InlineData("on")]
+    [InlineData("true")]
+    public void TerminalLoggerDefaultOn(string defaultValue)
+    {
+        string output = RunnerUtilities.ExecMSBuild($"{_cmd} -tlp:default={defaultValue}", out bool success);
+        success.ShouldBeTrue();
+
+        LoggingConfigurationTelemetry expectedTelemetry = new LoggingConfigurationTelemetry
+        {
+            TerminalLogger = true,
+            TerminalLoggerDefault = defaultValue,
+            TerminalLoggerDefaultSource = "sdk",
+            TerminalLoggerUserIntent = null,
+            TerminalLoggerUserIntentSource = null,
+            ConsoleLogger = false,
+            FileLogger = false,
+        };
+
+        expectedTelemetry.UpdateEventProperties();
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        {
+            output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
+        }
+
+        // Test if there is ANSI clear screen sequence, which shall only occur when the terminal logger was enabled.
+        ShouldBeTerminalLog(output);
+    }
+
+    [Theory]
+    [InlineData("off")]
+    [InlineData("false")]
+    public void TerminalLoggerDefaultOff(string defaultValue)
+    {
+        string output = RunnerUtilities.ExecMSBuild($"{_cmd} -tlp:default={defaultValue} -v:m", out bool success);
+        success.ShouldBeTrue();
+
+        LoggingConfigurationTelemetry expectedTelemetry = new LoggingConfigurationTelemetry
+        {
+            TerminalLogger = false,
+            TerminalLoggerDefault = defaultValue,
+            TerminalLoggerDefaultSource = "sdk",
+            TerminalLoggerUserIntent = null,
+            TerminalLoggerUserIntentSource = null,
+            ConsoleLogger = true,
+            ConsoleLoggerVerbosity = "minimal",
+            ConsoleLoggerType = "parallel", 
+            FileLogger = false,
+        };
+
+        expectedTelemetry.UpdateEventProperties();
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        {
+            output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
+        }
+
+        // Test if there is ANSI clear screen sequence, which shall only occur when the terminal logger was enabled.
+        ShouldNotBeTerminalLog(output);
+    }
+
+    private static void ShouldBeTerminalLog(string output) => output.ShouldContain($"\x1b[J");
+    private static void ShouldNotBeTerminalLog(string output) => output.ShouldNotContain($"\x1b[J");
+}

--- a/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
+++ b/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
@@ -228,8 +228,6 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         ShouldNotBeTerminalLog(output);
     }
 
-    // TODO: remove custom message
-    private static void ShouldBeTerminalLog(string output) => output.ShouldContain($"\x1b[J", output);
-    // TODO: remove custom message
-    private static void ShouldNotBeTerminalLog(string output) => output.ShouldNotContain($"\x1b[J", output);
+    private static void ShouldBeTerminalLog(string output) => output.ShouldContain("\x1b[?25l");
+    private static void ShouldNotBeTerminalLog(string output) => output.ShouldNotContain("\x1b[?25l");
 }

--- a/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
+++ b/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
@@ -23,10 +23,12 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
     private readonly TestEnvironment _env;
 
     private readonly string _cmd;
+    private readonly ITestOutputHelper _output;
 
     public TerminalLoggerConfiguration_Tests(ITestOutputHelper output)
     {
         _env = TestEnvironment.Create(output);
+        _output = output;
 
         TransientTestFolder logFolder = _env.CreateFolder(createFolder: true);
         TransientTestFile projectFile = _env.CreateFile(logFolder, "myProj.proj", $"""
@@ -161,6 +163,9 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         {
             output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
         }
+
+        // TODO: delete, this is for troubleshooting unit tests on macos
+        _output.WriteLine(output);
 
         // Test if there is ANSI clear screen sequence, which shall only occur when the terminal logger was enabled.
         ShouldBeTerminalLog(output);

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -566,6 +566,10 @@ namespace Microsoft.Build.Execution
                 // Log deferred messages and response files
                 LogDeferredMessages(loggingService, _deferredBuildMessages);
 
+                // Log known deferred telemetry
+                KnownTelemetry.LoggingConfigurationTelemetry.UpdateEventProperties();
+                loggingService.LogTelemetry(buildEventContext: null, KnownTelemetry.LoggingConfigurationTelemetry.EventName, KnownTelemetry.LoggingConfigurationTelemetry.Properties);
+
                 InitializeCaches();
 
                 _projectCacheService = new ProjectCacheService(

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Framework.Telemetry;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 
@@ -191,6 +192,8 @@ namespace Microsoft.Build.Logging
             LogInitialInfo();
 
             eventSource.AnyEventRaised += EventSource_AnyEventRaised;
+
+            KnownTelemetry.LoggingConfigurationTelemetry.BinaryLogger = true;
         }
 
         private void EventArgsWriter_EmbedFile(string filePath)
@@ -356,6 +359,7 @@ namespace Microsoft.Build.Logging
             {
                 FilePath = "msbuild.binlog";
             }
+            KnownTelemetry.LoggingConfigurationTelemetry.BinaryLoggerUsedDefaultName = FilePath == "msbuild.binlog";
 
             try
             {

--- a/src/Build/Logging/ConsoleLogger.cs
+++ b/src/Build/Logging/ConsoleLogger.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Framework.Telemetry;
 using Microsoft.Build.Shared;
 using BaseConsoleLogger = Microsoft.Build.BackEnd.Logging.BaseConsoleLogger;
 using ParallelConsoleLogger = Microsoft.Build.BackEnd.Logging.ParallelConsoleLogger;
@@ -158,10 +159,26 @@ namespace Microsoft.Build.Logging
             if (_numberOfProcessors == 1 && !useMPLogger)
             {
                 _consoleLogger = new SerialConsoleLogger(_verbosity, _write, _colorSet, _colorReset);
+                if (this is FileLogger)
+                {
+                    KnownTelemetry.LoggingConfigurationTelemetry.FileLoggerType = "serial";
+                }
+                else
+                {
+                    KnownTelemetry.LoggingConfigurationTelemetry.ConsoleLoggerType = "serial";
+                }
             }
             else
             {
                 _consoleLogger = new ParallelConsoleLogger(_verbosity, _write, _colorSet, _colorReset);
+                if (this is FileLogger)
+                {
+                    KnownTelemetry.LoggingConfigurationTelemetry.FileLoggerType = "parallel";
+                }
+                else
+                {
+                    KnownTelemetry.LoggingConfigurationTelemetry.ConsoleLoggerType = "parallel";
+                }
             }
 
             if (_showSummary != null)
@@ -339,6 +356,12 @@ namespace Microsoft.Build.Logging
             _numberOfProcessors = nodeCount;
             InitializeBaseConsoleLogger();
             _consoleLogger.Initialize(eventSource, nodeCount);
+
+            if (this is not FileLogger)
+            {
+                KnownTelemetry.LoggingConfigurationTelemetry.ConsoleLogger = true;
+                KnownTelemetry.LoggingConfigurationTelemetry.ConsoleLoggerVerbosity = Verbosity.ToString();
+            }
         }
 
         /// <summary>

--- a/src/Build/Logging/FileLogger.cs
+++ b/src/Build/Logging/FileLogger.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Framework.Telemetry;
 using Microsoft.Build.Shared;
 
 #nullable disable
@@ -87,6 +88,9 @@ namespace Microsoft.Build.Logging
             // Finally, ask the base console logger class to initialize. It may
             // want to make decisions based on our verbosity, so we do this last.
             base.Initialize(eventSource, nodeCount);
+            KnownTelemetry.LoggingConfigurationTelemetry.FileLoggersCount++;
+            KnownTelemetry.LoggingConfigurationTelemetry.FileLogger = true;
+            KnownTelemetry.LoggingConfigurationTelemetry.FileLoggerVerbosity = Verbosity.ToString();
 
             if (!SkipProjectStartedText && Verbosity >= LoggerVerbosity.Normal)
             {

--- a/src/Framework/Telemetry/KnownTelemetry.cs
+++ b/src/Framework/Telemetry/KnownTelemetry.cs
@@ -15,4 +15,9 @@ internal static class KnownTelemetry
     /// Null means there are no prior collected build telemetry data, new clean instance shall be created for particular build.
     /// </summary>
     public static BuildTelemetry? PartialBuildTelemetry { get; set; }
+
+    /// <summary>
+    /// Describes how logging was configured.
+    /// </summary>
+    public static LoggingConfigurationTelemetry LoggingConfigurationTelemetry { get; set; } = new LoggingConfigurationTelemetry();
 }

--- a/src/Framework/Telemetry/KnownTelemetry.cs
+++ b/src/Framework/Telemetry/KnownTelemetry.cs
@@ -19,5 +19,5 @@ internal static class KnownTelemetry
     /// <summary>
     /// Describes how logging was configured.
     /// </summary>
-    public static LoggingConfigurationTelemetry LoggingConfigurationTelemetry { get; set; } = new LoggingConfigurationTelemetry();
+    public static LoggingConfigurationTelemetry LoggingConfigurationTelemetry { get; } = new LoggingConfigurationTelemetry();
 }

--- a/src/Framework/Telemetry/LoggingConfigurationTelemetry.cs
+++ b/src/Framework/Telemetry/LoggingConfigurationTelemetry.cs
@@ -45,7 +45,7 @@ internal class LoggingConfigurationTelemetry : TelemetryBase
     /// <summary>
     /// How was default behavior signaled:
     ///   sdk -> from SDK
-    ///   DOTNET_CLI_BUILD_TERMINAL_LOGGER -> from environment variable
+    ///   DOTNET_CLI_CONFIGURE_MSBUILD_TERMINAL_LOGGER -> from environment variable
     ///   msbuild -> MSBuild hardcoded default
     ///   null -> unspecified
     /// </summary>

--- a/src/Framework/Telemetry/LoggingConfigurationTelemetry.cs
+++ b/src/Framework/Telemetry/LoggingConfigurationTelemetry.cs
@@ -1,0 +1,150 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.Build.Framework.Telemetry;
+
+internal class LoggingConfigurationTelemetry : TelemetryBase
+{
+    public override string EventName => "loggingConfiguration";
+
+    /// <summary>
+    /// True if terminal logger was used.
+    /// </summary>
+    public bool TerminalLogger { get; set; }
+
+    /// <summary>
+    /// What was user intent:
+    ///   on | true -> user intent to enable logging
+    ///   off | false -> user intent to disable logging
+    ///   auto -> user intent to use logging if terminal allows it
+    ///   null -> no user intent, using default
+    /// </summary>
+    public string? TerminalLoggerUserIntent { get; set; }
+
+    /// <summary>
+    /// How was user intent signalized:
+    ///   arg -> from command line argument or rsp file
+    ///   MSBUILDTERMINALLOGGER -> from environment variable
+    ///   MSBUILDLIVELOGGER -> from environment variable
+    ///   null -> no user intent
+    /// </summary>
+    public string? TerminalLoggerUserIntentSource { get; set; }
+
+    /// <summary>
+    /// The default behavior of terminal logger if user intent is not specified:
+    ///   on | true -> enable logging
+    ///   off | false -> disable logging
+    ///   auto -> use logging if terminal allows it
+    ///   null -> unspecified
+    /// </summary>
+    public string? TerminalLoggerDefault { get; set; }
+
+    /// <summary>
+    /// How was default behavior signalized:
+    ///   sdk -> from SDK
+    ///   DOTNET_CLI_BUILD_TERMINAL_LOGGER -> from environment variable
+    ///   msbuild -> MSBuild hardcoded default
+    ///   null -> unspecified
+    /// </summary>
+    public string? TerminalLoggerDefaultSource { get; set; }
+
+    /// <summary>
+    /// True if console logger was used.
+    /// </summary>
+    public bool ConsoleLogger { get; set; }
+
+    /// <summary>
+    /// Type of console logger: serial | parallel
+    /// </summary>
+    public string? ConsoleLoggerType { get; set; }
+
+    /// <summary>
+    /// Verbosity of console logger: quiet | minimal | normal | detailed | diagnostic
+    /// </summary>
+    public string? ConsoleLoggerVerbosity { get; set; }
+
+
+    /// <summary>
+    /// True if file logger was used.
+    /// </summary>
+    public bool FileLogger { get; set; }
+
+    /// <summary>
+    /// Type of file logger: serial | parallel
+    /// </summary>
+    public string? FileLoggerType { get; set; }
+
+    /// <summary>
+    /// Number of file loggers.
+    /// </summary>
+    public int FileLoggersCount { get; set; }
+
+    /// <summary>
+    /// Verbosity of file logger: quiet | minimal | normal | detailed | diagnostic
+    /// </summary>
+    public string? FileLoggerVerbosity { get; set; }
+
+    /// <summary>
+    /// True if binary logger was used.
+    /// </summary>
+    public bool BinaryLogger { get; set; }
+
+    /// <summary>
+    /// True if binary logger used default name i.e. no LogFile was specified.
+    /// </summary>
+    public bool BinaryLoggerUsedDefaultName { get; set; }
+
+    public override void UpdateEventProperties()
+    {
+        Properties["TerminalLogger"] = TerminalLogger.ToString(CultureInfo.InvariantCulture);
+
+        if (TerminalLoggerUserIntent != null)
+        {
+            Properties["TerminalLoggerUserIntent"] = TerminalLoggerUserIntent;
+        }
+
+        if (TerminalLoggerUserIntentSource != null)
+        {
+            Properties["TerminalLoggerUserIntentSource"] = TerminalLoggerUserIntentSource;
+        }
+
+        if (TerminalLoggerDefault != null)
+        {
+            Properties["TerminalLoggerDefault"] = TerminalLoggerDefault;
+        }
+
+        if (TerminalLoggerDefaultSource != null)
+        {
+            Properties["TerminalLoggerDefaultSource"] = TerminalLoggerDefaultSource;
+        }
+
+        Properties["ConsoleLogger"] = ConsoleLogger.ToString(CultureInfo.InvariantCulture);
+        if (ConsoleLoggerType != null)
+        {
+            Properties["ConsoleLoggerType"] = ConsoleLoggerType;
+        }
+
+        if (ConsoleLoggerVerbosity != null)
+        {
+            Properties["ConsoleLoggerVerbosity"] = ConsoleLoggerVerbosity;
+        }
+
+        Properties["FileLogger"] = FileLogger.ToString(CultureInfo.InvariantCulture);
+        if (FileLoggerType != null)
+        {
+            Properties["FileLoggerType"] = FileLoggerType;
+            Properties["FileLoggersCount"] = FileLoggersCount.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (FileLoggerVerbosity != null)
+        {
+            Properties["FileLoggerVerbosity"] = FileLoggerVerbosity;
+        }
+
+        Properties["BinaryLogger"] = BinaryLogger.ToString(CultureInfo.InvariantCulture);
+        Properties["BinaryLoggerUsedDefaultName"] = BinaryLoggerUsedDefaultName.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Framework/Telemetry/LoggingConfigurationTelemetry.cs
+++ b/src/Framework/Telemetry/LoggingConfigurationTelemetry.cs
@@ -25,7 +25,7 @@ internal class LoggingConfigurationTelemetry : TelemetryBase
     public string? TerminalLoggerUserIntent { get; set; }
 
     /// <summary>
-    /// How was user intent signalized:
+    /// How was user intent signaled:
     ///   arg -> from command line argument or rsp file
     ///   MSBUILDTERMINALLOGGER -> from environment variable
     ///   MSBUILDLIVELOGGER -> from environment variable
@@ -43,7 +43,7 @@ internal class LoggingConfigurationTelemetry : TelemetryBase
     public string? TerminalLoggerDefault { get; set; }
 
     /// <summary>
-    /// How was default behavior signalized:
+    /// How was default behavior signaled:
     ///   sdk -> from SDK
     ///   DOTNET_CLI_BUILD_TERMINAL_LOGGER -> from environment variable
     ///   msbuild -> MSBuild hardcoded default

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -203,6 +203,28 @@ namespace Microsoft.Build.UnitTests
             unquoteParameters.ShouldBeTrue();
         }
 
+        [Theory]
+        [InlineData("tlp")]
+        [InlineData("TLP")]
+        [InlineData("terminalLoggerParameters")]
+        [InlineData("TERMINALLOGGERPARAMETERS")]
+        public void TerminalLoggerParametersIdentificationTests(string terminalLoggerParameters)
+        {
+            CommandLineSwitches.ParameterizedSwitch parameterizedSwitch;
+            string duplicateSwitchErrorMessage;
+            bool multipleParametersAllowed;
+            string missingParametersErrorMessage;
+            bool unquoteParameters;
+            bool emptyParametersAllowed;
+
+            CommandLineSwitches.IsParameterizedSwitch(terminalLoggerParameters, out parameterizedSwitch, out duplicateSwitchErrorMessage, out multipleParametersAllowed, out missingParametersErrorMessage, out unquoteParameters, out emptyParametersAllowed).ShouldBeTrue();
+            parameterizedSwitch.ShouldBe(CommandLineSwitches.ParameterizedSwitch.TerminalLoggerParameters);
+            duplicateSwitchErrorMessage.ShouldBeNull();
+            multipleParametersAllowed.ShouldBeFalse();
+            missingParametersErrorMessage.ShouldNotBeNull();
+            unquoteParameters.ShouldBeTrue();
+        }
+
 #if FEATURE_NODE_REUSE
         [Theory]
         [InlineData("nr")]

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Build.CommandLine
             FileLoggerParameters8,
             FileLoggerParameters9,
             TerminalLogger,
+            TerminalLoggerParameters,
             NodeReuse,
             Preprocess,
             Targets,
@@ -248,6 +249,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "fileloggerparameters9", "flp9" },     ParameterizedSwitch.FileLoggerParameters9,      null,                           false,          "MissingFileLoggerParameterError",     true,   false),
             // To not break existing use, keep supporting live logger switches
             new ParameterizedSwitchInfo(  new string[] { "livelogger", "ll", "terminallogger", "tl" }, ParameterizedSwitch.TerminalLogger,      null,                           true,           null,                                  true,   true),
+            new ParameterizedSwitchInfo(  new string[] { "terminalloggerparameters", "tlp" },   ParameterizedSwitch.TerminalLoggerParameters,   null,                           false,          "MissingTerminalLoggerParameterError", true,   false),
             new ParameterizedSwitchInfo(  new string[] { "nodereuse", "nr" },                   ParameterizedSwitch.NodeReuse,                  null,                           false,          "MissingNodeReuseParameterError",      true,   false),
             new ParameterizedSwitchInfo(  new string[] { "preprocess", "pp" },                  ParameterizedSwitch.Preprocess,                 null,                           false,          null,                                  true,   false),
             new ParameterizedSwitchInfo(  new string[] { "targets", "ts" },                     ParameterizedSwitch.Targets,                    null,                           false,          null,                                  true,   false),

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1167,6 +1167,15 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </comment>
   </data>
+  <data name="MissingTerminalLoggerParameterError" UESanitized="true" Visibility="Public">
+    <value>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</value>
+    <comment>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </comment>
+  </data>
   <data name="MissingNodeReuseParameterError" UESanitized="true" Visibility="Public">
     <value>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the -nodeReuse switch</value>
     <comment>{StrBegin="MSBUILD : error MSB1041: "}
@@ -1509,7 +1518,7 @@
     <!--
         The command line message bucket is: MSB1001 - MSB1999
 
-        Next error code should be MSB1066.
+        Next error code should be MSB1067.
 
         Don't forget to update this comment after using the new code.
   -->

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1347,6 +1347,16 @@ Když se nastaví na MessageUponIsolationViolation (nebo jeho krátký
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: Zadejte verzi sady nástrojů.</target>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1334,6 +1334,16 @@ Dieses Protokollierungsformat ist standardmäßig aktiviert.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: Geben Sie die Version des Toolsets an.</target>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1341,6 +1341,16 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: Especifique la versión del conjunto de herramientas.</target>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1334,6 +1334,16 @@ Remarque : verbosité des enregistreurs d’événements de fichiers
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: Spécifiez la version de l'ensemble d'outils.</target>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1345,6 +1345,16 @@ Nota: livello di dettaglio dei logger di file
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: specificare la versione del set di strumenti.</target>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1334,6 +1334,16 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: ツールセットのバージョンを指定してください。</target>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1334,6 +1334,16 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: 도구 집합의 버전을 지정하십시오.</target>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1345,6 +1345,16 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: określ wersję zestawu narzędzi.</target>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1335,6 +1335,16 @@ arquivo de resposta.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: Especifique a versão do conjunto de ferramentas.</target>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1333,6 +1333,16 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: укажите версию набора инструментов.</target>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1338,6 +1338,16 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: Araç takımının sürümünü belirtin.</target>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1334,6 +1334,16 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: 指定工具集的版本。</target>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1334,6 +1334,16 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="MissingTerminalLoggerParameterError">
+        <source>MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1066: Specify one or more parameters for the terminal logger if using the -terminalLoggerParameters switch</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1066: "}
+      UE: This happens if the user does something like "msbuild.exe -termionalLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe -terminalLoggerParameters:default=auto".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
       <trans-unit id="MissingToolsVersionError">
         <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
         <target state="translated">MSBUILD : error MSB1039: 指定工具組的版本。</target>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2536,7 +2536,7 @@ namespace Microsoft.Build.CommandLine
 
             return KnownTelemetry.LoggingConfigurationTelemetry.TerminalLogger = useTerminalLogger;
 
-            static bool DoesEnvironmentSupportTerminalLogger()
+            static bool CheckIfTerminalIsSupportedAndTryEnableAnsiColorCodes()
             {
                 (var acceptAnsiColorCodes, var outputIsScreen, s_originalConsoleMode) = NativeMethodsShared.QueryIsScreenAndTryEnableAnsiColorCodes();
 
@@ -2708,7 +2708,7 @@ namespace Microsoft.Build.CommandLine
                     CommandLineSwitchException.Throw("InvalidTerminalLoggerValue", terminalLoggerArg);
                 }
 
-                useTerminalLogger = DoesEnvironmentSupportTerminalLogger();
+                useTerminalLogger = CheckIfTerminalIsSupportedAndTryEnableAnsiColorCodes();
             }
         }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2593,9 +2593,9 @@ namespace Microsoft.Build.CommandLine
                 else
                 {
                     // Lets check DOTNET CLI env var
-                    string dotnetCliEnvVar = Environment.GetEnvironmentVariable("DOTNET_CLI_BUILD_TERMINAL_LOGGER");
+                    string dotnetCliEnvVar = Environment.GetEnvironmentVariable("DOTNET_CLI_CONFIGURE_MSBUILD_TERMINAL_LOGGER");
                     KnownTelemetry.LoggingConfigurationTelemetry.TerminalLoggerDefault = terminalLoggerDefault;
-                    KnownTelemetry.LoggingConfigurationTelemetry.TerminalLoggerDefaultSource = string.IsNullOrWhiteSpace(dotnetCliEnvVar) ? "sdk" : "DOTNET_CLI_BUILD_TERMINAL_LOGGER";
+                    KnownTelemetry.LoggingConfigurationTelemetry.TerminalLoggerDefaultSource = string.IsNullOrWhiteSpace(dotnetCliEnvVar) ? "sdk" : "DOTNET_CLI_CONFIGURE_MSBUILD_TERMINAL_LOGGER";
                 }
 
                 return terminalLoggerDefault;

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2686,8 +2686,13 @@ namespace Microsoft.Build.CommandLine
                 if (bool.TryParse(terminalLoggerArg, out bool result))
                 {
                     useTerminalLogger = result;
-                    // This needs to be called so Ansi Color Codes are enabled for the terminal logger.
-                    (_, _, s_originalConsoleMode) =  NativeMethodsShared.QueryIsScreenAndTryEnableAnsiColorCodes();
+
+                    // Try Enable Ansi Color Codes when terminal logger is enabled/enforced.
+                    if (result)
+                    {
+                        // This needs to be called so Ansi Color Codes are enabled for the terminal logger.
+                        (_, _, s_originalConsoleMode) = NativeMethodsShared.QueryIsScreenAndTryEnableAnsiColorCodes();
+                    }
 
                     return true;
                 }

--- a/src/Shared/UnitTests/MockLogger.cs
+++ b/src/Shared/UnitTests/MockLogger.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.UnitTests
      * up a raw string (fullLog) that contains all messages, warnings, errors.
      * Thread-safe.
      */
-    internal sealed class MockLogger : ILogger
+    public sealed class MockLogger : ILogger
     {
         #region Properties
 
@@ -138,6 +138,11 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         internal List<BuildFinishedEventArgs> BuildFinishedEvents { get; } = new List<BuildFinishedEventArgs>();
 
+        /// <summary>
+        /// List of Telemetry events
+        /// </summary>
+        internal List<TelemetryEventArgs> TelemetryEvents { get; } = new();
+
         internal List<BuildEventArgs> AllBuildEvents { get; } = new List<BuildEventArgs>();
 
         /*
@@ -175,11 +180,7 @@ namespace Microsoft.Build.UnitTests
          * The mock logger does not take parameters.
          * 
          */
-        public string Parameters
-        {
-            get => null;
-            set {/* do nothing */}
-        }
+        public string Parameters { get; set; }
 
         /*
          * Method:  Initialize
@@ -190,12 +191,22 @@ namespace Microsoft.Build.UnitTests
         public void Initialize(IEventSource eventSource)
         {
             eventSource.AnyEventRaised += LoggerEventHandler;
+            if (eventSource is IEventSource2 eventSource2)
+            {
+                eventSource2.TelemetryLogged += TelemetryEventHandler;
+            }
 
             if (_profileEvaluation)
             {
                 var eventSource3 = eventSource as IEventSource3;
                 eventSource3.ShouldNotBeNull();
                 eventSource3.IncludeEvaluationProfiles();
+            }
+
+            // Apply parameters
+            if (Parameters?.IndexOf("reporttelemetry", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                _reportTelemetry = true;
             }
         }
 
@@ -221,6 +232,10 @@ namespace Microsoft.Build.UnitTests
             // do nothing
         }
         #endregion
+
+        public MockLogger() : this(null)
+        {
+        }
 
         public MockLogger(ITestOutputHelper testOutputHelper = null, bool profileEvaluation = false, bool printEventsToStdout = true, LoggerVerbosity verbosity = LoggerVerbosity.Normal)
         {
@@ -383,6 +398,27 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+        internal void TelemetryEventHandler(object sender, BuildEventArgs eventArgs)
+        {
+            lock (_lockObj)
+            {
+                if (eventArgs is TelemetryEventArgs telemetryEventArgs)
+                {
+                    TelemetryEvents.Add(telemetryEventArgs);
+
+                    if (_reportTelemetry)
+                    {
+                        // Log telemetry events to the full log so we can verify them in end-to-end tests by captured outputs.
+                        _fullLog.AppendLine($"Telemetry:{telemetryEventArgs.EventName}");
+                        foreach (KeyValuePair<string, string> pair in telemetryEventArgs.Properties)
+                        {
+                            _fullLog.AppendLine($"    {telemetryEventArgs.EventName}:{pair.Key}={pair.Value}");
+                        }
+                    }
+                }
+            }
+        }
+
         private void PrintFullLog()
         {
             if (_printEventsToStdout)
@@ -397,6 +433,7 @@ namespace Microsoft.Build.UnitTests
             typeof(ProjectCollection).GetTypeInfo().Assembly));
 
         private static ResourceManager s_engineResourceManager;
+        private bool _reportTelemetry;
 
         // Gets the resource string given the resource ID
         public static string GetString(string stringId) => EngineResourceManager.GetString(stringId, CultureInfo.CurrentUICulture);


### PR DESCRIPTION
Fixes part of #9063

### Context
See #9063 for requirements.
This PR address changes in msbuild only. SDK changes will be in different PR. This PRs are independent and could be merged in any order.

### Changes Made
- introduce /tlp:default={true|false|auto} to signalize what is SDK intent of default behavior. Such default will achieve requirements of overriding default by user intent (arguments, env vars, rsp files)
- introduced `LoggingConfigurationTelemetry` containing info about logger settings

### Testing
- locally
- existing and new unit tests

### Notes
