### PR TITLE
Allow proxying targets back to the original target

### DIFF
--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -766,6 +766,60 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             logger.AssertMessageCount("MSB4274", 1);
         }
 
+        [Fact]
+        public async Task ProxyTargetsToSameTarget()
+        {
+            const string ProjectContent = """
+                <Project>
+                  <Target Name="SomeTarget">
+                    <Message Text="SomeTarget running" />
+                  </Target>
+                  <Target Name="ProxyTarget">
+                    <Message Text="ProxyTarget running" />
+                  </Target>
+                  <Target Name="SomeOtherTarget">
+                    <Message Text="SomeOtherTarget running" />
+                  </Target>
+                </Project>
+                """;
+            TransientTestFile project = _env.CreateFile($"project.proj", ProjectContent);
+
+            BuildParameters buildParameters = new()
+            {
+                ProjectCacheDescriptor = ProjectCacheDescriptor.FromInstance(
+                    new ConfigurableMockCache
+                    {
+                        GetCacheResultImplementation = (_, _, _) =>
+                        {
+                            // A common scenario is to get a request for N targets, but only some of them can be handled by the cache.
+                            // In this case, proxy targets may reference themselves.
+                            return Task.FromResult(
+                                CacheResult.IndicateCacheHit(
+                                    new ProxyTargets(
+                                        new Dictionary<string, string>
+                                        {
+                                            { "ProxyTarget", "SomeTarget" },
+                                            { "SomeOtherTarget", "SomeOtherTarget" },
+                                        })));
+                        }
+                    }),
+            };
+
+            MockLogger logger;
+            using (Helpers.BuildManagerSession buildSession = new(_env, buildParameters))
+            {
+                logger = buildSession.Logger;
+                BuildResult buildResult = await buildSession.BuildProjectFileAsync(project.Path, new[] { "SomeTarget", "SomeOtherTarget" });
+
+                buildResult.Exception.ShouldBeNull();
+                buildResult.ShouldHaveSucceeded();
+            }
+
+            logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("SomeTarget running");
+            logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("ProxyTarget running");
+            logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("SomeOtherTarget running");
+        }
+
         private void AssertCacheBuild(
             ProjectGraph graph,
             GraphCacheResponse testData,

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1215,12 +1215,14 @@ namespace Microsoft.Build.BackEnd
                     // Update the results cache.
                     cachedResult.AddResultsForTarget(
                         realTarget,
-                        proxyTargetResult);
+                        proxyTargetResult,
+                        allowReplacement: true);
 
                     // Update and return this one because TargetBuilder.BuildTargets did some mutations on it not present in the cached result.
                     resultFromTargetBuilder.AddResultsForTarget(
                         realTarget,
-                        proxyTargetResult);
+                        proxyTargetResult,
+                        allowReplacement: true);
                 }
 
                 return resultFromTargetBuilder;

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -478,7 +478,15 @@ namespace Microsoft.Build.Execution
         /// </summary>
         /// <param name="target">The target to which these results apply.</param>
         /// <param name="result">The results for the target.</param>
-        public void AddResultsForTarget(string target, TargetResult result)
+        public void AddResultsForTarget(string target, TargetResult result) => AddResultsForTarget(target, result, allowReplacement: false);
+
+        /// <summary>
+        /// Adds the results for the specified target to this result collection.
+        /// </summary>
+        /// <param name="target">The target to which these results apply.</param>
+        /// <param name="result">The results for the target.</param>
+        /// <param name="allowReplacement">Whether to allow replacing existing results.</param>
+        internal void AddResultsForTarget(string target, TargetResult result, bool allowReplacement)
         {
             ErrorUtilities.VerifyThrowArgumentNull(target, nameof(target));
             ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
@@ -488,7 +496,7 @@ namespace Microsoft.Build.Execution
                 _resultsByTarget ??= CreateTargetResultDictionary(1);
             }
 
-            if (_resultsByTarget.TryGetValue(target, out TargetResult targetResult))
+            if (!allowReplacement && _resultsByTarget.TryGetValue(target, out TargetResult targetResult))
             {
                 ErrorUtilities.VerifyThrow(targetResult.ResultCode == TargetResultCode.Skipped, "Items already exist for target {0}.", target);
             }


### PR DESCRIPTION
Fixes #9117

For project cache plugins to only partially handle a build request, it makes sense that it proxy some targets back to the original targets. For example, in VS the build request has:

```
"Build"
"BuiltProjectOutputGroup"
"BuiltProjectOutputGroupDependencies"
"DebugSymbolsProjectOutputGroup"
"DebugSymbolsProjectOutputGroupDependencies"
"DocumentationProjectOutputGroup"
"DocumentationProjectOutputGroupDependencies"
"SatelliteDllsProjectOutputGroup"
"SatelliteDllsProjectOutputGroupDependencies"
"SGenFilesOutputGroup"
"SGenFilesOutputGroupDependencies"
```

"Build" is the only relevant one that a plugin would want to handle, while the rest are "information gathering" targets which should just be passed through.

This change fixes an exception that gets thrown when attempting to proxy targets back to themselves.