### PR TITLE
Populate unproxied targets to avoid dropping requested targets

### DIFF
--- a/src/Build.UnitTests/BackEnd/Scheduler_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/Scheduler_Tests.cs
@@ -822,6 +822,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             if (proxyTargets != null)
             {
+                parentRequest.ShouldBeNull();
                 return new BuildRequest(
                     submissionId: 1,
                     nodeRequestId,
@@ -831,7 +832,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     hostServices);
             }
 
-            parentRequest.ShouldBeNull();
             return new BuildRequest(
                 submissionId: 1,
                 nodeRequestId,

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -507,7 +507,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 }
             }
 
-
             AssertCacheBuild(graph, testData, mockCache, logger, nodesToBuildResults, targets: null);
         }
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1731,15 +1731,7 @@ namespace Microsoft.Build.Execution
             ProxyTargets proxyTargets,
             int projectContextId)
         {
-            // Reverse the map so we can look up requested targets
-            // The ProxyTargetToRealTargetMap is "backwards" from how most users would want to use it and doesn't provide as much flexibility as it could if reversed.
-            // Unfortunately this is part of a public API so cannot easily change at this point.
-            Dictionary<string, string> realTargetsToProxyTargets = new(proxyTargets.ProxyTargetToRealTargetMap.Count, StringComparer.OrdinalIgnoreCase);
-            foreach (KeyValuePair<string, string> kvp in proxyTargets.ProxyTargetToRealTargetMap)
-            {
-                // In the case of multiple proxy targets pointing to the same real target, the last one wins. Another awkwardness of ProxyTargetToRealTargetMap being "backwards".
-                realTargetsToProxyTargets[kvp.Value] = kvp.Key;
-            }
+            IReadOnlyDictionary<string, string> realTargetsToProxyTargets = proxyTargets.RealTargetToProxyTargetMap;
 
             ICollection<string> requestedTargets = submission.BuildRequestData.TargetNames.Count > 0
                 ? submission.BuildRequestData.TargetNames

--- a/src/Build/BackEnd/Components/ProjectCache/ProxyTargets.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProxyTargets.cs
@@ -27,6 +27,23 @@ namespace Microsoft.Build.Experimental.ProjectCache
         /// </summary>
         public IReadOnlyDictionary<string, string> ProxyTargetToRealTargetMap => _proxyTargetToRealTargetMap;
 
+        internal IReadOnlyDictionary<string, string> RealTargetToProxyTargetMap
+        {
+            get
+            {
+                // The ProxyTargetToRealTargetMap is "backwards" from how most users would want to use it and doesn't provide as much flexibility as it could if reversed.
+                // Unfortunately this is part of a public API so cannot easily change at this point.
+                Dictionary<string, string> realTargetsToProxyTargets = new(ProxyTargetToRealTargetMap.Count, StringComparer.OrdinalIgnoreCase);
+                foreach (KeyValuePair<string, string> kvp in ProxyTargetToRealTargetMap)
+                {
+                    // In the case of multiple proxy targets pointing to the same real target, the last one wins. Another awkwardness of ProxyTargetToRealTargetMap being "backwards".
+                    realTargetsToProxyTargets[kvp.Value] = kvp.Key;
+                }
+
+                return realTargetsToProxyTargets;
+            }
+        }
+
         private ProxyTargets()
         {
         }

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="nodeRequestId">The id of the node issuing the request</param>
         /// <param name="configurationId">The configuration id to use.</param>
         /// <param name="proxyTargets"><see cref="ProxyTargets"/></param>
+        /// <param name="targets">The set of targets to execute</param>
         /// <param name="hostServices">Host services if any. May be null.</param>
         /// <param name="buildRequestDataFlags">Additional flags for the request.</param>
         /// <param name="requestedProjectState">Filter for desired build results.</param>
@@ -137,6 +138,7 @@ namespace Microsoft.Build.BackEnd
             int nodeRequestId,
             int configurationId,
             ProxyTargets proxyTargets,
+            List<string> targets,
             HostServices hostServices,
             BuildRequestDataFlags buildRequestDataFlags = BuildRequestDataFlags.None,
             RequestedProjectState requestedProjectState = null,
@@ -144,7 +146,7 @@ namespace Microsoft.Build.BackEnd
             : this(submissionId, nodeRequestId, configurationId, hostServices, buildRequestDataFlags, requestedProjectState, projectContextId)
         {
             _proxyTargets = proxyTargets;
-            _targets = proxyTargets.ProxyTargetToRealTargetMap.Keys.ToList();
+            _targets = targets;
 
             // Only root requests can have proxy targets.
             _parentGlobalRequestId = InvalidGlobalRequestId;

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -745,13 +745,6 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrow(_projectInitialTargets != null, "Initial targets have not been set.");
             ErrorUtilities.VerifyThrow(_projectDefaultTargets != null, "Default targets have not been set.");
 
-            if (request.ProxyTargets != null)
-            {
-                ErrorUtilities.VerifyThrow(
-                    CollectionHelpers.SetEquivalent(request.Targets, request.ProxyTargets.ProxyTargetToRealTargetMap.Keys),
-                    "Targets must be same as proxy targets");
-            }
-
             List<string> initialTargets = _projectInitialTargets;
             List<string> nonInitialTargets = (request.Targets.Count == 0) ? _projectDefaultTargets : request.Targets;
 


### PR DESCRIPTION
Fixes #9117

For project cache plugins to only partially handle a build request, it makes sense for it to only proxy some targets and not others. For example, in VS the build request has:

```
"Build"
"BuiltProjectOutputGroup"
"BuiltProjectOutputGroupDependencies"
"DebugSymbolsProjectOutputGroup"
"DebugSymbolsProjectOutputGroupDependencies"
"DocumentationProjectOutputGroup"
"DocumentationProjectOutputGroupDependencies"
"SatelliteDllsProjectOutputGroup"
"SatelliteDllsProjectOutputGroupDependencies"
"SGenFilesOutputGroup"
"SGenFilesOutputGroupDependencies"
```

"Build" is the only relevant one that a plugin would want to handle, and would likely redirect to "GetTargetPath", while the rest are "information gathering" targets which should just be "passed through" and allowed to execute as-is.

Today if the plugin does this, the targets it does not proxy are dropped entire, which would make the caller confused about not getting results for a target they specifically requested. This change instead just fills in the remaining targets which were not proxied.

Example:
Original request: `Build, BuiltProjectOutputGroup, BuiltProjectOutputGroupDependencies, ...`
Cache plugin returns proxy targets `Build -> GetTargetPath`, and nothing more.
New request: `GetTargetPath, BuiltProjectOutputGroup, BuiltProjectOutputGroupDependencies, ...`

This fixes #9117 indirectly by not requiring a plugin to handle targets it wants to pass through at all, allowing it to just ignore them.