### PR TITLE
Use more-permissive ValidBooleanFalse in Culture tasks

### DIFF
--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -139,7 +139,7 @@ namespace Microsoft.Build.Tasks
                             dependentUpon,
                             // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
                             // https://github.com/dotnet/msbuild/issues/3064
-                            AssignedFiles[i].GetMetadata("WithCulture").Equals("false", StringComparison.OrdinalIgnoreCase));
+                            ConversionUtilities.ValidBooleanFalse(AssignedFiles[i].GetMetadata("WithCulture")));
 
                     if (!string.IsNullOrEmpty(info.culture))
                     {

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -44,7 +44,7 @@ namespace Microsoft.Build.Tasks
                 culture = item.GetMetadata("Culture");
                 // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
                 // https://github.com/dotnet/msbuild/issues/3064
-                treatAsCultureNeutral = item.GetMetadata("WithCulture").Equals("false", StringComparison.OrdinalIgnoreCase);
+                treatAsCultureNeutral = ConversionUtilities.ValidBooleanFalse(item.GetMetadata("WithCulture"));
             }
 
             /*

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -1,9 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
 
 #nullable disable
@@ -42,7 +43,7 @@ namespace Microsoft.Build.Tasks
                 culture = item.GetMetadata("Culture");
                 // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
                 // https://github.com/dotnet/msbuild/issues/3064
-                treatAsCultureNeutral = item.GetMetadata("WithCulture").Equals("false", StringComparison.OrdinalIgnoreCase);
+                treatAsCultureNeutral = ConversionUtilities.ValidBooleanFalse(item.GetMetadata("WithCulture"));
             }
 
             /*


### PR DESCRIPTION
Before, we were explicitly comparing to 'false', but usually MSBuild
allows alternate spellings, which we can pretty easily support here.
