### PR TITLE
Flow live version of System.Security.Permissions for source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -37,6 +37,11 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="System.Security.Permissions" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
     <Dependency Name="System.Text.Json" Version="7.0.3">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5b20af47d99620150c53eaf5db8636fdf730b126</Sha>


### PR DESCRIPTION
When .NET is source-built with the mono runtime, there can be scenarios where MSBuild is made to attempt to load a reference assembly for System.Security.Permissions. See https://github.com/dotnet/source-build/issues/3571#issuecomment-1687979644 for such a scenario.

The reason a reference assembly exists in this case is because MSBuild has a reference to the 7.0.0 version of System.Security.Permissions. When building with source-build, it loads that reference from SBRP (which only contains reference assemblies) in order to fulfill compile time references. The problem is that the assembly is also getting included in the output. This should have been detected by poison leak detection [but that doesn't yet handle reference assemblies](https://github.com/dotnet/source-build/issues/2817).

The solution is to update Version.Details so that the "live" version of System.Security.Permissions, that was previously built with source-build, will flow to the build of the MSBuild repo. Essentially, this causes the [SystemSecurityPermissionsVersion](https://github.com/dotnet/msbuild/blob/1d8146d3d17f756c6ae8ea7af6be1ab2d9c9c934/eng/Versions.props#L41) property to be overridden with the live version.

Fixes https://github.com/dotnet/source-build/issues/3571