### PR TITLE
Fix CG alerts on runtime 6.0.18 and npm

### DIFF
--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -79,7 +79,7 @@
       <ShimTargets Include="Workflow.Targets" />
       <ShimTargets Include="Workflow.VisualBasic.Targets" />
 
-      <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.*" />
+      <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.*" Exclude="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\NodeJs\**" />
 
       <InstalledNuGetFiles Include="$(MSBuildExtensionsPath)\Microsoft\NuGet\*" />
 

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "6.0.313",
+    "dotnet": "6.0.413",
     "vs": {
       "version": "17.2.1"
     },


### PR DESCRIPTION
Fixes 
Fix CG alerts on runtime 6.0.18 and npm

### Context
CG detected the following vulnerabilities.
**runtime**
Package name | Affected version | Patched version
-- | -- | --
Microsoft.AspNetCore.App.Runtime.win-x64 | 6.0.18 | 6.0.21
Microsoft.AspNetCore.App.Runtime.win-x86 | 6.0.18 | 6.0.21
Microsoft.WindowsDesktop.App.Runtime.win-x64 | 6.0.18 | 6.0.20
Microsoft.WindowsDesktop.App.Runtime.win-x86 | 6.0.18 | 6.0.20

**npm**
Vulnerable components were detected from `<repo root>/stage1/bin/bootstrap/net472/MSBuild/Microsoft/VisualStudio/NodeJs/node_modules/npm/node_modules/string_decoder/package.json`
- npm 8.3.1
- Artistic-2.0
- string_decoder 1.3.0

### Changes Made

- Bump up dotnet version to 6.0.413 that has runtime 6.0.21.
- Stop copying Node.js into bootstrap referring to #7537.

### Testing


### Notes
