### PR TITLE
Add packages to Version.Details for source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,6 +6,11 @@
       <Sha>f4903e46459e0348e3793055dd8b68b8b0264034</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="System.CodeDom" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
     <!-- Necessary for source-build due to being a transitive dependency of System.Reflection.MetadataLoadContext.
       This allows the package to be retrieved from previously-source-built artifacts and flow in as dependencies
       of the packages produced by msbuild. -->
@@ -31,9 +36,19 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="System.Resources.Extensions" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
     <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
       and flow in as dependencies of the packages produced by msbuild. -->
     <Dependency Name="System.Security.Cryptography.Pkcs" Version="7.0.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="System.Security.Cryptography.Xml" Version="7.0.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
     </Dependency>


### PR DESCRIPTION
This fixes a portion of the assemblies described in https://github.com/dotnet/source-build/issues/3599 that are showing up as reference assemblies in the source-built SDK. The reason they're showing up as ref assemblies is the same reason that's described in https://github.com/dotnet/msbuild/pull/9158, which is a related issue.

It's not known whether the existence of these ref assemblies causes a functional issue as it does with https://github.com/dotnet/msbuild/pull/9158. But we do know that the source-built 7.0 SDK doesn't define these as ref assemblies but rather implementation assemblies. So to maintain parity with 7.0 and avoid potential risk, it's best to ensure these are represented as implementation assemblies in the output.

These are the assemblies that are fixed by these changes:

* System.CodeDom
* System.Resources.Extensions
* System.Security.Cryptography.Xml