### PR TITLE
Don't compile SDK pattern regexes on .NET Framework

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverManifest.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverManifest.cs
@@ -110,7 +110,12 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                                     string pattern = reader.ReadElementContentAsString();
                                     try
                                     {
-                                        manifest.ResolvableSdkRegex = new Regex(pattern, RegexOptions.Compiled | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(SdkResolverPatternRegexTimeoutMsc));
+                                        RegexOptions regexOptions = RegexOptions.CultureInvariant;
+                                        // For the kind of patterns used here, compiled regexes on .NET Framework tend to run slower than interpreted ones.
+#if RUNTIME_TYPE_NETCORE
+                                        regexOptions |= RegexOptions.Compiled;
+#endif
+                                        manifest.ResolvableSdkRegex = new Regex(pattern, regexOptions, TimeSpan.FromMilliseconds(SdkResolverPatternRegexTimeoutMsc));
                                     }
                                     catch (ArgumentException ex)
                                     {


### PR DESCRIPTION
Contributes to [AB#1811625](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1811625)

### Context

Compiled regular expressions tend to run slower than interpreted ones on .NET Framework. Additionally, the cost of compiling is significant, especially on 64-bit.

Here's a benchmark running `IsMatch("Microsoft.NET.Sdk")` against the only SDK regex we ship inbox: `^(?i)vcpkg:.*`. Note that it does not include the compilation, which is an additional one-time cost.

![image](https://github.com/dotnet/msbuild/assets/12206368/2f12bc61-7dbe-444a-8213-d142c614d87c)

### Changes Made

Interpret `ResolvableSdkRegex` on .NET Framework. We made an analogous change to globbing some time ago in #6632.

### Testing

Existing unit tests, targeted micro benchmark.

### Notes

In the trace attached to the AzDO bug, this change eliminates 1/3 of the SDK resolution cost.