### PR TITLE
Change path to 64-bit path

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -203,6 +203,7 @@
             <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="VSToolsPath" value="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
             <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
           </searchPaths>
         </projectImportSearchPaths>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -173,6 +173,7 @@
             <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="VSToolsPath" value="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
             <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
           </searchPaths>
         </projectImportSearchPaths>


### PR DESCRIPTION
This permits the old probing path for 32-bit MSBuild in case we're running MSBuild from the command line with 32-bit VS installed but not 64-bit VS.

Inspired by https://github.com/dotnet/msbuild/issues/8168#issuecomment-1625318954

Fixes [AB#1874725](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1874725)
