### PR TITLE
Add EvaluationContext.SharingPolicy.SharedSDKCache

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4367,9 +4367,9 @@ $(
             Assert.True(Guid.TryParse(result, out Guid guid));
         }
 
-        // TODO: update features list
         [Theory]
         [InlineData("NonExistingFeature", "Undefined")]
+        [InlineData("EvaluationContext_SharedSDKCachePolicy", "Available")]
         public void PropertyFunctionCheckFeatureAvailability(string featureName, string availability)
         {
             var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), FileSystems.Default);

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -26,19 +26,28 @@ namespace Microsoft.Build.Evaluation.Context
         public enum SharingPolicy
         {
             /// <summary>
-            /// Instructs the <see cref="EvaluationContext"/> to reuse state between the different project evaluations that use it.
+            /// Instructs the <see cref="EvaluationContext"/> to reuse all cached state between the different project evaluations that use it.
             /// </summary>
             Shared,
 
             /// <summary>
-            /// Instructs the <see cref="EvaluationContext"/> not to reuse state between the different project evaluations that use it.
+            /// Instructs the <see cref="EvaluationContext"/> to not reuse any cached state between the different project evaluations that use it.
             /// </summary>
-            Isolated
+            Isolated,
+
+            /// <summary>
+            /// Instructs the <see cref="EvaluationContext"/> to reuse SDK resolver cache between the different project evaluations that use it.
+            /// No other cached state is reused.
+            /// </summary>
+            SharedSDKCache,
         }
 
-        internal static Action<EvaluationContext> TestOnlyHookOnCreate { get; set; }
-
+        /// <summary>
+        /// For contexts that are not fully shared, this field tracks whether the instance has already been used for evaluation.
+        /// </summary>
         private int _used;
+
+        internal static Action<EvaluationContext> TestOnlyHookOnCreate { get; set; }
 
         internal SharingPolicy Policy { get; }
 
@@ -65,28 +74,26 @@ namespace Microsoft.Build.Evaluation.Context
         /// <summary>
         ///     Factory for <see cref="EvaluationContext" />
         /// </summary>
+        /// <param name="policy">The <see cref="SharingPolicy"/> to use.</param>
         public static EvaluationContext Create(SharingPolicy policy)
         {
-
-            // ReSharper disable once IntroduceOptionalParameters.Global
-            // do not remove this method to avoid breaking binary compatibility
+            // Do not remove this method to avoid breaking binary compatibility.
             return Create(policy, fileSystem: null);
         }
 
         /// <summary>
         ///     Factory for <see cref="EvaluationContext" />
         /// </summary>
-        /// <param name="policy"> The <see cref="SharingPolicy"/> to use.</param>
+        /// <param name="policy">The <see cref="SharingPolicy"/> to use.</param>
         /// <param name="fileSystem">The <see cref="IFileSystem"/> to use.
         ///     This parameter is compatible only with <see cref="SharingPolicy.Shared"/>.
-        ///     The method throws if a file system is used with <see cref="SharingPolicy.Isolated"/>.
-        ///     The reasoning is that <see cref="SharingPolicy.Isolated"/> means not reusing any caches between evaluations,
+        ///     The method throws if a file system is used with <see cref="SharingPolicy.Isolated"/> or <see cref="SharingPolicy.SharedSDKCache"/>.
+        ///     The reasoning is that these values guarantee not reusing file system caches between evaluations,
         ///     and the passed in <paramref name="fileSystem"/> might cache state.
         /// </param>
         public static EvaluationContext Create(SharingPolicy policy, MSBuildFileSystemBase fileSystem)
         {
-            // Unsupported case: isolated context with non null file system.
-            // Isolated means caches aren't reused, but the given file system might cache.
+            // Unsupported case: not-fully-shared context with non null file system.
             ErrorUtilities.VerifyThrowArgument(
                 policy == SharingPolicy.Shared || fileSystem == null,
                 "IsolatedContextDoesNotSupportFileSystem");
@@ -100,27 +107,28 @@ namespace Microsoft.Build.Evaluation.Context
             return context;
         }
 
-        private EvaluationContext CreateUsedIsolatedContext()
-        {
-            var context = Create(SharingPolicy.Isolated);
-            context._used = 1;
-
-            return context;
-        }
-
         internal EvaluationContext ContextForNewProject()
         {
-            // Projects using isolated contexts need to get a new context instance
+            // Projects using Isolated and SharedSDKCache contexts need to get a new context instance.
             switch (Policy)
             {
                 case SharingPolicy.Shared:
                     return this;
+                case SharingPolicy.SharedSDKCache:
                 case SharingPolicy.Isolated:
-                    // reuse the first isolated context if it has not seen an evaluation yet.
-                    var previousValueWasUsed = Interlocked.CompareExchange(ref _used, 1, 0);
-                    return previousValueWasUsed == 0
-                        ? this
-                        : CreateUsedIsolatedContext();
+                    // Reuse the first not-fully-shared context if it's not been used for an evaluation yet.
+                    if (Interlocked.CompareExchange(ref _used, 1, 0) == 0)
+                    {
+                        return this;
+                    }
+                    // Create a copy if this context has already been used. Mark it used.
+                    EvaluationContext context = new EvaluationContext(Policy, fileSystem: null, sdkResolverService: Policy == SharingPolicy.SharedSDKCache ? SdkResolverService : null)
+                    {
+                        _used = 1,
+                    };
+                    TestOnlyHookOnCreate?.Invoke(context);
+                    return context;
+
                 default:
                     ErrorUtilities.ThrowInternalErrorUnreachable();
                     return null;
@@ -134,11 +142,10 @@ namespace Microsoft.Build.Evaluation.Context
         /// <returns>The new evaluation context.</returns>
         internal EvaluationContext ContextWithFileSystem(IFileSystem fileSystem)
         {
-            var newContext = new EvaluationContext(this.Policy, fileSystem, this.SdkResolverService, this.FileEntryExpansionCache)
+            return new EvaluationContext(Policy, fileSystem, SdkResolverService, FileEntryExpansionCache)
             {
-                _used = 1
+                _used = 1,
             };
-            return newContext;
         }
     }
 }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1911,7 +1911,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>Static graph loaded in {0} seconds: {1} nodes, {2} edges</value>
   </data>
   <data name="IsolatedContextDoesNotSupportFileSystem" xml:space="preserve">
-    <value>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</value>
+    <value>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</value>
   </data>
   <data name="LoadingProjectCachePlugin" xml:space="preserve">
     <value>Loading the following project cache plugin: {0}</value>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">Objekty EvaluationContext vytvořené pomocí SharingPolicy.Isolated nepodporují předávání souborového systému MSBuildFileSystemBase.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">Objekty EvaluationContext vytvořené pomocí SharingPolicy.Isolated nepodporují předávání souborového systému MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">Die Übergabe eines MSBuildFileSystemBase-Dateisystems an EvaluationContext-Objekte, die mit "SharingPolicy.Isolated" erstellt wurden, wird nicht unterstützt.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">Die Übergabe eines MSBuildFileSystemBase-Dateisystems an EvaluationContext-Objekte, die mit "SharingPolicy.Isolated" erstellt wurden, wird nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">Los objetos EvaluationContext creados con SharingPolicy.Isolated no admiten que se les pase un sistema de archivos MSBuildFileSystemBase.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">Los objetos EvaluationContext creados con SharingPolicy.Isolated no admiten que se les pase un sistema de archivos MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">Les objets EvaluationContext créés avec SharingPolicy.Isolated ne prennent pas en charge le passage d'un système de fichiers MSBuildFileSystemBase.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">Les objets EvaluationContext créés avec SharingPolicy.Isolated ne prennent pas en charge le passage d'un système de fichiers MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">Agli oggetti EvaluationContext creati con SharingPolicy.Isolated non è possibile passare un file system MSBuildFileSystemBase.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">Agli oggetti EvaluationContext creati con SharingPolicy.Isolated non è possibile passare un file system MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">SharingPolicy.Isolated を指定して作成された EvaluationContext オブジェクトに MSBuildFileSystemBase ファイル システムを渡すことはサポートされていません。</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">SharingPolicy.Isolated を指定して作成された EvaluationContext オブジェクトに MSBuildFileSystemBase ファイル システムを渡すことはサポートされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">SharingPolicy.Isolated로 만든 EvaluationContext 개체는 MSBuildFileSystemBase 파일 시스템 전달을 지원하지 않습니다.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">SharingPolicy.Isolated로 만든 EvaluationContext 개체는 MSBuildFileSystemBase 파일 시스템 전달을 지원하지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">Obiekty EvaluationContext utworzone za pomocą elementu SharingPolicy.Isolated nie obsługują przekazywania za pomocą systemu plików MSBuildFileSystemBase.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">Obiekty EvaluationContext utworzone za pomocą elementu SharingPolicy.Isolated nie obsługują przekazywania za pomocą systemu plików MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">Os objetos EvaluationContext criados com SharingPolicy.Isolated não são compatíveis com o recebimento de um sistema de arquivos MSBuildFileSystemBase.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">Os objetos EvaluationContext criados com SharingPolicy.Isolated não são compatíveis com o recebimento de um sistema de arquivos MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">Объекты EvaluationContext, созданные с помощью SharingPolicy.Isolated, не поддерживают передачу в файловую систему MSBuildFileSystemBase.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">Объекты EvaluationContext, созданные с помощью SharingPolicy.Isolated, не поддерживают передачу в файловую систему MSBuildFileSystemBase.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">SharingPolicy.Isolated ile oluşturulan EvaluationContext nesneleri bir MSBuildFileSystemBase dosya sisteminin geçirilmesini desteklemez.</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">SharingPolicy.Isolated ile oluşturulan EvaluationContext nesneleri bir MSBuildFileSystemBase dosya sisteminin geçirilmesini desteklemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">使用 SharingPolicy.Isolated 创建的 EvaluationContext 对象不支持通过 MSBuildFileSystemBase 文件系统传递。</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">使用 SharingPolicy.Isolated 创建的 EvaluationContext 对象不支持通过 MSBuildFileSystemBase 文件系统传递。</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -284,8 +284,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IsolatedContextDoesNotSupportFileSystem">
-        <source>EvaluationContext objects created with SharingPolicy.Isolated do not support being passed an MSBuildFileSystemBase file system.</source>
-        <target state="translated">使用 SharingPolicy.Isolated 建立的 EvaluationContext 物件不支援以 MSBuildFileSystemBase 檔案系統傳遞。</target>
+        <source>EvaluationContext objects created with SharingPolicy.Isolated or SharingPolicy.SharedSDKCache do not support being passed an MSBuildFileSystemBase file system.</source>
+        <target state="needs-review-translation">使用 SharingPolicy.Isolated 建立的 EvaluationContext 物件不支援以 MSBuildFileSystemBase 檔案系統傳遞。</target>
         <note />
       </trans-unit>
       <trans-unit id="ItemReferencingSelfInTarget">

--- a/src/Framework/Features.cs
+++ b/src/Framework/Features.cs
@@ -42,7 +42,8 @@ namespace Microsoft.Build.Framework
     {
         private static readonly Dictionary<string, FeatureStatus> _featureStatusMap = new Dictionary<string, FeatureStatus>
         {
-            // TODO: Fill in the dictionary with the features and their status
+            { "EvaluationContext_SharedSDKCachePolicy", FeatureStatus.Available }, // EvaluationContext supports the SharingPolicy.SharedSDKCache flag.
+            // Add more features here.
         };
 
         /// <summary>


### PR DESCRIPTION
Contributes to [AB#1811625](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1811625)

### Context

`EvaluationContext` is a container for various cached state, improving the performance of project evaluation. Sharing this state between evaluations is currently all-or-nothing, which has been identified as a blocker for wider adoption of `EvaluationContext` in Visual Studio scenarios.

### Changes Made

Added a new `SharedSDKCache` sharing policy with the semantics of sharing only SDK resolutions. Specifically, it does not allow sharing of general file system state, which could lead to over-sharing when used during VS background processing.

### Testing

Extended existing unit tests.

### Notes

In retrospect, it may have been more appropriate to make `SharingPolicy` bit flags with each piece of cached data controlled by its own bit. But because changing the existing enum values would be a binary compat break, I'm opting for a new simple ordinal value.