### PR TITLE
Ship BuildXL assemblies in our VSIX

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,8 +1,10 @@
 <Project>
   <ItemGroup>
     <ItemsToSign Include="$(VisualStudioSetupInsertionPath)Microsoft.Build.UnGAC.exe" />
+
+    <FileSignInfo Include="RuntimeContracts.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
-    
+
   <PropertyGroup>
     <UseDotNetCertificate>true</UseDotNetCertificate>
   </PropertyGroup>

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -40,7 +40,7 @@
 
     <PackageReference Include="Microsoft.IO.Redist" Condition="'$(FeatureMSIORedist)' == 'true'" />
 
-    <PackageReference Include="Microsoft.BuildXL.Processes" Condition="'$(FeatureReportFileAccesses)' == 'true'" />
+    <PackageReference Include="Microsoft.BuildXL.Processes" Condition="'$(FeatureReportFileAccesses)' == 'true'" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(DotNetBuildFromSource)' != 'true'">

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -217,6 +217,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.BuildXL.Processes" Condition="'$(FeatureReportFileAccesses)' == 'true'" PrivateAssets="all" />
     <PackageReference Include="Microsoft.IO.Redist" Condition="'$(FeatureMSIORedist)' == 'true'" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -55,6 +55,18 @@
 
         <!-- Redirects for assemblies redistributed by MSBuild (in the .vsix). -->
         <dependentAssembly>
+          <assemblyIdentity name="BuildXL.Native" publicKeyToken="6212d9137135ce5d" culture="neutral" />
+          <codeBase version="1.0.0.0" href="..\BuildXL.Native.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="BuildXL.Processes" publicKeyToken="6212d9137135ce5d" culture="neutral" />
+          <codeBase version="1.0.0.0" href="..\BuildXL.Processes.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="BuildXL.Utilities.Core" publicKeyToken="6212d9137135ce5d" culture="neutral" />
+          <codeBase version="1.0.0.0" href="..\BuildXL.Utilities.Core.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
           <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
           <codeBase version="7.0.0.0" href="..\Microsoft.Bcl.AsyncInterfaces.dll"/>

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -36,8 +36,12 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe.config
-  file source=$(TaskHostBinPath)MSBuildTaskHost.exe 
+  file source=$(TaskHostBinPath)MSBuildTaskHost.exe
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
+  file source=$(X86BinPath)BuildXL.Native.dll
+  file source=$(X86BinPath)BuildXL.Processes.dll
+  file source=$(X86BinPath)BuildXL.Utilities.Core.dll
+  file source=$(X86BinPath)RuntimeContracts.dll
   file source=$(X86BinPath)System.Buffers.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Memory.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Reflection.Metadata.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
@@ -312,6 +316,13 @@ folder InstallDir:\MSBuild\Current\Bin\amd64\zh-Hant
   file source=$(X64BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll
   file source=$(X64BinPath)zh-Hant\MSBuild.resources.dll
   file source=$(TaskHostX64BinPath)zh-Hant\MSBuildTaskHost.resources.dll
+
+folder InstallDir:\MSBuild\Current\Bin\x86
+  file source=$(X86BinPath)x86\DetoursServices.dll
+
+folder InstallDir:\MSBuild\Current\Bin\x64
+  file source=$(X86BinPath)x64\DetoursServices.dll
+  file source=$(X86BinPath)x64\BuildXLNatives.dll
 
 folder InstallDir:\Common7\IDE\CommonExtensions\MSBuild
   file source=$(SourceDir)Package\MSBuild.VSSetup\MSBuild.clientenabledpkg


### PR DESCRIPTION
New dependencies added in #8726 weren't being deployed to VS. Ship them once (rooted in `MSBuild\bin`) and add binding redirects for the 64-bit versions to use it from there.