### PR TITLE
Update Strings.it.xlf removing spurious character

### DIFF
--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -143,7 +143,7 @@
       </trans-unit>
       <trans-unit id="MSBuildVersionMessage">
         <source>MSBuild version {0} for {1}</source>
-        <target state="translated">Versione di MSBuild Ł{0} per {1}</target>
+        <target state="translated">Versione di MSBuild {0} per {1}</target>
         <note>LOCALIZATION: {0} contains the DLL version number. {1} contains the name of a runtime, like ".NET Framework", ".NET Core", or "Mono"</note>
       </trans-unit>
       <trans-unit id="CurrentDirectory">


### PR DESCRIPTION
Removed a spurious Ł character from the italian MSBuildVersionMessage message. The message is shown by VS Code every time a compilation is done, so it is quite annoying.

![image](https://github.com/dotnet/msbuild/assets/821344/ed409f17-2726-470c-96fd-5ac85ff453ff)

Fixes: one spurious character in a translation of the MSBuild Messages

Changes Made: removed the spurious character, compared the message to the english version of the same message

Notes: My first language is italian.
