### PR TITLE
Add test flag

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -207,6 +207,8 @@ namespace Microsoft.Build.Execution
 
         private bool _question;
 
+        private bool _test;
+
         /// <summary>
         /// The settings used to load the project under build
         /// </summary>
@@ -306,6 +308,7 @@ namespace Microsoft.Build.Execution
             DiscardBuildResults = other.DiscardBuildResults;
             LowPriority = other.LowPriority;
             Question = other.Question;
+            Test = other.Test;
             ProjectCacheDescriptor = other.ProjectCacheDescriptor;
         }
 
@@ -821,6 +824,15 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Gets or sets a value that will error when the build process fails an incremental check.
+        /// </summary>
+        public bool Test
+        {
+            get => _test;
+            set => _test = value;
+        }
+
+        /// <summary>
         /// Gets or sets the project cache description to use for all <see cref="BuildSubmission"/> or <see cref="GraphBuildSubmission"/>
         /// in addition to any potential project caches described in each project.
         /// </summary>
@@ -884,6 +896,7 @@ namespace Microsoft.Build.Execution
             translator.TranslateEnum(ref _projectLoadSettings, (int)_projectLoadSettings);
             translator.Translate(ref _interactive);
             translator.Translate(ref _question);
+            translator.Translate(ref _test);
             translator.TranslateEnum(ref _projectIsolationMode, (int)_projectIsolationMode);
 
             // ProjectRootElementCache is not transmitted.

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -109,6 +109,20 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Theory]
+        [InlineData("test")]
+        [InlineData("TEST")]
+        [InlineData("Test")]
+        public void TestSwitchIdentificationTests(string test)
+        {
+            CommandLineSwitches.ParameterlessSwitch parameterlessSwitch;
+            string duplicateSwitchErrorMessage;
+
+            CommandLineSwitches.IsParameterlessSwitch(test, out parameterlessSwitch, out duplicateSwitchErrorMessage).ShouldBeTrue();
+            parameterlessSwitch.ShouldBe(CommandLineSwitches.ParameterlessSwitch.Test);
+            duplicateSwitchErrorMessage.ShouldBeNull();
+        }
+
+        [Theory]
         [InlineData("noconsolelogger")]
         [InlineData("NOCONSOLELOGGER")]
         [InlineData("NoConsoleLogger")]
@@ -1127,6 +1141,7 @@ namespace Microsoft.Build.UnitTests
                                         graphBuildOptions: null,
                                         lowPriority: false,
                                         question: false,
+                                        test: false,
                                         inputResultsCaches: null,
                                         outputResultsCache: null,
                                         saveProjectResult: false,

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Build.CommandLine
             FileLogger8,
             FileLogger9,
             DistributedFileLogger,
+            Test,
 #if DEBUG
             WaitForDebugger,
 #endif
@@ -214,6 +215,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterlessSwitchInfo(  new string[] { "filelogger8", "fl8" },                     ParameterlessSwitch.FileLogger8,           null),
             new ParameterlessSwitchInfo(  new string[] { "filelogger9", "fl9" },                     ParameterlessSwitch.FileLogger9,           null),
             new ParameterlessSwitchInfo(  new string[] { "distributedfilelogger", "dfl" },           ParameterlessSwitch.DistributedFileLogger, null),
+            new ParameterlessSwitchInfo(  new string[] { "test" },                                   ParameterlessSwitch.Test,                  null),
 #if DEBUG
             new ParameterlessSwitchInfo(  new string[] { "waitfordebugger", "wfd" },                 ParameterlessSwitch.WaitForDebugger,       null),
 #endif

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -709,6 +709,7 @@ namespace Microsoft.Build.CommandLine
                 string[] inputResultsCaches = null;
                 string outputResultsCache = null;
                 bool question = false;
+                bool test = false;
                 string[] getProperty = Array.Empty<string>();
                 string[] getItem = Array.Empty<string>();
                 string[] getTargetResult = Array.Empty<string>();
@@ -749,6 +750,7 @@ namespace Microsoft.Build.CommandLine
                                             ref outputResultsCache,
                                             ref lowPriority,
                                             ref question,
+                                            ref test,
                                             ref getProperty,
                                             ref getItem,
                                             ref getTargetResult,
@@ -842,6 +844,7 @@ namespace Microsoft.Build.CommandLine
                                     graphBuildOptions,
                                     lowPriority,
                                     question,
+                                    test,
                                     inputResultsCaches,
                                     outputResultsCache,
                                     saveProjectResult: outputPropertiesItemsOrTargetResults,
@@ -1228,6 +1231,7 @@ namespace Microsoft.Build.CommandLine
             GraphBuildOptions graphBuildOptions,
             bool lowPriority,
             bool question,
+            bool test,
             string[] inputResultsCaches,
             string outputResultsCache,
             bool saveProjectResult,
@@ -1423,6 +1427,7 @@ namespace Microsoft.Build.CommandLine
                     parameters.InputResultsCacheFiles = inputResultsCaches;
                     parameters.OutputResultsCacheFile = outputResultsCache;
                     parameters.Question = question;
+                    parameters.Test = test;
 
                     // Propagate the profiler flag into the project load settings so the evaluator
                     // can pick it up
@@ -1506,6 +1511,11 @@ namespace Microsoft.Build.CommandLine
                                 if (saveProjectResult)
                                 {
                                     flags |= BuildRequestDataFlags.ProvideProjectStateAfterBuild;
+                                }
+
+                                if (test)
+                                {
+                                    targets = targets.Append(MSBuildConstants.TestTargetName).ToArray();
                                 }
 
                                 if (graphBuildOptions != null)
@@ -2385,6 +2395,7 @@ namespace Microsoft.Build.CommandLine
             ref string outputResultsCache,
             ref bool lowPriority,
             ref bool question,
+            ref bool test,
             ref string[] getProperty,
             ref string[] getItem,
             ref string[] getTargetResult,
@@ -2510,6 +2521,7 @@ namespace Microsoft.Build.CommandLine
                                                            ref outputResultsCache,
                                                            ref lowPriority,
                                                            ref question,
+                                                           ref test,
                                                            ref getProperty,
                                                            ref getItem,
                                                            ref getTargetResult,
@@ -2588,6 +2600,8 @@ namespace Microsoft.Build.CommandLine
                     }
 
                     question = commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Question);
+
+                    test = commandLineSwitches.IsParameterlessSwitchSet(CommandLineSwitches.ParameterlessSwitch.Test);
 
                     inputResultsCaches = ProcessInputResultsCaches(commandLineSwitches);
 

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -57,6 +57,12 @@ namespace Microsoft.Build.Shared
         /// The name of the target to run when a user specifies the /restore command-line argument.
         /// </summary>
         internal const string RestoreTargetName = "Restore";
+
+        /// <summary>
+        /// The name of the target to run when a user specifies the /test command-line argument.
+        /// </summary>
+        internal const string TestTargetName = "MSBuildRunTests";
+
         /// <summary>
         /// The most current Visual Studio Version known to this version of MSBuild.
         /// </summary>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5738,6 +5738,27 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Condition="'$(ClickOncePublishDir)'=='$(OutputPath)app.publish\' and Exists('$(ClickOncePublishDir)')"/>
 
   </Target>
+  
+  <!--
+    ***********************************************************************************************
+    ***********************************************************************************************
+                                                                Test Section
+    ***********************************************************************************************
+    ***********************************************************************************************
+  -->
+  <!--
+    ============================================================
+    This stub `MSBuildRunTests` target allows for targets implementing Test execution functionality
+    to run after it.
+    
+    For example:
+    <Target Name="ExecuteTests" AfterTargets="MSBuildRunTests">
+     (implementation)
+    </Target>
+    ============================================================
+  -->
+
+  <Target Name="MSBuildRunTests"></Target>
 
   <!--
     ***********************************************************************************************


### PR DESCRIPTION
### Context
At the moment there is no command `msbuild /test` or similar, that would allow for functionality similar to `dotnet /test`.

### Changes Made
- Adds new test flag that calls a new stub target called "MSBuildRunTests". 
- A test target implementation can then run after the stub target, as seen here: https://github.com/microsoft/MSBuildSdks/pull/473/files#diff-2c16aadae848b9a2376f0811f06a40a99ebb3172abe376864af90f8e79504a49 
