### PR TITLE
Add Extended messages data to binary log

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -35,6 +35,5 @@ namespace Microsoft.Build.Logging
         TaskParameter,
         ResponseFileUsed,
         AssemblyLoad,
-        ExtendedMessage,
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -35,5 +35,6 @@ namespace Microsoft.Build.Logging
         TaskParameter,
         ResponseFileUsed,
         AssemblyLoad,
+        ExtendedMessage,
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -61,7 +61,11 @@ namespace Microsoft.Build.Logging
         //   - new record kind: ResponseFileUsedEventArgs
         // version 16:
         //   - AssemblyLoadBuildEventArgs
-        internal const int FileFormatVersion = 16;
+        // version 17:
+        //   - new record kind: ExtendedMessage
+        //   - Error: added extended data
+        //   - Warning: added extended data
+        internal const int FileFormatVersion = 17;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -62,9 +62,7 @@ namespace Microsoft.Build.Logging
         // version 16:
         //   - AssemblyLoadBuildEventArgs
         // version 17:
-        //   - new record kind: ExtendedMessage
-        //   - Error: added extended data
-        //   - Warning: added extended data
+        //   - Added extended data for types implementing IExtendedBuildEventArgs
         internal const int FileFormatVersion = 17;
 
         private Stream stream;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsFieldFlags.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsFieldFlags.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Build.Logging
         EndLineNumber = 1 << 12,
         EndColumnNumber = 1 << 13,
         Arguments = 1 << 14,
-        Importance = 1 << 15
+        Importance = 1 << 15,
+        Extended = 1 << 16,
     }
 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsFields.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsFields.cs
@@ -32,5 +32,6 @@ namespace Microsoft.Build.Logging
         public int ColumnNumber { get; set; }
         public int EndLineNumber { get; set; }
         public int EndColumnNumber { get; set; }
+        public ExtendedDataFields Extended { get; set; }
     }
 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -946,15 +946,11 @@ namespace Microsoft.Build.Logging
 
         private ExtendedDataFields? ReadExtendedDataFields()
         {
-            ExtendedDataFields? fields = null;
+            string extendedType = ReadOptionalString()!;
+            IDictionary<string, string>? extendedMetadata = ReadStringDictionary();
+            string? extendedData = ReadOptionalString();
 
-            fields = new ExtendedDataFields();
-
-            fields.ExtendedType = ReadOptionalString();
-            fields.ExtendedMetadata = ReadStringDictionary();
-            fields.ExtendedData = ReadOptionalString();
-
-            return fields;
+            return new ExtendedDataFields(extendedType, extendedMetadata, extendedData);
         }
 
         private BuildEventArgsFields ReadBuildEventArgsFields(bool readImportance = false)

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -1361,9 +1361,9 @@ namespace Microsoft.Build.Logging
             return binaryReader.ReadBoolean();
         }
 
-        private unsafe Guid ReadGuid()
+        private Guid ReadGuid()
         {
-            return new Guid(binaryReader.ReadBytes(sizeof(Guid)));
+            return new Guid(binaryReader.ReadBytes(16 /*sizeof(Guid) - to avoid unsafe context, Guid will never change in size */));
         }
 
         private DateTime ReadDateTime()

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -947,7 +947,7 @@ namespace Microsoft.Build.Logging
         private ExtendedDataFields? ReadExtendedDataFields()
         {
             string extendedType = ReadOptionalString()!;
-            IDictionary<string, string>? extendedMetadata = ReadStringDictionary();
+            IDictionary<string, string?>? extendedMetadata = ReadStringDictionary()!;
             string? extendedData = ReadOptionalString();
 
             return new ExtendedDataFields(extendedType, extendedMetadata, extendedData);

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -484,7 +484,6 @@ namespace Microsoft.Build.Logging
             }
         }
 
-
         private void Write(ProjectImportedEventArgs e)
         {
             Write(BinaryLogRecordKind.ProjectImported);
@@ -697,7 +696,7 @@ namespace Microsoft.Build.Logging
             }
         }
 
-            private void WriteArguments(object[] arguments)
+        private void WriteArguments(object[] arguments)
         {
             if (arguments == null || arguments.Length == 0)
             {

--- a/src/Build/Logging/BinaryLogger/ExtendedDataFields.cs
+++ b/src/Build/Logging/BinaryLogger/ExtendedDataFields.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Build.Logging;
 
 internal class ExtendedDataFields
 {
-    public ExtendedDataFields(string extendedType, IDictionary<string, string>? extendedMetadata, string? extendedData)
+    public ExtendedDataFields(string extendedType, IDictionary<string, string?>? extendedMetadata, string? extendedData)
     {
         ExtendedType = extendedType;
         ExtendedMetadata = extendedMetadata;

--- a/src/Build/Logging/BinaryLogger/ExtendedDataFields.cs
+++ b/src/Build/Logging/BinaryLogger/ExtendedDataFields.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Logging;
+
+internal class ExtendedDataFields
+{
+    public string ExtendedType { get; set; }
+    public IDictionary<string, string> ExtendedMetadata { get; set; }
+    public string ExtendedData { get; set; }
+}

--- a/src/Build/Logging/BinaryLogger/ExtendedDataFields.cs
+++ b/src/Build/Logging/BinaryLogger/ExtendedDataFields.cs
@@ -1,14 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
 using System.Collections.Generic;
 
 namespace Microsoft.Build.Logging;
 
 internal class ExtendedDataFields
 {
-    public string ExtendedType { get; set; }
-    public IDictionary<string, string> ExtendedMetadata { get; set; }
-    public string ExtendedData { get; set; }
+    public ExtendedDataFields(string extendedType, IDictionary<string, string>? extendedMetadata, string? extendedData)
+    {
+        ExtendedType = extendedType;
+        ExtendedMetadata = extendedMetadata;
+        ExtendedData = extendedData;
+    }
+
+    public string ExtendedType { get; }
+    public IDictionary<string, string?>? ExtendedMetadata { get; }
+    public string? ExtendedData { get; }
 }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -159,6 +159,7 @@
     <Compile Include="BackEnd\Components\SdkResolution\TranslationHelpers.cs" />
     <Compile Include="FileSystem\*.cs" />
     <Compile Include="Evaluation\IItemTypeDefinition.cs" />
+    <Compile Include="Logging\BinaryLogger\ExtendedDataFields.cs" />
     <Compile Include="Logging\BinaryLogger\IBuildEventArgsReaderNotifications.cs" />
     <Compile Include="Logging\BinaryLogger\IBuildEventStringsReader.cs" />
     <Compile Include="Logging\BinaryLogger\StringReadEventArgs.cs" />

--- a/src/Framework/ExtendedBuildErrorEventArgs.cs
+++ b/src/Framework/ExtendedBuildErrorEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class ExtendedBuildErrorEventArgs : BuildErrorEventArgs, IExtended
     public string ExtendedType { get; set; }
 
     /// <inheritdoc />
-    public Dictionary<string, string?>? ExtendedMetadata { get; set; }
+    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <inheritdoc />
     public string? ExtendedData { get; set; }

--- a/src/Framework/ExtendedBuildMessageEventArgs.cs
+++ b/src/Framework/ExtendedBuildMessageEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class ExtendedBuildMessageEventArgs : BuildMessageEventArgs, IExte
     public string ExtendedType { get; set; }
 
     /// <inheritdoc />
-    public Dictionary<string, string?>? ExtendedMetadata { get; set; }
+    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <inheritdoc />
     public string? ExtendedData { get; set; }

--- a/src/Framework/ExtendedBuildWarningEventArgs.cs
+++ b/src/Framework/ExtendedBuildWarningEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class ExtendedBuildWarningEventArgs : BuildWarningEventArgs, IExte
     public string ExtendedType { get; set; }
 
     /// <inheritdoc />
-    public Dictionary<string, string?>? ExtendedMetadata { get; set; }
+    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <inheritdoc />
     public string? ExtendedData { get; set; }

--- a/src/Framework/ExtendedCustomBuildEventArgs.cs
+++ b/src/Framework/ExtendedCustomBuildEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class ExtendedCustomBuildEventArgs : CustomBuildEventArgs, IExtend
     public string ExtendedType { get; set; }
 
     /// <inheritdoc />
-    public Dictionary<string, string?>? ExtendedMetadata { get; set; }
+    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <inheritdoc />
     public string? ExtendedData { get; set; }

--- a/src/Framework/IExtendedBuildEventArgs.cs
+++ b/src/Framework/IExtendedBuildEventArgs.cs
@@ -22,7 +22,7 @@ public interface IExtendedBuildEventArgs
     ///   - data which needed in custom code to properly routing this message without interpreting/deserializing <see cref="ExtendedData"/>.
     ///   - simple extended data can be transferred in form of dictionary key-value per one extended property.
     /// </summary>
-    Dictionary<string, string?>? ExtendedMetadata { get; set; }
+    IDictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <summary>
     /// Transparent data as string.

--- a/src/Shared/BinaryReaderExtensions.cs
+++ b/src/Shared/BinaryReaderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
@@ -108,7 +109,7 @@ namespace Microsoft.Build.Shared
             bool haveMetadata = reader.ReadBoolean();
             if (haveMetadata)
             {
-                data.ExtendedMetadata = new();
+                data.ExtendedMetadata = new Dictionary<string, string?>();
 
                 int count = reader.Read7BitEncodedInt();
                 for (int i = 0; i < count; i++)


### PR DESCRIPTION
Fixes #9091

### Context
We have introducing new extended event args (error, warn, message, custom) so time ago. 
This PR is about logging extended data into binary log and will serve for modifying bin log viewer as well.

### Changes Made
Add `BuildEventArgsFieldFlags.Extended` and implement related code.

### Testing
Unit tests

### Notes
