### PR TITLE
Setting ReferenceOutputAssembly to falso on references to esproj

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 ***********************************************************************************************
 Microsoft.Common.CurrentVersion.targets
 
@@ -1511,6 +1511,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
     -->
   <Target Name="AfterResolveReferences"/>
+  
+  <!--
+    ============================================================
+                                        IgnoreJavaScriptOutputAssembly
+
+    esproj are JavaScript or TypeScript Projects that never produce an assembly. 
+    Set ReferenceOutputAssembly to false in any reference to an esproj.
+    ============================================================
+    -->
+  <Target Name="IgnoreJavaScriptOutputAssembly" BeforeTargets="AssignProjectConfiguration">
+      <ItemGroup>
+        <ProjectReference Condition="'%(Extension)' == '.esproj'">
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        </ProjectReference>
+      </ItemGroup>
+  </Target>
 
   <!--
     ============================================================

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 ***********************************************************************************************
 Microsoft.Common.CurrentVersion.targets
 
@@ -1516,11 +1516,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
                                         IgnoreJavaScriptOutputAssembly
 
-    esproj are JavaScript or TypeScript Projects that never produce an assembly. 
+    esproj are JavaScript or TypeScript Projects that never produce an assembly.
     Set ReferenceOutputAssembly to false in any reference to an esproj.
     ============================================================
     -->
-  <Target Name="IgnoreJavaScriptOutputAssembly" BeforeTargets="AssignProjectConfiguration">
+  <Target Name="IgnoreJavaScriptOutputAssembly"
+    BeforeTargets="AssignProjectConfiguration"
+    Condition="$([MSBuild]::AreFeaturesEnabled('17.8'))">
       <ItemGroup>
         <ProjectReference Condition="'%(Extension)' == '.esproj'">
           <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1524,7 +1524,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     BeforeTargets="AssignProjectConfiguration"
     Condition="$([MSBuild]::AreFeaturesEnabled('17.8'))">
       <ItemGroup>
-        <ProjectReference Condition="'%(Extension)' == '.esproj'">
+        <ProjectReference Condition="'%(ProjectReference.Extension)' == '.esproj' and '%(ProjectReference.ReferenceOutputAssembly)' == ''">
           <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         </ProjectReference>
       </ItemGroup>


### PR DESCRIPTION
Esprojs may be referenced by ASP.Net projects (or others). When this happens, the .net project will have to not reference output assembly on the esproj, because there is no output assembly. This targets provides that behavior. There was an argument for putting this in this file instead of in the sdk. The discussion can be found here: https://github.com/dotnet/sdk/pull/34983
