### PR TITLE
Fix dotnet path for RoslynCodeTaskFactory

### DIFF
--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -1106,8 +1106,7 @@ namespace InlineTask
             var logger = project.BuildProjectExpectSuccess();
             var logLines = logger.AllBuildEvents.Select(a => a.Message);
             var log = string.Join("\n", logLines);
-            var messages = logLines.Where(l => l.Contains(dotnetPath)).ToList();
-            messages.Count.ShouldBe(1, log);
+            logLines.Where(l => l.Contains(dotnetPath)).Count().ShouldBe(1, log);
         }
 #endif
 

--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -1068,6 +1068,7 @@ namespace InlineTask
             }
         }
 
+#if !FEATURE_RUN_EXE_IN_TESTS
         [Fact]
         public void RoslynCodeTaskFactory_UsingAPI()
         {
@@ -1082,7 +1083,6 @@ namespace InlineTask
       <SayHi ParameterType=""System.String"" Required=""true"" />
     </ParameterGroup>
     <Task>
-      <Reference Include=""{typeof(Enumerable).Assembly.Location}"" />
       <Code Type=""Fragment"" Language=""cs"">
         <![CDATA[
         string sayHi = ""Hello "" + SayHi;
@@ -1099,29 +1099,17 @@ namespace InlineTask
 </Project>";
 
             using var env = TestEnvironment.Create();
-#if !FEATURE_RUN_EXE_IN_TESTS
             RunnerUtilities.ApplyDotnetHostPathEnvironmentVariable(env);
-#endif
+            var dotnetPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
 
             var project = env.CreateTestProjectWithFiles("p1.proj", text);
-
             var logger = project.BuildProjectExpectSuccess();
-#if !FEATURE_RUN_EXE_IN_TESTS
-            var filter = "dotnet path is ";
-#else
-            var filter = "Compiling task source code";
-
-#endif
             var logLines = logger.AllBuildEvents.Select(a => a.Message);
             var log = string.Join("\n", logLines);
-            var messages = logLines.Where(l => l.Contains(filter)).ToList();
+            var messages = logLines.Where(l => l.Contains(dotnetPath)).ToList();
             messages.Count.ShouldBe(1, log);
-#if !FEATURE_RUN_EXE_IN_TESTS
-            var dotnetPath = messages[0].Replace(filter, string.Empty);
-            bool isFilePath = File.Exists(dotnetPath);
-            isFilePath.ShouldBeTrue(dotnetPath);
-#endif
         }
+#endif
 
         private void TryLoadTaskBodyAndExpectFailure(string taskBody, string expectedErrorMessage)
         {

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Build.Tasks
             }
 
 #if RUNTIME_TYPE_NETCORE
-            Log.LogMessageFromText($"dotnet path is {dotnetCliPath}", StandardOutputImportanceToUse);
             return dotnetCliPath;
 #else
             return _executablePath.Value;

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Tasks
     internal abstract class RoslynCodeTaskFactoryCompilerBase : ToolTaskExtension
     {
 #if RUNTIME_TYPE_NETCORE
-        private readonly string dotnetCliPath;
+        private readonly string _dotnetCliPath;
 #endif
 
         private readonly Lazy<string> _executablePath;
@@ -48,20 +48,20 @@ namespace Microsoft.Build.Tasks
 #if RUNTIME_TYPE_NETCORE
             // Tools and MSBuild Tasks within the SDK that invoke binaries via the dotnet host are expected
             // to honor the environment variable DOTNET_HOST_PATH to ensure a consistent experience.
-            dotnetCliPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
-            if (string.IsNullOrEmpty(dotnetCliPath))
+            _dotnetCliPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+            if (string.IsNullOrEmpty(_dotnetCliPath))
             {
                 // Fallback to get dotnet path from current process which might be dotnet executable.
-                dotnetCliPath = System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName;
+                _dotnetCliPath = System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName;
             }
 
             // If dotnet path is not found, rely on dotnet via the system's PATH
             bool runningOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             string exeSuffix = runningOnWindows ? ".exe" : string.Empty;
             var dotnetFileName = $"dotnet{exeSuffix}";
-            if (!dotnetCliPath.EndsWith(dotnetFileName, StringComparison.OrdinalIgnoreCase))
+            if (!_dotnetCliPath.EndsWith(dotnetFileName, StringComparison.OrdinalIgnoreCase))
             {
-                dotnetCliPath = "dotnet";
+                _dotnetCliPath = "dotnet";
             }
 #endif
         }
@@ -120,7 +120,7 @@ namespace Microsoft.Build.Tasks
             }
 
 #if RUNTIME_TYPE_NETCORE
-            return dotnetCliPath;
+            return _dotnetCliPath;
 #else
             return _executablePath.Value;
 #endif

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -15,6 +15,12 @@ namespace Microsoft.Build.UnitTests.Shared
         public static string PathToCurrentlyRunningMsBuildExe => BuildEnvironmentHelper.Instance.CurrentMSBuildExePath;
 #if !FEATURE_RUN_EXE_IN_TESTS
         private static readonly string s_dotnetExePath = EnvironmentProvider.GetDotnetExePath();
+
+        public static void ApplyDotnetHostPathEnvironmentVariable(TestEnvironment testEnvironment)
+        {
+            // Built msbuild.dll executed by dotnet.exe needs this environment variable for msbuild tasks such as RoslynCodeTaskFactory.
+            testEnvironment.SetEnvironmentVariable("DOTNET_HOST_PATH", s_dotnetExePath);
+        }
 #endif
 
         /// <summary>


### PR DESCRIPTION
Fixes #9052

### Context
For RoslynCodeTaskFactory, dotnet path is wrongly set using the path of the application when running the application via application.exe.

### Changes Made
Get dotnet path through the following in order.

1. Honor the environment variable DOTNET_HOST_PATH for tools and MSBuild tasks within the SDK to ensure a consistent experience.
2. Fallback to get dotnet path from current process which might be dotnet executable.
3. If the path resolved above is not dotnet executable, rely on dotnet via the system's PATH.

### Testing
Add a test that verifies build the task of RoslynCodeTaskFactory using API.

### Notes
