### PR TITLE
Return false if there are no sources

### DIFF
--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
+using Microsoft.Build.UnitTests.Shared;
 using Microsoft.Build.Utilities;
 using Shouldly;
 using Xunit;
@@ -338,7 +339,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
             /* Unmerged change from project 'Microsoft.Build.Tasks.UnitTests (net7.0)'
             Before:
             Utilities.AssertLogContainsResource(t, "GenerateResource.OutputDoesntExist", t.OutputResources[0].ItemSpec);
-            
+
             Utilities.AssertStateFileWasWritten(t);
             After:
             Utilities.AssertLogContainsResource(t, "GenerateResource.OutputDoesntExist", t.OutputResources[0].ItemSpec);
@@ -1718,7 +1719,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 /* Unmerged change from project 'Microsoft.Build.Tasks.UnitTests (net7.0)'
                 Before:
                 Assert.False(success);
-                
+
                 Utilities.AssertStateFileWasWritten(t);
                 After:
                 Assert.False(success);
@@ -1797,7 +1798,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 /* Unmerged change from project 'Microsoft.Build.Tasks.UnitTests (net7.0)'
                 Before:
                 Assert.False(success);
-                
+
                 Utilities.AssertStateFileWasWritten(t);
                 After:
                 Assert.False(success);
@@ -2317,7 +2318,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 /* Unmerged change from project 'Microsoft.Build.Tasks.UnitTests (net7.0)'
                 Before:
                 Assert.Equal(t.FilesWritten[2].ItemSpec, Path.ChangeExtension(t.Sources[3].ItemSpec, ".resources"));
-                
+
                 Utilities.AssertStateFileWasWritten(t);
                 After:
                 Assert.Equal(t.FilesWritten[2].ItemSpec, Path.ChangeExtension(t.Sources[3].ItemSpec, ".resources"));
@@ -3652,6 +3653,22 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
 
                 Utilities.FileUpdated(resourcesFile, initialWriteTime).ShouldBeFalse();
             }
+        }
+
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        /// <summary>
+        /// https://github.com/dotnet/msbuild/issues/9199
+        /// </summary>
+        [Fact]
+        public void NotValidSources()
+        {
+            GenerateResource t = new GenerateResource { BuildEngine = new MockEngine(_testOutputHelper) };
+            t.Sources = new ITaskItem[] { new TaskItem("non-existent") };
+            t.OutputResources = new ITaskItem[] { new TaskItem("out") };
+            Assert.False(t.Execute());
+            ((MockEngine)t.BuildEngine).AssertLogContains("MSB3552");
+            Assert.Equal(1, ((MockEngine)t.BuildEngine).Errors);
         }
     }
 }

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -3655,15 +3655,13 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
             }
         }
 
-        private readonly ITestOutputHelper _testOutputHelper;
-
         /// <summary>
         /// https://github.com/dotnet/msbuild/issues/9199
         /// </summary>
         [Fact]
         public void NotValidSources()
         {
-            GenerateResource t = new GenerateResource { BuildEngine = new MockEngine(_testOutputHelper) };
+            GenerateResource t = new GenerateResource { BuildEngine = new MockEngine(_output) };
             t.Sources = new ITaskItem[] { new TaskItem("non-existent") };
             t.OutputResources = new ITaskItem[] { new TaskItem("out") };
             Assert.False(t.Execute());

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -714,14 +714,22 @@ namespace Microsoft.Build.Tasks
 
                 GetResourcesToProcess(out inputsToProcess, out outputsToProcess, out cachedOutputFiles);
 
-                if (inputsToProcess.Count == 0 && !Log.HasLoggedErrors)
+                if (inputsToProcess.Count == 0)
                 {
-                    if (cachedOutputFiles.Count > 0)
+                    if (!Log.HasLoggedErrors)
                     {
-                        OutputResources = cachedOutputFiles.ToArray();
-                    }
+                        if (cachedOutputFiles.Count > 0)
+                        {
+                            OutputResources = cachedOutputFiles.ToArray();
+                        }
 
-                    Log.LogMessageFromResources("GenerateResource.NothingOutOfDate");
+                        Log.LogMessageFromResources("GenerateResource.NothingOutOfDate");
+                    }
+                    else
+                    {
+                        // No valid sources found
+                        return false;
+                    }
                 }
                 else if (FailIfNotIncremental)
                 {
@@ -729,6 +737,7 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
+
                     if (!ComputePathToResGen())
                     {
                         // unable to compute the path to resgen.exe and that is necessary to

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -737,7 +737,6 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
-
                     if (!ComputePathToResGen())
                     {
                         // unable to compute the path to resgen.exe and that is necessary to

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -727,7 +727,7 @@ namespace Microsoft.Build.Tasks
                     }
                     else
                     {
-                        // No valid sources found
+                        // No valid sources found--failures should have been logged in GetResourcesToProcess
                         return false;
                     }
                 }


### PR DESCRIPTION
Fixes [#9199](https://github.com/dotnet/msbuild/issues/9199)

### Context
The unhandled exception is from https://github.com/dotnet/msbuild/blob/3c910ba83fc9dbd8e12f50dddc8c381404f928c4/src/Tasks/GenerateResource.cs#L1132C13-L1133.  But when source is not found and has errors, it should return false in Execute function.

### Changes Made
Return false if there are no valid sources found.

### Testing
Add a unit test case.
![image](https://github.com/dotnet/msbuild/assets/26814373/833fc5a0-f928-45d6-b03d-7d8e7cb13586)


### Notes
