### PR TITLE
[ClickOnce] Fix publishing of content items from child projects.

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4359,6 +4359,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <DeploymentComputeClickOnceManifestInfoDependsOn>
       CleanPublishFolder;
+      GetCopyToOutputDirectoryItems;
       _DeploymentGenerateTrustInfo
       $(DeploymentComputeClickOnceManifestInfoDependsOn)
     </DeploymentComputeClickOnceManifestInfoDependsOn>
@@ -4426,7 +4427,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <!-- Include items from None itemgroup for publishing -->
       <_ClickOnceNoneItems Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always' or '%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
 
-      <_ClickOnceFiles Include="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce);@(_ClickOnceRuntimeCopyLocalItems);@(_ClickOnceNoneItems)"/>
+      <_ClickOnceFiles Include="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath);@(NetCoreRuntimeJsonFilesForClickOnce);@(_ClickOnceRuntimeCopyLocalItems);@(_ClickOnceNoneItems);@(_TransitiveItemsToCopyToOutputDirectory)"/>
     </ItemGroup>
 
     <!-- For single file publish, we need to include the SF bundle EXE, application icon file and files excluded from the bundle EXE in the clickonce manifest -->
@@ -5112,7 +5113,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <!-- Empty intermediate items to release memory -->
       <_TransitiveItemsToCopyToOutputDirectoryAlways               Remove="@(_TransitiveItemsToCopyToOutputDirectoryAlways)"/>
       <_TransitiveItemsToCopyToOutputDirectoryPreserveNewest       Remove="@(_TransitiveItemsToCopyToOutputDirectoryPreserveNewest)"/>
-      <_TransitiveItemsToCopyToOutputDirectory                     Remove="@(_TransitiveItemsToCopyToOutputDirectory)"/>
 
       <_ThisProjectItemsToCopyToOutputDirectoryAlways              Remove="@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>
       <_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest      Remove="@(_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest)"/>


### PR DESCRIPTION
[AB#1846089](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1846089)

### Context
ClickOnce is not publishing copy-local content items from child projects. 

### Changes Made
 GetCopyToOutputDirectoryItems target gets the content items of transitive project dependencies. The itemgroup with these contents is however getting cleared. 

With this change, the content item group is being preserved and ClickOnce publishing target is now adding the TransitiveItemsToCopyToOutputDirectory itemgroup to its publish output.

### Testing
Manual testing + Validation from CTI team of both customer repro and functional testing.

### Notes
