### PR TITLE
Change Copy task LogDiagnostics Warning so it is suppressible

### DIFF
--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Build.Tasks
         /// If MSBUILDALWAYSRETRY is set, also log useful diagnostic information -- as 
         /// a warning, so it's easily visible. 
         /// </summary>
-        private void LogDiagnosticFromResource(string messageResourceName, params object[] messageArgs)
+        private void LogAlwaysRetryDiagnosticFromResources(string messageResourceName, params object[] messageArgs)
         {
             if (s_alwaysRetryCopy)
             {
@@ -823,7 +823,7 @@ namespace Microsoft.Build.Tasks
                         case IOException: // Not clear why we can get one and not the other
                             int code = Marshal.GetHRForException(e);
 
-                            LogDiagnosticFromResource("Copy.IOException", e.ToString(), sourceFileState.Name, destinationFileState.Name, code);
+                            LogAlwaysRetryDiagnosticFromResources("Copy.IOException", e.ToString(), sourceFileState.Name, destinationFileState.Name, code);
                             if (code == NativeMethods.ERROR_ACCESS_DENIED)
                             {
                                 // ERROR_ACCESS_DENIED can either mean there's an ACL preventing us, or the file has the readonly bit set.
@@ -839,7 +839,7 @@ namespace Microsoft.Build.Tasks
                                 }
                                 else
                                 {
-                                    LogDiagnosticFromResource("Copy.RetryingOnAccessDenied");
+                                    LogAlwaysRetryDiagnosticFromResources("Copy.RetryingOnAccessDenied");
                                 }
                             }
                             else if (code == NativeMethods.ERROR_INVALID_FILENAME)

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -211,11 +211,11 @@ namespace Microsoft.Build.Tasks
         /// If MSBUILDALWAYSRETRY is set, also log useful diagnostic information -- as 
         /// a warning, so it's easily visible. 
         /// </summary>
-        private void LogDiagnostic(string message, params object[] messageArgs)
+        private void LogDiagnosticFromResource(string messageResourceName, params object[] messageArgs)
         {
             if (s_alwaysRetryCopy)
             {
-                Log.LogWarning(message, messageArgs);
+                Log.LogWarningWithCodeFromResources(messageResourceName, messageArgs);
             }
         }
 
@@ -823,7 +823,7 @@ namespace Microsoft.Build.Tasks
                         case IOException: // Not clear why we can get one and not the other
                             int code = Marshal.GetHRForException(e);
 
-                            LogDiagnostic("Got {0} copying {1} to {2} and HR is {3}", e.ToString(), sourceFileState.Name, destinationFileState.Name, code);
+                            LogDiagnosticFromResource("Copy.IOException", e.ToString(), sourceFileState.Name, destinationFileState.Name, code);
                             if (code == NativeMethods.ERROR_ACCESS_DENIED)
                             {
                                 // ERROR_ACCESS_DENIED can either mean there's an ACL preventing us, or the file has the readonly bit set.
@@ -839,7 +839,7 @@ namespace Microsoft.Build.Tasks
                                 }
                                 else
                                 {
-                                    LogDiagnostic("Retrying on ERROR_ACCESS_DENIED because MSBUILDALWAYSRETRY = 1");
+                                    LogDiagnosticFromResource("Copy.RetryingOnAccessDenied");
                                 }
                             }
                             else if (code == NativeMethods.ERROR_INVALID_FILENAME)

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2782,12 +2782,12 @@
     <comment>{StrBegin="MSB3893: "} LOCALIZATION: {0} and {1} are paths.</comment>
   </data>
   <data name="Copy.IOException">
-    <value>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</value>
-    <comment>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</comment>
+    <value>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</value>
+    <comment>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</comment>
   </data>
   <data name="Copy.RetryingOnAccessDenied">
-    <value>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</value>
-    <comment>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</comment>
+    <value>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</value>
+    <comment>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</comment>
   </data>
 
   <!--

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2781,6 +2781,14 @@
     <value>MSB3893: Could not use a link to copy "{0}" to "{1}".</value>
     <comment>{StrBegin="MSB3893: "} LOCALIZATION: {0} and {1} are paths.</comment>
   </data>
+  <data name="Copy.IOException">
+    <value>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</value>
+    <comment>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</comment>
+  </data>
+  <data name="Copy.RetryingOnAccessDenied">
+    <value>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</value>
+    <comment>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</comment>
+  </data>
 
   <!--
         MSB3901 - MSB3910   Task: Telemetry

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -191,6 +191,11 @@
         <target state="translated">Vytváří se pevný odkaz pro kopírování {0} do {1}.</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: Nedá se použít odkaz pro kopírování {0} do {1}.</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">Nepovedlo se použít pevný odkaz ke zkopírování „{0}“ do „{1}“. Místo toho se soubor kopíruje pomocí symbolického odkazu. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -191,6 +191,11 @@
         <target state="translated">Es wird ein fester Link erstellt, um "{0}" in "{1}" zu kopieren.</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: Es konnte kein Link verwendet werden, um "{0}" in "{1}" zu kopieren.</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">Es konnte kein fester Link verwendet werden, um "{0}" in "{1}" zu kopieren. Stattdessen wird die Datei mit einer symbolischen Verknüpfung kopiert. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -191,6 +191,11 @@
         <target state="translated">Creando un vínculo físico para copiar "{0}" en "{1}".</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: No se puede usar un vínculo para copiar "{0}" en "{1}".</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">No se puede usar un vínculo físico para copiar "{0}" en "{1}". Se va a copiar el archivo en un vínculo simbólico su lugar. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -191,6 +191,11 @@
         <target state="translated">Création d'un lien physique pour copier "{0}" vers "{1}".</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: impossible d'utiliser un lien pour copier "{0}" vers "{1}".</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">Impossible d’utiliser un lien physique pour copier «{0}» vers «{1}». Copie du fichier avec un lien symbolique à la place. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -191,6 +191,11 @@
         <target state="translated">Creazione del collegamento reale per copiare "{0}" in "{1}".</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: non è stato possibile usare un collegamento per copiare "{0}" in "{1}".</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">Impossibile utilizzare un collegamento reale per copiare "{0}" in "{1}". Verrà invece copiato il file con collegamento simbolico. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -191,6 +191,11 @@
         <target state="translated">ハード リンクを作成して "{0}" を "{1}" にコピーしています。</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: リンクを使用して "{0}" を "{1}" にコピーできませんでした。</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">ハード リンクを使用して "{0}" を "{1}" にコピーできませんでした。代わりにシンボリック リンクを使用してファイルをコピーしています。 {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -191,6 +191,11 @@
         <target state="translated">"{0}"을(를) "{1}"(으)로 복사하기 위해 하드 링크를 만듭니다.</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: 링크를 사용하여 "{0}"을(를) "{1}"에 복사할 수 없습니다.</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">하드 링크를 사용하여 "{0}(를) "{1}"에 복사할 수 없습니다. 대신 바로 가기 링크로 파일을 복사합니다. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -191,6 +191,11 @@
         <target state="translated">Tworzenie twardego łącza w celu skopiowania „{0}” do „{1}”.</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: Nie można użyć linku w celu skopiowania ścieżki „{0}” do ścieżki „{1}”.</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">Nie można użyć twardego linku do skopiowania „{0}” do „{1}”. Zamiast tego kopiuje plik za pomocą linku symbolicznego. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -191,6 +191,11 @@
         <target state="translated">Criando link físico para copiar "{0}" em "{1}".</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: Não foi possível usar um link para copiar "{0}" para "{1}".</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">Não foi possível usar um link físico para copiar "{0}" para "{1}". Em vez disso, copiando o arquivo com link simbólico. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -191,6 +191,11 @@
         <target state="translated">Создание жесткой связи для копирования "{0}" в "{1}".</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: не удалось использовать связь для копирования "{0}" в "{1}".</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">Не удалось использовать жесткую связь для копирования "{0}" в "{1}". Выполняется копирование файла с символьной ссылкой. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -191,6 +191,11 @@
         <target state="translated">"{0}" yolunu "{1}" yoluna kopyalamak için sabit bağlantı oluşturuluyor.</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: "{0}" dosyasını "{1}" yoluna kopyalama bağlantısı kullanılamadı.</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">"{0}" yolunu "{1}" yoluna kopyalamak için sabit bağlantı kullanılamadı. Dosya bunun yerine sembolik bağlantı ile kopyalanıyor. {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -191,6 +191,11 @@
         <target state="translated">创建硬链接以将“{0}”复制到“{1}”。</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: 无法使用链接将“{0}”复制到“{1}”。</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">无法使用硬链接将“{0}”复制到“{1}”。改为使用符号链接复制文件。 {2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -192,9 +192,9 @@
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
       <trans-unit id="Copy.IOException">
-        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
-        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
-        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+        <source>MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3894: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3894: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
       </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
@@ -227,9 +227,9 @@
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
       </trans-unit>
       <trans-unit id="Copy.RetryingOnAccessDenied">
-        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
-        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
-        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
+        <source>"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3895: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3895: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -191,6 +191,11 @@
         <target state="translated">正在建立永久連結將 "{0}" 複製到 "{1}"。</target>
         <note>LOCALIZATION: {0} and {1} are paths.</note>
       </trans-unit>
+      <trans-unit id="Copy.IOException">
+        <source>MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</source>
+        <target state="new">MSB3094: "Got {0} copying {1} to {2} and HR is {3}"</target>
+        <note>{StrBegin="MSB3094: "} LOCALIZATION: {0} is exception.ToString(), {1} and {2} are paths, {3} is a number")</note>
+      </trans-unit>
       <trans-unit id="Copy.LinkFailed">
         <source>MSB3893: Could not use a link to copy "{0}" to "{1}".</source>
         <target state="translated">MSB3893: 無法使用連結將 "{0}" 複製到 "{1}"。</target>
@@ -220,6 +225,11 @@
         <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file with symbolic link instead. {2}</source>
         <target state="translated">無法使用永久連結將 "{0}" 複製到 "{1}"。請改為使用符號連結複製檔案。{2}</target>
         <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingOnAccessDenied">
+        <source>"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</source>
+        <target state="new">"MSB3095: Retrying on ERROR_ACCESS_DENIED because environment variable MSBUILDALWAYSRETRY = 1"</target>
+        <note>{StrBegin="MSB3095: "} LOCALIZATION: Do NOT translate MSBUILDALWAYSRETRY")</note>
       </trans-unit>
       <trans-unit id="Copy.SourceIsDirectory">
         <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>


### PR DESCRIPTION
Fixes #9210 

### Context
Copy task implement `LogDiagnostics` as warnings. This is causing issues for `/WarnAsError` use cases.

### Changes Made
Change Copy task `LogDiagnostics` from Warning to low importance Message.
``` C#
/// <summary>
/// If MSBUILDALWAYSRETRY is set, also log useful diagnostic information -- as 
/// a warning, so it's easily visible. 
/// </summary>
private void LogDiagnostic(string message, params object[] messageArgs)
{
    if (s_alwaysRetryCopy)
    {
        Log.LogMessage(MessageImportance.Low, message, messageArgs);
    }
}
```
The reasoning for Warning level "so it's easily visible" is, IMO, not strong enough.

### Testing
Unit tests.
Locally.

### Notes
@rainersigwald  Since we see increasing number of people reporting issues with Copy conflicts, I believe it is candidate for 17.8 