### PR TITLE
Add deprecation notice and links

### DIFF
--- a/src/Framework/CustomBuildEventArgs.cs
+++ b/src/Framework/CustomBuildEventArgs.cs
@@ -11,15 +11,8 @@ namespace Microsoft.Build.Framework
     /// Arguments for custom build events.
     /// </summary>
     /// <remarks>
-    /// In .NET 8 and later, this type is deprecated; instead use <see cref="ExtendedCustomBuildEventArgs"/>.
+    /// In MSBuild 17.8 and later, this type is deprecated; instead use <see cref="ExtendedCustomBuildEventArgs"/>.
     /// For more information, see <see href="https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs"/>
-    ///
-    /// WARNING: marking a type [Serializable] without implementing
-    /// ISerializable imposes a serialization contract -- it is a
-    /// promise to never change the type's fields i.e. the type is
-    /// immutable; adding new fields in the next version of the type
-    /// without following certain special FX guidelines, can break both
-    /// forward and backward compatibility
     /// </remarks>
     [Serializable]
     public abstract class CustomBuildEventArgs : LazyFormattedBuildEventArgs

--- a/src/Framework/CustomBuildEventArgs.cs
+++ b/src/Framework/CustomBuildEventArgs.cs
@@ -10,12 +10,17 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for custom build events.
     /// </summary>
-    // WARNING: marking a type [Serializable] without implementing
-    // ISerializable imposes a serialization contract -- it is a
-    // promise to never change the type's fields i.e. the type is
-    // immutable; adding new fields in the next version of the type
-    // without following certain special FX guidelines, can break both
-    // forward and backward compatibility
+    /// <remarks>
+    /// In .NET 8 and later, this type is deprecated; instead use <see cref="ExtendedCustomBuildEventArgs"/>.
+    /// For more information, see <see href="https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs"/>
+    ///
+    /// WARNING: marking a type [Serializable] without implementing
+    /// ISerializable imposes a serialization contract -- it is a
+    /// promise to never change the type's fields i.e. the type is
+    /// immutable; adding new fields in the next version of the type
+    /// without following certain special FX guidelines, can break both
+    /// forward and backward compatibility
+    /// </remarks>
     [Serializable]
     public abstract class CustomBuildEventArgs : LazyFormattedBuildEventArgs
     {


### PR DESCRIPTION
Fixes #9220 

### Context
CustomBuildEventArgs is deprecated. Users are advised to use ExtendedCustomBuildEventArgs instead.
See https://github.com/dotnet/msbuild/pull/8917

The comment change results in a public-facing doc change at
https://learn.microsoft.com/en-us/dotnet/api/microsoft.build.framework.custombuildeventargs?view=msbuild-17-netcore

The new Remarks section includes a link to a public-facing doc that explains the change:
https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/custombuildeventargs

### Changes Made

Comment only change. 
I added the Remarks tag to be explicit. Previously, the double-slash comment was being implicitly treated as the Remarks section. The tag makes this explicit (not necessary but helpful to avoid ambiguity).

I left the existing warning in place in the Remarks section, even though it seems to be intended as an internal comment. This is present throughout the docs and may be good to review / clean up at some point.
### Testing


### Notes
