### PR TITLE
On windows there can be problems with Tools that do not support Unicode

### DIFF
--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -38,16 +38,10 @@ namespace Microsoft.Build.Shared
         // For all native calls, directly check their return values to prevent bad actors from getting in between checking if a directory exists and returning it.
         private static string CreateFolderUnderTemp()
         {
-            string msbuildTempFolder;
             // On windows Username with Unicode chars can give issues, so we dont append username to the temp folder name.
-            if (NativeMethodsShared.IsWindows)
-            {
-                msbuildTempFolder = msbuildTempFolderPrefix;
-            }
-            else
-            {
-                msbuildTempFolder = msbuildTempFolderPrefix + Environment.UserName;
-            }
+            string msbuildTempFolder = NativeMethodsShared.IsWindows ?
+                msbuildTempFolderPrefix :
+                msbuildTempFolderPrefix + Environment.UserName;
 
             string basePath = Path.Combine(Path.GetTempPath(), msbuildTempFolder);
 

--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Build.Shared
         // Lower order bits correspond to the same for "group" or "other" users.
         private const int userRWX = 0x100 | 0x80 | 0x40;
         private static string tempFileDirectory = null;
+        private const string msbuildTempFolderPrefix = "MSBuildTemp";
+
         internal static string TempFileDirectory
         {
             get
@@ -36,7 +38,18 @@ namespace Microsoft.Build.Shared
         // For all native calls, directly check their return values to prevent bad actors from getting in between checking if a directory exists and returning it.
         private static string CreateFolderUnderTemp()
         {
-            string basePath = Path.Combine(Path.GetTempPath(), $"MSBuildTemp{Environment.UserName}");
+            string msbuildTempFolder;
+            // On windows Username with Unicode chars can give issues, so we dont append username to the temp folder name.
+            if (NativeMethodsShared.IsWindows)
+            {
+                msbuildTempFolder = msbuildTempFolderPrefix;
+            }
+            else
+            {
+                msbuildTempFolder = msbuildTempFolderPrefix + Environment.UserName;
+            }
+
+            string basePath = Path.Combine(Path.GetTempPath(), msbuildTempFolder);
 
             if (NativeMethodsShared.IsLinux && NativeMethodsShared.mkdir(basePath, userRWX) != 0)
             {


### PR DESCRIPTION
Having a Username containing unicode chars, and tools that does not handle that well, makes it difficult when ToolTask are defined from NuGet Packages.

Fixes https://github.com/dotnet/msbuild/issues/9229


### Context
Tmp folder can be changed by updating the User env vars, but Username are not possible. Not prepending the Username makes it possible for Users to handle these rare cases.

### Changes Made
Changed to not append Username on Windows to tmp rsp file location.

### Testing
Tests already for ToolTasks using this.

### Notes
