### PR TITLE
Make the repo buildable with .NET 8 RC1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -401,3 +401,10 @@ dotnet_diagnostic.IDE0270.severity = suggestion
 
 # naming rule violation
 dotnet_diagnostic.IDE1006.severity = suggestion
+
+# Use primary constructor
+dotnet_diagnostic.IDE0290.severity = suggestion
+
+# Collection initialization can be simplified
+dotnet_diagnostic.IDE0300.severity = suggestion
+dotnet_diagnostic.IDE0301.severity = suggestion

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -18,6 +18,7 @@
          This is important for the MSBuild.VSSetup project, which "references" both the x86 and x64
          versions of this project -->
     <RuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' != 'true'">win7-x86;win7-x64</RuntimeIdentifiers>
+    <UseRidGraph>true</UseRidGraph>
 
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -14,6 +14,7 @@
          This is important for the MSBuild.VSSetup project, which "references" both the x86 and x64
          versions of this project -->
     <RuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' != 'true'">win7-x86;win7-x64</RuntimeIdentifiers>
+    <UseRidGraph>true</UseRidGraph>
 
     <EnableDefaultItems>false</EnableDefaultItems>
     <DefineConstants>$(DefineConstants);CLR2COMPATIBILITY;TASKHOST;NO_FRAMEWORK_IVT</DefineConstants>


### PR DESCRIPTION
### Context

RC1 introduced a [breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/rid-graph) related to RID graph. It also appears to have enabled new analyzers by default, which results in a large number of warnings in our tree.

### Changes Made

- Add `<UseRidGraph>true</UseRidGraph>` to opt into the old RID behavior.
- Make IDE0290, IDE0300, and IDE0301 suggestions.

### Testing

Build MSBuild.sln with a recent version of VS 2022.

### Notes

I've tried switching the projects to `<RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>` but I haven't figured out how to do it properly as `win7-x86` and `win7-x64` are still hard-coded in [the SDK](https://github.com/dotnet/sdk/blob/2eadc6e7fec180f6dc4d13b0d1f9597ef676fd2d/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets#L60-L61) for Framework projects.