### PR TITLE
Enable SDL (PoliCheck, Credscan) in official builds

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -40,6 +40,8 @@ variables:
     value: true
   - name: Codeql.Enabled
     value: true
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - group: DotNet-MSBuild-SDLValidation-Params
 
 stages:
 - stage: build
@@ -294,3 +296,16 @@ stages:
       enableSymbolValidation: false
       enableSourceLinkValidation: false
       enableNugetValidation: false
+      SDLValidationParameters:
+        enable: true
+        continueOnError: false
+        params: ' -SourceToolsList @("policheck","credscan")
+        -TsaInstanceURL "$(_TsaInstanceURL)"
+        -TsaProjectName "$(_TsaProjectName)"
+        -TsaNotificationEmail "$(_TsaNotificationEmail)"
+        -TsaCodebaseAdmin "$(_TsaCodebaseAdmin)"
+        -TsaBugAreaPath "$(_TsaBugAreaPath)"
+        -TsaIterationPath "$(_TsaIterationPath)"
+        -TsaRepositoryName "dotnet-msbuild"
+        -TsaCodebaseName "dotnet-msbuild"
+        -TsaPublish $True'

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -308,4 +308,5 @@ stages:
         -TsaIterationPath "$(_TsaIterationPath)"
         -TsaRepositoryName "dotnet-msbuild"
         -TsaCodebaseName "dotnet-msbuild"
-        -TsaPublish $True'
+        -TsaPublish $True
+        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)\eng\policheck_exclusions.xml")'

--- a/eng/policheck_exclusions.xml
+++ b/eng/policheck_exclusions.xml
@@ -1,0 +1,13 @@
+<PoliCheckExclusions>
+  <!-- All strings must be UPPER CASE -->
+  <!--Each of these exclusions is a folder name -if \[name]\exists in the file path, it will be skipped -->
+  <!--<Exclusion Type="FolderPathFull">ABC|XYZ</Exclusion>-->
+  <!--Each of these exclusions is a folder name -if any folder or file starts with "\[name]", it will be skipped -->
+  <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
+  <!--Each of these file types will be completely skipped for the entire scan -->
+  <!--<Exclusion Type="FileType">.ABC|.XYZ</Exclusion>-->
+  <!--The specified file names will be skipped during the scan regardless which folder they are in -->
+  <!--<Exclusion Type="FileName">ABC.TXT|XYZ.CS</Exclusion>-->
+
+  <Exclusion Type="FolderPathFull">.DOTNET</Exclusion>
+</PoliCheckExclusions>


### PR DESCRIPTION
Fixes #6021

### Context
Enable SDL (PoliCheck, Credscan) in official builds.

### Changes Made
Enable SDL run as part of Post-Build Validation Stage.

### Testing


### Notes
