### PR TITLE
Re-enable IdenticalSubmissionsShouldCompleteAndNotHangTheBuildOnMissingTargetExceptions

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -4046,7 +4046,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/msbuild/issues/9245")]
+        [Fact]
         public void IdenticalSubmissionsShouldCompleteAndNotHangTheBuildOnMissingTargetExceptions()
         {
             var projectContents =

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -4114,8 +4114,8 @@ $@"<Project InitialTargets=`Sleep`>
                     submission1.ExecuteAsync(null, null);
                     submission2.ExecuteAsync(null, null);
 
-                    submission1.WaitHandle.WaitOne(TimeSpan.FromSeconds(10));
-                    submission2.WaitHandle.WaitOne(TimeSpan.FromSeconds(10));
+                    submission1.WaitHandle.WaitOne(TimeSpan.FromSeconds(20));
+                    submission2.WaitHandle.WaitOne(TimeSpan.FromSeconds(20));
 
                     submission1.IsCompleted.ShouldBeTrue();
                     submission2.IsCompleted.ShouldBeTrue();


### PR DESCRIPTION
Fixes #9245

### Context

The test was disabled to unblock PR CI.

### Changes Made

Increased the relevant timeout.

### Testing

The test is reliably passing now.

### Notes

This turned out to be an issue with [the sleep command](https://github.com/dotnet/msbuild/blob/914c3e867444ac178bdc4dca78431871bebb415f/src/Shared/UnitTests/ObjectModelHelpers.cs#L1982) we use on Windows. In some cases PowerShell can take a super long time to start. I have been able to reproduce locally by enabling Fusion logging. Thread times of the `powershell` process:

![image](https://github.com/dotnet/msbuild/assets/12206368/76cbe00f-5f5e-496a-8037-0d40f53a9392)

We spend almost 10 seconds just loading assemblies, so the timeout of 10 seconds for the entire build was not enough.

I don't have a full understanding of the mechanism that slows down PowerShell this much. At this point I'm happy we were able to confirm it's not a product issue, although I'm wondering if there is a better and more light-weight sleep command we could use on Windows instead (e.g. `ping 127.0.0.1 -n <seconds>`). Reviewers please opine.

EDIT: In my trace, file system operations block extensively with `wdfilter.sys` on the stack, so the likely explanation for the issue appearing all of a sudden is a Defender update.