### PR TITLE
Add escape hatch MSBUILDCOPYWITHOUTDELETE

### DIFF
--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -189,6 +189,11 @@ namespace Microsoft.Build.Framework
         public readonly bool AlwaysDoImmutableFilesUpToDateCheck = Environment.GetEnvironmentVariable("MSBUILDDONOTCACHEMODIFICATIONTIME") == "1";
 
         /// <summary>
+        /// When copying over an existing file, copy directly into the existing file rather than deleting and recreating.
+        /// </summary>
+        public readonly bool CopyWithoutDelete = Environment.GetEnvironmentVariable("MSBUILDCOPYWITHOUTDELETE") == "1";
+
+        /// <summary>
         /// Emit events for project imports.
         /// </summary>
         private bool? _logProjectImports;

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -285,7 +285,10 @@ namespace Microsoft.Build.Tasks
                 MakeFileWriteable(destinationFileState, true);
             }
 
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_8) && destinationFileState.FileExists && !destinationFileState.IsReadOnly)
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_8) &&
+                Traits.Instance.EscapeHatches.CopyWithoutDelete != true &&
+                destinationFileState.FileExists &&
+                !destinationFileState.IsReadOnly)
             {
                 FileUtilities.DeleteNoThrow(destinationFileState.Name);
             }


### PR DESCRIPTION
Work item (Internal use): N/A

### Summary

This allows an opt-in workaround for #9250 that affected deployment processes can use, mitigating the risk of entirely reverting #8685.

### Customer Impact

Automated deployment of new versions of apps failed in some environments.

### Regression?

Yes, from #8685 (in 7.0.400/MSBuild 17.7).

### Testing

Tests in the affected environment using the more-broadly-scoped `MSBUILDDISABLEFEATURESFROMVERSION=17.8` pass.

### Risk

Minimal--adds new scoped opt-out that is redundant with known successful opt-out, using established mechanisms.