### PR TITLE
Make BinFmt changewave dependent on BinFmt runtime enablement

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -26,8 +26,9 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 ### 17.8
 - [[RAR] Don't do I/O on SDK-provided references](https://github.com/dotnet/msbuild/pull/8688)
 - [Delete destination file before copy](https://github.com/dotnet/msbuild/pull/8685)
-- [New serialization approach for transferring build exceptions between processes](https://github.com/dotnet/msbuild/pull/8779)
 - [Moving from SHA1 to SHA256 for Hash task](https://github.com/dotnet/msbuild/pull/8812)
+- [Deprecating custom derived BuildEventArgs](https://github.com/dotnet/msbuild/pull/8917) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`
+
 
 ### 17.6
 - [Parse invalid property under target](https://github.com/dotnet/msbuild/pull/8190)

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -587,7 +587,8 @@ namespace Microsoft.Build.Execution
 #if RUNTIME_TYPE_NETCORE
                 if (packet is LogMessagePacketBase logMessage
                     && logMessage.EventType == LoggingEventType.CustomEvent 
-                    && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_8) 
+                    &&
+                    (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_8) || !Traits.Instance.EscapeHatches.IsBinaryFormatterSerializationAllowed)
                     && Traits.Instance.EscapeHatches.EnableWarningOnCustomBuildEvent)
                 {
                     BuildEventArgs buildEvent = logMessage.NodeBuildEvent.Value.Value;

--- a/src/Framework/BinaryTranslator.cs
+++ b/src/Framework/BinaryTranslator.cs
@@ -582,12 +582,6 @@ namespace Microsoft.Build.BackEnd
 
             public void TranslateException(ref Exception value)
             {
-                if (!ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_8))
-                {
-                    TranslateDotNet<Exception>(ref value);
-                    return;
-                }
-
                 if (!TranslateNullable(value))
                 {
                     return;
@@ -1291,12 +1285,6 @@ namespace Microsoft.Build.BackEnd
 
             public void TranslateException(ref Exception value)
             {
-                if (!ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_8))
-                {
-                    TranslateDotNet<Exception>(ref value);
-                    return;
-                }
-
                 if (!TranslateNullable(value))
                 {
                     return;

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -400,6 +400,27 @@ namespace Microsoft.Build.Framework
             }
         }
 
+        private bool? _isBinaryFormatterSerializationAllowed;
+        public bool IsBinaryFormatterSerializationAllowed
+        {
+            get
+            {
+                if (!_isBinaryFormatterSerializationAllowed.HasValue)
+                {
+#if RUNTIME_TYPE_NETCORE
+                    AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization",
+                        out bool enabled);
+                    _isBinaryFormatterSerializationAllowed = enabled;
+#else
+                    _isBinaryFormatterSerializationAllowed = true;
+#endif
+                }
+
+                return _isBinaryFormatterSerializationAllowed.Value;
+            }
+        }
+
+
         private static bool? ParseNullableBoolFromEnvironmentVariable(string environmentVariable)
         {
             var value = Environment.GetEnvironmentVariable(environmentVariable);


### PR DESCRIPTION
Fixes #9258 

### Summary
Opting out of 17.8 features (via changewaves env variable) while `EnableUnsafeBinaryFormatterSerialization` is not allowed by the runtime can lead to MSBuild crashing ungracefully.

This is because BinaryFormatter serialization usage in core now leads to runtime failures (as of 8.0) unless explicitly opted-in by user. So MSBuild moved to alternative (secure) serialization. MSBuild normally allows users to opt out of the last batch of changes - with changewaves. In this specific case it can mean shooting self into foot without realizing.

Resolution: Ignoring the opt-out of the new secure serialization unless the BinaryFormatter is explicitly allowed by user in runtime (by editing `MSBuild.runtimeconfig.json` in the SDK).

### Customer Impact

If users have encountered a problem in the latest MSBuild and are working around it by enabling a changewave (for instance, working around the potential deployment blocker #9250), some categories of build failure manifest as an MSBuild crash rather than a failed build with a descriptive error.

### Changes Made

Allow flipping to the legacy serialization only if the BinFmt is allowed in runtime (or we are running on .NET Framework).
For exception serialization - it actually should be just internal technical detail without user behavior change - so not allowing to change this with changewave

### Regression?

Yes, introduced in #8917.

### Testing
Manual (mentioned in the item)

### Risk
Low (adding boolean check populated from AppContext switch)