### PR TITLE
Enable Windows Disabled Drive Enumeration Tests

### DIFF
--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -804,9 +804,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         [InlineData(@"%DRIVE%:\**\*.cs")]
         public void ProjectGetterResultsInWindowsDriveEnumerationWarning(string unevaluatedInclude)
         {
-            var mappedDriveUtils = new DummyMappedDriveUtils(_mappedDrive);
-            var mappedDrive = mappedDriveUtils.GetDummyMappedDrive();
-            unevaluatedInclude = mappedDriveUtils.UpdatePathToMappedDrive(unevaluatedInclude, mappedDrive.MappedDriveLetter);
+            _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
+            unevaluatedInclude = DummyMappedDriveUtils.UpdatePathToMappedDrive(unevaluatedInclude, _mappedDrive.MappedDriveLetter);
             ProjectGetterResultsInDriveEnumerationWarning(unevaluatedInclude);
         }
 
@@ -899,10 +898,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             @"%DRIVE%:\$(Microsoft_WindowsAzure_EngSys)**")]
         public void LogWindowsWarningUponProjectInstanceCreationFromDriveEnumeratingContent(string content, string placeHolder, string excludePlaceHolder = null)
         {
-            var mappedDriveUtils = new DummyMappedDriveUtils(_mappedDrive);
-            _mappedDrive = mappedDriveUtils.GetDummyMappedDrive();
-            placeHolder = mappedDriveUtils.UpdatePathToMappedDrive(placeHolder, _mappedDrive.MappedDriveLetter);
-            excludePlaceHolder = mappedDriveUtils.UpdatePathToMappedDrive(excludePlaceHolder, _mappedDrive.MappedDriveLetter);
+            _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
+            placeHolder = DummyMappedDriveUtils.UpdatePathToMappedDrive(placeHolder, _mappedDrive.MappedDriveLetter);
+            excludePlaceHolder = DummyMappedDriveUtils.UpdatePathToMappedDrive(excludePlaceHolder, _mappedDrive.MappedDriveLetter);
             content = string.Format(content, placeHolder, excludePlaceHolder);
             CleanContentsAndCreateProjectInstanceFromFileWithDriveEnumeratingWildcard(content, false);
         }
@@ -3762,10 +3760,10 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
     public class ProjectItemWithOptimizations_Tests : ProjectItem_Tests
     {
-        public ProjectItemWithOptimizations_Tests()
-        {
-            // Make sure we always use the dictionary-based Remove logic.
-            _env.SetEnvironmentVariable("MSBUILDDICTIONARYBASEDITEMREMOVETHRESHOLD", "0");
-        }
+       public ProjectItemWithOptimizations_Tests()
+       {
+           // Make sure we always use the dictionary-based Remove logic.
+           _env.SetEnvironmentVariable("MSBUILDDICTIONARYBASEDITEMREMOVETHRESHOLD", "0");
+       }
     }
 }

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 ";
 
         protected readonly TestEnvironment _env;
-        private DummyMappedDrive _mappedDrive = null;
+        private Lazy<DummyMappedDrive> _mappedDrive = DummyMappedDriveUtils.GetLazyDummyMappedDrive();
 
         public ProjectItem_Tests()
         {
@@ -67,7 +67,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void Dispose()
         {
             _env.Dispose();
-            _mappedDrive?.Dispose();
+            _mappedDrive.Value?.Dispose();
         }
 
         /// <summary>
@@ -804,8 +804,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         [InlineData(@"%DRIVE%:\**\*.cs")]
         public void ProjectGetterResultsInWindowsDriveEnumerationWarning(string unevaluatedInclude)
         {
-            _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
-            unevaluatedInclude = DummyMappedDriveUtils.UpdatePathToMappedDrive(unevaluatedInclude, _mappedDrive.MappedDriveLetter);
+            unevaluatedInclude = DummyMappedDriveUtils.UpdatePathToMappedDrive(unevaluatedInclude, _mappedDrive.Value.MappedDriveLetter);
             ProjectGetterResultsInDriveEnumerationWarning(unevaluatedInclude);
         }
 
@@ -898,9 +897,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             @"%DRIVE%:\$(Microsoft_WindowsAzure_EngSys)**")]
         public void LogWindowsWarningUponProjectInstanceCreationFromDriveEnumeratingContent(string content, string placeHolder, string excludePlaceHolder = null)
         {
-            _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
-            placeHolder = DummyMappedDriveUtils.UpdatePathToMappedDrive(placeHolder, _mappedDrive.MappedDriveLetter);
-            excludePlaceHolder = DummyMappedDriveUtils.UpdatePathToMappedDrive(excludePlaceHolder, _mappedDrive.MappedDriveLetter);
+            placeHolder = DummyMappedDriveUtils.UpdatePathToMappedDrive(placeHolder, _mappedDrive.Value.MappedDriveLetter);
+            excludePlaceHolder = DummyMappedDriveUtils.UpdatePathToMappedDrive(excludePlaceHolder, _mappedDrive.Value.MappedDriveLetter);
             content = string.Format(content, placeHolder, excludePlaceHolder);
             CleanContentsAndCreateProjectInstanceFromFileWithDriveEnumeratingWildcard(content, false);
         }

--- a/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
@@ -31,11 +31,12 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// The number of built-in metadata for items.
         /// </summary>
         public const int BuiltInMetadataCount = 15;
-        private DummyMappedDrive _mappedDrive = null;
+        private Lazy<DummyMappedDrive> _mappedDrive = DummyMappedDriveUtils.GetLazyDummyMappedDrive();
+
 
         public void Dispose()
         {
-            _mappedDrive?.Dispose();
+            _mappedDrive.Value?.Dispose();
         }
 
         internal const string TargetItemWithInclude = @"
@@ -1027,10 +1028,9 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             @"%DRIVE%:")]
         public void LogWindowsWarningUponBuildingProjectWithDriveEnumeration(string content, string include, string exclude = null, string property = null, string propertyValue = null)
         {
-             _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
-            include = DummyMappedDriveUtils.UpdatePathToMappedDrive(include, _mappedDrive.MappedDriveLetter);
-            exclude = DummyMappedDriveUtils.UpdatePathToMappedDrive(exclude, _mappedDrive.MappedDriveLetter);
-            propertyValue = DummyMappedDriveUtils.UpdatePathToMappedDrive(propertyValue, _mappedDrive.MappedDriveLetter);
+            include = DummyMappedDriveUtils.UpdatePathToMappedDrive(include, _mappedDrive.Value.MappedDriveLetter);
+            exclude = DummyMappedDriveUtils.UpdatePathToMappedDrive(exclude, _mappedDrive.Value.MappedDriveLetter);
+            propertyValue = DummyMappedDriveUtils.UpdatePathToMappedDrive(propertyValue, _mappedDrive.Value.MappedDriveLetter);
             content = (string.IsNullOrEmpty(property) && string.IsNullOrEmpty(propertyValue)) ?
                 string.Format(content, include, exclude) :
                 string.Format(content, property, propertyValue, include);

--- a/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
@@ -12,6 +12,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.UnitTests.Shared;
 using Shouldly;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -24,12 +25,18 @@ namespace Microsoft.Build.UnitTests.OM.Instance
     /// <summary>
     /// Tests for ProjectItemInstance public members
     /// </summary>
-    public class ProjectItemInstance_Tests
+    public class ProjectItemInstance_Tests : IDisposable
     {
         /// <summary>
         /// The number of built-in metadata for items.
         /// </summary>
         public const int BuiltInMetadataCount = 15;
+        private DummyMappedDrive _mappedDrive = null;
+
+        public void Dispose()
+        {
+            _mappedDrive?.Dispose();
+        }
 
         internal const string TargetItemWithInclude = @"
             <Project>
@@ -999,33 +1006,36 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// <summary>
         /// Log warning for drive enumerating wildcards that exist in projects on Windows platform.
         /// </summary>
-        [ActiveIssue("https://github.com/dotnet/msbuild/issues/7330")]
         [WindowsOnlyTheory]
         [InlineData(
             TargetItemWithIncludeAndExclude,
-            @"z:$(Microsoft_WindowsAzure_EngSys)\**\*",
+            @"%DRIVE%:$(Microsoft_WindowsAzure_EngSys)\**\*",
             @"$(Microsoft_WindowsAzure_EngSys)\*.pdb;$(Microsoft_WindowsAzure_EngSys)\Microsoft.WindowsAzure.Storage.dll;$(Microsoft_WindowsAzure_EngSys)\Certificates\**\*")]
 
         [InlineData(
             TargetItemWithIncludeAndExclude,
             @"$(Microsoft_WindowsAzure_EngSys)\*.pdb",
-            @"z:$(Microsoft_WindowsAzure_EngSys)\**\*")]
+            @"%DRIVE%:$(Microsoft_WindowsAzure_EngSys)\**\*")]
 
         [InlineData(
             TargetWithDefinedPropertyAndItemWithInclude,
             @"$(Microsoft_WindowsAzure_EngSys)**",
             null,
             "Microsoft_WindowsAzure_EngSys",
-            @"z:\")]
+            @"%DRIVE%:\")]
 
         [InlineData(
             TargetWithDefinedPropertyAndItemWithInclude,
             @"$(Microsoft_WindowsAzure_EngSys)\**\*",
             null,
             "Microsoft_WindowsAzure_EngSys",
-            @"z:")]
+            @"%DRIVE%:")]
         public void LogWindowsWarningUponBuildingProjectWithDriveEnumeration(string content, string include, string exclude = null, string property = null, string propertyValue = null)
         {
+             _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
+            include = DummyMappedDriveUtils.UpdatePathToMappedDrive(include, _mappedDrive.MappedDriveLetter);
+            exclude = DummyMappedDriveUtils.UpdatePathToMappedDrive(exclude, _mappedDrive.MappedDriveLetter);
+            propertyValue = DummyMappedDriveUtils.UpdatePathToMappedDrive(propertyValue, _mappedDrive.MappedDriveLetter);
             content = (string.IsNullOrEmpty(property) && string.IsNullOrEmpty(propertyValue)) ?
                 string.Format(content, include, exclude) :
                 string.Format(content, property, propertyValue, include);
@@ -1040,7 +1050,6 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// <summary>
         /// Log warning for drive enumerating wildcards that exist in projects on Unix platform.
         /// </summary>
-        [ActiveIssue("https://github.com/dotnet/msbuild/issues/7330")]
         [UnixOnlyTheory]
         [InlineData(
             TargetWithDefinedPropertyAndItemWithInclude,

--- a/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
@@ -1045,6 +1045,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// <summary>
         /// Log warning for drive enumerating wildcards that exist in projects on Unix platform.
         /// </summary>
+        [ActiveIssue("https://github.com/dotnet/msbuild/issues/7330")]
         [UnixOnlyTheory]
         [InlineData(
             TargetWithDefinedPropertyAndItemWithInclude,

--- a/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
@@ -1013,11 +1013,6 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             @"$(Microsoft_WindowsAzure_EngSys)\*.pdb;$(Microsoft_WindowsAzure_EngSys)\Microsoft.WindowsAzure.Storage.dll;$(Microsoft_WindowsAzure_EngSys)\Certificates\**\*")]
 
         [InlineData(
-            TargetItemWithIncludeAndExclude,
-            @"$(Microsoft_WindowsAzure_EngSys)\*.pdb",
-            @"%DRIVE%:$(Microsoft_WindowsAzure_EngSys)\**\*")]
-
-        [InlineData(
             TargetWithDefinedPropertyAndItemWithInclude,
             @"$(Microsoft_WindowsAzure_EngSys)**",
             null,

--- a/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
@@ -1045,7 +1045,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// <summary>
         /// Log warning for drive enumerating wildcards that exist in projects on Unix platform.
         /// </summary>
-        [ActiveIssue("https://github.com/dotnet/msbuild/issues/7330")]
+        [ActiveIssue("https://github.com/dotnet/msbuild/issues/8373")]
         [UnixOnlyTheory]
         [InlineData(
             TargetWithDefinedPropertyAndItemWithInclude,

--- a/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="..\UnitTests.Shared\RunnerUtilities.cs" />
     <Compile Include="..\UnitTests.Shared\DriveMapping.cs" />
     <Compile Include="..\UnitTests.Shared\DummyMappedDrive.cs" />
+    <Compile Include="..\UnitTests.Shared\DummyMappedDriveUtils.cs"/>
     <None Include="..\Shared\UnitTests\App.config">
       <Link>App.config</Link>
       <SubType>Designer</SubType>

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>Microsoft.Build.Engine.UnitTests</AssemblyName>
 
     <DefineConstants>$(DefineConstants);MICROSOFT_BUILD_ENGINE_UNITTESTS</DefineConstants>
-    
+
     <!-- Define a constant so we can skip tests that require MSBuildTaskHost -->
     <DefineConstants Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(MonoBuild)' == 'true'">$(DefineConstants);NO_MSBUILDTASKHOST</DefineConstants>
 
@@ -21,16 +21,14 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="System.Net.Http" />
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" />
-    <PackageReference Include="NuGet.Frameworks" >
+    <PackageReference Include="NuGet.Frameworks">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
     <ProjectReference Include="..\Build\Microsoft.Build.csproj" />
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
     <ProjectReference Include="..\MSBuild\MSBuild.csproj" />
-    <ProjectReference Include="..\MSBuildTaskHost\MSBuildTaskHost.csproj"
-                      Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(MonoBuild)' != 'true'"
-                      Aliases="MSBuildTaskHost" />
+    <ProjectReference Include="..\MSBuildTaskHost\MSBuildTaskHost.csproj" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(MonoBuild)' != 'true'" Aliases="MSBuildTaskHost" />
     <ProjectReference Include="..\Tasks\Microsoft.Build.Tasks.csproj" />
     <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" />
     <ProjectReference Include="..\Xunit.NetCore.Extensions\Xunit.NetCore.Extensions.csproj" />
@@ -48,8 +46,7 @@
       <SetTargetFramework Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">TargetFramework=$(LatestDotNetCoreForMSBuild)</SetTargetFramework>
     </ProjectReference>
 
-    <Reference Include="System.IO.Compression"
-               Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' " />
+    <Reference Include="System.IO.Compression" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' " />
   </ItemGroup>
 
   <ItemGroup>
@@ -85,6 +82,9 @@
     <Compile Include="..\UnitTests.Shared\RunnerUtilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\UnitTests.Shared\DriveMapping.cs" />
+    <Compile Include="..\UnitTests.Shared\DummyMappedDrive.cs" />
+    <Compile Include="..\UnitTests.Shared\DummyMappedDriveUtils.cs" />
     <Compile Include="..\Shared\UnitTests\StreamHelpers.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -144,14 +144,14 @@
     <!-- In TypeLoader, the following logic is used for loading assemblies on .NET Core:
             - if the simple name of the assembly exists in the same folder as msbuild.exe, then that assembly gets loaded, indifferent of the user specified path
             - otherwise, the assembly from the user specified path is loaded, if it exists.
-            
+
           So the custom tasks we are testing can't be in test output folder, because on .NET Core that would affect the loading behavior.  So this
-          target puts them in subfolders of the test output folder instead.    
+          target puts them in subfolders of the test output folder instead.
     -->
 
     <Error Condition="'@(PortableTaskResolvedProjectReferencePath)' == ''" Text="Couldn't find PortableTaskResolvedProjectReferencePath item for PortableTask" />
     <Error Condition="'@(TaskWithDependencyResolvedProjectReferencePath)' == ''" Text="Couldn't find TaskWithDependencyResolvedProjectReferencePath item for TaskWithDependency" />
-    
+
     <PropertyGroup>
       <PortableTaskOutputPath>@(PortableTaskResolvedProjectReferencePath->'%(RootDir)%(Directory)')</PortableTaskOutputPath>
       <TaskWithDependencyOutputPath>@(TaskWithDependencyResolvedProjectReferencePath->'%(RootDir)%(Directory)')</TaskWithDependencyOutputPath>
@@ -163,7 +163,7 @@
       <TaskWithDependencyContentContent Include="$(TaskWithDependencyOutputPath)*.*" />
       <Content Include="@(TaskWithDependencyContentContent)" Link="TaskWithDependency\%(TaskWithDependencyContentContent.Filename)%(TaskWithDependencyContentContent.Extension)" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
-    
+
   </Target>
 
   <ItemDefinitionGroup>
@@ -171,7 +171,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemDefinitionGroup>
-  
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.UnitTests.Shared;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,6 +23,7 @@ namespace Microsoft.Build.UnitTests
     public class FileMatcherTest : IDisposable
     {
         private readonly TestEnvironment _env;
+        private DummyMappedDrive _mappedDrive = null;
 
         public FileMatcherTest(ITestOutputHelper output)
         {
@@ -31,6 +33,7 @@ namespace Microsoft.Build.UnitTests
         public void Dispose()
         {
             _env.Dispose();
+            _mappedDrive?.Dispose();
         }
 
         [Theory]
@@ -1377,18 +1380,20 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/msbuild/issues/7330")]
         [WindowsOnlyTheory]
-        [InlineData(@"z:\**")]
-        [InlineData(@"z:\\**")]
-        [InlineData(@"z:\\\\\\\\**")]
-        [InlineData(@"z:\**\*.cs")]
+        [InlineData(@"%DRIVE%:\**")]
+        [InlineData(@"%DRIVE%:\\**")]
+        [InlineData(@"%DRIVE%:\\\\\\\\**")]
+        [InlineData(@"%DRIVE%:\**\*.cs")]
         public void DriveEnumeratingWildcardIsLoggedOnWindows(string driveEnumeratingWildcard)
         {
             using (var env = TestEnvironment.Create())
             {
                 try
                 {
+                    _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
+                    driveEnumeratingWildcard = DummyMappedDriveUtils.UpdatePathToMappedDrive(driveEnumeratingWildcard, _mappedDrive.MappedDriveLetter);
+
                     // Set env var to log on drive enumerating wildcard detection
                     Helpers.ResetStateForDriveEnumeratingWildcardTests(env, "0");
 

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.UnitTests
     public class FileMatcherTest : IDisposable
     {
         private readonly TestEnvironment _env;
-        private DummyMappedDrive _mappedDrive = null;
+        private Lazy<DummyMappedDrive> _mappedDrive = DummyMappedDriveUtils.GetLazyDummyMappedDrive();
 
         public FileMatcherTest(ITestOutputHelper output)
         {
@@ -33,7 +33,7 @@ namespace Microsoft.Build.UnitTests
         public void Dispose()
         {
             _env.Dispose();
-            _mappedDrive?.Dispose();
+            _mappedDrive.Value?.Dispose();
         }
 
         [Theory]
@@ -1391,8 +1391,7 @@ namespace Microsoft.Build.UnitTests
             {
                 try
                 {
-                    _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
-                    driveEnumeratingWildcard = DummyMappedDriveUtils.UpdatePathToMappedDrive(driveEnumeratingWildcard, _mappedDrive.MappedDriveLetter);
+                    driveEnumeratingWildcard = DummyMappedDriveUtils.UpdatePathToMappedDrive(driveEnumeratingWildcard, _mappedDrive.Value.MappedDriveLetter);
 
                     // Set env var to log on drive enumerating wildcard detection
                     Helpers.ResetStateForDriveEnumeratingWildcardTests(env, "0");

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -34,11 +34,11 @@ namespace Microsoft.Build.UnitTests
             ";
 
         private readonly ITestOutputHelper _testOutput;
-        private DummyMappedDrive _mappedDrive = null;
+        private Lazy<DummyMappedDrive> _mappedDrive = DummyMappedDriveUtils.GetLazyDummyMappedDrive();
 
         public void Dispose()
         {
-            _mappedDrive?.Dispose();
+            _mappedDrive.Value?.Dispose();
         }
 
         public CreateItem_Tests(ITestOutputHelper output)
@@ -327,8 +327,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData(@"%DRIVE%:\\\\**\*.log")]
         public void LogWindowsWarningUponCreateItemExecution(string itemSpec)
         {
-            _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
-            itemSpec = DummyMappedDriveUtils.UpdatePathToMappedDrive(itemSpec, _mappedDrive.MappedDriveLetter);
+            itemSpec = DummyMappedDriveUtils.UpdatePathToMappedDrive(itemSpec, _mappedDrive.Value.MappedDriveLetter);
             VerifyDriveEnumerationWarningLoggedUponCreateItemExecution(itemSpec);
         }
 
@@ -414,8 +413,7 @@ namespace Microsoft.Build.UnitTests
             @"%DRIVE%:$(empty)\**\*.cs")]
         public void LogWindowsWarningUponItemCreationWithDriveEnumeration(string content, string include)
         {
-            _mappedDrive = DummyMappedDriveUtils.GetDummyMappedDrive(_mappedDrive);
-            include = DummyMappedDriveUtils.UpdatePathToMappedDrive(include, _mappedDrive.MappedDriveLetter);
+            include = DummyMappedDriveUtils.UpdatePathToMappedDrive(include, _mappedDrive.Value.MappedDriveLetter);
             content = string.Format(content, include);
             Helpers.CleanContentsAndBuildTargetWithDriveEnumeratingWildcard(
                 content,

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -427,6 +427,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Logs warning when encountering wildcard drive enumeration during CreateItem task execution on Unix platform.
         /// </summary>
+        [ActiveIssue("https://github.com/dotnet/msbuild/issues/8373")]
         [UnixOnlyTheory]
         [InlineData(
             CreateItemWithInclude,

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -335,6 +335,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Logs warning when encountering wildcard drive enumeration during task item creation on Unix platform.
         /// </summary>
+        [ActiveIssue("https://github.com/dotnet/msbuild/issues/8373")]
         [UnixOnlyTheory]
         [InlineData(@"\**")]
         [InlineData(@"\**\*.log")]

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -58,6 +58,9 @@
     <Compile Include="..\Shared\ProcessExtensions.cs" />
     <Compile Include="..\UnitTests.Shared\EnvironmentProvider.cs" />
     <Compile Include="..\UnitTests.Shared\RunnerUtilities.cs" />
+    <Compile Include="..\UnitTests.Shared\DriveMapping.cs" />
+    <Compile Include="..\UnitTests.Shared\DummyMappedDrive.cs" />
+    <Compile Include="..\UnitTests.Shared\DummyMappedDriveUtils.cs" />
     <Compile Include="..\Shared\UnitTests\LongPathSupportDisabledFactAttribute.cs">
       <Link>Shared\LongPathSupportDisabledFactAttribute.cs</Link>
     </Compile>

--- a/src/UnitTests.Shared/DummyMappedDriveUtils.cs
+++ b/src/UnitTests.Shared/DummyMappedDriveUtils.cs
@@ -8,17 +8,8 @@ using Microsoft.Build.UnitTests.Shared;
 
 namespace Microsoft.Build.UnitTests.Shared;
 
-public static class DummyMappedDriveUtils
+internal static class DummyMappedDriveUtils
 {
-    public static DummyMappedDrive GetDummyMappedDrive(DummyMappedDrive mappedDrive)
-    {
-        if (NativeMethods.IsWindows)
-        {
-            mappedDrive ??= new DummyMappedDrive();
-        }
-
-        return mappedDrive;
-    }
     public static string UpdatePathToMappedDrive(string path, char driveLetter)
     {
         const string drivePlaceholder = "%DRIVE%";
@@ -29,4 +20,9 @@ public static class DummyMappedDriveUtils
         }
         return path;
     }
+
+    public static Lazy<DummyMappedDrive?> GetLazyDummyMappedDrive() => new Lazy<DummyMappedDrive?>(() =>
+        {
+            return NativeMethods.IsWindows ? new DummyMappedDrive() : default;
+        });
 }

--- a/src/UnitTests.Shared/DummyMappedDriveUtils.cs
+++ b/src/UnitTests.Shared/DummyMappedDriveUtils.cs
@@ -8,25 +8,18 @@ using Microsoft.Build.UnitTests.Shared;
 
 namespace Microsoft.Build.UnitTests.Shared;
 
-public class DummyMappedDriveUtils
+public static class DummyMappedDriveUtils
 {
-    private DummyMappedDrive _mappedDrive;
-
-    public DummyMappedDriveUtils(DummyMappedDrive mappedDrive)
-    {
-        _mappedDrive = mappedDrive;
-    }
-
-    public DummyMappedDrive GetDummyMappedDrive()
+    public static DummyMappedDrive GetDummyMappedDrive(DummyMappedDrive mappedDrive)
     {
         if (NativeMethods.IsWindows)
         {
-            _mappedDrive ??= new DummyMappedDrive();
+            mappedDrive ??= new DummyMappedDrive();
         }
 
-        return _mappedDrive;
+        return mappedDrive;
     }
-    public string UpdatePathToMappedDrive(string path, char driveLetter)
+    public static string UpdatePathToMappedDrive(string path, char driveLetter)
     {
         const string drivePlaceholder = "%DRIVE%";
         // if this seems to be rooted path - replace with the dummy mount

--- a/src/UnitTests.Shared/DummyMappedDriveUtils.cs
+++ b/src/UnitTests.Shared/DummyMappedDriveUtils.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.UnitTests.Shared;
+
+namespace Microsoft.Build.UnitTests.Shared;
+
+public class DummyMappedDriveUtils
+{
+    private DummyMappedDrive _mappedDrive;
+
+    public DummyMappedDriveUtils(DummyMappedDrive mappedDrive)
+    {
+        _mappedDrive = mappedDrive;
+    }
+
+    public DummyMappedDrive GetDummyMappedDrive()
+    {
+        if (NativeMethods.IsWindows)
+        {
+            _mappedDrive ??= new DummyMappedDrive();
+        }
+
+        return _mappedDrive;
+    }
+    public string UpdatePathToMappedDrive(string path, char driveLetter)
+    {
+        const string drivePlaceholder = "%DRIVE%";
+        // if this seems to be rooted path - replace with the dummy mount
+        if (!string.IsNullOrEmpty(path) && path.StartsWith(drivePlaceholder))
+        {
+            path = driveLetter + path.Substring(drivePlaceholder.Length);
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/7330
(plus one subtask of https://github.com/dotnet/msbuild/issues/8329)

### Changes Made
1. Based on https://github.com/dotnet/msbuild/pull/8366 fixes to enable other Drive enumeration integration tests with a dummy folder in windows
2. Remove one test data https://github.com/dotnet/msbuild/blob/fecef0fdffe59ba8b0251701a23be48bbd552726/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs#L1010-L1012C45 since there is no warning when inlude is not null and exclude with enumerating wildcards. The related logical code is https://github.com/dotnet/msbuild/blob/fecef0fdffe59ba8b0251701a23be48bbd552726/src/Build/Utilities/EngineFileUtilities.cs#L339. There is no condition satisfied.
3. Associate unix Enumeration Tests long time run with issue https://github.com/dotnet/msbuild/issues/8373

