### PR TITLE
Translate FileAccessData in TaskHostTaskComplete

### DIFF
--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -436,7 +436,7 @@ namespace Microsoft.Build.BackEnd
         private void HandleTaskHostTaskComplete(TaskHostTaskComplete taskHostTaskComplete)
         {
 #if FEATURE_REPORTFILEACCESSES
-            if (taskHostTaskComplete.FileAccessData.Count > 0)
+            if (taskHostTaskComplete.FileAccessData?.Count > 0)
             {
                 IFileAccessManager fileAccessManager = ((IFileAccessManager)_buildComponentHost.GetComponent(BuildComponentType.FileAccessManager));
                 foreach (FileAccessData fileAccessData in taskHostTaskComplete.FileAccessData)

--- a/src/Shared/TaskHostTaskComplete.cs
+++ b/src/Shared/TaskHostTaskComplete.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -245,6 +245,9 @@ namespace Microsoft.Build.BackEnd
             translator.TranslateDictionary(ref _buildProcessEnvironment, StringComparer.OrdinalIgnoreCase);
 #if FEATURE_REPORTFILEACCESSES
             translator.Translate(ref _fileAccessData);
+#else
+            bool hasFileAccessData = false;
+            translator.Translate(ref hasFileAccessData);
 #endif
         }
 


### PR DESCRIPTION
### Summary

Fix a reported regression that causes MSBuild to crash in net35-targeting projects.

### Customer Impact

Projects that use the .NET 3.5 taskhost (like projects that target .NET 3.5 and have `.resx` files) fail with `error MSB4217: Task host node exited prematurely.`

### Regression?

Yes, from 17.7. Introduced in #9214.

### Testing

Repro case from VSUnitTesting repo manually validated, automated tests.

### Risk

Low, adds a bool to the translation only in the known-broken case.

### Details

TaskHostTaskComplete packets can be sent between nodes that differ in
FEATURE_REPORTFILEACCESS, causing confusion when the sending side (for
example a net35 taskhost) does not send the FileAccessData field, but
the receiving side (net48) expects it.

Unify this by explicitly sending a bool `false` (no data) in the
!FEATURE_REPORTFILEACCESS case, so there's no difference on the
receiving end between "no data" and "couldn't be any data".