### PR TITLE
Update Microsoft.BuildXL.Processes to 0.1.0-20230929.2

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="LargeAddressAware" Version="1.0.5" />
     <PackageVersion Update="LargeAddressAware" Condition="'$(LargeAddressAwareVersion)' != ''" Version="$(LargeAddressAwareVersion)" />
 
-    <PackageVersion Include="Microsoft.BuildXL.Processes" Version="0.1.0-20230727.4.2" />
+    <PackageVersion Include="Microsoft.BuildXL.Processes" Version="0.1.0-20230929.2" />
     <PackageVersion Update="Microsoft.BuildXL.Processes" Condition="'$(BuildXLProcessesVersion)' != ''" Version="$(BuildXLProcessesVersion)" />
 
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" PrivateAssets="All" />


### PR DESCRIPTION
Update Microsoft.BuildXL.Processes to 0.1.0-20230929.2

This version of the package includes some (dead) code removal which was triggering APIScan bugs.