### PR TITLE
Reduce VS drop retention time for builds

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -217,6 +217,7 @@ stages:
       inputs:
         DropName: $(VisualStudio.DropName)
         DropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+        DropRetentionDays: '30' # extended by insertion + VS release
         AccessToken: '$(System.AccessToken)'
         DropServiceUri: 'https://devdiv.artifacts.visualstudio.com'
         VSDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'


### PR DESCRIPTION
The insertion release definition extends this when we try to insert, and
the VS release will extend it indefinitely for public builds.

Fixes a build warning in our official builds

    ##[warning]DropRetentionDays not set. Defaulting to 10 years (3650
    days). Please reduce drop retention period to 30 days if possible.
