### PR TITLE
Doc MSBUILDLOGALLENVIRONMENTVARIABLES

### DIFF
--- a/documentation/wiki/Binary-Log.md
+++ b/documentation/wiki/Binary-Log.md
@@ -38,6 +38,10 @@ Note that only `*.csproj`, `*.targets` and other MSBuild project formats are col
 
 If the binary log contains the projects/imports files the MSBuild Structured Log Viewer will display all the files contained in the log, let you search through them and even display preprocessed view for any project where all imported projects are inlined (similar to `msbuild /pp` switch).
 
+# Logging all environment variables
+
+By default, MSBuild logs only the environment variables that are used to influence MSBuild, which is a subset of what is set in the environment. This behavior can be changed to log the full environment by setting the environment variable `MSBUILDLOGALLENVIRONMENTVARIABLES=1`.
+
 # Replaying a binary log
 
 Instead of passing the project/solution to MSBuild.exe you can now pass a binary log to "build". This will replay all events to all other loggers (just the console by default). Here's an example of replaying a `.binlog` file to the diagnostic verbosity text log:

--- a/documentation/wiki/Binary-Log.md
+++ b/documentation/wiki/Binary-Log.md
@@ -40,7 +40,7 @@ If the binary log contains the projects/imports files the MSBuild Structured Log
 
 # Logging all environment variables
 
-By default, MSBuild logs only the environment variables that are used to influence MSBuild, which is a subset of what is set in the environment. This behavior can be changed to log the full environment by setting the environment variable `MSBUILDLOGALLENVIRONMENTVARIABLES=1`.
+By default, MSBuild logs only the environment variables that are used to influence MSBuild, which is a subset of what is set in the environment. This reduces, but does not eliminate, the likelihood of leaking sensitive information through logs. This behavior can be changed to log the full environment by setting the environment variable `MSBUILDLOGALLENVIRONMENTVARIABLES=1`.
 
 # Replaying a binary log
 


### PR DESCRIPTION
We generally don't expect people to need to set this, and it increases the likelihood of leaking secrets, but we should document it.
