### PR TITLE
Fix CG alerts caused by RoslynTools.MSBuild 17.7.2

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
     "vs": {
       "version": "17.7.0"
     },
-    "xcopy-msbuild": "17.7.2"
+    "xcopy-msbuild": "17.7.4"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23463.1"


### PR DESCRIPTION
Fixes #

### Context
RoslynTools.MSBuild 17.7.2 caused two CG alerts when doing signing validation. https://github.com/dotnet/arcade/issues/14055 and its linked PRs have more context.

### Changes Made
Following dotnet/arcade update xcopy-msbuild to 17.7.4.

### Testing
I used this experimental branch to verify and no CG alerts were detected.

### Notes
