### PR TITLE
Fix policheck error

### DIFF
--- a/eng/policheck_exclusions.xml
+++ b/eng/policheck_exclusions.xml
@@ -13,5 +13,5 @@
   <!-- This file contains entity names that were written out by the XML writer in the VS.NET 2002/2003 project system. Leave them unchanged and skip the file -->
   <Exclusion Type="FileName">OLDVSPROJECTFILEREADER.CS</Exclusion>
   <!-- A French word is scannded as English derogatory word. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1889125  -->
-  <Exclusion Type="FileName">SRC\MSBUILD\RESOURCES\XLF\STRINGS.FR.XLF</Exclusion>
+  <Exclusion Type="FolderPathFull">SRC\MSBUILD\RESOURCES\XLF\STRINGS.FR.XLF</Exclusion>
 </PoliCheckExclusions>

--- a/eng/policheck_exclusions.xml
+++ b/eng/policheck_exclusions.xml
@@ -10,4 +10,8 @@
   <!--<Exclusion Type="FileName">ABC.TXT|XYZ.CS</Exclusion>-->
 
   <Exclusion Type="FolderPathFull">.DOTNET</Exclusion>
+  <!-- This file contains entity names including the non-geopolitical captical and spades. Leave them unchanged and skip the file -->
+  <Exclusion Type="FileName">OLDVSPROJECTFILEREADER.CS</Exclusion>
+  <!-- A French word is scannded as English derogatory word. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1889125  -->
+  <Exclusion Type="FileName">STRINGS.FR.XLF</Exclusion>
 </PoliCheckExclusions>

--- a/eng/policheck_exclusions.xml
+++ b/eng/policheck_exclusions.xml
@@ -12,6 +12,6 @@
   <Exclusion Type="FolderPathFull">.DOTNET</Exclusion>
   <!-- This file contains entity names that were written out by the XML writer in the VS.NET 2002/2003 project system. Leave them unchanged and skip the file -->
   <Exclusion Type="FileName">OLDVSPROJECTFILEREADER.CS</Exclusion>
-  <!-- A French word is scannded as English derogatory word. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1889125  -->
-  <Exclusion Type="FolderPathFull">SRC\MSBUILD\RESOURCES\XLF\STRINGS.FR.XLF</Exclusion>
+  <!-- Since only support the locale en-us in our repo, skip the translated files currently. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1889125  -->
+  <Exclusion Type="FileType">.XLF</Exclusion>
 </PoliCheckExclusions>

--- a/eng/policheck_exclusions.xml
+++ b/eng/policheck_exclusions.xml
@@ -10,8 +10,8 @@
   <!--<Exclusion Type="FileName">ABC.TXT|XYZ.CS</Exclusion>-->
 
   <Exclusion Type="FolderPathFull">.DOTNET</Exclusion>
-  <!-- This file contains entity names including the non-geopolitical captical and spades. Leave them unchanged and skip the file -->
+  <!-- This file contains entity names that were written out by the XML writer in the VS.NET 2002/2003 project system. Leave them unchanged and skip the file -->
   <Exclusion Type="FileName">OLDVSPROJECTFILEREADER.CS</Exclusion>
   <!-- A French word is scannded as English derogatory word. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1889125  -->
-  <Exclusion Type="FileName">STRINGS.FR.XLF</Exclusion>
+  <Exclusion Type="FileName">SRC\MSBUILD\RESOURCES\XLF\STRINGS.FR.XLF</Exclusion>
 </PoliCheckExclusions>

--- a/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
+++ b/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Build.Tasks
             var cultureString = suggestedRedirect.CultureName;
             if (String.IsNullOrEmpty(cultureString))
             {
-                // We use "neutral" for "Invariant Language (Invariant Country)" in assembly names.
+                // We use "neutral" for "Invariant Language (Invariant Country/Region)" in assembly names.
                 cultureString = "neutral";
             }
 

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1207,7 +1207,7 @@ namespace Microsoft.Build.Tasks
 
                                         assemblyIdentityAttributes.Add(new XAttribute("name", idealRemappingPartialAssemblyName.Name));
 
-                                        // We use "neutral" for "Invariant Language (Invariant Country)" in assembly names.
+                                        // We use "neutral" for "Invariant Language (Invariant Country/Region)" in assembly names.
                                         var cultureString = idealRemappingPartialAssemblyName.CultureName;
                                         assemblyIdentityAttributes.Add(new XAttribute("culture", String.IsNullOrEmpty(idealRemappingPartialAssemblyName.CultureName) ? "neutral" : idealRemappingPartialAssemblyName.CultureName));
 


### PR DESCRIPTION
Fixes policheck:Error

### Changes Made
1. Skip the non en-us locale resource files.
2. Skip the file that contains the specified entity names in the deprecated folder
3. Change country to country/region based on https://policheck.microsoft.com/Pages/TermInfo.aspx?LCID=9&TermID=79570

### Testing
Test with MSBuild pipeline build https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8509007&view=logs&j=7d9eef18-6720-5c1f-4d30-89d7b76728e9&t=c5a86041-9185-53e8-42a2-1cadc4486f0d&l=5251. There are no active results now.


