### PR TITLE
Setup UnGAC: treat 259 as success

### DIFF
--- a/src/Package/Microsoft.Build.UnGAC/exe.swr
+++ b/src/Package/Microsoft.Build.UnGAC/exe.swr
@@ -17,3 +17,8 @@ vs.installSize
 
 vs.payloads
     vs.payload source=$(BinDir)Microsoft.Build.UnGAC.exe
+
+vs.returnCodes
+  vs.returnCode type=success
+    exitCode=259
+    details="Suppress return-code 259 since this is a best-effort ."


### PR DESCRIPTION
One of the top VS Setup failures is a 259 from our UnGAC,
even though we have a big try/catch that should make it
never fail. Tell the Setup engine that 259 is another
kind of success to keep this nonblocking.

Fixes [AB#1899796](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1899796).
