### PR TITLE
Use distinct signal to wait to cancel the submission

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -144,10 +145,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 BuildManager manager = new BuildManager();
                 ProjectCollection collection = new ProjectCollection();
 
+                string sleepCommand = Helpers.GetSleepCommand(TimeSpan.FromSeconds(10));
                 string contents = @"
                     <Project ToolsVersion ='Current'>
                      <Target Name='test'>
-                        <Exec Command='" + Helpers.GetSleepCommand(TimeSpan.FromSeconds(10)) + @"'/>
+                        <Exec Command='" + sleepCommand + @"'/>
                      </Target>
                     </Project>";
 
@@ -168,8 +170,18 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 BuildRequestData data = new BuildRequestData(project.CreateProjectInstance(), new string[] { "test" }, collection.HostServices);
                 manager.BeginBuild(_parameters);
                 BuildSubmission asyncResult = manager.PendBuildRequest(data);
+                string unescapedSleepCommand = sleepCommand.Replace("&quot;", "\"").Replace("&gt;", ">");
+                Func<bool> isSleepCommandExecuted = () => logger.AllBuildEvents.Any(a => unescapedSleepCommand.Equals(a.Message));
+                Task waitCommandExecuted = new Task(() =>
+                {
+                    while (!isSleepCommandExecuted())
+                    {
+                        Task.Delay(TimeSpan.FromMilliseconds(10)).Wait();
+                    }
+                });
                 asyncResult.ExecuteAsync(null, null);
-                Thread.Sleep(500);
+                waitCommandExecuted.Start();
+                waitCommandExecuted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue("Waiting for executing the command timed out.");
                 manager.CancelAllSubmissions();
                 asyncResult.WaitHandle.WaitOne();
                 BuildResult result = asyncResult.BuildResult;

--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -154,6 +153,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     </Project>";
 
                 MockLogger logger = new MockLogger(_testOutput);
+                ManualResetEvent waitCommandExecuted = new ManualResetEvent(false);
+                string unescapedSleepCommand = sleepCommand.Replace("&quot;", "\"").Replace("&gt;", ">");
+                logger.AdditionalHandlers.Add((sender, args) =>
+                {
+                    if (unescapedSleepCommand.Equals(args.Message))
+                    {
+                        waitCommandExecuted.Set();
+                    }
+                });
 
                 var project = new Project(XmlReader.Create(new StringReader(contents)), null, MSBuildConstants.CurrentToolsVersion, collection)
                 {
@@ -170,18 +178,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 BuildRequestData data = new BuildRequestData(project.CreateProjectInstance(), new string[] { "test" }, collection.HostServices);
                 manager.BeginBuild(_parameters);
                 BuildSubmission asyncResult = manager.PendBuildRequest(data);
-                string unescapedSleepCommand = sleepCommand.Replace("&quot;", "\"").Replace("&gt;", ">");
-                Func<bool> isSleepCommandExecuted = () => logger.AllBuildEvents.Any(a => unescapedSleepCommand.Equals(a.Message));
-                Task waitCommandExecuted = new Task(() =>
-                {
-                    while (!isSleepCommandExecuted())
-                    {
-                        Task.Delay(TimeSpan.FromMilliseconds(10)).Wait();
-                    }
-                });
                 asyncResult.ExecuteAsync(null, null);
-                waitCommandExecuted.Start();
-                waitCommandExecuted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue("Waiting for executing the command timed out.");
+                waitCommandExecuted.WaitOne();
                 manager.CancelAllSubmissions();
                 asyncResult.WaitHandle.WaitOne();
                 BuildResult result = asyncResult.BuildResult;

--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -179,11 +179,14 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 manager.BeginBuild(_parameters);
                 BuildSubmission asyncResult = manager.PendBuildRequest(data);
                 asyncResult.ExecuteAsync(null, null);
-                waitCommandExecuted.WaitOne();
+                int timeoutMilliseconds = 2000;
+                bool isCommandExecuted = waitCommandExecuted.WaitOne(timeoutMilliseconds);
                 manager.CancelAllSubmissions();
-                asyncResult.WaitHandle.WaitOne();
+                bool isSubmissionComplated = asyncResult.WaitHandle.WaitOne(timeoutMilliseconds);
                 BuildResult result = asyncResult.BuildResult;
                 manager.EndBuild();
+                isCommandExecuted.ShouldBeTrue($"Waiting for that the sleep command is executed failed in the timeout period {timeoutMilliseconds} ms.");
+                isSubmissionComplated.ShouldBeTrue($"Waiting for that the build submission is completed failed in the timeout period {timeoutMilliseconds} ms.");
 
                 // No errors from cancelling a build.
                 logger.ErrorCount.ShouldBe(0);


### PR DESCRIPTION
Fixes #9298

### Context
Waiting using `Thread.Sleep(500)` in the test is unreliable.

### Changes Made
Wait until the specified log appears rather than `Thread.Sleep(500)`.

### Testing


### Notes
