### PR TITLE
Stop touching GenerateBindingRedirects output

### DIFF
--- a/src/Tasks.UnitTests/GenerateBindingRedirects_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateBindingRedirects_Tests.cs
@@ -291,7 +291,8 @@ namespace Microsoft.Build.Tasks.UnitTests
             redirectResults2.TargetAppConfigContent.ShouldContain("<assemblyIdentity name=\"System\" publicKeyToken=\"b77a5c561934e089\" culture=\"neutral\" />");
             redirectResults2.TargetAppConfigContent.ShouldContain("newVersion=\"40.0.0.0\"");
 
-            File.GetLastWriteTime(outputAppConfigFile).ShouldBeGreaterThan(oldTimestamp);
+            File.GetCreationTime(outputAppConfigFile).ShouldBe(oldTimestamp, TimeSpan.FromSeconds(5));
+            File.GetLastWriteTime(outputAppConfigFile).ShouldBe(oldTimestamp, TimeSpan.FromSeconds(5));
         }
 
         private BindingRedirectsExecutionResult GenerateBindingRedirects(string appConfigFile, string targetAppConfigFile,

--- a/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
+++ b/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -138,13 +138,6 @@ namespace Microsoft.Build.Tasks
                 {
                     doc.Save(stream);
                 }
-            }
-            else if (outputExists)
-            {
-                // if the file exists and the content is up to date, then touch the output file.
-                var now = DateTime.Now;
-                File.SetLastAccessTime(OutputAppConfigFile.ItemSpec, now);
-                File.SetLastWriteTime(OutputAppConfigFile.ItemSpec, now);
             }
 
             return !Log.HasLoggedErrors;


### PR DESCRIPTION
Work item (Internal use): [AB#1875355](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1875355)

### Summary

Revert a behavior change in `GenerateBindingRedirects` that results in overwriting `app-under-development.exe.config` in situations where we didn't before 17.7, causing dev suprise.

### Customer Impact

Broken inner build loop because customizations stored in .exe.config file 

### Regression?

Yes, in 17.7. Introduced in 0aa8c5fc.

### Testing

Manual testing of repro scenario, automated tests.

### Risk

Low. Reverts to previous behavior in a .NET Framework-only codepath.