### PR TITLE
Cache Platform Negotiation in graph build

### DIFF
--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -93,6 +93,9 @@ namespace Microsoft.Build.Graph
 
             RootNodes = GetGraphRoots(EntryPointNodes);
             ProjectNodes = allParsedProjects.Values.Select(p => p.GraphNode).ToList();
+
+            // Clean and release some temporary used large memory objects.
+            _platformNegotiationInstancesCache.Clear();
         }
 
         private static IReadOnlyCollection<ProjectGraphNode> GetGraphRoots(IReadOnlyCollection<ProjectGraphNode> entryPointNodes)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1834963

### Context
PR  https://github.com/dotnet/msbuild/pull/7699 caused perf regression when running large-graphs-with-platform-negotiation kind of build.

Changes:
https://github.com/dotnet/msbuild/blob/867e26043663966e3fa29450476179aea148cd9e/src/Build/Graph/ProjectInterpretation.cs#L182-L184
have caused that dependency projects were evaluated for Platform Negotiation purpose (with null global properties) for each incoming dependency.

### Changes Made
Caching "evaluation for Platform Negotiation purpose".

### Testing
Unit tests.
Local.

### Notes
Without changes it was running 6K evaluations (for VS/VC build) and it took 132 s.
![image](https://github.com/dotnet/msbuild/assets/25249058/25ef0c6d-0d47-471f-8d1e-eef70a2d0765)

After changes only 1.5K evaluations with duration of 33 s.
![image](https://github.com/dotnet/msbuild/assets/25249058/edb7d502-4619-4022-a521-3b2fc5a124fe)

The fact that every dependency has to be specially evaluated for Platform Negotiation purposes has big enough, IMO, negative impact on performance, to reevaluate this approach.

