### PR TITLE
Ensure the built project is retained when restoring fixes #9339

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -619,22 +619,23 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Theory]
-        [InlineData("-getProperty:Foo;Bar", true, "EvalValue", false, false, false, true)]
-        [InlineData("-getProperty:Foo;Bar -t:Build", true, "TargetValue", false, false, false, true)]
-        [InlineData("-getItem:MyItem", false, "", true, false, false, true)]
-        [InlineData("-getItem:MyItem -t:Build", false, "", true, true, false, true)]
-        [InlineData("-getItem:WrongItem -t:Build", false, "", false, false, false, true)]
-        [InlineData("-getProperty:Foo;Bar -getItem:MyItem -t:Build", true, "TargetValue", true, true, false, true)]
-        [InlineData("-getProperty:Foo;Bar -getItem:MyItem", true, "EvalValue", true, false, false, true)]
-        [InlineData("-getProperty:Foo;Bar -getTargetResult:MyTarget", true, "TargetValue", false, false, true, true)]
-        [InlineData("-getProperty:Foo;Bar", true, "EvalValue", false, false, false, false)]
-        [InlineData("-getProperty:Foo;Bar -t:Build", true, "TargetValue", false, false, false, false)]
-        [InlineData("-getItem:MyItem", false, "", true, false, false, false)]
-        [InlineData("-getItem:MyItem -t:Build", false, "", true, true, false, false)]
-        [InlineData("-getItem:WrongItem -t:Build", false, "", false, false, false, false)]
-        [InlineData("-getProperty:Foo;Bar -getItem:MyItem -t:Build", true, "TargetValue", true, true, false, false)]
-        [InlineData("-getProperty:Foo;Bar -getItem:MyItem", true, "EvalValue", true, false, false, false)]
-        [InlineData("-getProperty:Foo;Bar -getTargetResult:MyTarget", true, "TargetValue", false, false, true, false)]
+        [InlineData("-getProperty:Foo;Bar", true, "EvalValue", false, false, false, true, false)]
+        [InlineData("-getProperty:Foo;Bar -t:Build", true, "TargetValue", false, false, false, true, false)]
+        [InlineData("-getItem:MyItem", false, "", true, false, false, true, false)]
+        [InlineData("-getItem:MyItem -t:Build", false, "", true, true, false, true, false)]
+        [InlineData("-getItem:WrongItem -t:Build", false, "", false, false, false, true, false)]
+        [InlineData("-getProperty:Foo;Bar -getItem:MyItem -t:Build", true, "TargetValue", true, true, false, true, false)]
+        [InlineData("-getProperty:Foo;Bar -getItem:MyItem", true, "EvalValue", true, false, false, true, false)]
+        [InlineData("-getProperty:Foo;Bar -getTargetResult:MyTarget", true, "TargetValue", false, false, true, true, false)]
+        [InlineData("-getProperty:Foo;Bar", true, "EvalValue", false, false, false, false, false)]
+        [InlineData("-getProperty:Foo;Bar -t:Build", true, "TargetValue", false, false, false, false, false)]
+        [InlineData("-getItem:MyItem", false, "", true, false, false, false, false)]
+        [InlineData("-getItem:MyItem -t:Build", false, "", true, true, false, false, false)]
+        [InlineData("-getItem:WrongItem -t:Build", false, "", false, false, false, false, false)]
+        [InlineData("-getProperty:Foo;Bar -getItem:MyItem -t:Build", true, "TargetValue", true, true, false, false, false)]
+        [InlineData("-getProperty:Foo;Bar -getItem:MyItem", true, "EvalValue", true, false, false, false, false)]
+        [InlineData("-getProperty:Foo;Bar -getTargetResult:MyTarget", true, "TargetValue", false, false, true, false, false)]
+        [InlineData("-getTargetResult:Restore", false, "", false, false, false, false, true)]
         public void ExecuteAppWithGetPropertyItemAndTargetResult(
             string extraSwitch,
             bool fooPresent,
@@ -642,7 +643,8 @@ namespace Microsoft.Build.UnitTests
             bool itemIncludesAlwaysThere,
             bool itemIncludesTargetItem,
             bool targetResultPresent,
-            bool isGraphBuild)
+            bool isGraphBuild,
+            bool restoreOnly)
         {
             using TestEnvironment env = TestEnvironment.Create();
             TransientTestFile project = env.CreateFile("testProject.csproj", @"
@@ -670,11 +672,15 @@ namespace Microsoft.Build.UnitTests
 
   </Target>
 
+  <Target Name=""Restore"">
+
+  </Target>
+
 </Project>
 ");
             string graph = isGraphBuild ? "--graph" : "";
             string results = RunnerUtilities.ExecMSBuild($" {project.Path} {extraSwitch} {graph}", out bool success);
-            success.ShouldBeTrue();
+            success.ShouldBeTrue(results);
             if (fooPresent)
             {
                 results.ShouldContain($"\"Foo\": \"{fooResult}\"");
@@ -687,7 +693,8 @@ namespace Microsoft.Build.UnitTests
             results.Contains("targetItem").ShouldBe(itemIncludesTargetItem);
 
             results.Contains("MyTarget").ShouldBe(targetResultPresent);
-            results.Contains("\"Result\": \"Success\"").ShouldBe(targetResultPresent);
+            results.Contains("\"Result\": \"Success\"").ShouldBe(targetResultPresent || restoreOnly);
+            results.ShouldNotContain(ResourceUtilities.GetResourceString("BuildFailedWithPropertiesItemsOrTargetResultsRequested"));
         }
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1538,7 +1538,7 @@ namespace Microsoft.Build.CommandLine
 
                             if (enableRestore || restoreOnly)
                             {
-                                result = ExecuteRestore(projectFile, toolsVersion, buildManager, restoreProperties.Count > 0 ? restoreProperties : globalProperties);
+                                result = ExecuteRestore(projectFile, toolsVersion, buildManager, restoreProperties.Count > 0 ? restoreProperties : globalProperties, saveProjectResult: saveProjectResult);
 
                                 if (result.OverallResult != BuildResultCode.Success)
                                 {
@@ -1762,7 +1762,7 @@ namespace Microsoft.Build.CommandLine
             return submission.Execute();
         }
 
-        private static BuildResult ExecuteRestore(string projectFile, string toolsVersion, BuildManager buildManager, Dictionary<string, string> globalProperties)
+        private static BuildResult ExecuteRestore(string projectFile, string toolsVersion, BuildManager buildManager, Dictionary<string, string> globalProperties, bool saveProjectResult = false)
         {
             // Make a copy of the global properties
             Dictionary<string, string> restoreGlobalProperties = new Dictionary<string, string>(globalProperties);
@@ -1779,13 +1779,19 @@ namespace Microsoft.Build.CommandLine
             //     make available an import that doesn't exist yet and the <Import /> might be missing a condition.
             //  - BuildRequestDataFlags.FailOnUnresolvedSdk to still fail in the case when an MSBuild project SDK can't be resolved since this is fatal and should
             //     fail the build.
+            BuildRequestDataFlags flags = BuildRequestDataFlags.ClearCachesAfterBuild | BuildRequestDataFlags.SkipNonexistentTargets | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports | BuildRequestDataFlags.FailOnUnresolvedSdk;
+            if (saveProjectResult)
+            {
+                flags |= BuildRequestDataFlags.ProvideProjectStateAfterBuild;
+            }
+
             BuildRequestData restoreRequest = new BuildRequestData(
                 projectFile,
                 restoreGlobalProperties,
                 toolsVersion,
                 targetsToBuild: new[] { MSBuildConstants.RestoreTargetName },
                 hostServices: null,
-                flags: BuildRequestDataFlags.ClearCachesAfterBuild | BuildRequestDataFlags.SkipNonexistentTargets | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports | BuildRequestDataFlags.FailOnUnresolvedSdk);
+                flags: flags);
 
             return ExecuteBuild(buildManager, restoreRequest);
         }


### PR DESCRIPTION
Fixes #9339

### Context
We need the built project to get the post-build results from it when using get* switches. They were almost always retained, but we didn't keep them if "RestoreOnly" was true. This fixes that.

### Changes Made
Save project when only restoring.

### Testing
Tweaked a unit test to cover this case.

### Notes
