### PR TITLE
Use AssemblyLoadContext Name instead of AppDomain

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
@@ -7,6 +7,9 @@ using System.Collections.Generic;
 using System.Linq;
 #endif
 using System.Reflection;
+#if FEATURE_ASSEMBLYLOADCONTEXT
+using System.Runtime.Loader;
+#endif
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
 
@@ -152,10 +155,15 @@ namespace Microsoft.Build.BackEnd.Components.RequestBuilder
             string? assemblyName = args.LoadedAssembly.FullName;
             string assemblyPath = args.LoadedAssembly.IsDynamic ? string.Empty : args.LoadedAssembly.Location;
             Guid mvid = args.LoadedAssembly.ManifestModule.ModuleVersionId;
+#if FEATURE_ASSEMBLYLOADCONTEXT
+            // AssemblyLoadContext.GetLoadContext returns null when the assembly isn't a RuntimeAssembly, which should not be the case here.
+            // Name would only be null if the AssemblyLoadContext didn't supply a name, but MSBuildLoadContext does.
+            string appDomainDescriptor = AssemblyLoadContext.GetLoadContext(args.LoadedAssembly)?.Name ?? "Unknown";
+#else
             string? appDomainDescriptor = _appDomain.IsDefaultAppDomain()
                 ? null
                 : $"{_appDomain.Id}|{_appDomain.FriendlyName}";
-
+#endif
 
             AssemblyLoadBuildEventArgs buildArgs = new(_context, _initiator, assemblyName, assemblyPath, mvid, appDomainDescriptor);
 

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1987,6 +1987,9 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="TaskAssemblyLoaded" xml:space="preserve">
     <value>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AppDomain: {5})</value>
   </data>
+  <data name="TaskAssemblyLoadedWithAssemblyLoadContext" xml:space="preserve">
+    <value>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</value>
+  </data>
   <data name="NodeReused" xml:space="preserve">
     <value>Reusing node {0} (PID: {1}).</value>
   </data>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -451,6 +451,11 @@
         <target state="translated">Sestavení načtené během {0}{1}: {2} (umístění: {3}, MVID: {4}, AppDomain: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">Úloha {0} uvolnila tento počet jader: {1}. Teď používá celkem tento počet jader: {2}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -451,6 +451,11 @@
         <target state="translated">Assembly während {0}{1} geladen: {2} (Speicherort: {3}, MVID: {4}, AppDomain: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">Die Aufgabe "{0}" hat {1} Kerne freigegeben und belegt jetzt insgesamt {2} Kerne.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -451,6 +451,11 @@
         <target state="translated">Ensamblado cargado durante {0}{1}: {2} (ubicación: {3}, MVID: {4}, AppDomain: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">La tarea "{0}" liberó {1} núcleos y ahora retiene un total de {2} núcleos.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -451,6 +451,11 @@
         <target state="translated">Assembly chargé pendant {0}{1}: {2} (emplacement : {3}, MVID : {4}, AppDomain : {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">La tâche "{0}" a libéré {1} cœur. Elle détient désormais {2} cœurs au total.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -451,6 +451,11 @@
         <target state="translated">Assembly caricato durante {0}{1}: {2} (percorso: {3}, MVID: {4}, AppDomain: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">L'attività "{0}" ha rilasciato {1} core e ora contiene {2} core in totale.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -451,6 +451,11 @@
         <target state="translated">{0}{1} 中にアセンブリが読み込まれました: {2} (場所: {3}、MVID: {4}、AppDomain: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">タスク "{0}" では、{1} 個のコアを解放したため、現在合計 {2} 個のコアを保持しています。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -451,6 +451,11 @@
         <target state="translated">{0}{1} 동안 로드된 어셈블리: {2}(위치: {3}%1, MVID: {4}%2, AppDomain: {5}%2).</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">"{0}" 작업에서 코어 {1}개를 해제했고 지금 총 {2}개의 코어를 보유하고 있습니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -451,6 +451,11 @@
         <target state="translated">Załadowano zestaw podczas {0}{1}: {2} (lokalizacja: {3}, MVID: {4}, domena aplikacji: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">Zadanie „{0}” zwolniło rdzenie ({1}) i teraz jego łączna liczba rdzeni to {2}.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -451,6 +451,11 @@
         <target state="translated">Montagem carregada durante {0}{1}: {2} (localização: {3}, MVID: {4}, AppDomain: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">A tarefa "{0}" liberou {1} núcleos e agora contém {2} núcleos no total.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -451,6 +451,11 @@
         <target state="translated">Сборка загружена во время {0}{1}: {2} (расположение: {3}, MVID: {4}, домен приложения: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">Задача "{0}" освободила указанное число ядер ({1}). Теперь общее число ядер, которыми располагает задача, равно {2}.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -451,6 +451,11 @@
         <target state="translated">Derleme {0}{1} sırasında yüklendi: {2} (konum: {3}, MVID: {4}, AppDomain: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">"{0}" görevi {1} çekirdeği serbest bıraktı. Şu anda toplam {2} çekirdek tutuyor.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -451,6 +451,11 @@
         <target state="translated">程序集加载期间 {0}{1}: {2} (位置: {3}, MVID: {4}, AppDomain: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">任务“{0}”发布了 {1} 个核心，现总共包含 {2} 个核心。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -451,6 +451,11 @@
         <target state="translated">組件在 {0}{1} 期間載入: {2} (位置: {3}，MVID: {4}，AppDomain: {5})</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskAssemblyLoadedWithAssemblyLoadContext">
+        <source>Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</source>
+        <target state="new">Assembly loaded during {0}{1}: {2} (location: {3}, MVID: {4}, AssemblyLoadContext: {5})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">工作 "{0}" 已發行 {1} 個核心，現在共保留 {2} 個核心。</target>

--- a/src/Framework/AssemblyLoadBuildEventArgs.cs
+++ b/src/Framework/AssemblyLoadBuildEventArgs.cs
@@ -79,10 +79,11 @@ namespace Microsoft.Build.Framework
                 {
                     string? loadingInitiator = LoadingInitiator == null ? null : $" ({LoadingInitiator})";
 #if FEATURE_ASSEMBLYLOADCONTEXT
-                    RawMessage = FormatResourceStringIgnoreCodeAndKeyword("TaskAssemblyLoadedWithAssemblyLoadContext", LoadingContext.ToString(), loadingInitiator, AssemblyName, AssemblyPath, MVID.ToString(), AppDomainDescriptor ?? DefaultAppDomainDescriptor);
+                    string resourceName = "TaskAssemblyLoadedWithAssemblyLoadContext";
 #else
-                    RawMessage = FormatResourceStringIgnoreCodeAndKeyword("TaskAssemblyLoaded", LoadingContext.ToString(), loadingInitiator, AssemblyName, AssemblyPath, MVID.ToString(), AppDomainDescriptor ?? DefaultAppDomainDescriptor);
+                    string resourceName = "TaskAssemblyLoaded";
 #endif
+                    RawMessage = FormatResourceStringIgnoreCodeAndKeyword(resourceName, LoadingContext.ToString(), loadingInitiator, AssemblyName, AssemblyPath, MVID.ToString(), AppDomainDescriptor ?? DefaultAppDomainDescriptor);
                 }
 
                 return RawMessage;

--- a/src/Framework/AssemblyLoadBuildEventArgs.cs
+++ b/src/Framework/AssemblyLoadBuildEventArgs.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Build.Framework
         public string? AssemblyName { get; private set; }
         public string? AssemblyPath { get; private set; }
         public Guid MVID { get; private set; }
-        // Null string indicates that load occurred on Default AppDomain (for both Core and Framework).
+        // Null string indicates that load occurred on Default AppDomain (for Framework).
+        // For Core, string won't be null.
         public string? AppDomainDescriptor { get; private set; }
 
         internal override void WriteToStream(BinaryWriter writer)

--- a/src/Framework/AssemblyLoadBuildEventArgs.cs
+++ b/src/Framework/AssemblyLoadBuildEventArgs.cs
@@ -78,7 +78,11 @@ namespace Microsoft.Build.Framework
                 if (RawMessage == null)
                 {
                     string? loadingInitiator = LoadingInitiator == null ? null : $" ({LoadingInitiator})";
+#if FEATURE_ASSEMBLYLOADCONTEXT
+                    RawMessage = FormatResourceStringIgnoreCodeAndKeyword("TaskAssemblyLoadedWithAssemblyLoadContext", LoadingContext.ToString(), loadingInitiator, AssemblyName, AssemblyPath, MVID.ToString(), AppDomainDescriptor ?? DefaultAppDomainDescriptor);
+#else
                     RawMessage = FormatResourceStringIgnoreCodeAndKeyword("TaskAssemblyLoaded", LoadingContext.ToString(), loadingInitiator, AssemblyName, AssemblyPath, MVID.ToString(), AppDomainDescriptor ?? DefaultAppDomainDescriptor);
+#endif
                 }
 
                 return RawMessage;

--- a/src/Shared/UnitTests/TypeLoader_Dependencies_Tests.cs
+++ b/src/Shared/UnitTests/TypeLoader_Dependencies_Tests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Build.UnitTests
                 string dllPath = Path.Combine(dir.Path, TaskDllFileName);
 
                 CheckIfCorrectAssemblyLoaded(output, dllPath);
+                CheckIfCorrectAssemblyLoadedMessageLogged(output);
             }
         }
 
@@ -51,6 +52,7 @@ namespace Microsoft.Build.UnitTests
                 successfulExit.ShouldBeTrue(output);
 
                 CheckIfCorrectAssemblyLoaded(output, newTaskDllPath);
+                CheckIfCorrectAssemblyLoadedMessageLogged(output);
             }
         }
 
@@ -106,6 +108,20 @@ namespace Microsoft.Build.UnitTests
             {
                 scriptOutput.ShouldNotContain(successfulMessage, Case.Insensitive);
             }
+        }
+
+        private void CheckIfCorrectAssemblyLoadedMessageLogged(string scriptOutput)
+        {
+            var assemblyLoadedTaskRun = "Assembly loaded during TaskRun";
+
+#if FEATURE_ASSEMBLYLOADCONTEXT
+            var message = "AssemblyLoadContext: MSBuild plugin";
+#else
+            var message = "AppDomain: [Default]";
+#endif
+
+            scriptOutput.ShouldContain(assemblyLoadedTaskRun);
+            scriptOutput.ShouldContain(message);
         }
     }
 }


### PR DESCRIPTION
Fixes #9348

### Context

When MSBuild was updated to isolate tasks into a custom `AssemblyLoadContext`, `AssemblyLoadsTracker` was not updated to be aware of this change. This means that the log messages always say `AppDomain: [Default]` and don't show any information about which `AssemblyLoadContext` was used to load the assembly.

### Changes Made

When `FEATURE_ASSEMBLYLOADCONTEXT` is defined:
- `AssemblyLoadsTracker` now populates `AssemblyLoadBuildEventArgs` with the name of the `AssemblyLoadContext` used to load the assembly . The `appDomainDescriptor` parameter is re-used to do this.
- A new string resource has been added to update the text of `AssemblyLoadBuildEventArgs.Message` to use label the `AppDomainDescriptor` value as "AssemblyLoadContext" instead of "AppDomain".

### Testing
~~I couldn't find any existing tests that covered `AssemblyLoadsTracker` behavior, so I haven't updated or added any tests yet.~~ Unit tests added.

### Notes

`AssemblyLoadContext.GetLoadContext` can return `null`, but only if the assembly loaded isn't derived from `RuntimeAssembly`. The only way I'm aware that would be true is if `MetadataLoadContext` was used to load the assembly as `ReflectionOnly`, and I wouldn't think that would be a relevant case here. For now, if it was `null` for some reason, I've made `appDomainDescriptor` have the value "unknown". Otherwise, if I let the `null` through, `AssemblyLoadBuildEventArgs` would print "[Default]" in its message, which would not be correct.

I added a new string resource in a separate commit because I wasn't sure if that would be okay or not. I know that means there's some translation work to do. Looking at the existing translations for `TaskAssemblyLoaded`, since "AppDomain" isn't translated, it looks like it should just be a matter of copying the existing one and replacing that one word.