### PR TITLE
Revert #9130

### DIFF
--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -507,6 +507,7 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
                 }
             }
 
+
             AssertCacheBuild(graph, testData, mockCache, logger, nodesToBuildResults, targets: null);
         }
 
@@ -763,59 +764,6 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             graphResult.ShouldHaveSucceeded();
 
             logger.AssertMessageCount("MSB4274", 1);
-        }
-
-        // A common scenario is to get a request for N targets, but only some of them can be handled by the cache.
-        // In this case, missing targets should be passed through.
-        [Fact]
-        public async Task PartialProxyTargets()
-        {
-            const string ProjectContent = """
-                <Project>
-                  <Target Name="SomeTarget">
-                    <Message Text="SomeTarget running" />
-                  </Target>
-                  <Target Name="ProxyTarget">
-                    <Message Text="ProxyTarget running" />
-                  </Target>
-                  <Target Name="SomeOtherTarget">
-                    <Message Text="SomeOtherTarget running" />
-                  </Target>
-                </Project>
-                """;
-            TransientTestFile project = _env.CreateFile($"project.proj", ProjectContent);
-
-            BuildParameters buildParameters = new()
-            {
-                ProjectCacheDescriptor = ProjectCacheDescriptor.FromInstance(
-                    new ConfigurableMockCache
-                    {
-                        GetCacheResultImplementation = (_, _, _) =>
-                        {
-                            return Task.FromResult(
-                                CacheResult.IndicateCacheHit(
-                                    new ProxyTargets(
-                                        new Dictionary<string, string>
-                                        {
-                                            { "ProxyTarget", "SomeTarget" },
-                                        })));
-                        }
-                    }),
-            };
-
-            MockLogger logger;
-            using (Helpers.BuildManagerSession buildSession = new(_env, buildParameters))
-            {
-                logger = buildSession.Logger;
-                BuildResult buildResult = await buildSession.BuildProjectFileAsync(project.Path, new[] { "SomeTarget", "SomeOtherTarget" });
-
-                buildResult.Exception.ShouldBeNull();
-                buildResult.ShouldHaveSucceeded();
-            }
-
-            logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("SomeTarget running");
-            logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("ProxyTarget running");
-            logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("SomeOtherTarget running");
         }
 
         private void AssertCacheBuild(

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1783,30 +1783,15 @@ namespace Microsoft.Build.Execution
 
         private static void AddProxyBuildRequestToSubmission(
             BuildSubmission submission,
-            BuildRequestConfiguration configuration,
+            int configurationId,
             ProxyTargets proxyTargets,
             int projectContextId)
         {
-            IReadOnlyDictionary<string, string> realTargetsToProxyTargets = proxyTargets.RealTargetToProxyTargetMap;
-
-            ICollection<string> requestedTargets = submission.BuildRequestData.TargetNames.Count > 0
-                ? submission.BuildRequestData.TargetNames
-                : configuration.Project.DefaultTargets;
-            List<string> targets = new(requestedTargets.Count);
-            foreach (string requestedTarget in requestedTargets)
-            {
-                string effectiveTarget = realTargetsToProxyTargets.TryGetValue(requestedTarget, out string proxyTarget)
-                    ? proxyTarget
-                    : requestedTarget;
-                targets.Add(effectiveTarget);
-            }
-
             submission.BuildRequest = new BuildRequest(
                 submission.SubmissionId,
                 BackEnd.BuildRequest.InvalidNodeRequestId,
-                configuration.ConfigurationId,
+                configurationId,
                 proxyTargets,
-                targets,
                 submission.BuildRequestData.HostServices,
                 submission.BuildRequestData.Flags,
                 submission.BuildRequestData.RequestedProjectState,
@@ -2309,7 +2294,7 @@ namespace Microsoft.Build.Execution
                         {
                             // Setup submission.BuildRequest with proxy targets. The proxy request is built on the inproc node (to avoid
                             // ProjectInstance serialization). The proxy target results are used as results for the real targets.
-                            AddProxyBuildRequestToSubmission(submission, configuration, cacheResult.ProxyTargets, projectContextId);
+                            AddProxyBuildRequestToSubmission(submission, configuration.ConfigurationId, cacheResult.ProxyTargets, projectContextId);
                             IssueBuildRequestForBuildSubmission(submission, configuration, allowMainThreadBuild: false);
                         }
                         else if (cacheResult.ResultType == CacheResultType.CacheHit && cacheResult.BuildResult != null)

--- a/src/Build/BackEnd/Components/ProjectCache/ProxyTargets.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProxyTargets.cs
@@ -27,23 +27,6 @@ namespace Microsoft.Build.Experimental.ProjectCache
         /// </summary>
         public IReadOnlyDictionary<string, string> ProxyTargetToRealTargetMap => _proxyTargetToRealTargetMap;
 
-        internal IReadOnlyDictionary<string, string> RealTargetToProxyTargetMap
-        {
-            get
-            {
-                // The ProxyTargetToRealTargetMap is "backwards" from how most users would want to use it and doesn't provide as much flexibility as it could if reversed.
-                // Unfortunately this is part of a public API so cannot easily change at this point.
-                Dictionary<string, string> realTargetsToProxyTargets = new(ProxyTargetToRealTargetMap.Count, StringComparer.OrdinalIgnoreCase);
-                foreach (KeyValuePair<string, string> kvp in ProxyTargetToRealTargetMap)
-                {
-                    // In the case of multiple proxy targets pointing to the same real target, the last one wins. Another awkwardness of ProxyTargetToRealTargetMap being "backwards".
-                    realTargetsToProxyTargets[kvp.Value] = kvp.Key;
-                }
-
-                return realTargetsToProxyTargets;
-            }
-        }
-
         private ProxyTargets()
         {
         }

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -128,7 +128,6 @@ namespace Microsoft.Build.BackEnd
         /// <param name="nodeRequestId">The id of the node issuing the request</param>
         /// <param name="configurationId">The configuration id to use.</param>
         /// <param name="proxyTargets"><see cref="ProxyTargets"/></param>
-        /// <param name="targets">The set of targets to execute</param>
         /// <param name="hostServices">Host services if any. May be null.</param>
         /// <param name="buildRequestDataFlags">Additional flags for the request.</param>
         /// <param name="requestedProjectState">Filter for desired build results.</param>
@@ -138,7 +137,6 @@ namespace Microsoft.Build.BackEnd
             int nodeRequestId,
             int configurationId,
             ProxyTargets proxyTargets,
-            List<string> targets,
             HostServices hostServices,
             BuildRequestDataFlags buildRequestDataFlags = BuildRequestDataFlags.None,
             RequestedProjectState requestedProjectState = null,
@@ -146,7 +144,7 @@ namespace Microsoft.Build.BackEnd
             : this(submissionId, nodeRequestId, configurationId, hostServices, buildRequestDataFlags, requestedProjectState, projectContextId)
         {
             _proxyTargets = proxyTargets;
-            _targets = targets;
+            _targets = proxyTargets.ProxyTargetToRealTargetMap.Keys.ToList();
 
             // Only root requests can have proxy targets.
             _parentGlobalRequestId = InvalidGlobalRequestId;

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -745,6 +745,13 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrow(_projectInitialTargets != null, "Initial targets have not been set.");
             ErrorUtilities.VerifyThrow(_projectDefaultTargets != null, "Default targets have not been set.");
 
+            if (request.ProxyTargets != null)
+            {
+                ErrorUtilities.VerifyThrow(
+                    CollectionHelpers.SetEquivalent(request.Targets, request.ProxyTargets.ProxyTargetToRealTargetMap.Keys),
+                    "Targets must be same as proxy targets");
+            }
+
             List<string> initialTargets = _projectInitialTargets;
             List<string> nonInitialTargets = (request.Targets.Count == 0) ? _projectDefaultTargets : request.Targets;
 


### PR DESCRIPTION
Revert ["Populate unproxied targets to avoid dropping requested targets (#9130)"](https://github.com/dotnet/msbuild/pull/9130)

This reverts commit 4256aed414cfbb6b32dc072c763145beb8fe0c0b.

Fixes [AB#1906434](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1906434).