### PR TITLE
Add ExtendedCriticalBuildMessageEventArgs and related tests

### DIFF
--- a/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ExtendedBuildMessageEventArgs extMessage = new("extMsg", "SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender", MessageImportance.Normal);
             ExtendedCustomBuildEventArgs extCustom = new("extCustom", "message", "help", "sender");
             CriticalBuildMessageEventArgs criticalMessage = new("Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "Sender", DateTime.Now, "arg1");
+            ExtendedCriticalBuildMessageEventArgs extCriticalMessage = new("extCritMsg", "Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "Sender", DateTime.Now, "arg1");
             PropertyInitialValueSetEventArgs propInit = new("prop", "val", "propsource", "message", "help", "sender", MessageImportance.Normal);
             MetaprojectGeneratedEventArgs metaProjectGenerated = new("metaName", "path", "message");
             PropertyReassignmentEventArgs propReassign = new("prop", "prevValue", "newValue", "loc", "message", "help", "sender", MessageImportance.Normal);
@@ -98,6 +99,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             VerifyLoggingPacket(extMessage, LoggingEventType.ExtendedBuildMessageEvent);
             VerifyLoggingPacket(extCustom, LoggingEventType.ExtendedCustomEvent);
             VerifyLoggingPacket(criticalMessage, LoggingEventType.CriticalBuildMessage);
+            VerifyLoggingPacket(extCriticalMessage, LoggingEventType.ExtendedCriticalBuildMessageEvent);
             VerifyLoggingPacket(propInit, LoggingEventType.PropertyInitialValueSet);
             VerifyLoggingPacket(metaProjectGenerated, LoggingEventType.MetaprojectGenerated);
             VerifyLoggingPacket(propReassign, LoggingEventType.PropertyReassignment);
@@ -294,6 +296,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
                         BuildEventContext = new BuildEventContext(1, 2, 3, 4, 5, 6, 7)
                     },
                     new ExtendedCustomBuildEventArgs("extCustom", "message", "help", "sender", DateTime.UtcNow, "arg1")
+                    {
+                        ExtendedData = "{'long-json':'mostly-strings'}",
+                        ExtendedMetadata = new Dictionary<string, string> { { "m1", "v1" }, { "m2", "v2" } },
+                        BuildEventContext = new BuildEventContext(1, 2, 3, 4, 5, 6, 7)
+                    },
+                    new ExtendedCriticalBuildMessageEventArgs("extCritMsg", "Subcategory", "Code", "File", 1, 2, 3, 4, "{0}", "HelpKeyword", "Sender", DateTime.Now, "arg1")
                     {
                         ExtendedData = "{'long-json':'mostly-strings'}",
                         ExtendedMetadata = new Dictionary<string, string> { { "m1", "v1" }, { "m2", "v2" } },

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -574,6 +574,48 @@ namespace Microsoft.Build.UnitTests
                 e => e.Subcategory);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RoundtripExtendedCriticalBuildMessageEventArgs(bool withOptionalData)
+        {
+            var args = new ExtendedCriticalBuildMessageEventArgs(
+                "extCrit",
+                "Subcategory",
+                "Code",
+                "File",
+                1,
+                2,
+                3,
+                4,
+                "Message",
+                "Help",
+                "SenderName",
+                DateTime.Parse("12/12/2015 06:11:56 PM"),
+                withOptionalData ? new object[] { "argument0" } : null)
+            {
+                ExtendedData = withOptionalData ? "{'long-json':'mostly-strings'}" : null,
+                ExtendedMetadata = withOptionalData ? new Dictionary<string, string> { { "m1", "v1" }, { "m2", "v2" } } : null,
+                BuildEventContext = withOptionalData ? new BuildEventContext(1, 2, 3, 4, 5, 6, 7) : null,
+            };
+
+
+            Roundtrip(args,
+                e => e.Code,
+                e => e.ColumnNumber.ToString(),
+                e => e.EndColumnNumber.ToString(),
+                e => e.EndLineNumber.ToString(),
+                e => e.File,
+                e => e.LineNumber.ToString(),
+                e => e.Message,
+                e => e.ProjectFile,
+                e => e.Subcategory,
+                e => e.ExtendedType,
+                e => TranslationHelpers.ToString(e.ExtendedMetadata),
+                e => e.ExtendedData,
+                e => string.Join(", ", e.RawArguments ?? Array.Empty<object>()));
+        }
+
         [Fact]
         public void RoundtripTaskCommandLineEventArgs()
         {

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -798,21 +798,49 @@ namespace Microsoft.Build.Logging
         {
             var fields = ReadBuildEventArgsFields(readImportance: true);
 
-            var e = new CriticalBuildMessageEventArgs(
-                fields.Subcategory,
-                fields.Code,
-                fields.File,
-                fields.LineNumber,
-                fields.ColumnNumber,
-                fields.EndLineNumber,
-                fields.EndColumnNumber,
-                fields.Message,
-                fields.HelpKeyword,
-                fields.SenderName,
-                fields.Timestamp,
-                fields.Arguments);
+            BuildEventArgs e;
+            if (fields.Extended == null)
+            {
+                e = new CriticalBuildMessageEventArgs(
+                    fields.Subcategory,
+                    fields.Code,
+                    fields.File,
+                    fields.LineNumber,
+                    fields.ColumnNumber,
+                    fields.EndLineNumber,
+                    fields.EndColumnNumber,
+                    fields.Message,
+                    fields.HelpKeyword,
+                    fields.SenderName,
+                    fields.Timestamp,
+                    fields.Arguments)
+                {
+                    ProjectFile = fields.ProjectFile,
+                };
+            }
+            else
+            {
+                e = new ExtendedCriticalBuildMessageEventArgs(
+                    fields.Extended?.ExtendedType ?? string.Empty,
+                    fields.Subcategory,
+                    fields.Code,
+                    fields.File,
+                    fields.LineNumber,
+                    fields.ColumnNumber,
+                    fields.EndLineNumber,
+                    fields.EndColumnNumber,
+                    fields.Message,
+                    fields.HelpKeyword,
+                    fields.SenderName,
+                    fields.Timestamp,
+                    fields.Arguments)
+                {
+                    ProjectFile = fields.ProjectFile,
+                    ExtendedMetadata = fields.Extended?.ExtendedMetadata,
+                    ExtendedData = fields.Extended?.ExtendedData,
+                };
+            }
             e.BuildEventContext = fields.BuildEventContext;
-            e.ProjectFile = fields.ProjectFile;
             return e;
         }
 

--- a/src/Framework/ExtendedCriticalBuildMessageEventArgs.cs
+++ b/src/Framework/ExtendedCriticalBuildMessageEventArgs.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Framework;
+
+/// <summary>
+/// Critical message events arguments including extended data for event enriching.
+/// Extended data are implemented by <see cref="IExtendedBuildEventArgs"/>
+/// </summary>
+public sealed class ExtendedCriticalBuildMessageEventArgs : CriticalBuildMessageEventArgs, IExtendedBuildEventArgs
+{
+    /// <inheritdoc />
+    public string ExtendedType { get; set; }
+
+    /// <inheritdoc />
+    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
+
+    /// <inheritdoc />
+    public string? ExtendedData { get; set; }
+
+    /// <summary>
+    /// This constructor allows all event data to be initialized
+    /// </summary>
+    /// <param name="type">Type of <see cref="IExtendedBuildEventArgs.ExtendedType"/>.</param>
+    /// <param name="subcategory">event subcategory</param>
+    /// <param name="code">event code</param>
+    /// <param name="file">file associated with the event</param>
+    /// <param name="lineNumber">line number (0 if not applicable)</param>
+    /// <param name="columnNumber">column number (0 if not applicable)</param>
+    /// <param name="endLineNumber">end line number (0 if not applicable)</param>
+    /// <param name="endColumnNumber">end column number (0 if not applicable)</param>
+    /// <param name="message">text message</param>
+    /// <param name="helpKeyword">help keyword </param>
+    /// <param name="senderName">name of event sender</param>
+    public ExtendedCriticalBuildMessageEventArgs(
+        string type,
+        string? subcategory,
+        string? code,
+        string? file,
+        int lineNumber,
+        int columnNumber,
+        int endLineNumber,
+        int endColumnNumber,
+        string? message,
+        string? helpKeyword,
+        string? senderName)
+        : this(type, subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, DateTime.UtcNow)
+    {
+        // do nothing
+    }
+
+    /// <summary>
+    /// This constructor allows timestamp to be set
+    /// </summary>
+    /// <param name="type">Type of <see cref="IExtendedBuildEventArgs.ExtendedType"/>.</param>
+    /// <param name="subcategory">event subcategory</param>
+    /// <param name="code">event code</param>
+    /// <param name="file">file associated with the event</param>
+    /// <param name="lineNumber">line number (0 if not applicable)</param>
+    /// <param name="columnNumber">column number (0 if not applicable)</param>
+    /// <param name="endLineNumber">end line number (0 if not applicable)</param>
+    /// <param name="endColumnNumber">end column number (0 if not applicable)</param>
+    /// <param name="message">text message</param>
+    /// <param name="helpKeyword">help keyword </param>
+    /// <param name="senderName">name of event sender</param>
+    /// <param name="eventTimestamp">custom timestamp for the event</param>
+    public ExtendedCriticalBuildMessageEventArgs(
+        string type,
+        string? subcategory,
+        string? code,
+        string? file,
+        int lineNumber,
+        int columnNumber,
+        int endLineNumber,
+        int endColumnNumber,
+        string? message,
+        string? helpKeyword,
+        string? senderName,
+        DateTime eventTimestamp)
+        : this(type, subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, eventTimestamp, null!)
+    {
+        // do nothing
+    }
+
+    /// <summary>
+    /// This constructor allows timestamp to be set
+    /// </summary>
+    /// <param name="type">Type of <see cref="IExtendedBuildEventArgs.ExtendedType"/>.</param>
+    /// <param name="subcategory">event subcategory</param>
+    /// <param name="code">event code</param>
+    /// <param name="file">file associated with the event</param>
+    /// <param name="lineNumber">line number (0 if not applicable)</param>
+    /// <param name="columnNumber">column number (0 if not applicable)</param>
+    /// <param name="endLineNumber">end line number (0 if not applicable)</param>
+    /// <param name="endColumnNumber">end column number (0 if not applicable)</param>
+    /// <param name="message">text message</param>
+    /// <param name="helpKeyword">help keyword </param>
+    /// <param name="senderName">name of event sender</param>
+    /// <param name="eventTimestamp">custom timestamp for the event</param>
+    /// <param name="messageArgs">message arguments</param>
+    public ExtendedCriticalBuildMessageEventArgs(
+        string type,
+        string? subcategory,
+        string? code,
+        string? file,
+        int lineNumber,
+        int columnNumber,
+        int endLineNumber,
+        int endColumnNumber,
+        string? message,
+        string? helpKeyword,
+        string? senderName,
+        DateTime eventTimestamp,
+        params object[]? messageArgs)
+        //// Force importance to High. 
+        : base(subcategory, code, file, lineNumber, columnNumber, endLineNumber, endColumnNumber, message, helpKeyword, senderName, eventTimestamp, messageArgs) => ExtendedType = type;
+
+    /// <summary>
+    /// Default constructor. Used for deserialization.
+    /// </summary>
+    internal ExtendedCriticalBuildMessageEventArgs() : this("undefined")
+    {
+        // do nothing
+    }
+
+    /// <summary>
+    /// This constructor specifies only type of extended data.
+    /// </summary>
+    /// <param name="type">Type of <see cref="IExtendedBuildEventArgs.ExtendedType"/>.</param>
+    public ExtendedCriticalBuildMessageEventArgs(string type) => ExtendedType = type;
+
+    internal override void WriteToStream(BinaryWriter writer)
+    {
+        base.WriteToStream(writer);
+        writer.WriteExtendedBuildEventData(this);
+    }
+
+    internal override void CreateFromStream(BinaryReader reader, int version)
+    {
+        base.CreateFromStream(reader, version);
+        reader.ReadExtendedBuildEventData(this);
+    }
+}

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -199,7 +199,12 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Event is <see cref="UninitializedPropertyReadEventArgs"/>
         /// </summary>
-        UninitializedPropertyRead = 32
+        UninitializedPropertyRead = 32,
+
+        /// <summary>
+        /// Event is <see cref="ExtendedCriticalBuildMessageEventArgs"/>
+        /// </summary>
+        ExtendedCriticalBuildMessageEvent = 33,
     }
     #endregion
 
@@ -597,6 +602,7 @@ namespace Microsoft.Build.Shared
                 LoggingEventType.ExtendedBuildErrorEvent => new ExtendedBuildErrorEventArgs(),
                 LoggingEventType.ExtendedBuildWarningEvent => new ExtendedBuildWarningEventArgs(),
                 LoggingEventType.ExtendedBuildMessageEvent => new ExtendedBuildMessageEventArgs(),
+                LoggingEventType.ExtendedCriticalBuildMessageEvent => new ExtendedCriticalBuildMessageEventArgs(),
                 LoggingEventType.ExternalProjectStartedEvent => new ExternalProjectStartedEventArgs(null, null, null, null, null),
                 LoggingEventType.ExternalProjectFinishedEvent => new ExternalProjectFinishedEventArgs(null, null, null, null, false),
                 LoggingEventType.CriticalBuildMessage => new CriticalBuildMessageEventArgs(null, null, null, -1, -1, -1, -1, null, null, null),
@@ -694,6 +700,10 @@ namespace Microsoft.Build.Shared
             else if (eventType == typeof(CriticalBuildMessageEventArgs))
             {
                 return LoggingEventType.CriticalBuildMessage;
+            }
+            else if (eventType == typeof(ExtendedCriticalBuildMessageEventArgs))
+            {
+                return LoggingEventType.ExtendedCriticalBuildMessageEvent;
             }
             else if (eventType == typeof(MetaprojectGeneratedEventArgs))
             {


### PR DESCRIPTION
Fixes #9355

### Context
During 1st phase of creating Extended events we I have missed CriticalBuildMessageEventArgs

### Changes Made
ExtendedCriticalBuildMessageEventArgs 
Related unit tests

### Testing
Local
Uni tests

### Notes
This change does not break logviewer - tested - however another small PR in log viewer will be done to better support it.
Old log viewer:
![image](https://github.com/dotnet/msbuild/assets/25249058/814a3091-361c-4c17-af48-72725ba34005)
Future log viewer:
![image](https://github.com/dotnet/msbuild/assets/25249058/fbe6b19b-89eb-4a65-a707-cc01abdaa614)
