### PR TITLE
Fix TL failure on MSBUILDNOINPROCNODE env variable

### DIFF
--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -196,7 +196,8 @@ internal sealed class TerminalLogger : INodeLogger
     /// <inheritdoc/>
     public void Initialize(IEventSource eventSource, int nodeCount)
     {
-        _nodes = new NodeStatus[nodeCount];
+        // When MSBUILDNOINPROCNODE enabled, NodeId reported by build equals 2. We need to reserve an extra spot for this case. 
+        _nodes = new NodeStatus[nodeCount + 1];
 
         Initialize(eventSource);
     }
@@ -500,10 +501,7 @@ internal sealed class TerminalLogger : INodeLogger
         lock (_lock)
         {
             int nodeIndex = NodeIndexForContext(buildEventContext);
-            if (_nodes != null && _nodes.Length - 1 >= nodeIndex)
-            {
-                _nodes[nodeIndex] = nodeStatus;
-            }
+            _nodes[nodeIndex] = nodeStatus;
         }
     }
 

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -191,7 +191,10 @@ internal sealed class TerminalLogger : INodeLogger
     public LoggerVerbosity Verbosity { get => LoggerVerbosity.Minimal; set { } }
 
     /// <inheritdoc/>
-    public string Parameters { get => ""; set { } }
+    public string Parameters
+    {
+        get => ""; set { }
+    }
 
     /// <inheritdoc/>
     public void Initialize(IEventSource eventSource, int nodeCount)


### PR DESCRIPTION
Fixes #9322

### Context
In an attempt to build an invalid project with MSBUILDNOINPROCNODE=1, the exception "Out of boundary" was thrown.


### Changes Made
Add a check before accessing the array element by index.

### Testing
UTs are added
