### PR TITLE
Graph: Mimic quirk for sln-based builds with target name containing semicolon

### DIFF
--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -21,7 +21,7 @@ using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Graph
 {
-    internal class GraphBuilder
+    internal sealed class GraphBuilder
     {
         internal const string SolutionItemReference = "_SolutionReference";
 
@@ -37,6 +37,8 @@ namespace Microsoft.Build.Graph
         public IReadOnlyCollection<ProjectGraphNode> EntryPointNodes { get; private set; }
 
         public GraphEdges Edges { get; private set; }
+
+        public bool IsSolution { get; private set; }
 
         private readonly List<ConfigurationMetadata> _entryPointConfigurationMetadata;
 
@@ -257,8 +259,7 @@ namespace Microsoft.Build.Graph
                         string.Join(";", entryPoints.Select(e => e.ProjectFile))));
             }
 
-            ErrorUtilities.VerifyThrowArgument(entryPoints.Count == 1, "StaticGraphAcceptsSingleSolutionEntryPoint");
-
+            IsSolution = true;
             ProjectGraphEntryPoint solutionEntryPoint = entryPoints.Single();
             ImmutableDictionary<string, string>.Builder solutionGlobalPropertiesBuilder = ImmutableDictionary.CreateBuilder(
                 keyComparer: StringComparer.OrdinalIgnoreCase,

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -601,16 +601,14 @@ namespace Microsoft.Build.Graph
         {
             ThrowOnEmptyTargetNames(entryProjectTargets);
 
-            List<string> entryTargets = entryProjectTargets == null ? null : new(entryProjectTargets);
-
             // Solutions have quirky behavior when provided a target with ';' in it, eg "Clean;Build". This can happen if via the command-line the user provides something
             // like /t:"Clean;Build". When building a project, the target named "Clean;Build" is executed (which usually doesn't exist, but could). However, for solutions
             // the generated metaproject ends up calling the MSBuild task with the provided targets, which ends up splitting the value as if it were [ "Clean", "Build" ].
             // Mimic this flattening behavior for consistency.
             if (_isSolution && entryProjectTargets != null && entryProjectTargets.Count != 0)
             {
-                List<string> newEntryTargets = new(entryTargets.Count);
-                foreach (string entryTarget in entryTargets)
+                List<string> newEntryTargets = new(entryProjectTargets.Count);
+                foreach (string entryTarget in entryProjectTargets)
                 {
                     foreach (string s in ExpressionShredder.SplitSemiColonSeparatedList(entryTarget))
                     {
@@ -618,7 +616,7 @@ namespace Microsoft.Build.Graph
                     }
                 }
 
-                entryTargets = newEntryTargets;
+                entryProjectTargets = newEntryTargets;
             }
 
             // Seed the dictionary with empty lists for every node. In this particular case though an empty list means "build nothing" rather than "default targets".
@@ -629,9 +627,9 @@ namespace Microsoft.Build.Graph
 
             foreach (ProjectGraphNode entryPointNode in EntryPointNodes)
             {
-                ImmutableList<string> nodeEntryTargets = entryTargets == null || entryTargets.Count == 0
+                ImmutableList<string> nodeEntryTargets = entryProjectTargets == null || entryProjectTargets.Count == 0
                     ? ImmutableList.CreateRange(entryPointNode.ProjectInstance.DefaultTargets)
-                    : ImmutableList.CreateRange(entryTargets);
+                    : ImmutableList.CreateRange(entryProjectTargets);
                 var entryEdge = new ProjectGraphBuildRequest(entryPointNode, nodeEntryTargets);
                 encounteredEdges.Add(entryEdge);
                 edgesToVisit.Enqueue(entryEdge);

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -8,7 +8,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 using Microsoft.Build.Evaluation;


### PR DESCRIPTION
Fixes #9376

There is a quirk for solution builds for targets containing semicolons. For example if you do a solution build using `/t:"Clean;Build"`, the metaproject ends up calling the `<MSBuild>` task using that value, which ends up splitting it into two targes: "Clean" and "Build". However if you try the same thing on a project, it will actually end up attempting to call a target named "Clean;Build", which would also certainly fail in practice (although in theory there could be a distinct target with that crazy name).

This change just mimics that quirk for graph builds.

See linked issue for a practical repro and test cases.