### PR TITLE
Exec: use C instead of en_US.UTF-8 to set the Exec locale.

### DIFF
--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -590,9 +590,7 @@ namespace Microsoft.Build.Tasks
             {
                 commandLine.AppendSwitch("-c");
                 commandLine.AppendTextUnquoted(" \"");
-                // Set the locale to the POSIX 'Computer C' English locale.
-                // This makes the task command output the same text independent of the system locale.
-                commandLine.AppendTextUnquoted("export LANG=C; export LC_ALL=C; . ");
+                commandLine.AppendTextUnquoted(". ");
                 commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
                 commandLine.AppendTextUnquoted("\"");
             }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -590,7 +590,7 @@ namespace Microsoft.Build.Tasks
             {
                 commandLine.AppendSwitch("-c");
                 commandLine.AppendTextUnquoted(" \"");
-                commandLine.AppendTextUnquoted("export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; . ");
+                commandLine.AppendTextUnquoted("export LANG=C.UTF-8; export LC_ALL=C.UTF-8; . ");
                 commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
                 commandLine.AppendTextUnquoted("\"");
             }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -590,9 +590,9 @@ namespace Microsoft.Build.Tasks
             {
                 commandLine.AppendSwitch("-c");
                 commandLine.AppendTextUnquoted(" \"");
-                // Set the locale to 'Computer C' English UTF-8 output.
-                // This makes the task output the same text regardless of the configured locale.
-                commandLine.AppendTextUnquoted("export LANG=C.UTF-8; export LC_ALL=C.UTF-8; . ");
+                // Set the locale to the POSIX 'Computer C' English locale.
+                // This makes the task command output the same text independent of the system locale.
+                commandLine.AppendTextUnquoted("export LANG=C; export LC_ALL=C; . ");
                 commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
                 commandLine.AppendTextUnquoted("\"");
             }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -590,6 +590,8 @@ namespace Microsoft.Build.Tasks
             {
                 commandLine.AppendSwitch("-c");
                 commandLine.AppendTextUnquoted(" \"");
+                // Set the locale to 'Computer C' English UTF-8 output.
+                // This makes the task output the same text regardless of the configured locale.
                 commandLine.AppendTextUnquoted("export LANG=C.UTF-8; export LC_ALL=C.UTF-8; . ");
                 commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
                 commandLine.AppendTextUnquoted("\"");


### PR DESCRIPTION
The en_US locale can't be used on systems where it is not installed. This is common in container images.

On such systems, setting the locale to en_US.UTF-8 causes unexpected warnings to be written to standard error.

When Exec.LogStandardErrorAsError is set, these warnings cause the Task to fail due to logging errors.

This changes to use the 'Computer English' C.UTF-8 locale, which is always available.

Fixes https://github.com/dotnet/msbuild/issues/4194

@rainersigwald @wfurt @janvorli ptal

cc @mthalman @omajid 