### PR TITLE
Fix the ui language override helper method for input language "en" 

### DIFF
--- a/src/Framework/EncodingUtilities.cs
+++ b/src/Framework/EncodingUtilities.cs
@@ -272,10 +272,7 @@ namespace Microsoft.Build.Shared
             CultureInfo? externalLanguageSetting = GetExternalOverriddenUILanguage();
             if (externalLanguageSetting != null)
             {
-                if (
-                    !externalLanguageSetting.TwoLetterISOLanguageName.Equals("en", StringComparison.InvariantCultureIgnoreCase) &&
-                    CurrentPlatformIsWindowsAndOfficiallySupportsUTF8Encoding()
-                    )
+                if (CurrentPlatformIsWindowsAndOfficiallySupportsUTF8Encoding())
                 {
                     // Setting both encodings causes a change in the CHCP, making it so we don't need to P-Invoke CHCP ourselves.
                     Console.OutputEncoding = Encoding.UTF8;

--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -895,22 +895,6 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(2, exec.ConsoleOutput.Length);
         }
 
-        /// <summary>
-        /// Test the CanEncode method with and without ANSI characters to determine if they can be encoded 
-        /// in the current system encoding.
-        /// </summary>
-        [WindowsOnlyFact]
-        public void CanEncodeTest()
-        {
-            var defaultEncoding = EncodingUtilities.CurrentSystemOemEncoding;
-
-            string nonAnsiCharacters = "\u521B\u5EFA";
-            string pathWithAnsiCharacters = @"c:\windows\system32\cmd.exe";
-
-            Assert.False(EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, nonAnsiCharacters));
-            Assert.True(EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, pathWithAnsiCharacters));
-        }
-
         [Fact]
         public void EndToEndMultilineExec()
         {

--- a/src/Utilities.UnitTests/EncodingUtilities_Tests.cs
+++ b/src/Utilities.UnitTests/EncodingUtilities_Tests.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests
+{
+    public sealed class EncodingUtilities_Tests
+    {
+        /// <summary>
+        /// Test the CanEncode method with and without ANSI characters to determine if they can be encoded 
+        /// in the current system encoding.
+        /// </summary>
+        [WindowsOnlyFact]
+        public void CanEncodeTest()
+        {
+            var defaultEncoding = EncodingUtilities.CurrentSystemOemEncoding;
+
+            string nonAnsiCharacters = "\u521B\u5EFA";
+            string pathWithAnsiCharacters = @"c:\windows\system32\cmd.exe";
+
+            Assert.False(EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, nonAnsiCharacters));
+            Assert.True(EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, pathWithAnsiCharacters));
+        }
+
+        /// <summary>
+        /// Test for bug where the MSBuild does not respect "en" CultureInfo
+        /// </summary>
+        [WindowsOnlyTheory]
+        [InlineData("en", "en")]
+        [InlineData("jp", "jp")]
+        [InlineData("fr", "fr")]
+        public void GetExternalOverriddenUILanguageIfSupportableWithEncoding_RespectsOverriddenLanguage(string inputLanguage, string expectedLanguage)
+        {
+            if (!EncodingUtilities.CurrentPlatformIsWindowsAndOfficiallySupportsUTF8Encoding())
+            {
+                return; // Do not run test to replicate the behaviour of the invoking method
+            }
+            const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
+            using TestEnvironment testEnvironment = TestEnvironment.Create();
+            
+            // Override the ui language by setting environment variable
+            testEnvironment.SetEnvironmentVariable(DOTNET_CLI_UI_LANGUAGE, inputLanguage);
+
+            var result = EncodingUtilities.GetExternalOverriddenUILanguageIfSupportableWithEncoding();
+            Assert.Equal(new CultureInfo(expectedLanguage), result);
+        }
+    }
+}

--- a/src/Utilities.UnitTests/EncodingUtilities_Tests.cs
+++ b/src/Utilities.UnitTests/EncodingUtilities_Tests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -33,7 +34,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Test for bug where the MSBuild does not respect "en" CultureInfo
         /// </summary>
-        [WindowsOnlyTheory]
+        [Theory]
         [InlineData("en", "en")]
         [InlineData("jp", "jp")]
         [InlineData("fr", "fr")]

--- a/src/Utilities.UnitTests/EncodingUtilities_Tests.cs
+++ b/src/Utilities.UnitTests/EncodingUtilities_Tests.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Shouldly;
 using Xunit;
 
 #nullable disable
@@ -27,8 +28,8 @@ namespace Microsoft.Build.UnitTests
             string nonAnsiCharacters = "\u521B\u5EFA";
             string pathWithAnsiCharacters = @"c:\windows\system32\cmd.exe";
 
-            Assert.False(EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, nonAnsiCharacters));
-            Assert.True(EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, pathWithAnsiCharacters));
+            EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, nonAnsiCharacters).ShouldBeFalse();
+            EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, pathWithAnsiCharacters).ShouldBeTrue();
         }
 
         /// <summary>
@@ -50,8 +51,7 @@ namespace Microsoft.Build.UnitTests
             // Override the ui language by setting environment variable
             testEnvironment.SetEnvironmentVariable(DOTNET_CLI_UI_LANGUAGE, inputLanguage);
 
-            var result = EncodingUtilities.GetExternalOverriddenUILanguageIfSupportableWithEncoding();
-            Assert.Equal(new CultureInfo(expectedLanguage), result);
+            EncodingUtilities.GetExternalOverriddenUILanguageIfSupportableWithEncoding().ShouldBeEquivalentTo(new CultureInfo(expectedLanguage));
         }
     }
 }


### PR DESCRIPTION
Fixes #9254

### Context
DOTNET_CLI_UI_LANGUAGE enviroment variable was not respected when TwoLetterISOLanguageName of CultureInfo was equal to en. 

### Changes Made
Removed the additional check for described in the context case

### Testing
Case covered by unit test of the method additionally to testing in debug mode. 
