### PR TITLE
Catch InvalidProjectFileException Fixes #9394

### DIFF
--- a/src/Build/Logging/SimpleErrorLogger.cs
+++ b/src/Build/Logging/SimpleErrorLogger.cs
@@ -70,11 +70,11 @@ namespace Microsoft.Build.Logging.SimpleErrorLogger
         {
             if (acceptAnsiColorCodes)
             {
-                Console.Error.Write(AnsiCodes.Colorize(message, color));
+                Console.Error.WriteLine(AnsiCodes.Colorize(message, color));
             }
             else
             {
-                Console.Error.Write(message);
+                Console.Error.WriteLine(message);
             }
         }
 

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -618,6 +618,17 @@ namespace Microsoft.Build.UnitTests
             });
         }
 
+        [Fact]
+        public void GetPropertyWithInvalidProjectThrowsInvalidProjectFileExceptionNotInternalError()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            TransientTestFile project = env.CreateFile("testProject.csproj", "Project");
+            string result = RunnerUtilities.ExecMSBuild($" {project.Path} -getProperty:Foo", out bool success);
+            success.ShouldBeFalse();
+            result.ShouldContain("MSB4025");
+            result.ShouldNotContain("MSB1025");
+        }
+
         [Theory]
         [InlineData("-getProperty:Foo;Bar", true, "EvalValue", false, false, false, true, false)]
         [InlineData("-getProperty:Foo;Bar -t:Build", true, "TargetValue", false, false, false, true, false)]

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -818,9 +818,8 @@ namespace Microsoft.Build.CommandLine
                                 collection.LogBuildFinishedEvent(exitType == ExitType.Success);
                             }
                         }
-                        catch (InvalidProjectFileException e)
+                        catch (InvalidProjectFileException)
                         {
-                            Console.Error.WriteLine(e.Message);
                             return ExitType.BuildError;
                         }
                     }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -820,7 +820,7 @@ namespace Microsoft.Build.CommandLine
                         }
                         catch (InvalidProjectFileException)
                         {
-                            return ExitType.BuildError;
+                            exitType = ExitType.BuildError;
                         }
                     }
                     else // regular build

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -900,6 +900,10 @@ namespace Microsoft.Build.CommandLine
 
                 exitType = ExitType.SwitchError;
             }
+            catch (InvalidProjectFileException)
+            {
+                exitType = ExitType.BuildError;
+            }
             // handle configuration exceptions: problems reading toolset information from msbuild.exe.config or the registry
             catch (InvalidToolsetDefinitionException e)
             {


### PR DESCRIPTION
Fixes #9394

### Context
InvalidProjectFileExceptions thrown by attempting to get the properties or items from an invalid project are not handled specially in XMake's big try/catch, which means they are caught as a generic "exception" and thrown as an unexpected internal error when in fact this should be an expected user error. This resolves that problem.

While poking at this, I happened to notice that if an error is logged, the next message is on the same line. I think it's better UI to move it to its own line, so that's the second commit.

### Changes Made
Handle InvalidProjectFileExceptions as expected/user errors.

Add \n to errors logged by SimpleErrorLogger.

### Testing
I tried the repro in 9394 and successfully reproduced the problem. I tried with this change, and it instead printed this:
[path]\invalid.proj(1,1): error MSB4025: The project file could not be loaded. Data at the root level is invalid. Line 1, position 1.

in red. That looks good to me.

To see what other bugs I might uncover, I also tried adding /t to force it into the post-build version, but that failed in the expected way.

Then I (briefly) looked for other types of errors that might get thrown at this point. I saw internal errors (but that seems legitimate to be thrown as internal) and logger exceptions, but those are already handled. If anyone is aware of any other kinds of errors that might arise that I should handle, please do let me know.

### Notes
