### PR TITLE
Don't throw on lazy item updating unexpanded globs

### DIFF
--- a/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
@@ -9,6 +9,8 @@ using System.Text;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
+
+using Shouldly;
 using Xunit;
 
 #nullable disable
@@ -622,6 +624,41 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 // recursive dir does not work with lazy wildcards
                 Assert.Equal(string.Empty, project.GetConcatenatedItemsOfType("RecursiveDir"));
             }
+        }
+
+        [Fact]
+        public void DoesNotCrashWhenUnEvaluatedWildCardLooksLikeUNC()
+        {
+            var content = """
+                <Project>
+
+                  <PropertyGroup>
+                    <A>$(B)\</A>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <None Include="$(A)\csc.*" />
+                    <None Update="2.txt">
+                      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+                    </None>
+                  </ItemGroup>
+
+                  <Target Name="a" />
+
+                </Project>
+                """.Cleanup();
+
+            using var env = TestEnvironment.Create();
+
+            var projectFiles = env.CreateTestProjectWithFiles(content);
+
+            env.SetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes", ".*");
+
+            EngineFileUtilities.CaptureLazyWildcardRegexes();
+
+            Project project = Should.NotThrow(() => new Project(projectFiles.ProjectFile));
+
+            project.GetConcatenatedItemsOfType("None").ShouldContain("csc.*");
         }
 
         [Theory]

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -436,14 +436,11 @@ namespace Microsoft.Build.Evaluation
 
             private static void ProcessNonWildCardItemUpdates(Dictionary<string, UpdateOperation> itemsWithNoWildcards, OrderedItemDataCollection.Builder items)
             {
-#if DEBUG
-                ErrorUtilities.VerifyThrow(itemsWithNoWildcards.All(fragment => !MSBuildConstants.CharactersForExpansion.Any(fragment.Key.Contains)), $"{nameof(itemsWithNoWildcards)} should not contain any text fragments with wildcards.");
-#endif
                 if (itemsWithNoWildcards.Count > 0)
                 {
                     for (int i = 0; i < items.Count; i++)
                     {
-                        string fullPath = FileUtilities.GetFullPath(items[i].Item.EvaluatedIncludeEscaped, items[i].Item.ProjectDirectory);
+                        string fullPath = FileUtilities.NormalizePathForComparisonNoThrow(items[i].Item.EvaluatedIncludeEscaped, items[i].Item.ProjectDirectory);
                         if (itemsWithNoWildcards.TryGetValue(fullPath, out UpdateOperation op))
                         {
                             items[i] = op.UpdateItem(items[i]);

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     for (int i = 0; i < items.Count; i++)
                     {
-                        string fullPath = FileUtilities.NormalizePathForComparisonNoThrow(items[i].Item.EvaluatedIncludeEscaped, items[i].Item.ProjectDirectory);
+                        string fullPath = FileUtilities.NormalizePathForComparisonNoThrow(items[i].Item.EvaluatedInclude, items[i].Item.ProjectDirectory);
                         if (itemsWithNoWildcards.TryGetValue(fullPath, out UpdateOperation op))
                         {
                             items[i] = op.UpdateItem(items[i]);


### PR DESCRIPTION
An Item `Update` operation may apply to items that are defined via
wildcard. In normal operation, the wildcard will have been expanded by
the time Update applies, and it's fine for Update to assume that
everything is a valid file path. But in
`MSBuildSkipEagerWildCardEvaluationRegexes` mode, wildcards may not be
expanded.

Fixes #9405 by using a more appropriate method to normalize
probably-but-not-necessarily paths for comparisons.
