### PR TITLE
Revert "Exec: use C instead of en_US.UTF-8 to set the Exec locale."

### DIFF
--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -591,7 +591,7 @@ namespace Microsoft.Build.Tasks
             {
                 commandLine.AppendSwitch("-c");
                 commandLine.AppendTextUnquoted(" \"");
-                commandLine.AppendTextUnquoted(". ");
+                commandLine.AppendTextUnquoted("export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; . ");
                 commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
                 commandLine.AppendTextUnquoted("\"");
             }


### PR DESCRIPTION
Reverts dotnet/msbuild#9391, which was merged before it was fully agreed on.