### PR TITLE
Log allowed environment vars case-insensitively

### DIFF
--- a/src/Shared/EnvironmentUtilities.cs
+++ b/src/Shared/EnvironmentUtilities.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Build.Shared
 
         public static bool IsWellKnownEnvironmentDerivedProperty(string propertyName)
         {
-            return propertyName.StartsWith("MSBUILD") ||
-                propertyName.StartsWith("COMPLUS_") ||
-                propertyName.StartsWith("DOTNET_");
+            return propertyName.StartsWith("MSBUILD", StringComparison.OrdinalIgnoreCase) ||
+                propertyName.StartsWith("COMPLUS_", StringComparison.OrdinalIgnoreCase) ||
+                propertyName.StartsWith("DOTNET_", StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
I was recently investigating a problem (https://github.com/jaredpar/complog/pull/73) where the issue was that `MSBuildSdksPath` was set incorrectly, so an SDK was being resolved incorrectly. I had initially ruled that out, because I knew that we should be logging environment variables that start with `MSBUILD`.

We were, but case-sensitively. Since the canonical case for some of our config environment variables is not all caps, we should change that.
