### PR TITLE
Fix language about binlog environment variable use

### DIFF
--- a/documentation/wiki/Providing-Binary-Logs.md
+++ b/documentation/wiki/Providing-Binary-Logs.md
@@ -2,7 +2,7 @@
 
 MSBuild has the ability to capture a detailed binary log file.  If you are having a build issue and are able to provide a binary log, this can be very helpful for investigating the issue.
 
-However, you should be aware what type of information is captured in the binary log to make sure you are not inadvertently sharing more than you intend.  The binary log captures almost everything your build does, including the contents of your project files and any files (such as .props and .targets) that they import, all tasks that are run during the build as well as the input and output, as well as all environment variables.  It generally doesn't include the contents of the source files that are compiled, but it does capture their full names and paths.
+However, you should be aware what type of information is captured in the binary log to make sure you are not inadvertently sharing more than you intend.  The binary log captures almost everything your build does, including the contents of your project files and any files (such as .props and .targets) that they import, all tasks that are run during the build as well as the input and output, as well as all environment variables used by the build logic.  It generally doesn't include the contents of the source files that are compiled, but it does capture their full names and paths.
 
 ⚠ NOTE: some build environments make secrets available using environment variables. Before sharing a binary log, make sure it does not expose API tokens or other important secrets.
 


### PR DESCRIPTION
This isn't quite correct anymore - updating the wording here.