### PR TITLE
Upgrade BenchmarkDotNet , FluentAssertions versions

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -10,10 +10,10 @@
   these properties to override package versions if necessary. -->
 
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
     <PackageVersion Update="BenchmarkDotNet" Condition="'$(BenchmarkDotNetVersion)' != ''" Version="$(BenchmarkDotNetVersion)" />
 
-    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Update="FluentAssertions" Condition="'$(FluentAssertionsVersion)' != ''" Version="$(FluentAssertionsVersion)" />
 
     <PackageVersion Include="LargeAddressAware" Version="1.0.5" />


### PR DESCRIPTION
### Context
While upgrading the version in this PR: https://github.com/dotnet/msbuild/pull/9426
It was identified that there are multiple references that could be upgraded. This PR contains only upgrades minor and patches versions not to include possible breaking changes. 
PR for upgrading major versions will be created separately. 

### Changes Made
Upgraded BenchmarkDotNet and FluentAssertions versions

### Testing
Existing tests should pass