### PR TITLE
Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -29,6 +29,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Cache SDK resolver data process-wide](https://github.com/dotnet/msbuild/pull/9335)
 - [Target parameters will be unquoted](https://github.com/dotnet/msbuild/pull/9452), meaning  the ';' symbol in the parameter target name will always be treated as separator
 - [Change Version switch output to finish with a newline](https://github.com/dotnet/msbuild/pull/9485)
+- [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/9439)
 
 ### 17.8
 - [[RAR] Don't do I/O on SDK-provided references](https://github.com/dotnet/msbuild/pull/8688)

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -226,6 +226,20 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         protected virtual Assembly LoadResolverAssembly(string resolverPath)
         {
 #if !FEATURE_ASSEMBLYLOADCONTEXT
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+            {
+                string resolverFileName = Path.GetFileNameWithoutExtension(resolverPath);
+                if (resolverFileName.Equals("Microsoft.DotNet.MSBuildSdkResolver", StringComparison.OrdinalIgnoreCase))
+                {
+                    // This will load the resolver assembly into the default load context if possible, and fall back to LoadFrom context.
+                    // We very much prefer the default load context because it allows native images to be used by the CLR, improving startup perf.
+                    AssemblyName assemblyName = new AssemblyName(resolverFileName)
+                    {
+                        CodeBase = resolverPath,
+                    };
+                    return Assembly.Load(assemblyName);
+                }
+            }
             return Assembly.LoadFrom(resolverPath);
 #else
             return s_loader.LoadFromPath(resolverPath);

--- a/src/Build/Microsoft.Build.pkgdef
+++ b/src/Build/Microsoft.Build.pkgdef
@@ -29,3 +29,17 @@
 "culture"="neutral"
 "oldVersion"="0.0.0.0-1.0.0.0"
 "newVersion"="1.0.0.0"
+
+[$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{838C80EF-8658-480D-A7DD-F7530A21142C}]
+"name"="Microsoft.DotNet.MSBuildSdkResolver"
+"version"="8.0.100.0"
+"codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.dll"
+"publicKeyToken"="adb9793829ddae60"
+"culture"="neutral"
+
+[$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{9CE1CEDE-35FC-4FC1-97F2-3D2A582CE805}]
+"name"="Microsoft.Deployment.DotNet.Releases"
+"version"="2.0.0.0"
+"codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.Deployment.DotNet.Releases.dll"
+"publicKeyToken"="31bf3856ad364e35"
+"culture"="neutral"

--- a/src/Build/Microsoft.Build.pkgdef
+++ b/src/Build/Microsoft.Build.pkgdef
@@ -29,17 +29,3 @@
 "culture"="neutral"
 "oldVersion"="0.0.0.0-1.0.0.0"
 "newVersion"="1.0.0.0"
-
-[$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{838C80EF-8658-480D-A7DD-F7530A21142C}]
-"name"="Microsoft.DotNet.MSBuildSdkResolver"
-"version"="8.0.100.0"
-"codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.dll"
-"publicKeyToken"="adb9793829ddae60"
-"culture"="neutral"
-
-[$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{9CE1CEDE-35FC-4FC1-97F2-3D2A582CE805}]
-"name"="Microsoft.Deployment.DotNet.Releases"
-"version"="2.0.0.0"
-"codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.Deployment.DotNet.Releases.dll"
-"publicKeyToken"="31bf3856ad364e35"
-"culture"="neutral"

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -184,6 +184,21 @@
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <codeBase version="17.0.0.0" href="..\..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
+
+        <!-- Redirects for SDK resolver components -->
+        <qualifyAssembly partialName="Microsoft.DotNet.MSBuildSdkResolver" fullName="Microsoft.DotNet.MSBuildSdkResolver, Version=8.0.100.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.DotNet.MSBuildSdkResolver" culture="neutral" publicKeyToken="adb9793829ddae60" />
+          <codeBase version="8.0.100.0" href="..\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Deployment.DotNet.Releases" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <codeBase version="2.0.0.0" href="..\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.Deployment.DotNet.Releases.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+          <codeBase version="13.0.0.0" href="..\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Newtonsoft.Json.dll" />
+        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -133,6 +133,21 @@
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <codeBase version="17.0.0.0" href="..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
+
+        <!-- Redirects for SDK resolver components -->
+        <qualifyAssembly partialName="Microsoft.DotNet.MSBuildSdkResolver" fullName="Microsoft.DotNet.MSBuildSdkResolver, Version=8.0.100.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.DotNet.MSBuildSdkResolver" culture="neutral" publicKeyToken="adb9793829ddae60" />
+          <codeBase version="8.0.100.0" href=".\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Deployment.DotNet.Releases" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <codeBase version="2.0.0.0" href=".\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.Deployment.DotNet.Releases.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+          <codeBase version="13.0.0.0" href=".\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Newtonsoft.Json.dll" />
+        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->


### PR DESCRIPTION
Fixes #9303

### Context

After a new version of `VS.Redist.Common.Net.Core.SDK.MSBuildExtensions` is inserted into VS, a native image for `Microsoft.DotNet.MSBuildSdkResolver` will be generated, both for devenv.exe and MSBuild.exe (see https://github.com/dotnet/installer/pull/17732).

We currently load SDK resolvers using `Assembly.LoadFrom` on .NET Framework, which disqualifies it from using native images even if they existed. This PR makes us use the native image.

### Changes Made

Added a code path to use `Assembly.Load` to load resolver assemblies. The call is made such that if the assembly cannot be found by simple name, it falls back to loading by path into the load-from context, just like today. The new code path is enabled only for `Microsoft.DotNet.MSBuildSdkResolver` under a change-wave check.

### Testing

Experimental insertions.

### Notes

Using `qualifyAssembly` in the app config has the advantage of keeping everything _field-configurable_, i.e. in the unlikely case that a custom build environment will ship with a different version of the resolver, it will be possible to compensate for that by tweaking the config file. The disadvantage is that the same `qualifyAssembly` will need to be added to devenv.exe.config because .pkgdef doesn't support this kind of entry, to my best knowledge. It should be a one-time change, though, because [we have frozen the version of `Microsoft.DotNet.MSBuildSdkResolver` to 8.0.100.0](https://github.com/dotnet/sdk/pull/36733).