### PR TITLE
[ClickOnce] Handle multiple apphost.exe files that could be published with an EXE to EXE P2P reference

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.8.4</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.8.5</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.7.0</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Tasks/ManifestUtil/Manifest.cs
+++ b/src/Tasks/ManifestUtil/Manifest.cs
@@ -487,7 +487,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
         private void UpdateFileReference(BaseReference f, string targetFrameworkVersion)
         {
-            if (String.IsNullOrEmpty(f.ResolvedPath))
+            if (string.IsNullOrEmpty(f.ResolvedPath))
             {
                 throw new FileNotFoundException(null, f.SourcePath);
             }
@@ -506,22 +506,33 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             f.Size = size;
 
             //
-            // .NETCore Launcher.exe based Deployment: If the filereference is for apphost.exe, we need to change
-            // the ResolvedPath and TargetPath to {assemblyname}.exe before we write the manifest, so that the
-            // manifest does not have a file reference to apphost.exe
+            // .NET >= 5 ClickOnce: If the file reference is for apphost.exe, we need to change the filename
+            // in ResolvedPath to TargetPath so we don't end up publishing the file as apphost.exe.
+            // If the TargetPath is not present, we will fallback to AssemblyName.
             //
             string fileName = Path.GetFileName(f.ResolvedPath);
             if (LauncherBasedDeployment &&
-                fileName.Equals(Constants.AppHostExe, StringComparison.InvariantCultureIgnoreCase) &&
-                !String.IsNullOrEmpty(AssemblyName))
+                fileName.Equals(Constants.AppHostExe, StringComparison.InvariantCultureIgnoreCase))
             {
-                f.ResolvedPath = Path.Combine(Path.GetDirectoryName(f.ResolvedPath), AssemblyName);
-                f.TargetPath = BaseReference.GetDefaultTargetPath(f.ResolvedPath);
+                if (!string.IsNullOrEmpty(f.TargetPath))
+                {
+                    f.ResolvedPath = Path.Combine(Path.GetDirectoryName(f.ResolvedPath), f.TargetPath);
+                }
+                else if (!string.IsNullOrEmpty(AssemblyName))
+                {
+                    f.ResolvedPath = Path.Combine(Path.GetDirectoryName(f.ResolvedPath), AssemblyName);
+                    f.TargetPath = BaseReference.GetDefaultTargetPath(f.ResolvedPath);
+                }
+                else
+                {
+                    Debug.Assert(false, "AssemblyName cannot be empty");
+                    OutputMessages.AddWarningMessage("GenerateManifest.InvalidValue", "AssemblyName");
+                }
             }
 
-            if (String.IsNullOrEmpty(f.TargetPath))
+            if (string.IsNullOrEmpty(f.TargetPath))
             {
-                if (!String.IsNullOrEmpty(f.SourcePath))
+                if (!string.IsNullOrEmpty(f.SourcePath))
                 {
                     f.TargetPath = BaseReference.GetDefaultTargetPath(f.SourcePath);
                 }

--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -285,14 +285,17 @@ namespace Microsoft.Build.Tasks
             {
                 targetPath = Path.GetFileName(item.ItemSpec);
                 //
-                // .NETCore Launcher.exe based deployment: If the file is apphost.exe, we need to set 'TargetPath' metadata
-                // to {assemblyname}.exe so that the file gets published as {assemblyname}.exe and not apphost.exe.
+                // .NET >= 5 ClickOnce: If TargetPath metadata is not present in apphost.exe's metadata, we'll fallback to using AssemblyName
                 //
                 if (LauncherBasedDeployment &&
                     targetPath.Equals(Constants.AppHostExe, StringComparison.InvariantCultureIgnoreCase) &&
                     !String.IsNullOrEmpty(AssemblyName))
                 {
-                    targetPath = AssemblyName;
+                    targetPath = item.GetMetadata(ItemMetadataNames.targetPath);
+                    if (String.IsNullOrEmpty(targetPath))
+                    {
+                        targetPath = AssemblyName;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #
[AB#1921068](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1921068)

### Description
PR [9299](https://github.com/dotnet/msbuild/pull/9299) added support for publishing content artifacts from P2P references. After this change, there is an installation failure that has been reported for a scenario where an EXE project has a P2P reference to another EXE project. For such a scenario, there are 2 apphost.exe's that are present in the list of artifacts to be published - one from the main project and the other from the referenced EXE project.

### Customer Impact
ClickOnce does not expect 2 apphost.exe's to be published together and both of the apphost.exe's get published as the assembly name of the main project. This leads to a duplicate entry in the ClickOnce application manifest and the installation of the app fails due to this.

### Regression: Yes, worked before 17.8.

### Risk: Low

### Changes Made
ClickOnce's ResolveManifestFiles and GenerateApplicationManifest task are being updated to handle the case where more than 1 apphost.exe files need to be published. Instead of publishing them with the name of the assembly of the main project, we use the TargetPath metadata of the file item to publish the file.

### Testing
CTI has done a full test pass for regression and the failing scenario.
The failing scenario has been added to the ClickOnce test suite.
