### PR TITLE
Facilitate exception from warning for well known type(s) in need of e…

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -928,37 +928,56 @@ namespace Microsoft.Build.BackEnd.Logging
                 BuildEventArgs buildEvent = loggingPacket.NodeBuildEvent.Value.Value;
                 BuildEventContext buildEventContext = buildEvent?.BuildEventContext ?? BuildEventContext.Invalid;
 
+                string typeName = buildEvent?.GetType().FullName ?? string.Empty;
                 string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(
                     out string warningCode,
                     out string helpKeyword,
                     "DeprecatedEventSerialization",
-                    buildEvent?.GetType().Name ?? string.Empty);
+                    typeName);
 
-                BuildWarningEventArgs warning = new(
-                    null,
-                    warningCode,
-                    BuildEventFileInfo.Empty.File,
-                    BuildEventFileInfo.Empty.Line,
-                    BuildEventFileInfo.Empty.Column,
-                    BuildEventFileInfo.Empty.EndLine,
-                    BuildEventFileInfo.Empty.EndColumn,
-                    message,
-                    helpKeyword,
-                    "MSBuild");
+                BuildEventArgs customEventUsedEventArgs =
+                    HasTypeException(typeName)
+                        ? new BuildMessageEventArgs(
+                            message,
+                            helpKeyword,
+                            "MSBuild",
+                            MessageImportance.Low)
+                        {
+                            BuildEventContext = buildEventContext,
+                            ProjectFile = GetProjectFile(),
+                        }
+                        : new BuildWarningEventArgs(
+                            null,
+                            warningCode,
+                            BuildEventFileInfo.Empty.File,
+                            BuildEventFileInfo.Empty.Line,
+                            BuildEventFileInfo.Empty.Column,
+                            BuildEventFileInfo.Empty.EndLine,
+                            BuildEventFileInfo.Empty.EndColumn,
+                            message,
+                            helpKeyword,
+                            "MSBuild")
+                        {
+                            BuildEventContext = buildEventContext,
+                            ProjectFile = GetProjectFile(),
+                        };
 
-                warning.BuildEventContext = buildEventContext;
-                if (warning.ProjectFile == null && buildEventContext.ProjectContextId != BuildEventContext.InvalidProjectContextId)
-                {
-                    warning.ProjectFile = buildEvent switch
-                    {
-                        BuildMessageEventArgs buildMessageEvent => buildMessageEvent.ProjectFile,
-                        BuildErrorEventArgs buildErrorEvent => buildErrorEvent.ProjectFile,
-                        BuildWarningEventArgs buildWarningEvent => buildWarningEvent.ProjectFile,
-                        _ => null,
-                    };
-                }
+                ProcessLoggingEvent(customEventUsedEventArgs);
 
-                ProcessLoggingEvent(warning);
+                string GetProjectFile()
+                    =>
+                        buildEventContext.ProjectContextId == BuildEventContext.InvalidProjectContextId
+                            ? null
+                            : buildEvent switch
+                            {
+                                BuildMessageEventArgs buildMessageEvent => buildMessageEvent.ProjectFile,
+                                BuildErrorEventArgs buildErrorEvent => buildErrorEvent.ProjectFile,
+                                BuildWarningEventArgs buildWarningEvent => buildWarningEvent.ProjectFile,
+                                _ => null,
+                            };
+
+                bool HasTypeException(string typeNameArg)
+                    => string.Equals(typeNameArg, "SarifBuildErrorEventArgs", StringComparison.OrdinalIgnoreCase);
             }
         }
 


### PR DESCRIPTION
### Context

This is to fix the failing insertion (https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8716158&view=ms.vss-test-web.build-test-results-tab&runId=89135836&resultId=100020&paneView=debug), until the proper fix is facilitated (https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1864133)

We'll temporarily log just low priority message (without code :-)) for well know types that are in need of temporary exception.

### Changes Made

Current warning is conditioned by typename

### Testing
Existing tests + insertion

### Notes
This should be reverted for 17.9 P3 (I'll create appropriate workitem once this PR is approved - or not if we decide other way)
