### PR TITLE
Exec: stop setting a locale on Unix.

### DIFF
--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -69,6 +69,42 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+        [UnixOnlyTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ExecSetsLocaleOnUnix(bool enableChangeWave)
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                env.SetEnvironmentVariable("LANG", null);
+                env.SetEnvironmentVariable("LC_ALL", null);
+
+                if (enableChangeWave)
+                {
+                    ChangeWaves.ResetStateForTests();
+                    // Important: use the version here
+                    env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_10.ToString());
+                    BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+                }
+
+                Exec exec = PrepareExec("echo LANG=$LANG; echo LC_ALL=$LC_ALL;");
+                bool result = exec.Execute();
+                Assert.True(result);
+
+                MockEngine engine = (MockEngine)exec.BuildEngine;
+                if (enableChangeWave)
+                {
+                    engine.AssertLogContains("LANG=en_US.UTF-8");
+                    engine.AssertLogContains("LC_ALL=en_US.UTF-8");
+                }
+                else
+                {
+                    engine.AssertLogDoesntContain("LANG=en_US.UTF-8");
+                    engine.AssertLogDoesntContain("LC_ALL=en_US.UTF-8");
+                }
+            }
+        }
+
         /// <summary>
         /// Ensures that calling the Exec task does not leave any extra TEMP files
         /// lying around.

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -591,7 +591,12 @@ namespace Microsoft.Build.Tasks
             {
                 commandLine.AppendSwitch("-c");
                 commandLine.AppendTextUnquoted(" \"");
-                commandLine.AppendTextUnquoted("export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; . ");
+                bool setLocale = !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10);
+                if (setLocale)
+                {
+                    commandLine.AppendTextUnquoted("export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; ");
+                }
+                commandLine.AppendTextUnquoted(". ");
                 commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
                 commandLine.AppendTextUnquoted("\"");
             }


### PR DESCRIPTION
The en_US locale can't be used on systems where it is not installed. This is common in container images.

On such systems, setting the locale to en_US.UTF-8 causes bash to print unexpected warnings to standard error.
When Exec.LogStandardErrorAsError is set, these warnings cause the Task to fail due to logging errors.

This changes to no longer set the locale explicitly. The Exec command will now run under the system locale instead of US English. Most tools should functionally behave the same under any locale.

Users may still set the locale environment variables themselves through Exec.EnvironmentVariables.

The previous behavior can also be restored as it is under a changewave.

@KalleOlaviNiemitalo @rainersigwald @wfurt @danmoseley ptal.

cc @mthalman @omajid 

Fixes https://github.com/dotnet/msbuild/issues/4194
