### PR TITLE
Always unquote target parameters

### DIFF
--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -400,6 +400,14 @@ namespace Microsoft.Build.Framework
             }
         }
 
+        public bool UnquoteSwitchParameterForTragetParametrizedSwitch
+        {
+            get
+            {
+                return ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10);
+            }
+        }
+
         private bool? _isBinaryFormatterSerializationAllowed;
         public bool IsBinaryFormatterSerializationAllowed
         {

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1055,6 +1055,43 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("build", parameters[2]);
         }
 
+        /// <summary>
+        /// Verifies that the Target property is unquoted and parsed properly.
+        /// This will remove the possibility to have the ';' in the target name. 
+        /// </summary>
+        [Theory]
+        [InlineData("/t:Clean;Build", "\"Clean;Build\"")]
+        [InlineData("/t:Clean;Build", "Clean;Build")]
+        public void ParameterizedSwitchTargetQuotedTest(string commandLineArg, string switchParameters)
+        {
+            CommandLineSwitches switches = new CommandLineSwitches();
+            switches.SetParameterizedSwitch(CommandLineSwitches.ParameterizedSwitch.Target, commandLineArg, switchParameters, true, true, false);
+            Assert.True(switches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Target));
+
+            switches[CommandLineSwitches.ParameterizedSwitch.Target].Length.ShouldBe(2);
+            switches[CommandLineSwitches.ParameterizedSwitch.Target][0].ShouldBe("Clean");
+            switches[CommandLineSwitches.ParameterizedSwitch.Target][1].ShouldBe("Build");
+        }
+
+        /// <summary>
+        /// Verifies that the parsing behaviour of quoted target properties is not change when ChangeWave configured.
+        /// </summary>
+        [Fact]
+        public void ParameterizedSwitchTargetQuotedChangeWaveTest()
+        {
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", "17.10");
+
+                CommandLineSwitches switches = new CommandLineSwitches();
+                switches.SetParameterizedSwitch(CommandLineSwitches.ParameterizedSwitch.Target, "/t:Clean;Build", "\"Clean;Build\"", true, true, false);
+                Assert.True(switches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Target));
+
+                switches[CommandLineSwitches.ParameterizedSwitch.Target].Length.ShouldBe(1);
+                switches[CommandLineSwitches.ParameterizedSwitch.Target][0].ShouldBe("Clean;Build");
+            }
+        }
+
         [Fact]
         public void AppendParameterizedSwitchesTests3()
         {

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -488,6 +488,11 @@ namespace Microsoft.Build.CommandLine
                 }
                 else
                 {
+                    if (IsMultipleAllowedSwithParameterDueToUnquote(unquoteParameters, parameterizedSwitch))
+                    {
+                        switchParameters = QuotingUtilities.Unquote(switchParameters);
+                    }
+
                     // store all the switch parameters
                     int emptyParameters;
                     _parameterizedSwitches[(int)parameterizedSwitch].parameters.AddRange(QuotingUtilities.SplitUnquoted(switchParameters, int.MaxValue, false /* discard empty parameters */, unquoteParameters, out emptyParameters, s_parameterSeparators));
@@ -649,6 +654,26 @@ namespace Microsoft.Build.CommandLine
             groupedFileLoggerParameters[9] = GetSpecificFileLoggerParameters(ParameterlessSwitch.FileLogger9, ParameterizedSwitch.FileLoggerParameters9);
 
             return groupedFileLoggerParameters;
+        }
+
+        /// <summary>
+        /// Checks if the provided parametrized switch needs to be unquoted.
+        /// The method will return 'true' in case:
+        ///     The changewave 17.10 is not set and
+        ///     The parametrized switch is 'Target'
+        /// </summary>
+        private bool IsMultipleAllowedSwithParameterDueToUnquote(bool unquoteParameter, ParameterizedSwitch parameterizedSwitch)
+        {
+            if (!unquoteParameter || !Traits.Instance.EscapeHatches.UnquoteSwitchParameterForTragetParametrizedSwitch)
+            {
+                return false;
+            }
+            if (parameterizedSwitch == ParameterizedSwitch.Target)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #9442

### Context
Currently if target parameter provided with the quoted value: /t:"Clean;Build" from cmd it will be parsed as "Clean;Build" 
Which results not finding the provided target, unless there is existing such target with name "Clean;Build". However it is not the case for powershell. 

### Changes Made
Unquote target switch parameters before prasing. 
The functionality is under the change wave. 

### Testing
Added UnitTesting, all existing tests should pass as well, without breaking it. 