### PR TITLE
Fix restore handling in Terminal Logger

### DIFF
--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -115,6 +115,11 @@ internal sealed class TerminalLogger : INodeLogger
     private bool _restoreFailed;
 
     /// <summary>
+    /// True if restore happened and finished.
+    /// </summary>
+    private bool _restoreFinished = false;
+
+    /// <summary>
     /// The project build context corresponding to the <c>Restore</c> initial target, or null if the build is currently
     /// not restoring.
     /// </summary>
@@ -323,7 +328,8 @@ internal sealed class TerminalLogger : INodeLogger
             }
             _projects[c] = new(targetFramework);
 
-            if (e.TargetNames == "Restore")
+            // First ever restore in the build is starting.
+            if (e.TargetNames == "Restore" && !_restoreFinished)
             {
                 _restoreContext = c;
                 int nodeIndex = NodeIndexForContext(buildEventContext);
@@ -398,6 +404,7 @@ internal sealed class TerminalLogger : INodeLogger
                         }
 
                         _restoreContext = null;
+                        _restoreFinished = true;
                     }
                     // If this was a notable project build, we print it as completed only if it's produced an output or warnings/error.
                     else if (project.OutputPath is not null || project.BuildMessages is not null)

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -636,10 +636,9 @@ internal sealed class TerminalLogger : INodeLogger
     /// </summary>
     private void ThreadProc()
     {
-        while (!_cts.IsCancellationRequested)
+        // 1_000 / 30 is a poor approx of 30Hz
+        while (!_cts.Token.WaitHandle.WaitOne(1_000 / 30))
         {
-            _cts.Token.WaitHandle.WaitOne(1_000 / 30);  // basically equivalent for a sleep with quick cancellation, 1_000 / 30 is a poor approx of 30Hz
-
             lock (_lock)
             {
                 DisplayNodes();

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -237,6 +237,7 @@ internal sealed class TerminalLogger : INodeLogger
         _cts.Cancel();
         _refresher?.Join();
         Terminal.Dispose();
+        _cts.Dispose();
     }
 
     #endregion
@@ -637,7 +638,7 @@ internal sealed class TerminalLogger : INodeLogger
     {
         while (!_cts.IsCancellationRequested)
         {
-            Thread.Sleep(1_000 / 30); // poor approx of 30Hz
+            _cts.Token.WaitHandle.WaitOne(1_000 / 30);  // basically equivalent for a sleep with quick cancellation, 1_000 / 30 is a poor approx of 30Hz
 
             lock (_lock)
             {


### PR DESCRIPTION
Fixes #9323

### Context
There are 4 related problems that occur in the issue #9323:

1. The logger fails and throws an internal logger exception because of the wrong assumptions about restore target appearance in the build. 
2. The internal logger exception is caught and causes the build to shut down all loggers, including terminal logger. Because it happens before the build finished event is produced or processed by terminal logger, the rendering thread is not finished, and it leads to an infinite hang.
3. The errors during restore are not logged.
4. There is inconsistency with showing the message error MSB4017. If the internal logger exception is thrown from one place it shows, from another - not. In the current situation the build and logger are shut downed, but the message did not appear, which is confusing. (see #9455)

### Changes Made
Fixed first 2 errors: 
1. Improved the handling of the restore such that there should not be throws. Only first restore that happens would be specially treated.  
2. I added shutting down of the render thread when shutting down the logger. 

### Testing
locally tested, unit tests

### Notes
Compatible with PR #9424, which covers the problem 3.