### PR TITLE
Fixed /restore and /graph conjunction error on exit code

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -15,7 +15,6 @@ using Microsoft.Build.CommandLine;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
-using Microsoft.Build.Tasks.Deployment.Bootstrapper;
 using Microsoft.Build.UnitTests.Shared;
 using Microsoft.Build.Utilities;
 using Shouldly;

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -722,9 +722,9 @@ namespace Microsoft.Build.UnitTests
             string result = RunnerUtilities.ExecMSBuild($" {project.Path} /restore {graph}", out bool success);
 
             success.ShouldBeFalse();
-            result.Contains("Program.cs(2,47): error CS1002: ; expected");
-            result.Contains("Program.cs(3,20): error CS1003: Syntax error, ','");
-            result.Contains("Program.cs(3,54): error CS1002: ; expected");
+            result.ShouldContain("Program.cs(2,47): error CS1002: ; expected");
+            result.ShouldContain("Program.cs(3,20): error CS1003: Syntax error, ','");
+            result.ShouldContain("Program.cs(3,54): error CS1002: ; expected");
         }
 
         /// <summary>

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -15,6 +15,7 @@ using Microsoft.Build.CommandLine;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Tasks.Deployment.Bootstrapper;
 using Microsoft.Build.UnitTests.Shared;
 using Microsoft.Build.Utilities;
 using Shouldly;
@@ -627,7 +628,6 @@ namespace Microsoft.Build.UnitTests
         [InlineData("-getProperty:Foo;Bar -getItem:MyItem -t:Build", true, "TargetValue", true, true, false, true, false)]
         [InlineData("-getProperty:Foo;Bar -getItem:MyItem", true, "EvalValue", true, false, false, true, false)]
         [InlineData("-getProperty:Foo;Bar -getTargetResult:MyTarget", true, "TargetValue", false, false, true, true, false)]
-        [InlineData("-getProperty:Foo;Bar -getTargetResult:MyTarget -t:restore", true, "TargetValue", false, false, true, true, false)]
         [InlineData("-getProperty:Foo;Bar", true, "EvalValue", false, false, false, false, false)]
         [InlineData("-getProperty:Foo;Bar -t:Build", true, "TargetValue", false, false, false, false, false)]
         [InlineData("-getItem:MyItem", false, "", true, false, false, false, false)]
@@ -696,6 +696,36 @@ namespace Microsoft.Build.UnitTests
             results.Contains("MyTarget").ShouldBe(targetResultPresent);
             results.Contains("\"Result\": \"Success\"").ShouldBe(targetResultPresent || restoreOnly);
             results.ShouldNotContain(ResourceUtilities.GetResourceString("BuildFailedWithPropertiesItemsOrTargetResultsRequested"));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void BuildFailsWithCompileErrorAndRestore(bool isGraphBuild)
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            TransientTestFile project = env.CreateFile("testProject.csproj", @"
+<Project>
+  <ItemGroup>
+    <CSFile Include=""Program.cs""/>
+  </ItemGroup>
+
+  <Target Name=""Build"">
+    <Csc Sources=""@(CSFile)"" />
+  </Target>
+</Project>
+        ");
+            TransientTestFile wrongSyntaxFile = env.CreateFile("Program.cs", @"
+            Console.WriteLine(""Hello, World!"")
+            A Line here for this to not compile right");
+
+            string graph = isGraphBuild ? "--graph" : "";
+            string result = RunnerUtilities.ExecMSBuild($" {project.Path} /restore {graph}", out bool success);
+
+            success.ShouldBeFalse();
+            result.Contains("Program.cs(2,47): error CS1002: ; expected");
+            result.Contains("Program.cs(3,20): error CS1003: Syntax error, ','");
+            result.Contains("Program.cs(3,54): error CS1002: ; expected");
         }
 
         /// <summary>

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -627,6 +627,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("-getProperty:Foo;Bar -getItem:MyItem -t:Build", true, "TargetValue", true, true, false, true, false)]
         [InlineData("-getProperty:Foo;Bar -getItem:MyItem", true, "EvalValue", true, false, false, true, false)]
         [InlineData("-getProperty:Foo;Bar -getTargetResult:MyTarget", true, "TargetValue", false, false, true, true, false)]
+        [InlineData("-getProperty:Foo;Bar -getTargetResult:MyTarget -t:restore", true, "TargetValue", false, false, true, true, false)]
         [InlineData("-getProperty:Foo;Bar", true, "EvalValue", false, false, false, false, false)]
         [InlineData("-getProperty:Foo;Bar -t:Build", true, "TargetValue", false, false, false, false, false)]
         [InlineData("-getItem:MyItem", false, "", true, false, false, false, false)]

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1538,9 +1538,9 @@ namespace Microsoft.Build.CommandLine
 
                             if (enableRestore || restoreOnly)
                             {
-                                result = ExecuteRestore(projectFile, toolsVersion, buildManager, restoreProperties.Count > 0 ? restoreProperties : globalProperties, saveProjectResult: saveProjectResult);
+                                BuildResult restoreResult = ExecuteRestore(projectFile, toolsVersion, buildManager, restoreProperties.Count > 0 ? restoreProperties : globalProperties, saveProjectResult: saveProjectResult);
 
-                                if (result.OverallResult != BuildResultCode.Success)
+                                if (restoreResult.OverallResult != BuildResultCode.Success)
                                 {
                                     return false;
                                 }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1544,6 +1544,10 @@ namespace Microsoft.Build.CommandLine
                                 {
                                     return false;
                                 }
+                                else
+                                {
+                                    success = result.OverallResult == BuildResultCode.Success;
+                                }
                             }
 
                             if (!restoreOnly)
@@ -1567,12 +1571,8 @@ namespace Microsoft.Build.CommandLine
                                             nodeResultKvp.Key.ProjectInstance.GlobalProperties.All(propertyKvp => entryPoint.GlobalProperties.TryGetValue(propertyKvp.Key, out string entryValue) &&
                                                                                                                                         entryValue.Equals(propertyKvp.Value)))
                                             .Value;
-                                        success = result.OverallResult == BuildResultCode.Success;
                                     }
-                                    else
-                                    {
-                                        success = graphResult.OverallResult == BuildResultCode.Success;
-                                    }
+                                    success = graphResult.OverallResult == BuildResultCode.Success;
                                 }
                                 else
                                 {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1515,7 +1515,6 @@ namespace Microsoft.Build.CommandLine
                             // approach.
                             GraphBuildRequestData graphBuildRequest = null;
                             BuildRequestData buildRequest = null;
-                            BuildResult restoreResult = null;
                             if (!restoreOnly)
                             {
                                 // By default, the project state is thrown out after a build. The ProvideProjectStateAfterBuild flag adds the project state after build
@@ -1539,9 +1538,9 @@ namespace Microsoft.Build.CommandLine
 
                             if (enableRestore || restoreOnly)
                             {
-                                restoreResult = ExecuteRestore(projectFile, toolsVersion, buildManager, restoreProperties.Count > 0 ? restoreProperties : globalProperties, saveProjectResult: saveProjectResult);
+                                result = ExecuteRestore(projectFile, toolsVersion, buildManager, restoreProperties.Count > 0 ? restoreProperties : globalProperties, saveProjectResult: saveProjectResult);
 
-                                if (restoreResult.OverallResult != BuildResultCode.Success)
+                                if (result.OverallResult != BuildResultCode.Success)
                                 {
                                     return false;
                                 }
@@ -1569,22 +1568,18 @@ namespace Microsoft.Build.CommandLine
                                                                                                                                         entryValue.Equals(propertyKvp.Value)))
                                             .Value;
                                     }
-                                    else
-                                    {
-                                        success = graphResult.OverallResult == BuildResultCode.Success;
-                                    }
                                 }
                                 else
                                 {
                                     result = ExecuteBuild(buildManager, buildRequest);
                                 }
                             }
-                            else
-                            {
-                                success = restoreResult.OverallResult == BuildResultCode.Success;
-                            }
 
-                            if (result != null && result.Exception == null)
+                            if (graphResult != null && !saveProjectResult)
+                            {
+                                success = graphResult.OverallResult == BuildResultCode.Success;
+                            }
+                            else if (result != null && result.Exception == null)
                             {
                                 success = result.OverallResult == BuildResultCode.Success;
                             }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1567,21 +1567,18 @@ namespace Microsoft.Build.CommandLine
                                             nodeResultKvp.Key.ProjectInstance.GlobalProperties.All(propertyKvp => entryPoint.GlobalProperties.TryGetValue(propertyKvp.Key, out string entryValue) &&
                                                                                                                                         entryValue.Equals(propertyKvp.Value)))
                                             .Value;
+                                        success = result.OverallResult == BuildResultCode.Success;
+                                    }
+                                    else
+                                    {
+                                        success = graphResult.OverallResult == BuildResultCode.Success;
                                     }
                                 }
                                 else
                                 {
                                     result = ExecuteBuild(buildManager, buildRequest);
+                                    success = result.OverallResult == BuildResultCode.Success;
                                 }
-                            }
-
-                            if (graphResult != null && !saveProjectResult)
-                            {
-                                success = graphResult.OverallResult == BuildResultCode.Success;
-                            }
-                            else if (result != null && result.Exception == null)
-                            {
-                                success = result.OverallResult == BuildResultCode.Success;
                             }
                         }
                         finally

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1515,6 +1515,7 @@ namespace Microsoft.Build.CommandLine
                             // approach.
                             GraphBuildRequestData graphBuildRequest = null;
                             BuildRequestData buildRequest = null;
+                            BuildResult restoreResult = null;
                             if (!restoreOnly)
                             {
                                 // By default, the project state is thrown out after a build. The ProvideProjectStateAfterBuild flag adds the project state after build
@@ -1538,7 +1539,7 @@ namespace Microsoft.Build.CommandLine
 
                             if (enableRestore || restoreOnly)
                             {
-                                BuildResult restoreResult = ExecuteRestore(projectFile, toolsVersion, buildManager, restoreProperties.Count > 0 ? restoreProperties : globalProperties, saveProjectResult: saveProjectResult);
+                                restoreResult = ExecuteRestore(projectFile, toolsVersion, buildManager, restoreProperties.Count > 0 ? restoreProperties : globalProperties, saveProjectResult: saveProjectResult);
 
                                 if (restoreResult.OverallResult != BuildResultCode.Success)
                                 {
@@ -1577,6 +1578,10 @@ namespace Microsoft.Build.CommandLine
                                 {
                                     result = ExecuteBuild(buildManager, buildRequest);
                                 }
+                            }
+                            else
+                            {
+                                success = restoreResult.OverallResult == BuildResultCode.Success;
                             }
 
                             if (result != null && result.Exception == null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/9443

### Context
When the `/graph` and `/restore` are used within the same command, the build exit code will always be 0. This is because of the variable used to define success of the restore action overrides the success of the graph build.

### Changes Made
Added an extra condition when defining the success of the build to account for this case.

### Testing
Made sure existing tests passed and added a unit test for this case, an some manual testing.

