### PR TITLE
Add Link metadata to Resources in AssignLinkMetadata target

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1367,6 +1367,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_Temp Remove="@(_Temp)" />
     </ItemGroup>
 
+    <!-- RESOURCE ITEMS -->
+    <AssignLinkMetadata Items="@(Resource)"
+                        Condition="'@(Resource)' != '' and '%(Resource.DefiningProjectFullPath)' != '$(MSBuildProjectFullPath)' and $([MSBuild]::AreFeaturesEnabled('17.10'))">
+      <Output TaskParameter="OutputItems" ItemName="_Temp" />
+    </AssignLinkMetadata>
+
+    <ItemGroup Condition="$([MSBuild]::AreFeaturesEnabled('17.10'))">
+      <Resource Remove="@(_Temp)" />
+      <Resource Include="@(_Temp)" />
+      <_Temp Remove="@(_Temp)" />
+    </ItemGroup>
+
   </Target>
 
   <!--


### PR DESCRIPTION
Fixes #9120

### Context
In the target AssignLinkMetadata Link is added to Page and ApplicationDefinition items, but not for Resource items., causing issues with WPF projects.

### Changes Made
Adding Link metadata to Resource items under a ChangeWave.

### Testing
unit tests and experimental insertion
