### PR TITLE
Exclude the PFX file used in the unit tests from policy check

### DIFF
--- a/eng/policheck_exclusions.xml
+++ b/eng/policheck_exclusions.xml
@@ -10,6 +10,8 @@
   <!--<Exclusion Type="FileName">ABC.TXT|XYZ.CS</Exclusion>-->
 
   <Exclusion Type="FolderPathFull">.DOTNET</Exclusion>
+  <!-- This file is intentionally used in the unit tests. -->
+  <Exclusion Type="FileName">MYCERT.PFX</Exclusion>
   <!-- This file contains entity names that were written out by the XML writer in the VS.NET 2002/2003 project system. Leave them unchanged and skip the file -->
   <Exclusion Type="FileName">OLDVSPROJECTFILEREADER.CS</Exclusion>
   <!-- Since only support the locale en-us in our repo, skip the translated files currently. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1889125  -->


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1922736

### Context
CredentialScanner detected  .\src\Tasks.UnitTests\TestResources\mycert.pfx that had certificate keys. Since it's used in unit tests, this is false positive.

### Changes Made
Exclude the PFX file from policy check.

### Testing


### Notes
