### PR TITLE
Pass submissionId to the BuildEventContext used by SolutionProjectGenerator

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1453,13 +1453,20 @@ namespace Microsoft.Build.Execution
             }
 
             ErrorUtilities.VerifyThrow(FileUtilities.IsSolutionFilename(config.ProjectFullPath), "{0} is not a solution", config.ProjectFullPath);
+
+            var buildEventContext = request.BuildEventContext;
+            if (buildEventContext == BuildEventContext.Invalid)
+            {
+                buildEventContext = new BuildEventContext(request.SubmissionId, 0, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+            }
+
             var instances = ProjectInstance.LoadSolutionForBuild(
                 config.ProjectFullPath,
                 config.GlobalProperties,
                 config.ExplicitToolsVersionSpecified ? config.ToolsVersion : null,
                 _buildParameters,
                 ((IBuildComponentHost)this).LoggingService,
-                request.BuildEventContext,
+                buildEventContext,
                 false /* loaded by solution parser*/,
                 config.RequestedTargets,
                 SdkResolverService,

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -498,7 +498,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal ProjectInstance(ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, ILoggingService loggingService, int visualStudioVersionFromSolution, ProjectCollection projectCollection, ISdkResolverService sdkResolverService, int submissionId)
         {
-            BuildEventContext buildEventContext = new BuildEventContext(0, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
+            BuildEventContext buildEventContext = new BuildEventContext(submissionId, 0, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
             Initialize(xml, globalProperties, toolsVersion, null, visualStudioVersionFromSolution, new BuildParameters(projectCollection), loggingService, buildEventContext, sdkResolverService, submissionId);
         }
 


### PR DESCRIPTION
When evaluating the generated .sln.metaproj, we do pass a valid submissionId, but then we don't use it when creating the BuildEventContext used by the ProjectInstance to log evaluation events. So evaluation logging events end up having SubmissionId == -1, and thus the loggers registered with the MuxLogger in the IDE do not get the evaluation events.

Fixes #9469

I've built a bootstrap MSBuild and validated that the events show up in the log now:

Before:
![image](https://github.com/dotnet/msbuild/assets/679326/ce4a70d9-d8a2-4a25-ab44-b3f3580017fb)

After:
![image](https://github.com/dotnet/msbuild/assets/679326/4c7a2231-f81c-4437-a592-a6e386b22787)
