### PR TITLE
Add VersionOverride to XSD for PackageReference elements

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -214,6 +214,13 @@ elementFormDefault="qualified">
                   </xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element name="VersionOverride">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="PackageReference_VersionOverride" _locComment="" -->When using Central Package Management (CPM), overrides the centrally defined version for this package.  If the project is not using CPM, this element has no effect.
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
             </xs:choice>
           </xs:sequence>
           <xs:attribute name="Include" type="xs:string">
@@ -262,6 +269,13 @@ elementFormDefault="qualified">
             <xs:annotation>
               <xs:documentation>
                 <!-- _locID_text="PackageReference_Attribute_GeneratePathProperty" _locComment="" -->Set to true to generate a Pkg* property that points to the restored location of the NuGet package contents
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="VersionOverride" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="PackageReference_Attribute_VersionOverride" _locComment="" -->When using Central Package Management (CPM), overrides the centrally defined version for this package.  If the project is not using CPM, this attribute has no effect.
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>


### PR DESCRIPTION
Fixes VS feedback ticket https://developercommunity.visualstudio.com/t/Code-Completion-for-Nuget-Package-Refere/10525616

### Context
NuGet's Central Package Management (CPM) allows users to specify package versions in a central location.  However, sometimes you may need to override the centrally defined version for a particular package so you specify the `VersionOverride` attribute documented [here](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management#overriding-package-versions).

### Changes Made
Added `VersionOverride` to the XSD for auto-completion in Visual Studio.

### Testing
Unsure how to test this.

### Notes
