### PR TITLE
Update Microsoft.BuildXL.Processes

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="LargeAddressAware" Version="1.0.5" />
     <PackageVersion Update="LargeAddressAware" Condition="'$(LargeAddressAwareVersion)' != ''" Version="$(LargeAddressAwareVersion)" />
 
-    <PackageVersion Include="Microsoft.BuildXL.Processes" Version="0.1.0-20230929.2" />
+    <PackageVersion Include="Microsoft.BuildXL.Processes" Version="0.1.0-20231128.3" />
     <PackageVersion Update="Microsoft.BuildXL.Processes" Condition="'$(BuildXLProcessesVersion)' != ''" Version="$(BuildXLProcessesVersion)" />
 
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.8.2112" />

--- a/src/Build/BackEnd/Components/Communications/DetouredNodeLauncher.cs
+++ b/src/Build/BackEnd/Components/Communications/DetouredNodeLauncher.cs
@@ -15,6 +15,7 @@ using Microsoft.Build.FileAccesses;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using static BuildXL.Processes.FileAccessManifest;
 
 #nullable disable
 
@@ -106,7 +107,14 @@ namespace Microsoft.Build.BackEnd
                 FileAccessPolicy.AllowAll | FileAccessPolicy.ReportAccess);
 
             // Support shared compilation
-            info.FileAccessManifest.ChildProcessesToBreakawayFromSandbox = new string[] { NativeMethodsShared.IsWindows ? "VBCSCompiler.exe" : "VBCSCompiler" };
+            info.FileAccessManifest.ChildProcessesToBreakawayFromSandbox = new BreakawayChildProcess[]
+            {
+#if RUNTIME_TYPE_NETCORE
+                new BreakawayChildProcess(NativeMethodsShared.IsWindows ? "dotnet.exe" : "dotnet", "vbcscompiler.dll", CommandLineArgsSubstringContainmentIgnoreCase: true)
+#else
+                new BreakawayChildProcess(NativeMethodsShared.IsWindows ? "VBCSCompiler.exe" : "VBCSCompiler")
+#endif
+            };
             info.FileAccessManifest.MonitorChildProcesses = true;
             info.FileAccessManifest.IgnoreReparsePoints = true;
             info.FileAccessManifest.UseExtraThreadToDrainNtClose = false;


### PR DESCRIPTION
Update Microsoft.BuildXL.Processes

The primary motivation behind this update is to bring in a bug fix related to the BuildXL.Process assembly depending on BuildXL.Tracing, which is not available in the package.

Before and after:
![image](https://github.com/dotnet/msbuild/assets/6445614/05081801-5d31-42fe-bb09-31c3c91a40f8)

This change also adjusts a breaking change to `ChildProcessesToBreakawayFromSandbox`, as well as added some extra logic associated with the reason behind the breaking change which supports `dotnet` scenarios better. This is just future-proofing though since reporting file accesses via detours is currently only available in MSBuild.exe.