### PR TITLE
Suppress CredScan error from legitimate unit test PFX file with private key

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -311,4 +311,5 @@ stages:
         -TsaRepositoryName "dotnet-msbuild"
         -TsaCodebaseName "dotnet-msbuild"
         -TsaPublish $True
+        -CrScanAdditionalRunConfigParams @("SuppressionsPath < $(Build.SourcesDirectory)\eng\CredScanSuppressions.json")
         -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)\eng\policheck_exclusions.xml")'

--- a/eng/CredScanSuppressions.json
+++ b/eng/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+      {
+        "file": "\\src\\Tasks.UnitTests\\TestResources\\mycert.pfx",
+        "_justification": "Legitimate UT certificate file with private key"
+      }
+    ]
+ }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1922736

### Context
CredentialScanner detected .\src\Tasks.UnitTests\TestResources\mycert.pfx that had certificate keys. Since it's legitimate unit test PFX file, this is false positive.

### Changes Made
Suppress the CredScan error from the UT PFX file.

### Testing
Verified the run with this experimental branch. The CredScan error was eliminated.

### Notes
