### PR TITLE
Delete checks for retired change waves

### DIFF
--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -36,6 +36,13 @@ namespace Microsoft.Build.Framework
         /// </summary>
         internal static readonly Version EnableAllFeatures = new Version(999, 999);
 
+#if DEBUG
+        /// <summary>
+        /// True if <see cref="ResetStateForTests"/> has been called.
+        /// </summary>
+        private static bool _runningTests = false;
+#endif
+
         /// <summary>
         /// The lowest wave in the current rotation of Change Waves.
         /// </summary>
@@ -163,7 +170,9 @@ namespace Microsoft.Build.Framework
         {
             ApplyChangeWave();
 
-            Debug.Assert(AllWaves.Contains(wave), $"Change wave version {wave} is invalid");
+#if DEBUG
+            Debug.Assert(_runningTests || AllWaves.Contains(wave), $"Change wave version {wave} is invalid");
+#endif
 
             return wave < _cachedWave;
         }
@@ -174,6 +183,9 @@ namespace Microsoft.Build.Framework
         /// </summary>
         internal static void ResetStateForTests()
         {
+#if DEBUG
+            _runningTests = true;
+#endif
             _cachedWave = null;
             _state = ChangeWaveConversionState.NotConvertedYet;
         }

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 
 #nullable disable
@@ -22,7 +23,7 @@ namespace Microsoft.Build.Framework
     /// </summary>
     /// See docs here: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves.md
     /// For dev docs: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves-Dev.md
-    internal class ChangeWaves
+    internal static class ChangeWaves
     {
         internal static readonly Version Wave17_4 = new Version(17, 4);
         internal static readonly Version Wave17_6 = new Version(17, 6);
@@ -161,6 +162,8 @@ namespace Microsoft.Build.Framework
         internal static bool AreFeaturesEnabled(Version wave)
         {
             ApplyChangeWave();
+
+            Debug.Assert(AllWaves.Contains(wave), $"Change wave version {wave} is invalid");
 
             return wave < _cachedWave;
         }

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -323,7 +323,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Example, C:\MyProjects\MyProject\bin\Debug\MyAssembly.dll -->
     <TargetPath Condition=" '$(TargetPath)' == '' ">$(TargetDir)$(TargetFileName)</TargetPath>
 
-    <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(ProduceReferenceAssembly)' == 'true' and ('$(ProduceReferenceAssemblyInOutDir)' == 'true' or '$([MSBuild]::AreFeaturesEnabled(17.0))' != 'true' ) ">$([MSBuild]::NormalizePath($(TargetDir), 'ref', $(TargetFileName)))</TargetRefPath>
+    <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(ProduceReferenceAssembly)' == 'true' and '$(ProduceReferenceAssemblyInOutDir)' == 'true' ">$([MSBuild]::NormalizePath($(TargetDir), 'ref', $(TargetFileName)))</TargetRefPath>
     <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(ProduceReferenceAssembly)' == 'true' ">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(IntermediateOutputPath), 'ref', $(TargetFileName)))</TargetRefPath>
 
     <!-- Example, C:\MyProjects\MyProject\ -->
@@ -5014,7 +5014,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       This target enforces the dependency.
     -->
 
-    <MSBuildCopyContentTransitively Condition=" '$(MSBuildCopyContentTransitively)' == '' and $([MSBuild]::AreFeaturesEnabled('17.0'))">true</MSBuildCopyContentTransitively>
+    <MSBuildCopyContentTransitively Condition=" '$(MSBuildCopyContentTransitively)' == ''">true</MSBuildCopyContentTransitively>
 
     <_TargetsThatPrepareProjectReferences Condition=" '$(MSBuildCopyContentTransitively)' == 'true' ">
       AssignProjectConfiguration;


### PR DESCRIPTION
### Context

We still have checks for a change wave that's already out of rotation.

### Changes Made

`[MSBuild]::AreFeaturesEnabled('17.0')` is now unconditionally true, let's remove the checks from `Microsoft.Common.CurrentVersion.targets`.