### PR TITLE
Change Version switch output to finish with a newline

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -28,6 +28,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Warning on serialization custom events by default in .NET framework](https://github.com/dotnet/msbuild/pull/9318)
 - [Cache SDK resolver data process-wide](https://github.com/dotnet/msbuild/pull/9335)
 - [Target parameters will be unquoted](https://github.com/dotnet/msbuild/pull/9452), meaning  the ';' symbol in the parameter target name will always be treated as separator
+- [Change Version switch output to finish with a newline](https://github.com/dotnet/msbuild/pull/9485)
 
 ### 17.8
 - [[RAR] Don't do I/O on SDK-provided references](https://github.com/dotnet/msbuild/pull/8688)

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -526,6 +526,13 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void VersionSwitch()
         {
+            using TestEnvironment env = UnitTests.TestEnvironment.Create();
+
+            // Ensure Change Wave 17.10 is enabled.
+            ChangeWaves.ResetStateForTests();
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", "");
+            BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+
             List<string> cmdLine = new()
             {
 #if !FEATURE_RUN_EXE_IN_TESTS
@@ -552,15 +559,7 @@ namespace Microsoft.Build.UnitTests
             process.ExitCode.ShouldBe(0);
 
             string output = process.StandardOutput.ReadToEnd();
-            // Change Version switch output to finish with a newline https://github.com/dotnet/msbuild/pull/9485
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
-            {
-                output.EndsWith(Environment.NewLine).ShouldBeTrue();
-            }
-            else
-            {
-                output.EndsWith(Environment.NewLine).ShouldBeFalse();
-            }
+            output.EndsWith(Environment.NewLine).ShouldBeTrue();
 
             process.Close();
         }
@@ -571,6 +570,13 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void VersionSwitchDisableChangeWave()
         {
+            using TestEnvironment env = UnitTests.TestEnvironment.Create();
+
+            // Disable Change Wave 17.10
+            ChangeWaves.ResetStateForTests();
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_10.ToString());
+            BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+
             List<string> cmdLine = new()
             {
 #if !FEATURE_RUN_EXE_IN_TESTS
@@ -591,8 +597,6 @@ namespace Microsoft.Build.UnitTests
                     RedirectStandardOutput = true,
                 },
             };
-            // Disable Change Wave 17.10
-            process.StartInfo.Environment.Add("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_10.ToString());
 
             process.Start();
             process.WaitForExit();

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -523,13 +523,8 @@ namespace Microsoft.Build.UnitTests
             .ShouldBe(MSBuildApp.ExitType.Success);
         }
 
-        [Theory]
-        [InlineData("--version")]
-        [InlineData("-version")]
-        [InlineData(@"/version")]
-        [InlineData("-ver")]
-        [InlineData(@"/ver")]
-        public void VersionSwitch(string cmdSwitch)
+        [Fact]
+        public void VersionSwitch()
         {
             List<string> cmdLine = new()
             {
@@ -538,7 +533,7 @@ namespace Microsoft.Build.UnitTests
 #endif
                 FileUtilities.EnsureDoubleQuotes(RunnerUtilities.PathToCurrentlyRunningMsBuildExe),
                 "-nologo",
-                cmdSwitch
+                "-version"
             };
 
             using Process process = new()

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -4487,7 +4487,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private static void ShowVersion()
         {
-            Console.Write(ProjectCollection.Version.ToString());
+            Console.WriteLine(ProjectCollection.Version.ToString());
         }
     }
 }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -4487,7 +4487,15 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private static void ShowVersion()
         {
-            Console.WriteLine(ProjectCollection.Version.ToString());
+            // Change Version switch output to finish with a newline https://github.com/dotnet/msbuild/pull/9485
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+            {
+                Console.WriteLine(ProjectCollection.Version.ToString());
+            }
+            else
+            {
+                Console.Write(ProjectCollection.Version.ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #9482

### Context
The -version switch doesn't terminate its output with a newline which some shells don't like.

### Changes Made
- Added a unit test.
- Changed `ShowVersion()`.

### Testing
Tested on Windows 10 and macOS 14.
Tested by running the full unit test suite and by manually running the `-version` switch under cmd (Windows), pwsh (Windows and macOS), and zsh (macOS).
