### PR TITLE
Exit the loop after finding the switch name in the map

### DIFF
--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -305,12 +305,12 @@ namespace Microsoft.Build.CommandLine
                     {
                         parameterlessSwitch = switchInfo.parameterlessSwitch;
                         duplicateSwitchErrorMessage = switchInfo.duplicateSwitchErrorMessage;
-                        break;
+                        return true;
                     }
                 }
             }
 
-            return parameterlessSwitch != ParameterlessSwitch.Invalid;
+            return false;
         }
 
         /// <summary>
@@ -362,12 +362,12 @@ namespace Microsoft.Build.CommandLine
                         missingParametersErrorMessage = switchInfo.missingParametersErrorMessage;
                         unquoteParameters = switchInfo.unquoteParameters;
                         emptyParametersAllowed = switchInfo.emptyParametersAllowed;
-                        break;
+                        return true;
                     }
                 }
             }
 
-            return parameterizedSwitch != ParameterizedSwitch.Invalid;
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
origin PR: https://github.com/dotnet/msbuild/pull/9453
### Context
The methods: IsParameterlessSwitch and IsParameterizedSwitch are desgined to identify if the switch is exist or not, iterates the switches map and assignes the found values to the output variables, however after finding the needed parameter (name comparison) it continues to search till the end of the map, which makes it unnecessary since the name is unique across the all presented switches

### Changes Made
Exit the method as soon the parameter name is find and the values are assigned.

### Testing
Existing tests should pass