### PR TITLE
Сhange ProperyReassignment logged message type

### DIFF
--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4616,7 +4616,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
                     logger
                         .AllBuildEvents
                         .OfType<PropertyReassignmentEventArgs>()
-                        .ShouldHaveSingleItem();
+                        .Count()
+                        .ShouldBe(2);
 
                     logger
                         .AllBuildEvents
@@ -4683,7 +4684,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
                     logger
                        .AllBuildEvents
                        .OfType<PropertyReassignmentEventArgs>()
-                       .ShouldHaveSingleItem();
+                       .Count()
+                       .ShouldBe(2);
                 });
         }
 

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4615,6 +4615,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                     logger
                         .AllBuildEvents
+                        .OfType<PropertyReassignmentEventArgs>()
+                        .ShouldHaveSingleItem();
+
+                    logger
+                        .AllBuildEvents
                         .OfType<PropertyInitialValueSetEventArgs>()
                         .ShouldBeEmpty();
                 });
@@ -4674,6 +4679,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
                         .AllBuildEvents
                         .OfType<PropertyInitialValueSetEventArgs>()
                         .ShouldBeEmpty();
+
+                    logger
+                       .AllBuildEvents
+                       .OfType<PropertyReassignmentEventArgs>()
+                       .ShouldHaveSingleItem();
                 });
         }
 

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4597,7 +4597,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void VerifyPropertyTrackingLoggingDefault()
         {
             // Having just environment variables defined should default to nothing being logged except one environment variable read.
-            this.VerifyPropertyTrackingLoggingScenario(
+            VerifyPropertyTrackingLoggingScenario(
                 null,
                 logger =>
                 {
@@ -4615,11 +4615,6 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                     logger
                         .AllBuildEvents
-                        .OfType<PropertyReassignmentEventArgs>()
-                        .ShouldBeEmpty();
-
-                    logger
-                        .AllBuildEvents
                         .OfType<PropertyInitialValueSetEventArgs>()
                         .ShouldBeEmpty();
                 });
@@ -4628,7 +4623,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void VerifyPropertyTrackingLoggingPropertyReassignment()
         {
-            this.VerifyPropertyTrackingLoggingScenario(
+            VerifyPropertyTrackingLoggingScenario(
                 "1",
                 logger =>
                 {
@@ -4674,11 +4669,6 @@ namespace Microsoft.Build.UnitTests.Evaluation
                         .ShouldHaveSingleItem()
                         .EnvironmentVariableName
                         .ShouldBe("DEFINED_ENVIRONMENT_VARIABLE2");
-
-                    logger
-                        .AllBuildEvents
-                        .OfType<PropertyReassignmentEventArgs>()
-                        .ShouldBeEmpty();
 
                     logger
                         .AllBuildEvents

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4915,11 +4915,14 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void VerifyLogPropertyReassignment()
         {
-            string testtargets = ObjectModelHelpers.CleanupFileContents(@"
+            string propertyName = "Prop";
+            string propertyOldValue = "OldValue";
+            string propertyNewValue = "NewValue";
+            string testtargets = ObjectModelHelpers.CleanupFileContents(@$"
                                 <Project xmlns='msbuildnamespace'>
                                      <PropertyGroup>
-                                         <Prop>OldValue</Prop>
-                                         <Prop>NewValue</Prop>
+                                         <{propertyName}>{propertyOldValue}</{propertyName}>
+                                         <{propertyName}>{propertyNewValue}</{propertyName}>
                                      </PropertyGroup>
                                   <Target Name=""Test""/>
                                 </Project>");
@@ -4928,10 +4931,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string targetDirectory = Path.Combine(tempPath, "LogPropertyAssignments");
             string testTargetPath = Path.Combine(targetDirectory, "test.proj");
 
-            try
+            using (TestEnvironment env = TestEnvironment.Create())
             {
-                Directory.CreateDirectory(targetDirectory);
-                File.WriteAllText(testTargetPath, testtargets);
+                env.CreateFolder(targetDirectory);
+                env.CreateFile(testTargetPath, testtargets);
 
                 MockLogger logger = new()
                 {
@@ -4945,18 +4948,13 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 result.ShouldBeTrue();
                 logger.BuildMessageEvents
                       .OfType<PropertyReassignmentEventArgs>()
-                      .ShouldContain(r => r.PropertyName == "Prop"
-                      && r.PreviousValue == "OldValue"
-                      && r.NewValue == "NewValue"
-                      && r.Message.StartsWith("Property reassignment: $(Prop)=\"NewValue\" (previous value: \"OldValue\")"));
+                      .ShouldContain(r => r.PropertyName == propertyName
+                      && r.PreviousValue == propertyOldValue
+                      && r.NewValue == propertyNewValue
+                      && r.Message.StartsWith($"{
+                          ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
+                              "PropertyReassignment", propertyName, propertyNewValue, propertyOldValue, string.Empty)}"));
                 logger.BuildMessageEvents.ShouldBeOfTypes(new[] { typeof(PropertyReassignmentEventArgs) });
-            }
-            finally
-            {
-                if (Directory.Exists(targetDirectory))
-                {
-                    FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true /* recursive delete */);
-                }
             }
         }
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1348,17 +1348,30 @@ namespace Microsoft.Build.Evaluation
 
             if (newValue != oldValue)
             {
-                var args = new PropertyReassignmentEventArgs(
-                    property.Name,
-                    oldValue,
-                    newValue,
-                    location,
-                    message: null)
+                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
                 {
-                    BuildEventContext = _evaluationLoggingContext.BuildEventContext,
-                };
+                    var args = new PropertyReassignmentEventArgs(
+                        property.Name,
+                        oldValue,
+                        newValue,
+                        location,
+                        message: null)
+                    {
+                        BuildEventContext = _evaluationLoggingContext.BuildEventContext,
+                    };
 
-                _evaluationLoggingContext.LogBuildEvent(args);
+                    _evaluationLoggingContext.LogBuildEvent(args);
+                }
+                else
+                {
+                    _evaluationLoggingContext.LogComment(
+                        MessageImportance.Low,
+                        "PropertyReassignment",
+                        property.Name,
+                        newValue,
+                        oldValue,
+                        location);
+                }
             }
         }
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1348,13 +1348,17 @@ namespace Microsoft.Build.Evaluation
 
             if (newValue != oldValue)
             {
-                _evaluationLoggingContext.LogComment(
-                    MessageImportance.Low,
-                    "PropertyReassignment",
+                var args = new PropertyReassignmentEventArgs(
                     property.Name,
-                    newValue,
                     oldValue,
-                    location);
+                    newValue,
+                    location,
+                    message: null)
+                {
+                    BuildEventContext = _evaluationLoggingContext.BuildEventContext,
+                };
+
+                _evaluationLoggingContext.LogBuildEvent(args);
             }
         }
 


### PR DESCRIPTION
Fixes #9385

### Context
During the Evaluation phase, property reassignment was logged as a plain message.

### Changes Made
convert plain message to -> PropertyReassignmentEventArgs

### Testing
UT is added
