### PR TITLE
Remove U2D marker dependency on ProjectGuid property

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.10.0</VersionPrefix>
+    <VersionPrefix>17.9.0</VersionPrefix>
     <PackageValidationBaselineVersion>17.8.0-preview-23471-08</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.9.0</VersionPrefix>
+    <VersionPrefix>17.10.0</VersionPrefix>
     <PackageValidationBaselineVersion>17.8.0-preview-23471-08</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -388,9 +388,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   
   <PropertyGroup Condition="'$(MSBuildCopyMarkerName)' == ''">
     <MSBuildCopyMarkerName>$(MSBuildProjectFile)</MSBuildCopyMarkerName>
-    <!-- For a long MSBuildProjectFile let's shorten this to 17 chars - using the first 8 chars of the filename and either the ProjectGuid if it exists -->
-    <MSBuildCopyMarkerName Condition="'$(MSBuildCopyMarkerName.Length)' &gt; '17' and '$(ProjectGuid)' != ''">$(MSBuildProjectFile.Substring(0,8)).$(ProjectGuid.Substring(1,8))</MSBuildCopyMarkerName>
-    <!-- or a filename hash if the guid is not present (in such case the filename was not shortened and is still over 17 chars long). -->
+    <!-- For a long MSBuildProjectFile let's shorten this to 17 chars - using the first 8 chars of the filename and a filename hash. -->
     <MSBuildCopyMarkerName Condition="'$(MSBuildCopyMarkerName.Length)' &gt; '17'">$(MSBuildProjectFile.Substring(0,8)).$([MSBuild]::StableStringHash($(MSBuildProjectFile)).ToString("X8"))</MSBuildCopyMarkerName>
     <MSBuildCopyMarkerName>$(MSBuildCopyMarkerName).Up2Date</MSBuildCopyMarkerName>
   </PropertyGroup>


### PR DESCRIPTION
Fixes: 1P issue

### Context
#9387 intorduced Up2Date check marekr file shortening - but this was leveraging `ProjectGuid` property (if present). That property can be user altered and lead to invalid path issues.
Let's simplify and solidify the marker file shortening via relying on the filename hash only.

### Changes Made
Removed the usage of `ProjectGuid`
