### PR TITLE
Remove Microsoft.SourceBuild.Intermediate from prebuilt baseline

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -3,8 +3,6 @@
 
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
-
     <!-- Baseline 7.0 dependencies until msbuild targets net8 and uses a net8 arcade, SBRP, etc.
          These cannot be added to 7.0 SBRP, because they would are produced in the 7.0 build. -->
     <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/*7.0.0*" />


### PR DESCRIPTION
Prebuilt detection no longer detects Microsoft.SourceBuild.Intermediates as prebuilts due to https://github.com/dotnet/arcade/pull/13935.

Addresses https://github.com/dotnet/source-build/issues/3010