### PR TITLE
Change Extended args api back to be compatible with 17.8

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -642,7 +642,7 @@ namespace Microsoft.Build.Logging
                     fields.Arguments)
                 {
                     ProjectFile = fields.ProjectFile,
-                    ExtendedMetadata = fields.Extended.ExtendedMetadata,
+                    ExtendedMetadata = fields.Extended.ExtendedMetadataAsDictionary,
                     ExtendedData = fields.Extended.ExtendedData,
                 };
             }
@@ -694,7 +694,7 @@ namespace Microsoft.Build.Logging
                     fields.Arguments)
                 {
                     ProjectFile = fields.ProjectFile,
-                    ExtendedMetadata = fields.Extended.ExtendedMetadata,
+                    ExtendedMetadata = fields.Extended.ExtendedMetadataAsDictionary,
                     ExtendedData = fields.Extended.ExtendedData,
                 };
             }
@@ -747,7 +747,7 @@ namespace Microsoft.Build.Logging
                     fields.Arguments)
                 {
                     ProjectFile = fields.ProjectFile,
-                    ExtendedMetadata = fields.Extended?.ExtendedMetadata,
+                    ExtendedMetadata = fields.Extended?.ExtendedMetadataAsDictionary,
                     ExtendedData = fields.Extended?.ExtendedData,
                 };
             }
@@ -836,7 +836,7 @@ namespace Microsoft.Build.Logging
                     fields.Arguments)
                 {
                     ProjectFile = fields.ProjectFile,
-                    ExtendedMetadata = fields.Extended?.ExtendedMetadata,
+                    ExtendedMetadata = fields.Extended?.ExtendedMetadataAsDictionary,
                     ExtendedData = fields.Extended?.ExtendedData,
                 };
             }

--- a/src/Build/Logging/BinaryLogger/ExtendedDataFields.cs
+++ b/src/Build/Logging/BinaryLogger/ExtendedDataFields.cs
@@ -17,4 +17,14 @@ internal class ExtendedDataFields
     public string ExtendedType { get; }
     public IDictionary<string, string?>? ExtendedMetadata { get; }
     public string? ExtendedData { get; }
+
+    /// <summary>
+    /// We need to this for Extended event args have Dictionary as ExtendedMetadata.
+    /// </summary>
+    public Dictionary<string, string?>? ExtendedMetadataAsDictionary =>
+        ExtendedMetadata == null ?
+            null :
+            ExtendedMetadata is Dictionary<string, string?> asDictionary ?
+                asDictionary :
+                new Dictionary<string, string?>(ExtendedMetadata);
 }

--- a/src/Framework/ExtendedBuildErrorEventArgs.cs
+++ b/src/Framework/ExtendedBuildErrorEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class ExtendedBuildErrorEventArgs : BuildErrorEventArgs, IExtended
     public string ExtendedType { get; set; }
 
     /// <inheritdoc />
-    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
+    public Dictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <inheritdoc />
     public string? ExtendedData { get; set; }

--- a/src/Framework/ExtendedBuildMessageEventArgs.cs
+++ b/src/Framework/ExtendedBuildMessageEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class ExtendedBuildMessageEventArgs : BuildMessageEventArgs, IExte
     public string ExtendedType { get; set; }
 
     /// <inheritdoc />
-    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
+    public Dictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <inheritdoc />
     public string? ExtendedData { get; set; }

--- a/src/Framework/ExtendedBuildWarningEventArgs.cs
+++ b/src/Framework/ExtendedBuildWarningEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class ExtendedBuildWarningEventArgs : BuildWarningEventArgs, IExte
     public string ExtendedType { get; set; }
 
     /// <inheritdoc />
-    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
+    public Dictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <inheritdoc />
     public string? ExtendedData { get; set; }

--- a/src/Framework/ExtendedCriticalBuildMessageEventArgs.cs
+++ b/src/Framework/ExtendedCriticalBuildMessageEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class ExtendedCriticalBuildMessageEventArgs : CriticalBuildMessage
     public string ExtendedType { get; set; }
 
     /// <inheritdoc />
-    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
+    public Dictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <inheritdoc />
     public string? ExtendedData { get; set; }

--- a/src/Framework/ExtendedCustomBuildEventArgs.cs
+++ b/src/Framework/ExtendedCustomBuildEventArgs.cs
@@ -18,7 +18,7 @@ public sealed class ExtendedCustomBuildEventArgs : CustomBuildEventArgs, IExtend
     public string ExtendedType { get; set; }
 
     /// <inheritdoc />
-    public IDictionary<string, string?>? ExtendedMetadata { get; set; }
+    public Dictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <inheritdoc />
     public string? ExtendedData { get; set; }

--- a/src/Framework/IExtendedBuildEventArgs.cs
+++ b/src/Framework/IExtendedBuildEventArgs.cs
@@ -22,7 +22,7 @@ public interface IExtendedBuildEventArgs
     ///   - data which needed in custom code to properly routing this message without interpreting/deserializing <see cref="ExtendedData"/>.
     ///   - simple extended data can be transferred in form of dictionary key-value per one extended property.
     /// </summary>
-    IDictionary<string, string?>? ExtendedMetadata { get; set; }
+    Dictionary<string, string?>? ExtendedMetadata { get; set; }
 
     /// <summary>
     /// Transparent data as string.


### PR DESCRIPTION
Fixes Arcade update PRs #9371 and #9516

### Context
ApiCompat reported issue from current to 17.8.3

### Changes Made
We have decided to be compatible with 17.8.3 so breaking changes are reverted.

### Testing
dotnet pack
