### PR TITLE
Unset NUGET_PACKAGES in official build only

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -94,6 +94,8 @@ stages:
       value: 'int.main'
     - name: VisualStudio.DropName
       value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+    - name: NUGET_PACKAGES
+      value:
 
     steps:
     - task: NuGetToolInstaller@0


### PR DESCRIPTION
The devdiv build machine images appear to have started setting the
environment variable `NUGET_PACKAGES`, which caused a mismatch between
the location where `drop.app` was restored (repo-local location) and
where it was used from (environment-variable defined machine location),
causing build failures.

Co-authored-by: AR-May <67507805+AR-May@users.noreply.github.com>
