### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
+# See https://help.github.com/articles/about-code-owners/
+
+/eng/SourceBuild*       @dotnet/source-build-internal
+/eng/                   @dotnet/kitten
+/.github/               @dotnet/kitten
+/global.json            @dotnet/kitten
+/.exp-insertions.yml    @dotnet/kitten
+/.opt-prof.yml          @dotnet/kitten
+/.vsts-dotnet-ci.yml    @dotnet/kitten
+/.vsts-dotnet.yml       @dotnet/kitten
+/NuGet.config           @dotnet/kitten
+/Directory.Build*       @dotnet/kitten
+/.git*                  @dotnet/kitten


### PR DESCRIPTION
Fixes #9513

### Context
Creation of CODEOWNERS file as per request in issue. Having a code owners file would also be generally useful when opening PRs in this repo, as it can sometimes be difficult and time consuming to determine who should be included as a reviewer.

### Changes Made
Added @dotnet/source-build-internal as code owners for SB files
Added @dotnet/kitten as code owner for some of files and folders.

### Testing
No testing
