### PR TITLE
Revert "Unset NUGET_PACKAGES in official build only (#9523)"

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -94,8 +94,6 @@ stages:
       value: 'int.main'
     - name: VisualStudio.DropName
       value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
-    - name: NUGET_PACKAGES
-      value:
 
     steps:
     - task: NuGetToolInstaller@0


### PR DESCRIPTION
This reverts commit 67d742f0a7a0de2d770909319bc334d0338b1fbd.
This workaround no more needed.