### PR TITLE
Switch official builds to floating NuGet.exe

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -98,9 +98,8 @@ stages:
       value:
 
     steps:
-    - task: NuGetToolInstaller@0
-      inputs:
-        versionSpec: '4.9.2'
+    - task: NuGetToolInstaller@1
+      displayName: 'Install NuGet.exe'
 
     - task: NuGetCommand@2
       displayName: Restore internal tools


### PR DESCRIPTION
We were hard-coded to an ancient version of NuGet.exe, but we should be fine taking the latest stable, which is default for NuGetToolInstaller.

Experimental (internal) build with this (restored successfully, used tools from that restoration successfully so far): https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=8812367