### PR TITLE
Lock Telemetry properties for updating/retrieving

### DIFF
--- a/src/Build.UnitTests/BackEnd/KnownTelemetry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/KnownTelemetry_Tests.cs
@@ -50,7 +50,7 @@ public class KnownTelemetry_Tests
         buildTelemetry.Version.ShouldBeNull();
 
         buildTelemetry.UpdateEventProperties();
-        buildTelemetry.Properties.ShouldBeEmpty();
+        buildTelemetry.GetProperties().ShouldBeEmpty();
     }
 
     [Fact]
@@ -76,21 +76,23 @@ public class KnownTelemetry_Tests
         buildTelemetry.Version = new Version(1, 2, 3, 4);
 
         buildTelemetry.UpdateEventProperties();
-        buildTelemetry.Properties.Count.ShouldBe(11);
+        var properties = buildTelemetry.GetProperties();
 
-        buildTelemetry.Properties["BuildEngineDisplayVersion"].ShouldBe("Some Display Version");
-        buildTelemetry.Properties["BuildEngineFrameworkName"].ShouldBe("new .NET");
-        buildTelemetry.Properties["BuildEngineHost"].ShouldBe("Host description");
-        buildTelemetry.Properties["InitialMSBuildServerState"].ShouldBe("hot");
-        buildTelemetry.Properties["ProjectPath"].ShouldBe(@"C:\\dev\\theProject");
-        buildTelemetry.Properties["ServerFallbackReason"].ShouldBe("busy");
-        buildTelemetry.Properties["BuildSuccess"].ShouldBe("True");
-        buildTelemetry.Properties["BuildTarget"].ShouldBe("clean");
-        buildTelemetry.Properties["BuildEngineVersion"].ShouldBe("1.2.3.4");
+        properties.Count.ShouldBe(11);
+
+        properties["BuildEngineDisplayVersion"].ShouldBe("Some Display Version");
+        properties["BuildEngineFrameworkName"].ShouldBe("new .NET");
+        properties["BuildEngineHost"].ShouldBe("Host description");
+        properties["InitialMSBuildServerState"].ShouldBe("hot");
+        properties["ProjectPath"].ShouldBe(@"C:\\dev\\theProject");
+        properties["ServerFallbackReason"].ShouldBe("busy");
+        properties["BuildSuccess"].ShouldBe("True");
+        properties["BuildTarget"].ShouldBe("clean");
+        properties["BuildEngineVersion"].ShouldBe("1.2.3.4");
 
         // verify computed
-        buildTelemetry.Properties["BuildDurationInMilliseconds"] = (finishedAt - startAt).TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
-        buildTelemetry.Properties["InnerBuildDurationInMilliseconds"] = (finishedAt - innerStartAt).TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+        properties["BuildDurationInMilliseconds"] = (finishedAt - startAt).TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+        properties["InnerBuildDurationInMilliseconds"] = (finishedAt - innerStartAt).TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
     }
 
     [Fact]
@@ -101,21 +103,21 @@ public class KnownTelemetry_Tests
         buildTelemetry.StartAt = DateTime.MinValue;
         buildTelemetry.FinishedAt = null;
         buildTelemetry.UpdateEventProperties();
-        buildTelemetry.Properties.ShouldBeEmpty();
+        buildTelemetry.GetProperties().ShouldBeEmpty();
 
         buildTelemetry.StartAt = null;
         buildTelemetry.FinishedAt = DateTime.MaxValue;
         buildTelemetry.UpdateEventProperties();
-        buildTelemetry.Properties.ShouldBeEmpty();
+        buildTelemetry.GetProperties().ShouldBeEmpty();
 
         buildTelemetry.InnerStartAt = DateTime.MinValue;
         buildTelemetry.FinishedAt = null;
         buildTelemetry.UpdateEventProperties();
-        buildTelemetry.Properties.ShouldBeEmpty();
+        buildTelemetry.GetProperties().ShouldBeEmpty();
 
         buildTelemetry.InnerStartAt = null;
         buildTelemetry.FinishedAt = DateTime.MaxValue;
         buildTelemetry.UpdateEventProperties();
-        buildTelemetry.Properties.ShouldBeEmpty();
+        buildTelemetry.GetProperties().ShouldBeEmpty();
     }
 }

--- a/src/Build.UnitTests/BackEnd/LoggingConfigurationTelemetry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingConfigurationTelemetry_Tests.cs
@@ -41,7 +41,7 @@ public class LoggingConfigurationTelemetry_Tests
         telemetry.BinaryLoggerUsedDefaultName.ShouldBe(false);
 
         telemetry.UpdateEventProperties();
-        telemetry.Properties.Where(kv => kv.Value != bool.FalseString).ShouldBeEmpty();
+        telemetry.GetProperties().Where(kv => kv.Value != bool.FalseString).ShouldBeEmpty();
     }
 
     [Fact]
@@ -66,20 +66,20 @@ public class LoggingConfigurationTelemetry_Tests
         };
 
         telemetry.UpdateEventProperties();
-
-        telemetry.Properties["TerminalLogger"].ShouldBe(bool.TrueString);
-        telemetry.Properties["TerminalLoggerUserIntent"].ShouldBe("on");
-        telemetry.Properties["TerminalLoggerUserIntentSource"].ShouldBe("arg");
-        telemetry.Properties["TerminalLoggerDefault"].ShouldBe("auto");
-        telemetry.Properties["TerminalLoggerDefaultSource"].ShouldBe("sdk");
-        telemetry.Properties["ConsoleLogger"].ShouldBe(bool.TrueString);
-        telemetry.Properties["ConsoleLoggerType"].ShouldBe("serial");
-        telemetry.Properties["ConsoleLoggerVerbosity"].ShouldBe("minimal");
-        telemetry.Properties["FileLogger"].ShouldBe(bool.TrueString);
-        telemetry.Properties["FileLoggerType"].ShouldBe("serial");
-        telemetry.Properties["FileLoggersCount"].ShouldBe("2");
-        telemetry.Properties["FileLoggerVerbosity"].ShouldBe("normal");
-        telemetry.Properties["BinaryLogger"].ShouldBe(bool.TrueString);
-        telemetry.Properties["BinaryLoggerUsedDefaultName"].ShouldBe(bool.TrueString);
+        var properties = telemetry.GetProperties();
+        properties["TerminalLogger"].ShouldBe(bool.TrueString);
+        properties["TerminalLoggerUserIntent"].ShouldBe("on");
+        properties["TerminalLoggerUserIntentSource"].ShouldBe("arg");
+        properties["TerminalLoggerDefault"].ShouldBe("auto");
+        properties["TerminalLoggerDefaultSource"].ShouldBe("sdk");
+        properties["ConsoleLogger"].ShouldBe(bool.TrueString);
+        properties["ConsoleLoggerType"].ShouldBe("serial");
+        properties["ConsoleLoggerVerbosity"].ShouldBe("minimal");
+        properties["FileLogger"].ShouldBe(bool.TrueString);
+        properties["FileLoggerType"].ShouldBe("serial");
+        properties["FileLoggersCount"].ShouldBe("2");
+        properties["FileLoggerVerbosity"].ShouldBe("normal");
+        properties["BinaryLogger"].ShouldBe(bool.TrueString);
+        properties["BinaryLoggerUsedDefaultName"].ShouldBe(bool.TrueString);
     }
 }

--- a/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
+++ b/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
@@ -71,7 +71,7 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         };
 
         expectedTelemetry.UpdateEventProperties();
-        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.GetProperties())
         {
             output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
         }
@@ -102,7 +102,7 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         };
 
         expectedTelemetry.UpdateEventProperties();
-        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.GetProperties())
         {
             output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
         }
@@ -130,7 +130,7 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         };
 
         expectedTelemetry.UpdateEventProperties();
-        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.GetProperties())
         {
             output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
         }
@@ -160,7 +160,7 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         };
 
         expectedTelemetry.UpdateEventProperties();
-        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.GetProperties())
         {
             output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
         }
@@ -189,7 +189,7 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         };
 
         expectedTelemetry.UpdateEventProperties();
-        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.GetProperties())
         {
             output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
         }
@@ -220,7 +220,7 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
         };
 
         expectedTelemetry.UpdateEventProperties();
-        foreach (KeyValuePair<string, string> pair in expectedTelemetry.Properties)
+        foreach (KeyValuePair<string, string> pair in expectedTelemetry.GetProperties())
         {
             output.ShouldContain($"{expectedTelemetry.EventName}:{pair.Key}={pair.Value}");
         }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -577,7 +577,7 @@ namespace Microsoft.Build.Execution
 
                 // Log known deferred telemetry
                 KnownTelemetry.LoggingConfigurationTelemetry.UpdateEventProperties();
-                loggingService.LogTelemetry(buildEventContext: null, KnownTelemetry.LoggingConfigurationTelemetry.EventName, KnownTelemetry.LoggingConfigurationTelemetry.Properties);
+                loggingService.LogTelemetry(buildEventContext: null, KnownTelemetry.LoggingConfigurationTelemetry.EventName, KnownTelemetry.LoggingConfigurationTelemetry.GetProperties());
 
                 InitializeCaches();
 
@@ -1091,7 +1091,7 @@ namespace Microsoft.Build.Execution
                             _buildTelemetry.Host = host;
 
                             _buildTelemetry.UpdateEventProperties();
-                            loggingService.LogTelemetry(buildEventContext: null, _buildTelemetry.EventName, _buildTelemetry.Properties);
+                            loggingService.LogTelemetry(buildEventContext: null, _buildTelemetry.EventName, _buildTelemetry.GetProperties());
                             // Clean telemetry to make it ready for next build submission.
                             _buildTelemetry = null;
                         }

--- a/src/Framework/Telemetry/BuildTelemetry.cs
+++ b/src/Framework/Telemetry/BuildTelemetry.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace Microsoft.Build.Framework.Telemetry
@@ -83,6 +84,11 @@ namespace Microsoft.Build.Framework.Telemetry
         /// Framework name suitable for display to a user.
         /// </summary>
         public string? FrameworkName { get; set; }
+
+        public override IDictionary<string, string> GetProperties()
+        {
+            return Properties;
+        }
 
         public override void UpdateEventProperties()
         {

--- a/src/Framework/Telemetry/LoggingConfigurationTelemetry.cs
+++ b/src/Framework/Telemetry/LoggingConfigurationTelemetry.cs
@@ -2,12 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace Microsoft.Build.Framework.Telemetry;
 
 internal class LoggingConfigurationTelemetry : TelemetryBase
 {
+    private readonly object _propertiesLock = new object();
+
     public override string EventName => "loggingConfiguration";
 
     /// <summary>
@@ -97,54 +100,65 @@ internal class LoggingConfigurationTelemetry : TelemetryBase
     /// </summary>
     public bool BinaryLoggerUsedDefaultName { get; set; }
 
+    public override IDictionary<string, string> GetProperties()
+    {
+        lock (_propertiesLock)
+        {
+            return new Dictionary<string, string>(Properties);
+        }
+    }
+
     public override void UpdateEventProperties()
     {
-        Properties["TerminalLogger"] = TerminalLogger.ToString(CultureInfo.InvariantCulture);
-
-        if (TerminalLoggerUserIntent != null)
+        lock (_propertiesLock)
         {
-            Properties["TerminalLoggerUserIntent"] = TerminalLoggerUserIntent;
-        }
+            Properties["TerminalLogger"] = TerminalLogger.ToString(CultureInfo.InvariantCulture);
 
-        if (TerminalLoggerUserIntentSource != null)
-        {
-            Properties["TerminalLoggerUserIntentSource"] = TerminalLoggerUserIntentSource;
-        }
+            if (TerminalLoggerUserIntent != null)
+            {
+                Properties["TerminalLoggerUserIntent"] = TerminalLoggerUserIntent;
+            }
 
-        if (TerminalLoggerDefault != null)
-        {
-            Properties["TerminalLoggerDefault"] = TerminalLoggerDefault;
-        }
+            if (TerminalLoggerUserIntentSource != null)
+            {
+                Properties["TerminalLoggerUserIntentSource"] = TerminalLoggerUserIntentSource;
+            }
 
-        if (TerminalLoggerDefaultSource != null)
-        {
-            Properties["TerminalLoggerDefaultSource"] = TerminalLoggerDefaultSource;
-        }
+            if (TerminalLoggerDefault != null)
+            {
+                Properties["TerminalLoggerDefault"] = TerminalLoggerDefault;
+            }
 
-        Properties["ConsoleLogger"] = ConsoleLogger.ToString(CultureInfo.InvariantCulture);
-        if (ConsoleLoggerType != null)
-        {
-            Properties["ConsoleLoggerType"] = ConsoleLoggerType;
-        }
+            if (TerminalLoggerDefaultSource != null)
+            {
+                Properties["TerminalLoggerDefaultSource"] = TerminalLoggerDefaultSource;
+            }
 
-        if (ConsoleLoggerVerbosity != null)
-        {
-            Properties["ConsoleLoggerVerbosity"] = ConsoleLoggerVerbosity;
-        }
+            Properties["ConsoleLogger"] = ConsoleLogger.ToString(CultureInfo.InvariantCulture);
+            if (ConsoleLoggerType != null)
+            {
+                Properties["ConsoleLoggerType"] = ConsoleLoggerType;
+            }
 
-        Properties["FileLogger"] = FileLogger.ToString(CultureInfo.InvariantCulture);
-        if (FileLoggerType != null)
-        {
-            Properties["FileLoggerType"] = FileLoggerType;
-            Properties["FileLoggersCount"] = FileLoggersCount.ToString(CultureInfo.InvariantCulture);
-        }
+            if (ConsoleLoggerVerbosity != null)
+            {
+                Properties["ConsoleLoggerVerbosity"] = ConsoleLoggerVerbosity;
+            }
 
-        if (FileLoggerVerbosity != null)
-        {
-            Properties["FileLoggerVerbosity"] = FileLoggerVerbosity;
-        }
+            Properties["FileLogger"] = FileLogger.ToString(CultureInfo.InvariantCulture);
+            if (FileLoggerType != null)
+            {
+                Properties["FileLoggerType"] = FileLoggerType;
+                Properties["FileLoggersCount"] = FileLoggersCount.ToString(CultureInfo.InvariantCulture);
+            }
 
-        Properties["BinaryLogger"] = BinaryLogger.ToString(CultureInfo.InvariantCulture);
-        Properties["BinaryLoggerUsedDefaultName"] = BinaryLoggerUsedDefaultName.ToString(CultureInfo.InvariantCulture);
+            if (FileLoggerVerbosity != null)
+            {
+                Properties["FileLoggerVerbosity"] = FileLoggerVerbosity;
+            }
+
+            Properties["BinaryLogger"] = BinaryLogger.ToString(CultureInfo.InvariantCulture);
+            Properties["BinaryLoggerUsedDefaultName"] = BinaryLoggerUsedDefaultName.ToString(CultureInfo.InvariantCulture);
+        }
     }
 }

--- a/src/Framework/Telemetry/TelemetryBase.cs
+++ b/src/Framework/Telemetry/TelemetryBase.cs
@@ -15,7 +15,12 @@ internal abstract class TelemetryBase
     /// <summary>
     /// Gets or sets a list of properties associated with the event.
     /// </summary>
-    public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+    private protected IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Fetch current properties <see cref="Properties"/>.
+    /// </summary>
+    public abstract IDictionary<string, string> GetProperties();
 
     /// <summary>
     /// Translate all derived type members into properties which will be used to build <see cref="TelemetryEventArgs"/>.


### PR DESCRIPTION
Fixes #9550

### Context
There is a possibility to access LoggingConfigurationTelemetry Properties field from different threads, which makes it possible to have curruption of data. 
https://github.com/dotnet/msbuild/blob/b0e2b79230019c8f28ad7bedd82ecaa85a114761/src/Build/BackEnd/BuildManager/BuildManager.cs#L580

### Changes Made
Update access level of Properties, Lock the update or fetch properties in LoggingConfigurationTelemetry implementations. 

### Testing
All existing tests should pass