### PR TITLE
Fix Arcade's BeforeCommon imports not being respected

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -3,7 +3,7 @@
 <Project>
 
   <PropertyGroup>
-    <RestoreUseStaticGraphEvaluation Condition="'$(DotNetBuildFromSource)' != 'true'">true</RestoreUseStaticGraphEvaluation>
+    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -3,7 +3,7 @@
 <Project>
 
   <PropertyGroup>
-    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <RestoreUseStaticGraphEvaluation Condition="'$(DotNetBuildFromSource)' != 'true'">true</RestoreUseStaticGraphEvaluation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,8 +24,8 @@
 
     <ProduceReferenceAssembly Condition="'$(IsTestProject)' != 'true'">true</ProduceReferenceAssembly>
 
-    <!-- Set up BeforeCommon.targets -->
-    <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Directory.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
+    <!-- Set up BeforeCommon.targets. Arcade uses this property as well, so don't overwrite it. -->
+    <CustomBeforeMicrosoftCommonTargets>$(CustomBeforeMicrosoftCommonTargets);$(MSBuildThisFileDirectory)Directory.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
 
     <Platforms>AnyCPU;x64;arm64</Platforms>
 


### PR DESCRIPTION
MSBuild's build ifnrastructure overwrites the `CustomBeforeMicrosoftCommonTargets` property which results in Arcade's entry to get dropped.

Arcade adds to that property to import common files.

This fixes static graph restore not working in this repository when using Arcade's `ExcludeFromBuild` properties.