### PR TITLE
Added import of .user file for multi-targeted builds

### DIFF
--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -19,6 +19,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.CrossTargeting.targets\ImportBefore\*.targets"
           Condition="'$(ImportByWildcardBeforeMicrosoftCommonCrossTargetingTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.CrossTargeting.targets\ImportBefore')"/>
 
+  <Import Project="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')"/>
+
   <Import Project="$(CustomBeforeMicrosoftCommonCrossTargetingTargets)" Condition="'$(CustomBeforeMicrosoftCommonCrossTargetingTargets)' != '' and Exists('$(CustomBeforeMicrosoftCommonCrossTargetingTargets)')"/>
 
   <Target Name="GetTargetFrameworks"


### PR DESCRIPTION
Fixes #9131

### Context
As described on the issue, muti-targeted builds did not import the .user file on the outer build. This change makes the outer build import the .user file.

### Changes Made
Added import reference to .user file in  Microsoft.Common.CrossTargeting.targets .

### Testing
Test is in SDK repo (dotnet/sdk#37192)

### Notes
This is cherry-picked from main branch