### PR TITLE
Add requested targets to CacheContext

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1332,6 +1332,7 @@ namespace Microsoft.Build.Execution
                             _projectCacheService.InitializePluginsForVsScenario(
                                 ProjectCacheDescriptors.Values,
                                 resolvedConfiguration,
+                                submission.BuildRequestData.TargetNames,
                                 _executionCancellationTokenSource.Token);
                         }
 
@@ -1953,7 +1954,7 @@ namespace Microsoft.Build.Execution
 
             if (submission.BuildRequestData.GraphBuildOptions.Build)
             {
-                _projectCacheService.InitializePluginsForGraph(projectGraph, _executionCancellationTokenSource.Token);
+                _projectCacheService.InitializePluginsForGraph(projectGraph, submission.BuildRequestData.TargetNames, _executionCancellationTokenSource.Token);
 
                 var targetListTask = projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames);
 

--- a/src/Build/BackEnd/Components/ProjectCache/CacheContext.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/CacheContext.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Build.FileSystem;
 using Microsoft.Build.Graph;
@@ -22,10 +23,21 @@ namespace Microsoft.Build.Experimental.ProjectCache
         public IReadOnlyCollection<ProjectGraphEntryPoint>? GraphEntryPoints { get; }
         public string? MSBuildExePath { get; }
         public MSBuildFileSystemBase FileSystem { get; }
+        public IReadOnlyCollection<string> RequestedTargets { get; }
 
         public CacheContext(
             IReadOnlyDictionary<string, string> pluginSettings,
             MSBuildFileSystemBase fileSystem,
+            ProjectGraph? graph = null,
+            IReadOnlyCollection<ProjectGraphEntryPoint>? graphEntryPoints = null)
+            : this(pluginSettings, fileSystem, requestedTargets: Array.Empty<string>(), graph, graphEntryPoints)
+        {
+        }
+
+        public CacheContext(
+            IReadOnlyDictionary<string, string> pluginSettings,
+            MSBuildFileSystemBase fileSystem,
+            IReadOnlyCollection<string> requestedTargets,
             ProjectGraph? graph = null,
             IReadOnlyCollection<ProjectGraphEntryPoint>? graphEntryPoints = null)
         {
@@ -38,6 +50,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
             GraphEntryPoints = graphEntryPoints;
             MSBuildExePath = BuildEnvironmentHelper.Instance.CurrentMSBuildExePath;
             FileSystem = fileSystem;
+            RequestedTargets = requestedTargets;
         }
     }
 }


### PR DESCRIPTION
Fixes #9554

As usual, the Visual Studio code path is a bit icky. It basically just uses the target names of whatever the first request it receives which uses a given plugin. In practice this is fine since VS uses the same target across all projects depending on scenario (Build, Rebuild, Clean, etc.).