### PR TITLE
Log before unregistering Fixes #9455

### DIFF
--- a/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
@@ -542,16 +542,13 @@ namespace Microsoft.Build.BackEnd.Logging
                 }
                 catch (Exception exception)
                 {
-                    // first unregister all loggers, since other loggers may receive remaining events in unexpected orderings
-                    // if a fellow logger is throwing in an event handler.
-                    this.UnregisterAllEventHandlers();
-
                     if (ExceptionHandling.IsCriticalException(exception))
                     {
                         throw;
                     }
 
                     InternalLoggerException.Throw(exception, buildEvent, "FatalErrorWhileLogging", false);
+                    UnregisterAllEventHandlers();
                 }
             }
 
@@ -873,9 +870,9 @@ namespace Microsoft.Build.BackEnd.Logging
                     // if a logger has failed politely, abort immediately
                     // first unregister all loggers, since other loggers may receive remaining events in unexpected orderings
                     // if a fellow logger is throwing in an event handler.
-                    this.UnregisterAllEventHandlers();
+                    UnregisterAllEventHandlers();
 
-                    // We ought to dump this farther up the stack, but if for example a task is logging an event within a
+                    // We ought to dump this further up the stack, but if for example a task is logging an event within a
                     // catch(Exception) block and not rethrowing it, there's the possibility that this exception could
                     // just get silently eaten.  So better to have duplicates than to not log the problem at all. :)
                     ExceptionHandling.DumpExceptionToFile(exception);
@@ -884,11 +881,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 }
                 catch (Exception exception)
                 {
-                    // first unregister all loggers, since other loggers may receive remaining events in unexpected orderings
-                    // if a fellow logger is throwing in an event handler.
-                    this.UnregisterAllEventHandlers();
-
-                    // We ought to dump this farther up the stack, but if for example a task is logging an event within a
+                    // We ought to dump this further up the stack, but if for example a task is logging an event within a
                     // catch(Exception) block and not rethrowing it, there's the possibility that this exception could
                     // just get silently eaten.  So better to have duplicates than to not log the problem at all. :)
                     ExceptionHandling.DumpExceptionToFile(exception);
@@ -899,6 +892,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     }
 
                     InternalLoggerException.Throw(exception, buildEvent, "FatalErrorWhileLogging", false);
+                    UnregisterAllEventHandlers();
                 }
             }
         }

--- a/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     // if a logger has failed politely, abort immediately
                     // first unregister all loggers, since other loggers may receive remaining events in unexpected orderings
                     // if a fellow logger is throwing in an event handler.
-                    this.UnregisterAllEventHandlers();
+                    UnregisterAllEventHandlers();
                     throw;
                 }
                 catch (Exception exception)
@@ -548,7 +548,6 @@ namespace Microsoft.Build.BackEnd.Logging
                     }
 
                     InternalLoggerException.Throw(exception, buildEvent, "FatalErrorWhileLogging", false);
-                    UnregisterAllEventHandlers();
                 }
             }
 
@@ -892,7 +891,6 @@ namespace Microsoft.Build.BackEnd.Logging
                     }
 
                     InternalLoggerException.Throw(exception, buildEvent, "FatalErrorWhileLogging", false);
-                    UnregisterAllEventHandlers();
                 }
             }
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -842,13 +842,17 @@ namespace Microsoft.Build.BackEnd
                 {
                     // The build was likely cancelled. We do not need to log an error in this case.
                 }
-                else if (_projectLoggingContext is null)
+                else if (ex is InternalLoggerException)
                 {
-                    _nodeLoggingContext.LogError(BuildEventFileInfo.Empty, "UnhandledMSBuildError", ex.ToString());
+                    (((LoggingContext)_projectLoggingContext) ?? _nodeLoggingContext).LogError(
+                        BuildEventFileInfo.Empty,
+                        "FatalErrorWhileLoggingWithInnerExceptionAndStack",
+                        ex.InnerException?.Message ?? string.Empty,
+                        ex.StackTrace);
                 }
                 else
                 {
-                    _projectLoggingContext.LogError(BuildEventFileInfo.Empty, "UnhandledMSBuildError", ex.ToString());
+                    (((LoggingContext)_projectLoggingContext) ?? _nodeLoggingContext).LogError(BuildEventFileInfo.Empty, "UnhandledMSBuildError", ex.ToString());
                 }
 
                 if (ExceptionHandling.IsCriticalException(ex))

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -844,19 +844,14 @@ namespace Microsoft.Build.BackEnd
                 }
                 else if (ex is InternalLoggerException)
                 {
-                    string realMessage = ex.Message;
-                    Exception realEx = ex;
-                    while (realEx.InnerException is not null)
-                    {
-                        realEx = realEx.InnerException;
-                        realMessage = realEx.Message;
-                    }
-
-                    (((LoggingContext)_projectLoggingContext) ?? _nodeLoggingContext).LogError(
+                    string realMessage = TaskLoggingHelper.GetInnerExceptionMessageString(ex);
+                    LoggingContext loggingContext = ((LoggingContext)_projectLoggingContext) ?? _nodeLoggingContext;
+                    loggingContext.LogError(
                         BuildEventFileInfo.Empty,
-                        "FatalErrorWhileLoggingWithInnerExceptionAndStack",
-                        realMessage,
-                        realEx.StackTrace);
+                        "FatalErrorWhileLoggingWithInnerException",
+                        realMessage);
+
+                    loggingContext.LogCommentFromText(MessageImportance.Low, ex.ToString());
                 }
                 else
                 {

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -844,11 +844,19 @@ namespace Microsoft.Build.BackEnd
                 }
                 else if (ex is InternalLoggerException)
                 {
+                    string realMessage = ex.Message;
+                    Exception realEx = ex;
+                    while (realEx.InnerException is not null)
+                    {
+                        realEx = realEx.InnerException;
+                        realMessage = realEx.Message;
+                    }
+
                     (((LoggingContext)_projectLoggingContext) ?? _nodeLoggingContext).LogError(
                         BuildEventFileInfo.Empty,
                         "FatalErrorWhileLoggingWithInnerExceptionAndStack",
-                        ex.InnerException?.Message ?? string.Empty,
-                        ex.StackTrace);
+                        realMessage,
+                        realEx.StackTrace);
                 }
                 else
                 {

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -469,10 +469,9 @@
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</comment>
   </data>
-  <data name="FatalErrorWhileLoggingWithInnerExceptionAndStack" xml:space="preserve">
+  <data name="FatalErrorWhileLoggingWithInnerException" xml:space="preserve">
     <value>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</value>
+    {0}</value>
     <comment>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</comment>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -469,6 +469,14 @@
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</comment>
   </data>
+  <data name="FatalErrorWhileLoggingWithInnerExceptionAndStack" xml:space="preserve">
+    <value>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+    {0}
+    {1}</value>
+    <comment>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</comment>
+  </data>
   <data name="General.TwoVectorsMustHaveSameLength">
     <value>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</value>
     <comment>{StrBegin="MSB3094: "}</comment>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: Položka {2} odkazuje na {0} položek a položka {3} odkazuje na {1} položek. Musí mít stejný počet položek.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}" verweist auf {0} Element(e), und "{3}" verweist auf {1} Element(e). Die Anzahl von Elementen muss identisch sein.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}" hace referencia a {0} elementos y "{3}" hace referencia a {1} elementos. Deben tener el mismo número de elementos.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}" fait référence à {0} élément(s) et "{3}", à {1} élément(s). Ils doivent avoir le même nombre d'éléments.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}" fa riferimento a {0} elemento/i, mentre "{3}" fa riferimento a {1} elemento/i. Devono avere lo stesso numero di elementi.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}" は {0} 項目を参照し、"{3}" は {1} 項目を参照します。これらは同じ項目数を持たなければなりません。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}"은(는) 항목을 {0}개 참조하고 "{3}"은(는) 항목을 {1}개 참조합니다. 참조하는 항목 수는 같아야 합니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: „{2}” odwołuje się do następującej liczby elementów: {0}, a „{3}” odwołuje się do następującej liczby elementów: {1}. Liczba tych elementów musi być taka sama.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}" refere-se ao(s) item(ns) {0} e "{3}" refere-se ao(s) item(ns) {1}. Eles devem ter o mesmo número de itens.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}" ссылается на следующее число элементов: {0}, а "{3}" — на {1}. Число элементов должно быть одинаковым.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}", {0} öğeye; "{3}", {1} öğeye başvuruyor. Aynı sayıda öğeye sahip olmaları gerekir.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: “{2}”引用 {0} 个项，而“{3}”引用 {1} 个项。它们必须具有相同的项数。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -151,11 +151,11 @@
       </trans-unit>
       <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</source>
+    {0}
+    {1}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-{0}
-{1}</target>
+    {0}
+    {1}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -149,13 +149,11 @@
   {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+      <trans-unit id="FatalErrorWhileLoggingWithInnerException">
         <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</source>
+    {0}</source>
         <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
-    {0}
-    {1}</target>
+    {0}</target>
         <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
     likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
     special exception to abort the build.</note>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -149,6 +149,17 @@
   {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FatalErrorWhileLoggingWithInnerExceptionAndStack">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
+{0}
+{1}</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
       <trans-unit id="General.TwoVectorsMustHaveSameLength">
         <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
         <target state="translated">MSB3094: "{2}" 參考 {0} 個項目，"{3}" 則參考 {1} 個項目。兩者參考的項目數目必須相同。</target>


### PR DESCRIPTION
Fixes #9455

### Context
If we crash very early—like in the midst of setting up the ProjectLoggingContext—we have all the machinery set up to log information like that the build started, but then we unregister the relevant handlers before we actually log that we'd failed.

### Changes Made
Do not unregister handlers until shutdown

### Testing
I tested with the repro from #9455, and it now looks like this:
```
MSBUILD : error MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
MSBUILD : error MSB4017:     Exception of type 'System.Exception' was thrown.
MSBUILD : error MSB4017:        at Microsoft.Build.BackEnd.Logging.ParallelConsoleLogger.ProjectStartedHandler(Object s
ender, ProjectStartedEventArgs e) in C:\GitHub\msbuild\src\Build\Logging\ParallelLogger\ParallelConsoleLogger.cs:line 5
86
MSBUILD : error MSB4017:    at Microsoft.Build.Evaluation.ProjectCollection.ReusableLogger.ProjectStartedHandler(Object
 sender, ProjectStartedEventArgs e) in C:\GitHub\msbuild\src\Build\Definition\ProjectCollection.cs:line 2342
MSBUILD : error MSB4017:    at Microsoft.Build.BackEnd.Logging.EventSourceSink.RaiseProjectStartedEvent(Object sender,
ProjectStartedEventArgs buildEvent) in C:\GitHub\msbuild\src\Build\BackEnd\Components\Logging\EventSourceSink.cs:line 5
33
```

(with a full stack trace).

Notice that it finds the real exception—just an ordinary System.Exception with no message in this case.

### Notes
I went directly against the advice of a comment to make this change. I tried to see what motivated that comment, but it came with the initial commit along with all the code next to it. Regardless, it does not make me feel good to do so. I don't understand why the comment should be true, but please do read it and let me know if this is a horrible idea.

I also intentionally reused MSB4017 because this feels like the same exception, and I didn't want to confuse people. I just added some extra formatting around it. Like with going against the comment, I can find a new number if reviewers don't like that idea.