### PR TITLE
Revert "Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only) (#9439)"

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -29,7 +29,6 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Cache SDK resolver data process-wide](https://github.com/dotnet/msbuild/pull/9335)
 - [Target parameters will be unquoted](https://github.com/dotnet/msbuild/pull/9452), meaning  the ';' symbol in the parameter target name will always be treated as separator
 - [Change Version switch output to finish with a newline](https://github.com/dotnet/msbuild/pull/9485)
-- [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/9439)
 
 ### 17.8
 - [[RAR] Don't do I/O on SDK-provided references](https://github.com/dotnet/msbuild/pull/8688)

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -226,20 +226,6 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         protected virtual Assembly LoadResolverAssembly(string resolverPath)
         {
 #if !FEATURE_ASSEMBLYLOADCONTEXT
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
-            {
-                string resolverFileName = Path.GetFileNameWithoutExtension(resolverPath);
-                if (resolverFileName.Equals("Microsoft.DotNet.MSBuildSdkResolver", StringComparison.OrdinalIgnoreCase))
-                {
-                    // This will load the resolver assembly into the default load context if possible, and fall back to LoadFrom context.
-                    // We very much prefer the default load context because it allows native images to be used by the CLR, improving startup perf.
-                    AssemblyName assemblyName = new AssemblyName(resolverFileName)
-                    {
-                        CodeBase = resolverPath,
-                    };
-                    return Assembly.Load(assemblyName);
-                }
-            }
             return Assembly.LoadFrom(resolverPath);
 #else
             return s_loader.LoadFromPath(resolverPath);

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -184,21 +184,6 @@
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <codeBase version="17.0.0.0" href="..\..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
-
-        <!-- Redirects for SDK resolver components -->
-        <qualifyAssembly partialName="Microsoft.DotNet.MSBuildSdkResolver" fullName="Microsoft.DotNet.MSBuildSdkResolver, Version=8.0.100.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
-        <dependentAssembly>
-          <assemblyIdentity name="Microsoft.DotNet.MSBuildSdkResolver" culture="neutral" publicKeyToken="adb9793829ddae60" />
-          <codeBase version="8.0.100.0" href="..\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.dll" />
-        </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="Microsoft.Deployment.DotNet.Releases" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <codeBase version="2.0.0.0" href="..\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.Deployment.DotNet.Releases.dll" />
-        </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-          <codeBase version="13.0.0.0" href="..\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Newtonsoft.Json.dll" />
-        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -133,21 +133,6 @@
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <codeBase version="17.0.0.0" href="..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
-
-        <!-- Redirects for SDK resolver components -->
-        <qualifyAssembly partialName="Microsoft.DotNet.MSBuildSdkResolver" fullName="Microsoft.DotNet.MSBuildSdkResolver, Version=8.0.100.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
-        <dependentAssembly>
-          <assemblyIdentity name="Microsoft.DotNet.MSBuildSdkResolver" culture="neutral" publicKeyToken="adb9793829ddae60" />
-          <codeBase version="8.0.100.0" href=".\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.dll" />
-        </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="Microsoft.Deployment.DotNet.Releases" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <codeBase version="2.0.0.0" href=".\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.Deployment.DotNet.Releases.dll" />
-        </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-          <codeBase version="13.0.0.0" href=".\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Newtonsoft.Json.dll" />
-        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->


### PR DESCRIPTION
**Likely a red herring - closing** (a separate issue will be opened for an unrelated issue hit with that change)

This reverts commit 6257b8ee53833e060efd7b7c4cdbda5789ab17b5.

### Context
 * https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1931676
 * https://portal.microsofticm.com/imp/v3/outages/details/452776892/overview
Latest VS main msbuild fails to restore VS sources.

### Testing
For a quicker test loop I was testing only on a specific project:
```
.\MSBuild.exe /t:Restore C:\src\VS\src\vset\Agile\TestPlatform\RocksteadyCLI\Rocksteady.csproj
```

~~With the latest VS main (17.9.0 Preview 3.0 [34422.22.main]) it received bunch of `NU1604` and `NU1103` - showing that dependencies versions were not properly resolved.
When injected msbuild build on latest vs17.9 - the same symptomps remained.
When injected backsynced msbuild or msbuild from latest vs17.9 with reverted #9439 - the issues disappeared~~

~~With previous VS main (17.9.0 Preview 3.0 [34414.216.main]) - the issue doesn't repro
With previous VS main with injected msbuild build on latest vs17.9 - the same symptomps remained.~~

With the latest VS main (17.9.0 Preview 3.0 [34422.22.main]) it received bunch of `NU1604` and `NU1103` - showing that dependencies versions were not properly resolved.
When injected msbuild build on latest vs17.9 - the same symptomps remained.
When injected backsynced msbuild or msbuild from latest vs17.9 with reverted #9439 - the issues is still there (**so likely that change is not a culprit**)
When injected backsynced msbuild prior the inserted commits (to https://github.com/dotnet/msbuild/commit/fcff9b0a5eb7165ca2f81cb3a80ca4294afbebaa) - the issues is still there (**so likely no msbuild change is a culprit**)

With previous VS main (17.9.0 Preview 3.0 [34414.216.main]) - the issue doesn't repro
With previous VS main with injected msbuild build on latest vs17.9 - there is a different issue:

```
C:\src\VS\Directory.Build.props(201,3): error : Could not resolve SDK "Microsoft.DevDiv.DownloadTasks". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
C:\src\VS\Directory.Build.props(201,3): error :   The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
C:\src\VS\Directory.Build.props(201,3): error :   MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.DevDiv.DownloadTasks" because directory "C:\Program Files\Microsoft Visual Studio\2022\main-2\MSBuild\Sdks\Microsoft.DevDiv.DownloadTasks\Sdk" did not exist.
C:\src\VS\Directory.Build.props(201,31): error MSB4236: The SDK 'Microsoft.DevDiv.DownloadTasks' specified could not be found. [C:\src\VS\src\vset\Agile\TestPlatform\RocksteadyCLI\Rocksteady.csproj]
```

**That issue dissapears when the #9439 is reverted.** - that originaly misslead me to think it's a culprit. But it seems completely unrelated

### Analysis

TBD - (separate item will be created)
