### PR TITLE
BuildIncludeOperation optimizations

### DIFF
--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal static ItemsAndMetadataPair GetReferencedItemNamesAndMetadata(IEnumerable<string> expressions)
         {
-            ItemsAndMetadataPair pair = new ItemsAndMetadataPair(null, null);
+            ItemsAndMetadataPair pair = default;
 
             foreach (string expression in expressions)
             {

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -38,18 +38,10 @@ namespace Microsoft.Build.Evaluation
                 ImmutableArray<I>.Builder? itemsToAdd = null;
 
                 Lazy<Func<string, bool>>? excludeTester = null;
-                ImmutableList<string>.Builder excludePatterns = ImmutableList.CreateBuilder<string>();
-                // STEP 4: Evaluate, split, expand and subtract any Exclude
-                foreach (string exclude in _excludes)
-                {
-                    string excludeExpanded = _expander.ExpandIntoStringLeaveEscaped(exclude, ExpanderOptions.ExpandPropertiesAndItems, _itemElement.ExcludeLocation);
-                    var excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(excludeExpanded);
-                    excludePatterns.AddRange(excludeSplits);
-                }
 
-                if (excludePatterns.Count > 0)
+                if (_excludes.Count > 0)
                 {
-                    excludeTester = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory));
+                    excludeTester = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(_excludes, _rootDirectory));
                 }
 
                 ISet<string>? excludePatternsForGlobs = null;
@@ -95,7 +87,7 @@ namespace Microsoft.Build.Evaluation
 
                             if (excludePatternsForGlobs == null)
                             {
-                                excludePatternsForGlobs = BuildExcludePatternsForGlobs(globsToIgnore, excludePatterns);
+                                excludePatternsForGlobs = BuildExcludePatternsForGlobs(globsToIgnore, _excludes);
                             }
 
                             string[] includeSplitFilesEscaped;
@@ -137,7 +129,7 @@ namespace Microsoft.Build.Evaluation
                 return itemsToAdd?.ToImmutable() ?? ImmutableArray<I>.Empty;
             }
 
-            private static ISet<string> BuildExcludePatternsForGlobs(ImmutableHashSet<string> globsToIgnore, ImmutableList<string>.Builder excludePatterns)
+            private static ISet<string> BuildExcludePatternsForGlobs(ImmutableHashSet<string> globsToIgnore, ImmutableSegmentedList<string> excludePatterns)
             {
                 var anyExcludes = excludePatterns.Count > 0;
                 var anyGlobsToIgnore = globsToIgnore.Count > 0;

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -39,20 +39,17 @@ namespace Microsoft.Build.Evaluation
 
                 Lazy<Func<string, bool>>? excludeTester = null;
                 ImmutableList<string>.Builder excludePatterns = ImmutableList.CreateBuilder<string>();
-                if (_excludes != null)
+                // STEP 4: Evaluate, split, expand and subtract any Exclude
+                foreach (string exclude in _excludes)
                 {
-                    // STEP 4: Evaluate, split, expand and subtract any Exclude
-                    foreach (string exclude in _excludes)
-                    {
-                        string excludeExpanded = _expander.ExpandIntoStringLeaveEscaped(exclude, ExpanderOptions.ExpandPropertiesAndItems, _itemElement.ExcludeLocation);
-                        var excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(excludeExpanded);
-                        excludePatterns.AddRange(excludeSplits);
-                    }
+                    string excludeExpanded = _expander.ExpandIntoStringLeaveEscaped(exclude, ExpanderOptions.ExpandPropertiesAndItems, _itemElement.ExcludeLocation);
+                    var excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(excludeExpanded);
+                    excludePatterns.AddRange(excludeSplits);
+                }
 
-                    if (excludePatterns.Count > 0)
-                    {
-                        excludeTester = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory));
-                    }
+                if (excludePatterns.Count > 0)
+                {
+                    excludeTester = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory));
                 }
 
                 ISet<string>? excludePatternsForGlobs = null;

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -129,14 +129,14 @@ namespace Microsoft.Build.Evaluation
                 return itemsToAdd?.ToImmutable() ?? ImmutableArray<I>.Empty;
             }
 
-            private static ISet<string> BuildExcludePatternsForGlobs(ImmutableHashSet<string> globsToIgnore, ImmutableSegmentedList<string> excludePatterns)
+            private static ImmutableHashSet<string> BuildExcludePatternsForGlobs(ImmutableHashSet<string> globsToIgnore, ImmutableSegmentedList<string> excludePatterns)
             {
                 var anyExcludes = excludePatterns.Count > 0;
                 var anyGlobsToIgnore = globsToIgnore.Count > 0;
 
                 if (anyGlobsToIgnore && anyExcludes)
                 {
-                    return excludePatterns.Concat(globsToIgnore).ToImmutableHashSet();
+                    return globsToIgnore.Union(excludePatterns);
                 }
 
                 return anyExcludes ? excludePatterns.ToImmutableHashSet() : globsToIgnore;
@@ -144,7 +144,7 @@ namespace Microsoft.Build.Evaluation
 
             protected override void MutateItems(ImmutableArray<I> items)
             {
-                DecorateItemsWithMetadata(items.Select(i => new ItemBatchingContext(i)), _metadata);
+                DecorateItemsWithMetadata(items, _metadata);
             }
 
             protected override void SaveItems(ImmutableArray<I> items, OrderedItemDataCollection.Builder listBuilder)

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -315,32 +315,15 @@ namespace Microsoft.Build.Evaluation
             {
                 itemsAndMetadataFound = ExpressionShredder.GetReferencedItemNamesAndMetadata(GetMetadataValuesAndConditions(metadata));
 
-                bool needToExpandMetadataForEachItem = false;
+                // If there is bare metadata of any kind, and the Include involved an item list, we should
+                // run items individually, as even non-built-in metadata might differ between items
 
-                if (itemsAndMetadataFound.Metadata?.Values.Count > 0)
-                {
-                    // If there is bare metadata of any kind, and the Include involved an item list, we should
-                    // run items individually, as even non-built-in metadata might differ between items
+                // If there is bare built-in metadata, we must always run items individually, as that almost
+                // always differs between items.
 
-                    if (_referencedItemLists.Count >= 0)
-                    {
-                        needToExpandMetadataForEachItem = true;
-                    }
-                    else
-                    {
-                        // If there is bare built-in metadata, we must always run items individually, as that almost
-                        // always differs between items.
-
-                        // UNDONE: When batching is implemented for real, we need to make sure that
-                        // item definition metadata is included in all metadata operations during evaluation
-                        if (itemsAndMetadataFound.Metadata.Values.Count > 0)
-                        {
-                            needToExpandMetadataForEachItem = true;
-                        }
-                    }
-                }
-
-                return needToExpandMetadataForEachItem;
+                // UNDONE: When batching is implemented for real, we need to make sure that
+                // item definition metadata is included in all metadata operations during evaluation
+                return itemsAndMetadataFound.Metadata?.Values.Count > 0;
             }
 
             /// <summary>

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Build.Evaluation
     {
         private abstract class LazyItemOperation : IItemOperation
         {
-            private readonly string _itemType;
             private readonly ImmutableDictionary<string, LazyItemList> _referencedItemLists;
 
             protected readonly LazyItemEvaluator<P, I, M, D> _lazyEvaluator;
@@ -36,7 +35,6 @@ namespace Microsoft.Build.Evaluation
             protected LazyItemOperation(OperationBuilder builder, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
             {
                 _itemElement = builder.ItemElement;
-                _itemType = builder.ItemType;
                 _itemSpec = builder.ItemSpec;
                 _referencedItemLists = builder.ReferencedItemLists.ToImmutable();
                 _conditionResult = builder.ConditionResult;
@@ -226,7 +224,7 @@ namespace Microsoft.Build.Evaluation
                     {
                         // Metadata expressions are allowed here.
                         // Temporarily gather and expand these in a table so they can reference other metadata elements above.
-                        EvaluatorMetadataTable metadataTable = new EvaluatorMetadataTable(_itemType, capacity: metadata.Length);
+                        EvaluatorMetadataTable metadataTable = new EvaluatorMetadataTable(_itemElement.ItemType, capacity: metadata.Length);
                         _expander.Metadata = metadataTable;
 
                         // Also keep a list of everything so we can get the predecessor objects correct.

--- a/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Evaluation
         private class UpdateOperation : LazyItemOperation
         {
             private readonly ImmutableArray<ProjectMetadataElement> _metadata;
-            private ImmutableList<ItemBatchingContext>.Builder _itemsToUpdate = null;
+            private ImmutableArray<ItemBatchingContext>.Builder _itemsToUpdate = null;
             private ItemSpecMatchesItem _matchItemSpec = null;
             private bool? _needToExpandMetadataForEachItem = null;
 
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 SetMatchItemSpec();
-                _itemsToUpdate ??= ImmutableList.CreateBuilder<ItemBatchingContext>();
+                _itemsToUpdate ??= ImmutableArray.CreateBuilder<ItemBatchingContext>();
                 _itemsToUpdate.Clear();
 
                 for (int i = 0; i < listBuilder.Count; i++)
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
-                DecorateItemsWithMetadata(_itemsToUpdate.ToImmutableList(), _metadata, _needToExpandMetadataForEachItem);
+                DecorateItemsWithMetadata(_itemsToUpdate.ToImmutableArray(), _metadata, _needToExpandMetadataForEachItem);
             }
 
             /// <summary>
@@ -77,13 +77,13 @@ namespace Microsoft.Build.Evaluation
                 if (_conditionResult)
                 {
                     SetMatchItemSpec();
-                    _itemsToUpdate ??= ImmutableList.CreateBuilder<ItemBatchingContext>();
+                    _itemsToUpdate ??= ImmutableArray.CreateBuilder<ItemBatchingContext>();
                     _itemsToUpdate.Clear();
                     MatchResult matchResult = _matchItemSpec(_itemSpec, item.Item);
                     if (matchResult.IsMatch)
                     {
                         ItemData clonedData = UpdateItem(item, matchResult.CapturedItemsFromReferencedItemTypes);
-                        DecorateItemsWithMetadata(_itemsToUpdate.ToImmutableList(), _metadata, _needToExpandMetadataForEachItem);
+                        DecorateItemsWithMetadata(_itemsToUpdate.ToImmutableArray(), _metadata, _needToExpandMetadataForEachItem);
                         return clonedData;
                     }
                 }

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -466,7 +466,6 @@ namespace Microsoft.Build.Evaluation
             private static readonly ImmutableDictionary<string, LazyItemList> s_emptyIgnoreCase = ImmutableDictionary.Create<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
 
             public ProjectItemElement ItemElement { get; set; }
-            public string ItemType { get; set; }
             public ItemSpec<P, I> ItemSpec { get; set; }
 
             public ImmutableDictionary<string, LazyItemList>.Builder ReferencedItemLists { get; } = Traits.Instance.EscapeHatches.UseCaseSensitiveItemNames ?
@@ -478,7 +477,6 @@ namespace Microsoft.Build.Evaluation
             public OperationBuilder(ProjectItemElement itemElement, bool conditionResult)
             {
                 ItemElement = itemElement;
-                ItemType = itemElement.ItemType;
                 ConditionResult = conditionResult;
             }
         }
@@ -547,10 +545,12 @@ namespace Microsoft.Build.Evaluation
 
         private IncludeOperation BuildIncludeOperation(string rootDirectory, ProjectItemElement itemElement, bool conditionResult)
         {
-            IncludeOperationBuilder operationBuilder = new IncludeOperationBuilder(itemElement, conditionResult);
-            operationBuilder.ElementOrder = _nextElementOrder++;
-            operationBuilder.RootDirectory = rootDirectory;
-            operationBuilder.ConditionResult = conditionResult;
+            IncludeOperationBuilder operationBuilder = new(itemElement, conditionResult)
+            {
+                ElementOrder = _nextElementOrder++,
+                RootDirectory = rootDirectory,
+                ConditionResult = conditionResult,
+            };
 
             // Process include
             ProcessItemSpec(rootDirectory, itemElement.Include, itemElement.IncludeLocation, operationBuilder);

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -562,7 +562,7 @@ namespace Microsoft.Build.Evaluation
             {
                 // Expand properties here, because a property may have a value which is an item reference (ie "@(Bar)"), and
                 //  if so we need to add the right item reference
-                string evaluatedExclude = _expander.ExpandIntoStringLeaveEscaped(itemElement.Exclude, ExpanderOptions.ExpandProperties, itemElement.ExcludeLocation);
+                string evaluatedExclude = _expander.ExpandIntoStringLeaveEscaped(itemElement.Exclude, ExpanderOptions.ExpandPropertiesAndItems, itemElement.ExcludeLocation);
 
                 if (evaluatedExclude.Length > 0)
                 {

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -551,11 +551,13 @@ namespace Microsoft.Build.Internal
         /// <returns>A Func that will return true IFF its argument matches any of the specified filespecs.</returns>
         internal static Func<string, bool> GetFileSpecMatchTester(IList<string> filespecsEscaped, string currentDirectory)
         {
-            var matchers = filespecsEscaped
-                .Select(fs => new Lazy<FileSpecMatcherTester>(() => FileSpecMatcherTester.Parse(currentDirectory, fs)))
-                .ToList();
+            List<FileSpecMatcherTester> matchers = new(filespecsEscaped.Count);
+            foreach (string fs in filespecsEscaped)
+            {
+                matchers.Add(FileSpecMatcherTester.Parse(currentDirectory, fs));
+            }
 
-            return file => matchers.Any(m => m.Value.IsMatch(file));
+            return file => matchers.Any(m => m.IsMatch(file));
         }
 
         internal sealed class IOCache


### PR DESCRIPTION
Working on [AB#1827820](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1827820)

### Context
BuildIncludeOperation is allocate-y. davkean found a case in which it was allocating over 900 MB/s. This tries to make it a bit better.

### Changes Made
Please review commit-by-commit. I'm not 100% confident in all of them, but I tried to separate them into disjoint pieces so we can accept or reject them as relevant.

### Testing
I tried building OrchardCore before and after these changes, and MSBuild as a whole allocated about 0.5% less. When not everyone is on break, I may try to get help with finding a percent change within BuildIncludeOperation specifically, since that was my target 🙂

### Notes
ImmutableArray outperforms ImmutableList if either the number of items in the array/list is small, or adding to it is very rare. As far as I know, the ones I changed are never modified after they're created, so I changed them to arrays.