### PR TITLE
Improve ConfigurableForwardingLogger

### DIFF
--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -185,6 +185,7 @@ namespace Microsoft.Build.Logging
                     break;
                 case ProjectEvaluationStartedEventDescription:
                 case ProjectEvaluationFinishedEventDescription:
+                case ProjectEvaluationEventDescription:
                     eventSource.StatusEventRaised -= BuildStatusHandler;
                     eventSource.StatusEventRaised += BuildStatusHandler;
                     break;
@@ -385,10 +386,10 @@ namespace Microsoft.Build.Logging
         private void MessageHandler(object sender, BuildMessageEventArgs e)
         {
             bool forwardEvent =
-                _forwardLowImportanceMessages && e.Importance == MessageImportance.Low ||
-                _forwardNormalImportanceMessages && e.Importance == MessageImportance.Normal ||
-                _forwardHighImportanceMessages && e.Importance == MessageImportance.High ||
-                _forwardTaskCommandLine && e is TaskCommandLineEventArgs;
+                (_forwardLowImportanceMessages && e.Importance == MessageImportance.Low) ||
+                (_forwardNormalImportanceMessages && e.Importance == MessageImportance.Normal) ||
+                (_forwardHighImportanceMessages && e.Importance == MessageImportance.High) ||
+                (_forwardTaskCommandLine && e is TaskCommandLineEventArgs);
 
             if (forwardEvent)
             {
@@ -494,9 +495,24 @@ namespace Microsoft.Build.Logging
         private bool _showCommandLine = false;
 
         /// <summary>
-        /// Fine tunning of BuildMessageEventArgs forwarding
+        /// Fine-tuning of BuildMessageEventArgs forwarding
         /// </summary>
-        private bool _forwardLowImportanceMessages, _forwardNormalImportanceMessages, _forwardHighImportanceMessages, _forwardTaskCommandLine;
+        private bool _forwardLowImportanceMessages;
+
+        /// <summary>
+        /// Fine-tuning of BuildMessageEventArgs forwarding
+        /// </summary>
+        private bool _forwardNormalImportanceMessages;
+
+        /// <summary>
+        /// Fine-tuning of BuildMessageEventArgs forwarding
+        /// </summary>
+        private bool _forwardHighImportanceMessages;
+
+        /// <summary>
+        /// Fine-tuning of BuildMessageEventArgs forwarding
+        /// </summary>
+        private bool _forwardTaskCommandLine;
 
         /// <summary>
         /// Id of the node the logger is attached to

--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -22,9 +22,7 @@ namespace Microsoft.Build.Logging
         /// Default constructor.
         /// </summary>
         public ConfigurableForwardingLogger()
-        {
-            InitializeForwardingTable();
-        }
+        { }
         #endregion
 
         #region Properties
@@ -73,34 +71,9 @@ namespace Microsoft.Build.Logging
         #region Methods
 
         /// <summary>
-        /// Initialize the Forwarding Table with the default values
-        /// </summary>
-        private void InitializeForwardingTable()
-        {
-            _forwardingTable = new Dictionary<string, int>(16, StringComparer.OrdinalIgnoreCase);
-            _forwardingTable[BuildStartedEventDescription] = 0;
-            _forwardingTable[BuildFinishedEventDescription] = 0;
-            _forwardingTable[ProjectStartedEventDescription] = 0;
-            _forwardingTable[ProjectFinishedEventDescription] = 0;
-            _forwardingTable[ProjectEvaluationEventDescription] = 0;
-            _forwardingTable[TargetStartedEventDescription] = 0;
-            _forwardingTable[TargetFinishedEventDescription] = 0;
-            _forwardingTable[TaskStartedEventDescription] = 0;
-            _forwardingTable[TaskFinishedEventDescription] = 0;
-            _forwardingTable[ErrorEventDescription] = 0;
-            _forwardingTable[WarningEventDescription] = 0;
-            _forwardingTable[HighMessageEventDescription] = 0;
-            _forwardingTable[NormalMessageEventDescription] = 0;
-            _forwardingTable[LowMessageEventDescription] = 0;
-            _forwardingTable[CustomEventDescription] = 0;
-            _forwardingTable[CommandLineDescription] = 0;
-            _forwardingSetFromParameters = false;
-        }
-
-        /// <summary>
         /// Parses out the logger parameters from the Parameters string.
         /// </summary>
-        private void ParseParameters()
+        private void ParseParameters(IEventSource eventSource)
         {
             if (_loggerParameters != null)
             {
@@ -109,7 +82,7 @@ namespace Microsoft.Build.Logging
                 {
                     if (parameterComponents[param].Length > 0)
                     {
-                        ApplyParameter(parameterComponents[param]);
+                        ApplyParameter(eventSource, parameterComponents[param]);
                     }
                 }
                 // Setting events to forward on the commandline will override the verbosity and other switches such as
@@ -125,8 +98,10 @@ namespace Microsoft.Build.Logging
                     // We can't know whether the project items needed to find ForwardProjectContextDescription
                     // will be set on ProjectStarted or ProjectEvaluationFinished because we don't know
                     // all of the other loggers that will be attached. So turn both on.
-                    _forwardingTable[ProjectStartedEventDescription] = 1;
-                    _forwardingTable[ProjectEvaluationEventDescription] = 1;
+                    eventSource.StatusEventRaised -= BuildStatusHandler;
+                    eventSource.StatusEventRaised += BuildStatusHandler;
+                    eventSource.ProjectStarted -= ForwardEvent;
+                    eventSource.ProjectStarted += ForwardEvent;
                 }
             }
         }
@@ -135,39 +110,108 @@ namespace Microsoft.Build.Logging
         /// Logger parameters can be used to enable and disable specific event types.
         /// Otherwise, the verbosity is used to choose which events to forward.
         /// </summary>
-        private void ApplyParameter(string parameterName)
+        private void ApplyParameter(IEventSource eventSource, string parameterName)
         {
             ErrorUtilities.VerifyThrowArgumentNull(parameterName, nameof(parameterName));
 
-            if (_forwardingTable.ContainsKey(parameterName))
+            bool isEventForwardingParameter = true;
+
+            // Careful - we need to brace before double specified parameters - hence the unsubscriptions before subscriptions
+            switch (parameterName.ToUpperInvariant())
             {
-                _forwardingSetFromParameters = true;
-                _forwardingTable[parameterName] = 1;
-            }
-            else if (String.Equals(parameterName, ProjectEvaluationStartedEventDescription, StringComparison.OrdinalIgnoreCase) ||
-                String.Equals(parameterName, ProjectEvaluationFinishedEventDescription, StringComparison.OrdinalIgnoreCase))
-            {
-                _forwardingSetFromParameters = true;
-                _forwardingTable[ProjectEvaluationEventDescription] = 1;
+                case BuildStartedEventDescription:
+                    eventSource.BuildStarted -= ForwardEvent;
+                    eventSource.BuildStarted += ForwardEvent;
+                    break;
+                case BuildFinishedEventDescription:
+                    eventSource.BuildFinished -= ForwardEvent;
+                    eventSource.BuildFinished += ForwardEvent;
+                    break;
+                case ProjectStartedEventDescription:
+                    eventSource.ProjectStarted -= ForwardEvent;
+                    eventSource.ProjectStarted += ForwardEvent;
+                    break;
+                case ProjectFinishedEventDescription:
+                    eventSource.ProjectFinished -= ForwardEvent;
+                    eventSource.ProjectFinished += ForwardEvent;
+                    break;
+                case TargetStartedEventDescription:
+                    eventSource.TargetStarted -= ForwardEvent;
+                    eventSource.TargetStarted += ForwardEvent;
+                    break;
+                case TargetFinishedEventDescription:
+                    eventSource.TargetFinished -= ForwardEvent;
+                    eventSource.TargetFinished += ForwardEvent;
+                    break;
+                case TaskStartedEventDescription:
+                    eventSource.TaskStarted -= ForwardEvent;
+                    eventSource.TaskStarted += ForwardEvent;
+                    break;
+                case TaskFinishedEventDescription:
+                    eventSource.TaskFinished -= ForwardEvent;
+                    eventSource.TaskFinished += ForwardEvent;
+                    break;
+                case ErrorEventDescription:
+                    eventSource.ErrorRaised -= ForwardEvent;
+                    eventSource.ErrorRaised += ForwardEvent;
+                    break;
+                case WarningEventDescription:
+                    eventSource.WarningRaised -= ForwardEvent;
+                    eventSource.WarningRaised += ForwardEvent;
+                    break;
+                case CustomEventDescription:
+                    eventSource.CustomEventRaised -= ForwardEvent;
+                    eventSource.CustomEventRaised += ForwardEvent;
+                    break;
+                case HighMessageEventDescription:
+                    eventSource.MessageRaised -= MessageHandler;
+                    eventSource.MessageRaised += MessageHandler;
+                    _forwardHighImportanceMessages = true;
+                    break;
+                case NormalMessageEventDescription:
+                    eventSource.MessageRaised -= MessageHandler;
+                    eventSource.MessageRaised += MessageHandler;
+                    _forwardNormalImportanceMessages = true;
+                    break;
+                case LowMessageEventDescription:
+                    eventSource.MessageRaised -= MessageHandler;
+                    eventSource.MessageRaised += MessageHandler;
+                    _forwardLowImportanceMessages = true;
+                    break;
+                case CommandLineDescription:
+                    eventSource.MessageRaised -= MessageHandler;
+                    eventSource.MessageRaised += MessageHandler;
+                    _forwardTaskCommandLine = true;
+                    break;
+                case ProjectEvaluationStartedEventDescription:
+                case ProjectEvaluationFinishedEventDescription:
+                    eventSource.StatusEventRaised -= BuildStatusHandler;
+                    eventSource.StatusEventRaised += BuildStatusHandler;
+                    break;
+                case PerformanceSummaryDescription:
+                    _showPerfSummary = true;
+                    isEventForwardingParameter = false;
+                    break;
+                case NoSummaryDescription:
+                    _showSummary = false;
+                    isEventForwardingParameter = false;
+                    break;
+                case ShowCommandLineDescription:
+                    _showCommandLine = true;
+                    isEventForwardingParameter = false;
+                    break;
+                case ForwardProjectContextDescription:
+                    _forwardProjectContext = true;
+                    isEventForwardingParameter = false;
+                    break;
+                default:
+                    isEventForwardingParameter = false;
+                    break;
             }
 
-            // If any of the following parameters are set, we will make sure we forward the events
-            // necessary for the central logger to emit the requested information
-            if (String.Equals(parameterName, PerformanceSummaryDescription, StringComparison.OrdinalIgnoreCase))
+            if (isEventForwardingParameter)
             {
-                _showPerfSummary = true;
-            }
-            else if (String.Equals(parameterName, NoSummaryDescription, StringComparison.OrdinalIgnoreCase))
-            {
-                _showSummary = false;
-            }
-            else if (String.Equals(parameterName, ShowCommandLineDescription, StringComparison.OrdinalIgnoreCase))
-            {
-                _showCommandLine = true;
-            }
-            else if (string.Equals(parameterName, ForwardProjectContextDescription, StringComparison.OrdinalIgnoreCase))
-            {
-                _forwardProjectContext = true;
+                _forwardingSetFromParameters = true;
             }
         }
 
@@ -178,28 +222,14 @@ namespace Microsoft.Build.Logging
         {
             ErrorUtilities.VerifyThrowArgumentNull(eventSource, nameof(eventSource));
 
-            ParseParameters();
+            ParseParameters(eventSource);
 
             ResetLoggerState();
 
             if (!_forwardingSetFromParameters)
             {
-                SetForwardingBasedOnVerbosity();
+                SetForwardingBasedOnVerbosity(eventSource);
             }
-
-            eventSource.BuildStarted += BuildStartedHandler;
-            eventSource.BuildFinished += BuildFinishedHandler;
-            eventSource.ProjectStarted += ProjectStartedHandler;
-            eventSource.ProjectFinished += ProjectFinishedHandler;
-            eventSource.TargetStarted += TargetStartedHandler;
-            eventSource.TargetFinished += TargetFinishedHandler;
-            eventSource.TaskStarted += TaskStartedHandler;
-            eventSource.TaskFinished += TaskFinishedHandler;
-            eventSource.ErrorRaised += ErrorHandler;
-            eventSource.WarningRaised += WarningHandler;
-            eventSource.MessageRaised += MessageHandler;
-            eventSource.CustomEventRaised += CustomEventHandler;
-            eventSource.StatusEventRaised += BuildStatusHandler;
         }
 
         /// <summary>
@@ -210,69 +240,83 @@ namespace Microsoft.Build.Logging
             Initialize(eventSource);
         }
 
-        private void SetForwardingBasedOnVerbosity()
+        private void SetForwardingBasedOnVerbosity(IEventSource eventSource)
         {
-            _forwardingTable[BuildStartedEventDescription] = 1;
-            _forwardingTable[BuildFinishedEventDescription] = 1;
-
             if (IsVerbosityAtLeast(LoggerVerbosity.Quiet))
             {
-                _forwardingTable[ErrorEventDescription] = 1;
-                _forwardingTable[WarningEventDescription] = 1;
+                eventSource.ErrorRaised += ForwardEvent;
+                eventSource.WarningRaised += ForwardEvent;
             }
 
             if (IsVerbosityAtLeast(LoggerVerbosity.Minimal))
             {
-                _forwardingTable[HighMessageEventDescription] = 1;
+                eventSource.MessageRaised += MessageHandler;
+                _forwardHighImportanceMessages = true;
             }
 
             if (IsVerbosityAtLeast(LoggerVerbosity.Normal))
             {
-                _forwardingTable[NormalMessageEventDescription] = 1;
-                _forwardingTable[ProjectStartedEventDescription] = 1;
-                _forwardingTable[ProjectFinishedEventDescription] = 1;
-                _forwardingTable[TargetStartedEventDescription] = 1;
-                _forwardingTable[TargetFinishedEventDescription] = 1;
-                _forwardingTable[CommandLineDescription] = 1;
+                // MessageHandler already subscribed
+                _forwardNormalImportanceMessages = true;
+
+                eventSource.ProjectStarted += ForwardEvent;
+                eventSource.ProjectFinished += ForwardEvent;
+                eventSource.TargetStarted += ForwardEvent;
+                eventSource.TargetFinished += ForwardEvent;
             }
 
             if (IsVerbosityAtLeast(LoggerVerbosity.Detailed))
             {
-                _forwardingTable[TargetStartedEventDescription] = 1;
-                _forwardingTable[TargetFinishedEventDescription] = 1;
-                _forwardingTable[TaskStartedEventDescription] = 1;
-                _forwardingTable[TaskFinishedEventDescription] = 1;
-                _forwardingTable[LowMessageEventDescription] = 1;
+                eventSource.TaskStarted += ForwardEvent;
+                eventSource.TaskFinished += ForwardEvent;
+
+                // MessageHandler already subscribed
+                _forwardLowImportanceMessages = true;
+                _forwardTaskCommandLine = true;
             }
 
             if (IsVerbosityAtLeast(LoggerVerbosity.Diagnostic))
             {
-                _forwardingTable[CustomEventDescription] = 1;
-                _forwardingTable[ProjectEvaluationEventDescription] = 1;
+                eventSource.CustomEventRaised += ForwardEvent;
+                eventSource.StatusEventRaised += BuildStatusHandler;
             }
 
             if (_showSummary)
             {
-                _forwardingTable[ErrorEventDescription] = 1;
-                _forwardingTable[WarningEventDescription] = 1;
+                // Prevent double subscribe
+                eventSource.ErrorRaised -= ForwardEvent;
+                eventSource.WarningRaised -= ForwardEvent;
+                eventSource.ErrorRaised += ForwardEvent;
+                eventSource.WarningRaised += ForwardEvent;
             }
 
             if (_showPerfSummary)
             {
-                _forwardingTable[TargetStartedEventDescription] = 1;
-                _forwardingTable[TargetFinishedEventDescription] = 1;
-                _forwardingTable[TaskStartedEventDescription] = 1;
-                _forwardingTable[TaskFinishedEventDescription] = 1;
-                _forwardingTable[TargetStartedEventDescription] = 1;
-                _forwardingTable[TargetFinishedEventDescription] = 1;
-                _forwardingTable[ProjectStartedEventDescription] = 1;
-                _forwardingTable[ProjectFinishedEventDescription] = 1;
-                _forwardingTable[ProjectEvaluationEventDescription] = 1;
+                // Prevent double subscribe
+                eventSource.TaskStarted -= ForwardEvent;
+                eventSource.TaskFinished -= ForwardEvent;
+                eventSource.TargetStarted -= ForwardEvent;
+                eventSource.TargetFinished -= ForwardEvent;
+                eventSource.ProjectStarted -= ForwardEvent;
+                eventSource.ProjectFinished -= ForwardEvent;
+                eventSource.StatusEventRaised -= BuildStatusHandler;
+
+                eventSource.TaskStarted += ForwardEvent;
+                eventSource.TaskFinished += ForwardEvent;
+                eventSource.TargetStarted += ForwardEvent;
+                eventSource.TargetFinished += ForwardEvent;
+                eventSource.ProjectStarted += ForwardEvent;
+                eventSource.ProjectFinished += ForwardEvent;
+                eventSource.StatusEventRaised += BuildStatusHandler;
             }
 
             if (_showCommandLine)
             {
-                _forwardingTable[CommandLineDescription] = 1;
+                // Prevent double subscribe
+                eventSource.MessageRaised -= MessageHandler;
+                eventSource.MessageRaised += MessageHandler;
+
+                _forwardTaskCommandLine = true;
             }
         }
 
@@ -285,20 +329,17 @@ namespace Microsoft.Build.Logging
         /// </returns>
         internal MessageImportance GetMinimumMessageImportance()
         {
-            if (_forwardingTable[LowMessageEventDescription] == 1)
+            return _verbosity switch
             {
-                return MessageImportance.Low;
-            }
-            if (_forwardingTable[NormalMessageEventDescription] == 1)
-            {
-                return MessageImportance.Normal;
-            }
-            if (_forwardingTable[HighMessageEventDescription] == 1)
-            {
-                return MessageImportance.High;
-            }
-            // The logger does not log messages of any importance.
-            return MessageImportance.High - 1;
+                LoggerVerbosity.Minimal => MessageImportance.High,
+                LoggerVerbosity.Normal => MessageImportance.Normal,
+                LoggerVerbosity.Detailed => MessageImportance.Low,
+                LoggerVerbosity.Diagnostic => MessageImportance.Low,
+
+                // The logger does not log messages of any importance.
+                LoggerVerbosity.Quiet => MessageImportance.High - 1,
+                _ => MessageImportance.High - 1,
+            };
         }
 
         /// <summary>
@@ -319,178 +360,37 @@ namespace Microsoft.Build.Logging
         }
 
         /// <summary>
-        /// Handler for build started events
+        /// Handler for build events
         /// </summary>
         /// <param name="sender">sender (should be null)</param>
         /// <param name="e">event arguments</param>
-        private void BuildStartedHandler(object sender, BuildStartedEventArgs e)
+        private void ForwardEvent(object sender, BuildEventArgs e)
         {
-            // This is false by default
-            if (_forwardingTable[BuildStartedEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Handler for build finished events
-        /// </summary>
-        /// <param name="sender">sender (should be null)</param>
-        /// <param name="e">event arguments</param>
-        private void BuildFinishedHandler(object sender, BuildFinishedEventArgs e)
-        {
-            // This is false by default
-            if (_forwardingTable[BuildFinishedEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-            ResetLoggerState();
-        }
-
-        /// <summary>
-        /// Handler for project started events
-        /// </summary>
-        /// <param name="sender">sender (should be null)</param>
-        /// <param name="e">event arguments</param>
-        private void ProjectStartedHandler(object sender, ProjectStartedEventArgs e)
-        {
-            if (_forwardingTable[ProjectStartedEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Handler for project finished events
-        /// </summary>
-        /// <param name="sender">sender (should be null)</param>
-        /// <param name="e">event arguments</param>
-        private void ProjectFinishedHandler(object sender, ProjectFinishedEventArgs e)
-        {
-            if (_forwardingTable[ProjectFinishedEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Handler for target started events
-        /// </summary>
-        /// <param name="sender">sender (should be null)</param>
-        /// <param name="e">event arguments</param>
-        private void TargetStartedHandler(object sender, TargetStartedEventArgs e)
-        {
-            if (_forwardingTable[TargetStartedEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Handler for target finished events
-        /// </summary>
-        /// <param name="sender">sender (should be null)</param>
-        /// <param name="e">event arguments</param>
-        private void TargetFinishedHandler(object sender, TargetFinishedEventArgs e)
-        {
-            if (_forwardingTable[TargetFinishedEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Handler for task started events
-        /// </summary>
-        /// <param name="sender">sender (should be null)</param>
-        /// <param name="e">event arguments</param>
-        private void TaskStartedHandler(object sender, TaskStartedEventArgs e)
-        {
-            if (_forwardingTable[TaskStartedEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Handler for task finished events
-        /// </summary>
-        /// <param name="sender">sender (should be null)</param>
-        /// <param name="e">event arguments</param>
-        private void TaskFinishedHandler(object sender, TaskFinishedEventArgs e)
-        {
-            if (_forwardingTable[TaskFinishedEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Prints an error event
-        /// </summary>
-        private void ErrorHandler(object sender, BuildErrorEventArgs e)
-        {
-            if (_forwardingTable[ErrorEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Prints a warning event
-        /// </summary>
-        private void WarningHandler(object sender, BuildWarningEventArgs e)
-        {
-            if (_forwardingTable[WarningEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Prints a message event
-        /// </summary>
-        private void MessageHandler(object sender, BuildMessageEventArgs e)
-        {
-            bool forwardEvent = false;
-
-            if (_forwardingTable[LowMessageEventDescription] == 1 && e.Importance == MessageImportance.Low)
-            {
-                forwardEvent = true;
-            }
-            else if (_forwardingTable[NormalMessageEventDescription] == 1 && e.Importance == MessageImportance.Normal)
-            {
-                forwardEvent = true;
-            }
-            else if (_forwardingTable[HighMessageEventDescription] == 1 && e.Importance == MessageImportance.High)
-            {
-                forwardEvent = true;
-            }
-            else if (_forwardingTable[CommandLineDescription] == 1 && e is TaskCommandLineEventArgs)
-            {
-                forwardEvent = true;
-            }
-
-            if (forwardEvent)
-            {
-                ForwardToCentralLogger(e);
-            }
-        }
-
-        /// <summary>
-        /// Prints a custom event
-        /// </summary>
-        private void CustomEventHandler(object sender, CustomBuildEventArgs e)
-        {
-            if (_forwardingTable[CustomEventDescription] == 1)
-            {
-                ForwardToCentralLogger(e);
-            }
+            ForwardToCentralLogger(e);
         }
 
         private void BuildStatusHandler(object sender, BuildStatusEventArgs e)
         {
-            if (_forwardingTable[ProjectEvaluationEventDescription] == 1 && (e is ProjectEvaluationStartedEventArgs || e is ProjectEvaluationFinishedEventArgs))
+            if (e is ProjectEvaluationStartedEventArgs || e is ProjectEvaluationFinishedEventArgs)
+            {
+                ForwardToCentralLogger(e);
+            }
+        }
+
+        /// <summary>
+        /// Tailored handler for BuildMessageEventArgs - fine tunes forwarding of messages.
+        /// </summary>
+        /// <param name="sender">sender (should be null)</param>
+        /// <param name="e">event arguments</param>
+        private void MessageHandler(object sender, BuildMessageEventArgs e)
+        {
+            bool forwardEvent =
+                _forwardLowImportanceMessages && e.Importance == MessageImportance.Low ||
+                _forwardNormalImportanceMessages && e.Importance == MessageImportance.Normal ||
+                _forwardHighImportanceMessages && e.Importance == MessageImportance.High ||
+                _forwardTaskCommandLine && e is TaskCommandLineEventArgs;
+
+            if (forwardEvent)
             {
                 ForwardToCentralLogger(e);
             }
@@ -562,13 +462,6 @@ namespace Microsoft.Build.Logging
         #region Per-build Members
 
         /// <summary>
-        /// A table indicating if a particular event type should be forwarded
-        /// The value is type int rather than bool to avoid the problem of JITting generics.
-        /// <see cref="Dictionary{String, Int}" /> is already compiled into mscorlib.
-        /// </summary>
-        private Dictionary<string, int> _forwardingTable;
-
-        /// <summary>
         /// A pointer to the central logger
         /// </summary>
         private IEventRedirector _buildEventRedirector;
@@ -599,6 +492,11 @@ namespace Microsoft.Build.Logging
         /// When true the commandline message is sent
         /// </summary>
         private bool _showCommandLine = false;
+
+        /// <summary>
+        /// Fine tunning of BuildMessageEventArgs forwarding
+        /// </summary>
+        private bool _forwardLowImportanceMessages, _forwardNormalImportanceMessages, _forwardHighImportanceMessages, _forwardTaskCommandLine;
 
         /// <summary>
         /// Id of the node the logger is attached to

--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -243,6 +243,9 @@ namespace Microsoft.Build.Logging
 
         private void SetForwardingBasedOnVerbosity(IEventSource eventSource)
         {
+            eventSource.BuildStarted += ForwardEvent;
+            eventSource.BuildFinished += ForwardEvent;
+
             if (IsVerbosityAtLeast(LoggerVerbosity.Quiet))
             {
                 eventSource.ErrorRaised += ForwardEvent;
@@ -259,6 +262,7 @@ namespace Microsoft.Build.Logging
             {
                 // MessageHandler already subscribed
                 _forwardNormalImportanceMessages = true;
+                _forwardTaskCommandLine = true;
 
                 eventSource.ProjectStarted += ForwardEvent;
                 eventSource.ProjectFinished += ForwardEvent;
@@ -273,6 +277,7 @@ namespace Microsoft.Build.Logging
 
                 // MessageHandler already subscribed
                 _forwardLowImportanceMessages = true;
+                _forwardTaskCommandLine = true;
                 _forwardTaskCommandLine = true;
             }
 

--- a/src/Framework/IEventSource.cs
+++ b/src/Framework/IEventSource.cs
@@ -152,4 +152,165 @@ namespace Microsoft.Build.Framework
         /// </summary>
         event AnyEventHandler AnyEventRaised;
     }
+
+    /// <summary>
+    /// Helper methods for <see cref="IEventSource"/> interface.
+    /// </summary>
+    public static class EventSourceExtensions
+    {
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.MessageRaised"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleMessageRaised(this IEventSource eventSource, BuildMessageEventHandler handler)
+        {
+            eventSource.MessageRaised -= handler;
+            eventSource.MessageRaised += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.ErrorRaised"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleErrorRaised(this IEventSource eventSource, BuildErrorEventHandler handler)
+        {
+            eventSource.ErrorRaised -= handler;
+            eventSource.ErrorRaised += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.WarningRaised"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleWarningRaised(this IEventSource eventSource, BuildWarningEventHandler handler)
+        {
+            eventSource.WarningRaised -= handler;
+            eventSource.WarningRaised += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.BuildStarted"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleBuildStarted(this IEventSource eventSource, BuildStartedEventHandler handler)
+        {
+            eventSource.BuildStarted -= handler;
+            eventSource.BuildStarted += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.BuildFinished"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleBuildFinished(this IEventSource eventSource, BuildFinishedEventHandler handler)
+        {
+            eventSource.BuildFinished -= handler;
+            eventSource.BuildFinished += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.ProjectStarted"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleProjectStarted(this IEventSource eventSource, ProjectStartedEventHandler handler)
+        {
+            eventSource.ProjectStarted -= handler;
+            eventSource.ProjectStarted += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.ProjectFinished"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleProjectFinished(this IEventSource eventSource, ProjectFinishedEventHandler handler)
+        {
+            eventSource.ProjectFinished -= handler;
+            eventSource.ProjectFinished += handler;
+        }
+
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.TargetStarted"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleTargetStarted(this IEventSource eventSource, TargetStartedEventHandler handler)
+        {
+            eventSource.TargetStarted -= handler;
+            eventSource.TargetStarted += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.TargetFinished"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleTargetFinished(this IEventSource eventSource, TargetFinishedEventHandler handler)
+        {
+            eventSource.TargetFinished -= handler;
+            eventSource.TargetFinished += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.TaskStarted"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleTaskStarted(this IEventSource eventSource, TaskStartedEventHandler handler)
+        {
+            eventSource.TaskStarted -= handler;
+            eventSource.TaskStarted += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.TaskFinished"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleTaskFinished(this IEventSource eventSource, TaskFinishedEventHandler handler)
+        {
+            eventSource.TaskFinished -= handler;
+            eventSource.TaskFinished += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.CustomEventRaised"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleCustomEventRaised(this IEventSource eventSource, CustomBuildEventHandler handler)
+        {
+            eventSource.CustomEventRaised -= handler;
+            eventSource.CustomEventRaised += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.StatusEventRaised"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleStatusEventRaised(this IEventSource eventSource, BuildStatusEventHandler handler)
+        {
+            eventSource.StatusEventRaised -= handler;
+            eventSource.StatusEventRaised += handler;
+        }
+
+        /// <summary>
+        /// Helper method ensuring single deduplicated subscription to the <see cref="IEventSource.AnyEventRaised"/> event.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        /// <param name="handler">Handler to the event. If this handler is already subscribed, single subscription will be ensured.</param>
+        public static void HandleAnyEventRaised(this IEventSource eventSource, AnyEventHandler handler)
+        {
+            eventSource.AnyEventRaised -= handler;
+            eventSource.AnyEventRaised += handler;
+        }
+    }
 }


### PR DESCRIPTION
### Context
Random find - `ConfigurableForwardingLogger` is checking a string dictionary for each build event, while a simple events (un)subscriptions can achieve same job with less efforts (coding and CPU)

### Testing
Existing tests ([`ConfigureableForwardingLogger_Tests`](https://github.com/dotnet/msbuild/blob/main/src/Build.UnitTests/ConfigureableForwardingLogger_Tests.cs))
