### PR TITLE
[ClickOnce] Fix nonce generation in timestamping of signed manifest.

### DIFF
--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -814,12 +814,27 @@ namespace System.Deployment.Internal.CodeSigning
 
                 try
                 {
-                    byte[] nonce = new byte[24];
+                    byte[] nonce = new byte[32];
 
                     using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
                     {
                         rng.GetBytes(nonce);
                     }
+
+                    // Eventually, CryptEncodeObjectEx(...) is called on a CRYPT_TIMESTAMP_REQUEST with this nonce,
+                    // and CryptEncodeObjectEx(...) interprets the nonce as a little endian, DER-encoded integer value
+                    // (without tag and length), and may even strip leading bytes from the big endian representation
+                    // of the byte sequence to achieve proper integer DER encoding.
+                    //
+                    // If the nonce is changed after the client generates it, the timestamp server would receive
+                    // and return a nonce that does not agree with the client's original nonce.
+                    //
+                    // To ensure this does not happen, ensure that the most significant byte in the little
+                    // endian byte sequence is in the 0x01-0x7F range; clear that byte's most significant bit
+                    // and set that byte's least significant bit.
+ 
+                    nonce[nonce.Length - 1] &= 0x7f;
+                    nonce[nonce.Length - 1] |= 0x01;
 
                     Win32.CRYPT_TIMESTAMP_PARA para = new Win32.CRYPT_TIMESTAMP_PARA()
                     {


### PR DESCRIPTION
Fixes
#9505 

### Summary
SecurityUtilities.SignFile function to sign ClickOnce manifest can fail occasionally during timestamping because the random bytes generated for the nonce can be invalid DER encodings for integer values

#### Changes Made
To ensure the encoding is not invalid, clear the nonce MSB's most significant bit and set the MSB's least significant bit.

This is a port of the fix made for the same issue in the NuGet client:
https://github.com/NuGet/NuGet.Client/pull/2041/commits/3e55190496b44811c4b5240bdb8ec65521e39161

### Customer Impact
Customers calling SignFile API through the Microsoft.Build.Tasks.Core NuGet package encounter occasional failures because the Nonce generated is invalid per DER encoding. The fix will address this issue of the SignFile API failing intermittently.

### Regression?
No

### Testing
Failing scenario validated + signing scenarios in ClickOnce validated for regression.

### Risk
Low
