### PR TITLE
Emit NETSDK1057 at most once in -tl

### DIFF
--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -575,8 +575,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             {
                 RenderImmediateMessage(message);
             }
-
-            if (e.Code == "NETSDK1057" && !_loggedPreviewMessage)
+            else if (e.Code == "NETSDK1057" && !_loggedPreviewMessage)
             {
                 // The SDK will log the high-pri "not-a-warning" message NETSDK1057
                 // when it's a preview version up to MaxCPUCount times, but that's

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -139,6 +139,11 @@ internal sealed partial class TerminalLogger : INodeLogger
     private bool _manualRefresh;
 
     /// <summary>
+    /// True if we've logged the ".NET SDK is preview" message.
+    /// </summary>
+    private bool _loggedPreviewMessage;
+
+    /// <summary>
     /// List of events the logger needs as parameters to the <see cref="ConfigurableForwardingLogger"/>.
     /// </summary>
     /// <remarks>
@@ -569,6 +574,16 @@ internal sealed partial class TerminalLogger : INodeLogger
             if (IsImmediateMessage(message))
             {
                 RenderImmediateMessage(message);
+            }
+
+            if (e.Code == "NETSDK1057" && !_loggedPreviewMessage)
+            {
+                // The SDK will log the high-pri "not-a-warning" message NETSDK1057
+                // when it's a preview version up to MaxCPUCount times, but that's
+                // an implementation detail--the user cares about at most one.
+
+                RenderImmediateMessage(message);
+                _loggedPreviewMessage = true;
             }
         }
     }


### PR DESCRIPTION
Fixes #9602 by emitting NETSDK1057 as an immediate message at most once in the TerminalLogger.

```sh-session
❯ dotnet build
MSBuild version 17.10.0-dev-24055-01+3500455af for .NET
Restore complete (1.1s)
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  Lib1 succeeded (3.1s) → Lib1\bin\Debug\net9.0\Lib1.dll
  Lib2 succeeded (3.1s) → Lib2\bin\Debug\net9.0\Lib2.dll
  App succeeded (3.2s) → App\bin\Debug\net9.0\App.dll

Build succeeded in 4.5s
```

It is slightly ugly to do this deduplication at the logger level, but it cleans up a customer annoyance so I think it's worth it.