### PR TITLE
Log SDK resolution result

### DIFF
--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -94,8 +94,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             result.Path.ShouldBe("path");
 
-            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
-
             _logger.WarningCount.ShouldBe(1);
             _logger.Warnings.First().Code.ShouldStartWith("MSB4241");
         }
@@ -125,7 +123,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern2");
-            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver2 running");
@@ -143,7 +140,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath1");
-            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
         }
@@ -165,7 +161,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
                 result.Path.ShouldBe("resolverpath1");
-                _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
                 ChangeWaves.ResetStateForTests();
@@ -184,9 +179,24 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern1");
-            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver1 running");
+        }
+
+        [Fact]
+        public void AssertSdkResolutionMessagesAreLogged()
+        {
+            SdkResolverService.Instance.InitializeForTests(new MockLoaderStrategy());
+            SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
+
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
+
+            // First resolver attemopted to resolve, but failed.
+            var errorMessage = "\nErrors:\n" + ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverReturnedNull", nameof(MockResolverReturnsNull));
+            _logger.BuildMessageEvents.Select(i => i.Message)
+                .ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverAttempt", nameof(MockResolverReturnsNull), sdk.ToString(), errorMessage));
+            // Second resolver succeeded.
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString(), nameof(MockSdkResolver1), result.Path, result.Version));
         }
 
         [Fact]
@@ -201,8 +211,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath2");
-            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
-
             // Both resolvers should run, and no ERROR string.
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver2 running");
@@ -372,7 +380,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(includePropertiesAndItems, result);
 
-            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue(); 
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -409,7 +416,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(true, result);
 
-            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -462,7 +468,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(includePropertiesAndItems, result);
 
-            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -508,7 +513,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(true, result);
 
-            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.WarningCount.ShouldBe(1);
             _logger.Warnings.First().Code.ShouldStartWith("MSB4241");
         }

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -210,6 +210,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath2");
+
             // Both resolvers should run, and no ERROR string.
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver2 running");

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -192,9 +192,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             // First resolver attemopted to resolve, but failed.
-            var errorMessage = "\nErrors:\n" + ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverReturnedNull", nameof(MockResolverReturnsNull));
-            _logger.BuildMessageEvents.Select(i => i.Message)
-                .ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverAttempt", nameof(MockResolverReturnsNull), sdk.ToString(), errorMessage));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverAttempt", nameof(MockResolverReturnsNull), sdk.ToString(), "null",
+                ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverReturnedNull", nameof(MockResolverReturnsNull))));
             // Second resolver succeeded.
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString(), nameof(MockSdkResolver1), result.Path, result.Version));
         }

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -94,6 +94,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             result.Path.ShouldBe("path");
 
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+
             _logger.WarningCount.ShouldBe(1);
             _logger.Warnings.First().Code.ShouldStartWith("MSB4241");
         }
@@ -111,7 +113,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             e.Sdk.Name.ShouldBe("1sdkName");
         }
 
-
         [Fact]
         // Scenario: MockSdkResolverWithResolvableSdkPattern2 is a specific resolver (i.e. resolver with pattern)
         // and it successfully resolves sdk.
@@ -124,6 +125,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern2");
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver2 running");
@@ -141,6 +143,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath1");
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
         }
@@ -162,6 +165,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
                 result.Path.ShouldBe("resolverpath1");
+                _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
                 ChangeWaves.ResetStateForTests();
@@ -180,6 +184,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern1");
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver1 running");
         }
@@ -196,6 +201,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath2");
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
 
             // Both resolvers should run, and no ERROR string.
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -366,6 +372,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(includePropertiesAndItems, result);
 
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -402,6 +409,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(true, result);
 
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -454,6 +462,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(includePropertiesAndItems, result);
 
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -499,6 +508,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(true, result);
 
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
             _logger.WarningCount.ShouldBe(1);
             _logger.Warnings.First().Code.ShouldStartWith("MSB4241");
         }

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
-            // First resolver attemopted to resolve, but failed.
+            // First resolver attempted to resolve, but failed.
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverAttempt", nameof(MockResolverReturnsNull), sdk.ToString(), "null",
                 ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SDKResolverReturnedNull", nameof(MockResolverReturnsNull))));
             // Second resolver succeeded.

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             result.Path.ShouldBe("path");
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
 
             _logger.WarningCount.ShouldBe(1);
             _logger.Warnings.First().Code.ShouldStartWith("MSB4241");
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern2");
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver2 running");
@@ -143,7 +143,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath1");
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
         }
@@ -165,7 +165,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
                 result.Path.ShouldBe("resolverpath1");
-                _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+                _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
                 ChangeWaves.ResetStateForTests();
@@ -184,7 +184,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern1");
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver1 running");
         }
@@ -201,7 +201,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath2");
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
 
             // Both resolvers should run, and no ERROR string.
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -372,7 +372,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(includePropertiesAndItems, result);
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue(); 
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -409,7 +409,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(true, result);
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -462,7 +462,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(includePropertiesAndItems, result);
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -508,7 +508,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(true, result);
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Any(i => i.Message.StartsWith($"The SDK \"{sdk}\" was successfully resolved")).ShouldBeTrue();
             _logger.WarningCount.ShouldBe(1);
             _logger.Warnings.First().Code.ShouldStartWith("MSB4241");
         }

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             result.Path.ShouldBe("path");
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
 
             _logger.WarningCount.ShouldBe(1);
             _logger.Warnings.First().Code.ShouldStartWith("MSB4241");
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern2");
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern2 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver2 running");
@@ -143,7 +143,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath1");
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
         }
@@ -165,7 +165,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
                 result.Path.ShouldBe("resolverpath1");
-                _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+                _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
                 _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolverWithResolvableSdkPattern1 running");
                 ChangeWaves.ResetStateForTests();
@@ -184,7 +184,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpathwithresolvablesdkpattern1");
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolverWithResolvableSdkPattern1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldNotContain("MockSdkResolver1 running");
         }
@@ -201,7 +201,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
 
             result.Path.ShouldBe("resolverpath2");
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
 
             // Both resolvers should run, and no ERROR string.
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -372,7 +372,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(includePropertiesAndItems, result);
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -409,7 +409,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(true, result);
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -462,7 +462,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(includePropertiesAndItems, result);
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
             _logger.WarningCount.ShouldBe(0);
         }
 
@@ -508,7 +508,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             ValidateExpectedPropertiesAndItems(true, result);
 
-            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SuccededToResolveSDK", sdk.ToString()));
+            _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("SucceededToResolveSDK", sdk.ToString()));
             _logger.WarningCount.ShouldBe(1);
             _logger.Warnings.First().Code.ShouldStartWith("MSB4241");
         }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
                 if (result.Success)
                 {
-                    loggingContext.LogComment(MessageImportance.Low, "SucceededToResolveSDK", sdk.ToString());
+                    loggingContext.LogComment(MessageImportance.Low, "SucceededToResolveSDK", sdk.ToString(), sdkResolver.Name, result.Path ?? "null", result.Version ?? "null");
 
                     LogWarnings(loggingContext, sdkReferenceLocation, result.Warnings);
 

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -312,8 +312,6 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             // Loop through resolvers which have already been sorted by priority, returning the first result that was successful
             SdkLogger buildEngineLogger = new SdkLogger(loggingContext);
 
-            loggingContext.LogComment(MessageImportance.Low, "SdkResolving", sdk.ToString());
-
             foreach (SdkResolver sdkResolver in resolvers)
             {
                 SdkResolverContext context = new SdkResolverContext(buildEngineLogger, projectPath, solutionPath, ProjectCollection.Version, interactive, isRunningInVisualStudio)
@@ -370,6 +368,13 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
                     sdkResult = result;
                     return true;
+                }
+                else
+                {
+                    string resultWarningsAndErrors = (result.Warnings?.Any() == true ? "\nWarnings:\n" + string.Join("\n", result.Warnings) : string.Empty)
+                        + (result.Errors?.Any() == true ? "\nErrors:\n" + string.Join("\n", result.Errors) : string.Empty);
+
+                    loggingContext.LogComment(MessageImportance.Low, "SDKResolverAttempt", sdkResolver.Name, sdk.ToString(), resultWarningsAndErrors);
                 }
 
                 results.Add(result);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     sdkResult = result;
                     return true;
                 }
-                else
+                else if (loggingContext.LoggingService.MinimumRequiredMessageImportance >= MessageImportance.Low)
                 {
                     string resultWarnings = result.Warnings?.Any() == true ? string.Join(Environment.NewLine, result.Warnings) : "null";
                     string resultErrors = result.Errors?.Any() == true ? string.Join(Environment.NewLine, result.Errors) : "null";

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -355,6 +355,8 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
                 if (result.Success)
                 {
+                    loggingContext.LogComment(MessageImportance.Low, "SuccededToResolveSDK", sdk.ToString());
+
                     LogWarnings(loggingContext, sdkReferenceLocation, result.Warnings);
 
                     if (!IsReferenceSameVersion(sdk, result.Version))

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
                 if (result.Success)
                 {
-                    loggingContext.LogComment(MessageImportance.Low, "SuccededToResolveSDK", sdk.ToString());
+                    loggingContext.LogComment(MessageImportance.Low, "SucceededToResolveSDK", sdk.ToString());
 
                     LogWarnings(loggingContext, sdkReferenceLocation, result.Warnings);
 

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -371,10 +371,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 }
                 else
                 {
-                    string resultWarningsAndErrors = (result.Warnings?.Any() == true ? "\nWarnings:\n" + string.Join("\n", result.Warnings) : string.Empty)
-                        + (result.Errors?.Any() == true ? "\nErrors:\n" + string.Join("\n", result.Errors) : string.Empty);
+                    string resultWarnings = result.Warnings?.Any() == true ? string.Join(Environment.NewLine, result.Warnings) : "null";
+                    string resultErrors = result.Errors?.Any() == true ? string.Join(Environment.NewLine, result.Errors) : "null";
 
-                    loggingContext.LogComment(MessageImportance.Low, "SDKResolverAttempt", sdkResolver.Name, sdk.ToString(), resultWarningsAndErrors);
+                    loggingContext.LogComment(MessageImportance.Low, "SDKResolverAttempt", sdkResolver.Name, sdk.ToString(), resultWarnings, resultErrors);
                 }
 
                 results.Add(result);

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1332,7 +1332,7 @@
 Warnings: {2}
 Errors: {3}</value>
     <comment>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </comment>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1325,7 +1325,10 @@
   {1}</value>
   </data>
   <data name="SucceededToResolveSDK" xml:space="preserve">
-    <value>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</value>
+    <value>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</value>
+  </data>
+  <data name="SDKResolverAttempt" xml:space="preserve">
+    <value>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</value>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">
     <value>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>
@@ -1769,12 +1772,6 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="SdkResultVersionDifferentThanReference" xml:space="preserve">
     <value>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</value>
     <comment>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </comment>
-  </data>
-  <data name="SdkResolving" xml:space="preserve">
-    <value>Resolving SDK '{0}'...</value>
-    <comment>
       LOCALIZATION:  Do not localize the word SDK.
     </comment>
   </data>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1324,6 +1324,9 @@
     <value>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
   {1}</value>
   </data>
+  <data name="SuccededToResolveSDK" xml:space="preserve">
+    <value>SDK "{0}" successfully resolved.</value>
+  </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">
     <value>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>
   </data>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1328,7 +1328,12 @@
     <value>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</value>
   </data>
   <data name="SDKResolverAttempt" xml:space="preserve">
-    <value>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</value>
+    <value>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</value>
+    <comment>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </comment>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">
     <value>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1324,7 +1324,7 @@
     <value>Could not resolve SDK "{0}". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
   {1}</value>
   </data>
-  <data name="SuccededToResolveSDK" xml:space="preserve">
+  <data name="SucceededToResolveSDK" xml:space="preserve">
     <value>SDK "{0}" successfully resolved.</value>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1325,7 +1325,7 @@
   {1}</value>
   </data>
   <data name="SucceededToResolveSDK" xml:space="preserve">
-    <value>SDK "{0}" successfully resolved.</value>
+    <value>SDK "{0}" was successfully resolved.</value>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">
     <value>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1325,7 +1325,7 @@
   {1}</value>
   </data>
   <data name="SucceededToResolveSDK" xml:space="preserve">
-    <value>SDK "{0}" was successfully resolved.</value>
+    <value>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</value>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" xml:space="preserve">
     <value>The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -390,6 +390,11 @@
         <target state="translated">Přístupy k souborům sestav se v současné době podporují jenom pomocí varianty x64 nástroje MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: Selhání překladače sady SDK: {0}</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: Odkaz na sadu SDK {0} verze {1} byl místo toho přeložen na verzi {2}. Pokud neaktualizujete odkazovanou verzi tak, aby se shodovala, může se používat jiná verze, než kterou očekáváte.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">Překládá se sada SDK {0}...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">Úloha {0} požadovala tento počet jader: {1}. Získala tento počet jader: {2}. Teď používá celkem tento počet jader: {3}</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">Die Aufgabe "{0}" hat {1} Kerne angefordert und {2} Kerne erhalten und belegt jetzt insgesamt {3} Kerne.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -390,6 +390,11 @@
         <target state="translated">Das Melden von Dateizugriffen wird derzeit nur mit der x64-Variante von MSBuild unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: Fehler bei SDK-Resolver: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: Der SDK-Verweis "{0}" auf Version "{1}" wurde stattdessen in Version "{2}" aufgelöst. Sie könnten eine andere Version als die erwartete verwenden, wenn Sie die referenzierte Version nicht entsprechend aktualisieren.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">SDK "{0}" wird aufgelöst...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -390,6 +390,11 @@
         <target state="translated">Los accesos a archivos de informes solo se admiten actualmente con el tipo x64 de MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: Error del solucionador del SDK: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: La referencia del SKD "{0}", versión "{1}", se resolvió en la versión "{2}". Podría estar utilizando una versión diferente de la esperada si no actualiza la versión de referencia para que coincida.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">Resolviendo SDK "{0}"...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">La tarea "{0}" solicitó {1} núcleos, adquirió {2} núcleos y ahora retiene un total de {3} núcleos.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">La tâche "{0}" a demandé {1} cœurs et a obtenu {2} cœurs. Elle détient désormais {3} cœurs au total.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -390,6 +390,11 @@
         <target state="translated">Les accès aux fichiers de création de rapports sont uniquement pris en charge à l’aide de la saveur x64 de MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: Échec du Programme de Résolution SDK : «{0}»</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: La référence du SDK "{0}" version "{1}" a été résolue avec la version "{2}" à la place. Vous risquez d'utiliser une version différente de celle attendue si vous ne mettez pas à jour la version référencée correspondante.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">Résolution du SDK '{0}'...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -390,6 +390,11 @@
         <target state="translated">Gli accessi ai file di report sono attualmente supportati solo con la versione x64 di MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: errore sistema di risoluzione SDK: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: la versione "{1}" del riferimento "{0}" all'SDK è stata risolta nella versione "{2}". Se non si aggiorna la versione di riferimento in modo che corrisponda, è possibile che la versione in uso sia diversa da quella prevista.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">Risoluzione dell'SDK '{0}'...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">L'attività "{0}" ha richiesto {1} core, ha acquisito {2} core e ora contiene {3} core in totale.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">タスク "{0}" では、{1} 個のコアを要求し、{2} 個のコアを取得したため、現在合計 {3} 個のコアを保持しています。</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -390,6 +390,11 @@
         <target state="translated">ファイル アクセスのレポートは、現在、MSBuild の x64 フレーバーを使用してのみサポートされています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: SDK リゾルバー エラー: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: SDK 参照 "{0}" のバージョン "{1}" は、代わりにバージョン "{2}" に解決されました。  参照されたバージョンを一致するように更新しない場合、必要なバージョンとは別のバージョンを使用する可能性があります。</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">SDK '{0}' を解決しています...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">"{0}" 작업에서 코어 {1}개를 요청했고 코어 {2}개를 획득했으며 지금 총 {3}개의 코어를 보유하고 있습니다.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -390,6 +390,11 @@
         <target state="translated">파일 액세스 보고는 현재 x64 버전의 MSBuild를 사용하는 경우에만 지원됩니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: SDK 해결 프로그램 오류: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: SDK 참조 "{0}" 버전 "{1}"이(가) 대신 "{2}" 버전으로 확인되었습니다. 참조된 버전을 일치하도록 업데이트하지 않는 경우 예상과 다른 버전을 사용할 수 있습니다.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">SDK '{0}'을(를) 확인하는 중...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">Zadanie „{0}” żądało {1} rdzeni, uzyskało {2} i teraz jego łączna liczba rdzeni to {3}.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -390,6 +390,11 @@
         <target state="translated">Raportowanie dostępu do plików jest obecnie obsługiwane tylko przy użyciu wersji x64 programu MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: niepowodzenia programu do rozpoznawania zestawu SDK: „{0}”</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: Odwołanie do zestawu SDK „{0}” w wersji „{1}” zostało rozpoznane jako wersja „{2}”. Może zostać użyta inna wersja niż oczekiwana, jeśli nie zaktualizujesz wersji określonej w odwołaniu, tak aby była zgodna.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">Trwa rozpoznawanie zestawu SDK „{0}”...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">A tarefa "{0}" solicitou {1} núcleos, adquiriu {2} núcleos e agora contém {3} núcleos no total.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -390,6 +390,11 @@
         <target state="translated">Atualmente, o relatório de acessos a arquivos só tem suporte usando o tipo x64 do MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: Falha no Resolvedor do SDK: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: a referência do SDK "{0}" versão "{1}" foi resolvida para a versão "{2}". Talvez você estava usando um versão diferente que a esperada caso não tenha atualizado a versão referenciada de maneira correspondente.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">Resolvendo o SDK '{0}'...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -390,6 +390,11 @@
         <target state="translated">Доступ к файлам отчетов сейчас поддерживается только при использовании 64-разрядного варианта приложения MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: сбой сопоставителя SDK: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: ссылка на пакет SDK "{0}" версии "{1}" была сопоставлена версии "{2}". Возможно, вы используете версию, отличную от ожидаемой, если вы не обновили версию по ссылке.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">Сопоставление SDK "{0}"…</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">Задача "{0}" запросила указанное число ядер ({1}) и получила указанное число ядер ({2}). Теперь общее число ядер, которыми располагает задача, равно {3}.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -390,6 +390,11 @@
         <target state="translated">Raporlama dosyası erişimleri şu anda yalnızca MSBuild x64 varyantı kullanıldığında destekleniyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: SDK Çözümleyici Hatası: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: "{0}" SDK başvurusunun "{1}" sürümü, bunun yerine sürüm "{2}" olarak çözümlendi. Başvurulan sürümü eşleşecek şekilde güncelleştirmezseniz beklenen sürümden farklı bir sürüm kullanıyor olabilirsiniz.</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">'{0}' SDK’sı çözümleniyor...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">"{0}" görevi {1} çekirdek istedi, {2} çekirdek aldı ve şu anda toplam {3} çekirdek tutuyor.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -390,6 +390,11 @@
         <target state="translated">当前仅支持使用 x64 风格的 MSBuild 来报告文件访问情况。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: SDK 解析程序失败: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: SDK 引用“{0}”版本“{1}”已改为解析到版本“{2}”。如果不更新要匹配的已引用版本，你可能会使用与预期不同的版本。</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">正在解析 SDK“{0}”...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">任务“{0}”请求了 {1} 个核心，已获取 {2} 个核心，现总共包含 {3} 个核心。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -451,6 +451,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="SuccededToResolveSDK">
+        <source>SDK "{0}" successfully resolved.</source>
+        <target state="new">SDK "{0}" successfully resolved.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskAcquiredCores">
         <source>Task "{0}" requested {1} cores, acquired {2} cores, and now holds {3} cores total.</source>
         <target state="translated">工作 "{0}" 已要求 {1} 個核心、已取得 {2} 個核心，現在共保留 {3} 個核心。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -390,6 +390,11 @@
         <target state="translated">目前只支援使用 MSBuild 的 x64 變體來報告檔案存取。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SDKResolverAttempt">
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>
         <target state="translated">MSB4242: SDK 解析程式失敗: "{0}"</target>
@@ -452,8 +457,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
-        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
+        <source>The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the "{1}" resolver to location "{2}" and version "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">
@@ -2585,13 +2590,6 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
         <target state="translated">MSB4241: SDK 參考 "{0}" 版本 "{1}" 已改為解析成版本 "{2}"。若您未將參考的版本更新為符合的版本，您可能使用了與預期不同的版本。</target>
         <note>{StrBegin="MSB4241: "}
-      LOCALIZATION:  Do not localize the word SDK.
-    </note>
-      </trans-unit>
-      <trans-unit id="SdkResolving">
-        <source>Resolving SDK '{0}'...</source>
-        <target state="translated">正在解析 SDK '{0}'...</target>
-        <note>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" was successfully resolved.</source>
-        <target state="new">SDK "{0}" was successfully resolved.</target>
+        <source>The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</source>
+        <target state="new">The SDK "{0}" was successfully resolved by the SDK resolver "{1}". SDK Result: "Path : {2}, Version : {3}"</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -452,8 +452,8 @@
     </note>
       </trans-unit>
       <trans-unit id="SucceededToResolveSDK">
-        <source>SDK "{0}" successfully resolved.</source>
-        <target state="new">SDK "{0}" successfully resolved.</target>
+        <source>SDK "{0}" was successfully resolved.</source>
+        <target state="new">SDK "{0}" was successfully resolved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskAcquiredCores">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -391,9 +391,15 @@
         <note />
       </trans-unit>
       <trans-unit id="SDKResolverAttempt">
-        <source>The "{0}" resolver attempted to resolve the SDK "{1}". {2}</source>
-        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}". {2}</target>
-        <note />
+        <source>The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</source>
+        <target state="new">The "{0}" resolver attempted to resolve the SDK "{1}".
+Warnings: {2}
+Errors: {3}</target>
+        <note>
+      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+    </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">
         <source>MSB4242: SDK Resolver Failure: "{0}"</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -398,7 +398,7 @@ Errors: {3}</source>
 Warnings: {2}
 Errors: {3}</target>
         <note>
-      LOCALIZATION: "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
+      LOCALIZATION: Do not localize the word SDK. "{2}" is new line separated warnings or "null". "{3}" is new line separated errors or "null".
     </note>
       </trans-unit>
       <trans-unit id="SDKResolverCriticalFailure">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -451,7 +451,7 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
-      <trans-unit id="SuccededToResolveSDK">
+      <trans-unit id="SucceededToResolveSDK">
         <source>SDK "{0}" successfully resolved.</source>
         <target state="new">SDK "{0}" successfully resolved.</target>
         <note />


### PR DESCRIPTION
Fixes #9413

### Context
We currently log [when we are starting to resolve SDK](https://github.com/dotnet/msbuild/blob/9a0cef6f75bf13ffbbde956b8f7d7ad7d6e0d996/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs#L315) and [when we failed to resolve SDK](https://github.com/dotnet/msbuild/blob/9a0cef6f75bf13ffbbde956b8f7d7ad7d6e0d996/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs#L134) but not when we succeeded or any resolvers' attempts.

Currently we log:
- If any of the resolvers succeeded, we log warnings only from its result
- If all the resolvers fail, we accumulate the warnings and errors from each of them. In the end, depending on the log flag, we either log one error containing all the errors or do not to log any errors, while logging all warnings.

### Changes Made
1. Log each resolver's  unsuccessful attempt with its warnings and errors as a message
2. Log success message when SDK is resolved by the resolver
3. Remove "Resolving SDK ..." message as it doesn't give us much

### Testing
Unit tests + manual 

### Notes
Example of new log output:
![Screenshot 2024-01-11 170404](https://github.com/dotnet/msbuild/assets/114938397/704484e7-bc07-4513-8a02-edb3f967b9b7)

