### PR TITLE
Fix parsing GB18030

### DIFF
--- a/src/BannedSymbols.txt
+++ b/src/BannedSymbols.txt
@@ -5,3 +5,5 @@ M:System.Xml.XmlReader.Create(System.String,System.Xml.XmlReaderSettings);Do not
 M:System.Xml.XmlReader.Create(System.String,System.Xml.XmlReaderSettings,System.Xml.XmlParserContext);Do not pass paths to XmlReader.Create--use the Stream overload
 M:System.Xml.XPath.XPathDocument.#ctor(System.String);Do not pass string paths to XPathDocument ctor--use the Stream overload
 M:System.Xml.XPath.XPathDocument.#ctor(System.String,System.Xml.XmlSpace);Do not pass string paths to XPathDocument ctor--use the Stream overload
+M:System.Xml.Linq.XDocument.Load(System.String);Do not pass uri to XDocument.Load, use overload with XmlReader instead
+M:System.Xml.Linq.XDocument.Load(System.String, System.Xml.Linq.LoadOptions);Do not pass uri to XDocument.Load, use overload with XmlReader instead

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -4,7 +4,9 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
+using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
@@ -103,7 +105,13 @@ namespace Microsoft.Build.UnitTests
                 string potentialVersionsPropsPath = Path.Combine(currentFolder, "build", "Versions.props");
                 if (FileSystems.Default.FileExists(potentialVersionsPropsPath))
                 {
-                    var doc = XDocument.Load(potentialVersionsPropsPath);
+                    XDocument doc = null;
+                    var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                    using (XmlReader xr = XmlReader.Create(File.OpenRead(potentialVersionsPropsPath), xrs))
+                    {
+                        doc = XDocument.Load(xr);
+                    }
+
                     var ns = doc.Root.Name.Namespace;
                     var cliVersionElement = doc.Root.Elements(ns + "PropertyGroup").Elements(ns + "DotNetCliVersion").FirstOrDefault();
                     if (cliVersionElement != null)

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Build.UnitTests
                 if (FileSystems.Default.FileExists(potentialVersionsPropsPath))
                 {
                     XDocument doc = null;
-                    var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                    var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true, IgnoreWhitespace = true };
                     using (XmlReader xr = XmlReader.Create(File.OpenRead(potentialVersionsPropsPath), xrs))
                     {
                         doc = XDocument.Load(xr);

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Xml;
 using System.Xml.Linq;

--- a/src/Tasks.UnitTests/GenerateBindingRedirects_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateBindingRedirects_Tests.cs
@@ -264,10 +264,10 @@ namespace Microsoft.Build.Tasks.UnitTests
         {
             using (TestEnvironment env = TestEnvironment.Create())
             {
-                TransientTestFolder rootTestFolder = _env.CreateFolder(); 
-                TransientTestFolder testFolder = _env.CreateFolder(Path.Combine(rootTestFolder.Path, "𬴂龨苘爫麤υ㏑䡫3"));
+                TransientTestFolder rootTestFolder = env.CreateFolder(); 
+                TransientTestFolder testFolder = env.CreateFolder(Path.Combine(rootTestFolder.Path, "\uD873\uDD02\u9FA8\u82D8\u722B\u9EA4\u03C5\u33D1\uE038\u486B\u0033"));
                 string appConfigContents = WriteAppConfigRuntimeSection(string.Empty, testFolder);
-                string outputAppConfigFile = _env.ExpectFile(".config").Path;
+                string outputAppConfigFile = env.ExpectFile(".config").Path;
 
                 TaskItemMock redirect = new TaskItemMock("System, Version=10.0.0.0, Culture=Neutral, PublicKeyToken='b77a5c561934e089'", "40.0.0.0");
 

--- a/src/Tasks.UnitTests/GenerateBindingRedirects_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateBindingRedirects_Tests.cs
@@ -260,6 +260,22 @@ namespace Microsoft.Build.Tasks.UnitTests
         }
 
         [Fact]
+        public void AppConfigWhenFilePlacedInLocationWithGB18030Characters()
+        {
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                TransientTestFolder rootTestFolder = _env.CreateFolder(); 
+                TransientTestFolder testFolder = _env.CreateFolder(Path.Combine(rootTestFolder.Path, "𬴂龨苘爫麤υ㏑䡫3"));
+                string appConfigContents = WriteAppConfigRuntimeSection(string.Empty, testFolder);
+                string outputAppConfigFile = _env.ExpectFile(".config").Path;
+
+                TaskItemMock redirect = new TaskItemMock("System, Version=10.0.0.0, Culture=Neutral, PublicKeyToken='b77a5c561934e089'", "40.0.0.0");
+
+                _ = Should.NotThrow(() => GenerateBindingRedirects(appConfigContents, outputAppConfigFile, redirect));
+            }
+        }
+
+        [Fact]
         public void AppConfigFileNotSavedWhenIdentical()
         {
             string appConfigFile = WriteAppConfigRuntimeSection(string.Empty);
@@ -306,11 +322,10 @@ namespace Microsoft.Build.Tasks.UnitTests
             GenerateBindingRedirects bindingRedirects = new GenerateBindingRedirects
             {
                 BuildEngine = engine,
-                SuggestedRedirects = suggestedRedirects ?? System.Array.Empty<ITaskItem>(),
+                SuggestedRedirects = suggestedRedirects ?? Array.Empty<ITaskItem>(),
                 AppConfigFile = new TaskItem(appConfigFile),
                 OutputAppConfigFile = new TaskItem(outputAppConfig)
             };
-
 
             bool executionResult = bindingRedirects.Execute();
 
@@ -324,7 +339,9 @@ namespace Microsoft.Build.Tasks.UnitTests
             };
         }
 
-        private string WriteAppConfigRuntimeSection(string runtimeSection)
+        private string WriteAppConfigRuntimeSection(
+            string runtimeSection,
+            TransientTestFolder transientTestFolder = null)
         {
             string formatString =
 @"<configuration>
@@ -334,7 +351,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 </configuration>";
             string appConfigContents = string.Format(formatString, runtimeSection);
 
-            string appConfigFile = _env.CreateFile(".config").Path;
+            string appConfigFile = _env.CreateFile(transientTestFolder ?? new TransientTestFolder(), ".config").Path;
             File.WriteAllText(appConfigFile, appConfigContents);
             return appConfigFile;
         }

--- a/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
+++ b/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 using System.IO;
+using System.Xml;
 
 #nullable disable
 
@@ -335,7 +336,12 @@ namespace Microsoft.Build.Tasks
             }
             else
             {
-                document = XDocument.Load(appConfigItem.ItemSpec);
+                var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                using (XmlReader xr = XmlReader.Create(File.OpenRead(appConfigItem.ItemSpec), xrs))
+                {
+                    document = XDocument.Load(xr);
+                }
+
                 if (document.Root == null || document.Root.Name != "configuration")
                 {
                     Log.LogErrorWithCodeFromResources("GenerateBindingRedirects.MissingConfigurationNode");

--- a/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
+++ b/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Build.Tasks
             }
             else
             {
-                var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
+                var xrs = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true, IgnoreWhitespace = true };
                 using (XmlReader xr = XmlReader.Create(File.OpenRead(appConfigItem.ItemSpec), xrs))
                 {
                     document = XDocument.Load(xr);


### PR DESCRIPTION
### Fixes 
[1921343](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1921343/)

### Context
XDocument.Load doesn't handle parsing GB18030 symbols and returns path like 𬴂龨苘爫麤υ㏑%EE%80%B8䡫3\𬴂龨苘爫麤υ㏑%EE%80%B8䡫3 instead of 𬴂龨苘爫麤υ㏑䡫3\𬴂龨苘爫麤υ㏑䡫3. It causes System.IO.DirectoryNotFoundException.

### Changes Made
Using XmlReader for handling encoding issues.

### Testing
UT + manual
