### PR TITLE
Checking for VS pathing when import not found

### DIFF
--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -924,7 +924,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 // Does not matter that the file or folder does not exist, we are checking for the VS pathing here
                 importPath = "path\\that\\does\\not\\exist\\Microsoft\\VisualStudio\\FileName.txt";
 
-                string content = ObjectModelHelpers.CleanupFileContents(@"
+                var content = env.CreateTestProjectWithFiles(@"
                     <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns='msbuildnamespace' >
                         <Import Project='" + importPath + @"'/>
                     </Project>
@@ -932,7 +932,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 InvalidProjectFileException ex = Assert.Throws<InvalidProjectFileException>(() =>
                 {
-                        Project project = new Project(XmlReader.Create(new StringReader(content)));
+                        Project project = new Project(content.ProjectFile, null, null);
                 });
 
                 Assert.Contains("MSB4278", ex.ErrorCode);

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -914,6 +914,44 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
 
+        [Fact]
+        public void importOnVSPathutputsRightError()
+        {
+            InvalidProjectFileException ex = Assert.Throws<InvalidProjectFileException>(() =>
+            {
+                string projectPath = null;
+                string importPath = null;
+
+                try
+                {
+                    // Does not matter that the file or folder does not exist, we are checking for the VS pathing here
+                    importPath = "path\\that\\does\\not\\exist\\Microsoft\\VisualStudio\\FileName.txt";
+                    projectPath = FileUtilities.GetTemporaryFileName();
+
+                    string import = ObjectModelHelpers.CleanupFileContents(@"
+                            <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns='msbuildnamespace' >
+                            </Project>
+                        ");
+
+                    File.WriteAllText(projectPath, import);
+
+                    string content = ObjectModelHelpers.CleanupFileContents(@"
+                            <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns='msbuildnamespace' >
+                                <Import Project='" + importPath + @"'/>
+                            </Project>
+                        ");
+
+                    Project project = new Project(XmlReader.Create(new StringReader(content)));
+                }
+                finally
+                {
+                    File.Delete(projectPath);
+                }
+            });
+
+            Assert.Contains("MSB4278", ex.ErrorCode);
+        }
+
         /// <summary>
         /// RecordDuplicateButNotCircularImports should not record circular imports (which do come under the category of "duplicate imports".
         /// </summary>

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -914,7 +914,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
 
-        [Fact]
+        [DotNetOnlyFact("Tests .NET SDK-only error")]
         public void ImportWithVSPathThrowsCorrectError()
         {
             InvalidProjectFileException ex = Assert.Throws<InvalidProjectFileException>(() =>

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -915,7 +915,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
-        public void importOnVSPathutputsRightError()
+        public void ImportWithVSPathThrowsCorrectError()
         {
             InvalidProjectFileException ex = Assert.Throws<InvalidProjectFileException>(() =>
             {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2304,6 +2304,8 @@ namespace Microsoft.Build.Evaluation
                                 continue;
                             }
 
+                            VerifyVSDistributionPath(importElement.Project, importLocationInProject);
+
                             ProjectErrorUtilities.ThrowInvalidProject(importLocationInProject, "ImportedProjectNotFound",
                                                                       importFileUnescaped, importExpressionEscaped);
                         }
@@ -2577,6 +2579,8 @@ namespace Microsoft.Build.Evaluation
 
             string stringifiedListOfSearchPaths = StringifyList(onlyFallbackSearchPaths);
 
+            VerifyVSDistributionPath(importElement.Project, importElement.ProjectLocation);
+
 #if FEATURE_SYSTEM_CONFIGURATION
             string configLocation = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
 
@@ -2638,6 +2642,14 @@ namespace Microsoft.Build.Evaluation
                         : $"{_lastModifiedProject.FullPath}{streamImports};{oldValue.EvaluatedValue}",
                     isGlobalProperty: false,
                     mayBeReserved: false);
+            }
+        }
+
+        private void VerifyVSDistributionPath(string path, ElementLocation importLocationInProject)
+        {
+            if (path.Contains("Microsoft\\VisualStudio"))
+            {
+                ProjectErrorUtilities.ThrowInvalidProject(importLocationInProject, "ImportedProjectFromVSDistribution", path);
             }
         }
     }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2304,7 +2304,9 @@ namespace Microsoft.Build.Evaluation
                                 continue;
                             }
 
+#if !FEATURE_VISUALSTUDIOSETUP
                             VerifyVSDistributionPath(importElement.Project, importLocationInProject);
+#endif
 
                             ProjectErrorUtilities.ThrowInvalidProject(importLocationInProject, "ImportedProjectNotFound",
                                                                       importFileUnescaped, importExpressionEscaped);
@@ -2579,7 +2581,9 @@ namespace Microsoft.Build.Evaluation
 
             string stringifiedListOfSearchPaths = StringifyList(onlyFallbackSearchPaths);
 
+#if !FEATURE_VISUALSTUDIOSETUP
             VerifyVSDistributionPath(importElement.Project, importElement.ProjectLocation);
+#endif
 
 #if FEATURE_SYSTEM_CONFIGURATION
             string configLocation = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
@@ -2647,7 +2651,8 @@ namespace Microsoft.Build.Evaluation
 
         private void VerifyVSDistributionPath(string path, ElementLocation importLocationInProject)
         {
-            if (path.IndexOf($"Microsoft{Path.DirectorySeparatorChar}VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (path.IndexOf("Microsoft\\VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0
+                || path.IndexOf("Microsoft/VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 ProjectErrorUtilities.ThrowInvalidProject(importLocationInProject, "ImportedProjectFromVSDistribution", path);
             }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2647,7 +2647,8 @@ namespace Microsoft.Build.Evaluation
 
         private void VerifyVSDistributionPath(string path, ElementLocation importLocationInProject)
         {
-            if (path.IndexOf("Microsoft\\VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (path.IndexOf("Microsoft\\VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0
+                || path.IndexOf("Microsoft/VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 ProjectErrorUtilities.ThrowInvalidProject(importLocationInProject, "ImportedProjectFromVSDistribution", path);
             }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2647,8 +2647,7 @@ namespace Microsoft.Build.Evaluation
 
         private void VerifyVSDistributionPath(string path, ElementLocation importLocationInProject)
         {
-            if (path.IndexOf("Microsoft\\VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0
-                || path.IndexOf("Microsoft/VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (path.IndexOf($"Microsoft{Path.DirectorySeparatorChar}VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 ProjectErrorUtilities.ThrowInvalidProject(importLocationInProject, "ImportedProjectFromVSDistribution", path);
             }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2304,9 +2304,7 @@ namespace Microsoft.Build.Evaluation
                                 continue;
                             }
 
-#if !FEATURE_VISUALSTUDIOSETUP
                             VerifyVSDistributionPath(importElement.Project, importLocationInProject);
-#endif
 
                             ProjectErrorUtilities.ThrowInvalidProject(importLocationInProject, "ImportedProjectNotFound",
                                                                       importFileUnescaped, importExpressionEscaped);
@@ -2581,9 +2579,7 @@ namespace Microsoft.Build.Evaluation
 
             string stringifiedListOfSearchPaths = StringifyList(onlyFallbackSearchPaths);
 
-#if !FEATURE_VISUALSTUDIOSETUP
             VerifyVSDistributionPath(importElement.Project, importElement.ProjectLocation);
-#endif
 
 #if FEATURE_SYSTEM_CONFIGURATION
             string configLocation = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
@@ -2649,6 +2645,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
+        [Conditional("FEATURE_GUIDE_TO_VS_ON_UNSUPPORTED_PROJECTS")]
         private void VerifyVSDistributionPath(string path, ElementLocation importLocationInProject)
         {
             if (path.IndexOf("Microsoft\\VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2647,7 +2647,7 @@ namespace Microsoft.Build.Evaluation
 
         private void VerifyVSDistributionPath(string path, ElementLocation importLocationInProject)
         {
-            if (path.Contains("Microsoft\\VisualStudio"))
+            if (path.IndexOf("Microsoft\\VisualStudio", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 ProjectErrorUtilities.ThrowInvalidProject(importLocationInProject, "ImportedProjectFromVSDistribution", path);
             }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -527,6 +527,10 @@
     <value>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}" is correct, and that the file exists on disk.</value>
     <comment>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
   </data>
+  <data name="ImportedProjectFromVSDistribution" xml:space="preserve">
+    <value>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </value>
+    <comment>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
+  </data>
   <data name="ImportedProjectFromExtensionsPathNotFoundFromAppConfig" xml:space="preserve">
     <value>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</value>
     <comment>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
@@ -2013,7 +2017,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <!--
         The Build message bucket is: MSB4000 - MSB4999
 
-        Next message code should be MSB4278
+        Next message code should be MSB4279
 
         Don't forget to update this comment after using a new code.
   -->

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -528,7 +528,7 @@
     <comment>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
   </data>
   <data name="ImportedProjectFromVSDistribution" xml:space="preserve">
-    <value>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </value>
+    <value>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </value>
     <comment>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
   </data>
   <data name="ImportedProjectFromExtensionsPathNotFoundFromAppConfig" xml:space="preserve">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -528,7 +528,7 @@
     <comment>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
   </data>
   <data name="ImportedProjectFromVSDistribution" xml:space="preserve">
-    <value>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </value>
+    <value>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </value>
     <comment>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
   </data>
   <data name="ImportedProjectFromExtensionsPathNotFoundFromAppConfig" xml:space="preserve">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -528,7 +528,7 @@
     <comment>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
   </data>
   <data name="ImportedProjectFromVSDistribution" xml:space="preserve">
-    <value>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </value>
+    <value>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </value>
     <comment>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
   </data>
   <data name="ImportedProjectFromExtensionsPathNotFoundFromAppConfig" xml:space="preserve">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: Na pozici {1} podmínky {0} je neočekávaná mezera. Nezapomněli jste ji odebrat?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Následující vstupní soubory mezipaměti pro výsledky neexistují: {0}</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: Unerwartetes Leerzeichen an Position "{1}" der Bedingung "{0}". Haben Sie vergessen, ein Leerzeichen zu entfernen?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Die folgenden Cachedateien für Eingabeergebnisse sind nicht vorhanden: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: Espacio inesperado en la posición "{1}" de la condición "{0}". ¿Olvidó quitar un espacio?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Los siguientes archivos de caché de resultados de entrada no existen: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: espace inattendu à la position "{1}" de la condition "{0}". Avez-vous oublié de supprimer un espace ?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Les fichiers cache des résultats d'entrée suivants n'existent pas : "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: spazio imprevisto alla posizione "{1}" della condizione "{0}". Si è dimenticato di rimuovere uno spazio?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: i file della cache dei risultati di input seguenti non esistono: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: 条件 "{0}" の位置 "{1}" に予期しないスペースがあります。スペースを削除したか確認してください。</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: 以下の入力結果キャッシュ ファイルが存在しません: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: "{0}" 조건의 "{1}" 위치에 예기치 않은 공백이 있습니다. 공백을 제거했는지 확인하세요.</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: 다음 입력 결과 캐시 파일이 존재하지 않습니다. "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: Nieoczekiwana spacja na pozycji „{1}” warunku „{0}”. Czy zapomniano o usunięciu spacji?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Następujące pliki wejściowej pamięci podręcznej wyników nie istnieją: „{0}”</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: espaço inesperado na posição "{1}" da condição "{0}". Você esqueceu de remover um espaço?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: os arquivos de cache do resultado de entrada a seguir não existem: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: неожиданный пробел в позиции "{1}" условия "{0}". Вы забыли удалить пробел?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: следующие входные файлы кэша результатов не существуют: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: "{0}" koşulunun "{1}" konumunda beklenmeyen boşluk var. Boşluğu kaldırmayı unutmuş olabilirsiniz.</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: Şu giriş sonucu önbellek dosyaları mevcut değil: "{0}"</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: 在条件“{0}”的位置“{1}”处出现意外空格。是否忘记了删除空格?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: 以下输入结果缓存文件不存在:“{0}”</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
-        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file "{0}" does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -160,8 +160,8 @@
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromVSDistribution">
-        <source>MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </source>
-        <target state="new">MSB4278: The imported project {0} does not exist and appears to be part of Visual Studio. This project may require MSBuild.exe and fail to build in the dotnet CLI. </target>
+        <source>MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </source>
+        <target state="new">MSB4278: The imported file {0} does not exist and appears to be part of a Visual Studio component. This file may require MSBuild.exe in order to be imported successfully, and so may fail to build in the dotnet CLI. </target>
         <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -159,6 +159,11 @@
         <target state="translated">MSB4259: 條件 "{0}" 的位置 "{1}" 出現非預期的空格。忘記移除空格了嗎?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
+      <trans-unit id="ImportedProjectFromVSDistribution">
+        <source>MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </source>
+        <target state="new">MSB4278: The imported project {0} is from the Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt. </target>
+        <note>{StrBegin="MSB4278: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
       <trans-unit id="InputCacheFilesDoNotExist">
         <source>MSB4255: The following input result cache files do not exist: "{0}"</source>
         <target state="translated">MSB4255: 下列輸入結果快取檔案不存在: "{0}"</target>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -89,6 +89,7 @@
     <CompilerToolsDir>$([System.IO.Path]::Combine($(ToolPackagesDir)Microsoft.Net.Compilers, $(CompilerToolsVersion), "tools"))$([System.IO.Path]::DirectorySeparatorChar)</CompilerToolsDir>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYLOADCONTEXT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEINFORMATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_GUIDE_TO_VS_ON_UNSUPPORTED_PROJECTS</DefineConstants>
     <DefineConstants>$(DefineConstants);USE_MSBUILD_DLL_EXTN</DefineConstants>
     <DefineConstants>$(DefineConstants);WORKAROUND_COREFX_19110</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SYMLINK_TARGET</DefineConstants>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/8967

### Context
Users sometimes use different distributions to build projects, however some files available in the VS distribution are not available with `dotnet build`. It used to throw a "File not found" error, but now it is switched to "this imported project is in a VS distribution".

An example message is: ` error MSB4278: The imported project $(MSBuildE
xtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\DSLTools\Microsoft.DslTools.settings.targets is from the
Visual Studio distribution of MSBuild. Build with MSBuild.exe in a Developer Command Prompt.`

### Changes Made
Before throwing a `invalidProject` error for file not found, check the path of the file if it is within Visual Studio. If it is, throw new error instead.


