### PR TITLE
Use all MSBuild binding redirects in NuGet.Frameworks AppDomain

### DIFF
--- a/documentation/NETFramework-NGEN.md
+++ b/documentation/NETFramework-NGEN.md
@@ -102,7 +102,9 @@ right binding redirects, allowing MSBuild to use `Assembly.Load` and get the nat
 
 This approach has some small startup cost (building the config, creating AppDomain & a `MarshalByRefObject`) and a small run-time overhead
 of cross-domain calls. The former is orders of magnitude smaller that the startup hit of JITting and the latter is negligible as long as
-the types moved across the AppDomain boundary do not require expensive marshaling.
+the types moved across the AppDomain boundary do not require expensive marshaling. Additionally, the requirement to execute code in multiple
+AppDomains necessitates the use of `LoaderOptimization.MultiDomain` for loading all assemblies domain-neutral. This may come with run-time
+cost for certain code patterns, although none has been measured in MSBuild scenarios.
 
 ## Task assemblies
 

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -681,7 +681,9 @@
     <NuGetFrameworkWrapperRedirects_FilePath>$(IntermediateOutputPath)NuGetFrameworkWrapper.redirects.cs</NuGetFrameworkWrapperRedirects_FilePath>
   </PropertyGroup>
 
-  <!-- Extract binding redirects for Microsoft.Build from MSBuild.exe.config into a source file -->
+  <!-- Extract binding redirects for MSBuild and dependencies from MSBuild.exe.config into a source file.
+       This allows us to create secondary AppDomains with the same redirects at run-time, see
+       https://github.com/dotnet/msbuild/blob/main/documentation/NETFramework-NGEN.md#nugetframeworks -->
   <Target Name="GenerateAppDomainConfig"
           Inputs="..\MSBuild\app.config;..\MSBuild\app.amd64.config"
           Outputs="$(NuGetFrameworkWrapperRedirects_FilePath)"

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -685,7 +685,7 @@
        This allows us to create secondary AppDomains with the same redirects at run-time, see
        https://github.com/dotnet/msbuild/blob/main/documentation/NETFramework-NGEN.md#nugetframeworks -->
   <Target Name="GenerateAppDomainConfig"
-          Inputs="..\MSBuild\app.config;..\MSBuild\app.amd64.config"
+          Inputs="..\MSBuild\app.config;..\MSBuild\app.amd64.config;$(MSBuildThisFileFullPath)"
           Outputs="$(NuGetFrameworkWrapperRedirects_FilePath)"
           BeforeTargets="CoreCompile"
           Condition="'$(FeatureAppDomain)' == 'true'">

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -689,14 +689,14 @@
           Condition="'$(FeatureAppDomain)' == 'true'">
     <PropertyGroup>
       <BindingRedirectNamespace>&lt;Namespace Prefix='ns' Uri='urn:schemas-microsoft-com:asm.v1' /&gt;</BindingRedirectNamespace>
-      <BindingRedirectXPath>/configuration/runtime/ns:assemblyBinding/ns:dependentAssembly[ns:assemblyIdentity/@name='Microsoft.Build']</BindingRedirectXPath>
+      <BindingRedirectXPath>/configuration/runtime/ns:assemblyBinding/*</BindingRedirectXPath>
     </PropertyGroup>
 
     <XmlPeek XmlInputPath="..\MSBuild\app.config" Query="$(BindingRedirectXPath)" Namespaces="$(BindingRedirectNamespace)">
-      <Output TaskParameter="Result" ItemName="BindingRedirect32" />
+      <Output TaskParameter="Result" ItemName="BindingRedirects32" />
     </XmlPeek>
     <XmlPeek XmlInputPath="..\MSBuild\app.amd64.config" Query="$(BindingRedirectXPath)" Namespaces="$(BindingRedirectNamespace)">
-      <Output TaskParameter="Result" ItemName="BindingRedirect64" />
+      <Output TaskParameter="Result" ItemName="BindingRedirects64" />
     </XmlPeek>
 
     <PropertyGroup>
@@ -709,8 +709,8 @@ namespace Microsoft.Build.Evaluation%3B;
 [System.CodeDom.Compiler.GeneratedCode("GenerateAppDomainConfig", "1.0")]
 internal sealed partial class NuGetFrameworkWrapper
 {
-    private const string _bindingRedirect32 = """;@(BindingRedirect32);"""%3B;
-    private const string _bindingRedirect64 = """;@(BindingRedirect64);"""%3B;
+    private const string _bindingRedirects32 = """;@(BindingRedirects32);"""%3B;
+    private const string _bindingRedirects64 = """;@(BindingRedirects64);"""%3B;
 }
 ]]>
       </NuGetFrameworkWrapperRedirects_Content>

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -157,6 +157,11 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public override object InitializeLifetimeService() => null;
 
+        /// <summary>
+        /// Creates <see cref="AppDomainSetup"/> suitable for loading Microsoft.Build, NuGet.Frameworks, and dependencies.
+        /// See https://github.com/dotnet/msbuild/blob/main/documentation/NETFramework-NGEN.md#nugetframeworks for the motivation
+        /// to use a separate AppDomain.
+        /// </summary>
         private static AppDomainSetup CreateAppDomainSetup(AssemblyName assemblyName, string assemblyPath)
         {
             byte[] publicKeyToken = assemblyName.GetPublicKeyToken();

--- a/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Build.Evaluation
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-        {(Environment.Is64BitProcess ? _bindingRedirect64 : _bindingRedirect32)}
+        {(Environment.Is64BitProcess ? _bindingRedirects64 : _bindingRedirects32)}
         <dependentAssembly>
           <assemblyIdentity name="{NuGetFrameworksAssemblyName}" publicKeyToken="{publicKeyTokenString}" culture="{assemblyName.CultureName}" />
           <codeBase version="{assemblyName.Version}" href="{assemblyPath}" />

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -211,14 +211,14 @@ namespace Microsoft.Build.CommandLine
         /// MSBuild no longer runs any arbitrary code (tasks or loggers) on the main thread, so it never needs the
         /// main thread to be in an STA. Accordingly, to avoid ambiguity, we explicitly use the [MTAThread] attribute.
         /// This doesn't actually do any work unless COM interop occurs for some reason.
-        /// We use the MultiDomainHost loader policy because we may create secondary AppDomains and need NGEN images
-        /// for Framework / GACed assemblies to be loaded domain neutral so their native images can be used.
+        /// We use the MultiDomain loader policy because we may create secondary AppDomains and need NGEN images
+        /// for our as well as Framework assemblies to be loaded domain neutral so their native images can be used.
         /// See <see cref="NuGetFrameworkWrapper"/>.
         /// </remarks>
         /// <returns>0 on success, 1 on failure</returns>
         [MTAThread]
 #if FEATURE_APPDOMAIN
-        [LoaderOptimization(LoaderOptimization.MultiDomainHost)]
+        [LoaderOptimization(LoaderOptimization.MultiDomain)]
 #endif
 #pragma warning disable SA1111, SA1009 // Closing parenthesis should be on line of last parameter
         public static int Main(


### PR DESCRIPTION
### Context

The secondary AppDomain hosting `NuGet.Frameworks` was set up with a binding redirect for `Microsoft.Build` but not its dependencies. Additionally, `MSBuild.exe` loader policy was set to `MultiDomainHost`, making it possible to share only Framework assemblies between AppDomains, but still loading MSBuild assemblies domain specific. These issues were resulting in NGEN rejections at run-time.

### Changes Made

Made the `GenerateAppDomainConfig` target use all binding redirects from `MSBuild.exe.config` and switched to `MultiDomain` loader policy. Also pluralized the relevant identifiers (redirect -> redirects).

### Testing

Experimental VS insertion with PerfDDRITs & Speedometer runs.
