### PR TITLE
[Graph] Emit NoTargetSpecified when an entry point project doesn't have any targets

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -4346,5 +4346,29 @@ $@"<Project InitialTargets=`Sleep`>
 
             Assert.Equal(BuildResultCode.Success, result.OverallResult);
         }
+
+        [Fact]
+        public void ProjectWithNoTargets()
+        {
+            string contents = @"<Project />";
+
+            BuildRequestData data = GetBuildRequestData(contents);
+            BuildResult result = _buildManager.Build(_parameters, data);
+            Assert.Equal(BuildResultCode.Failure, result.OverallResult);
+
+            _logger.AssertLogContains("MSB4040");
+        }
+
+        [Fact]
+        public void ProjectWithNoTargetsGraph()
+        {
+            string contents = @"<Project />";
+
+            GraphBuildRequestData data = GetGraphBuildRequestData(contents);
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+            Assert.Equal(BuildResultCode.Failure, result.OverallResult);
+
+            _logger.AssertLogContains("MSB4040");
+        }
     }
 }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1956,11 +1956,20 @@ namespace Microsoft.Build.Execution
             {
                 _projectCacheService.InitializePluginsForGraph(projectGraph, submission.BuildRequestData.TargetNames, _executionCancellationTokenSource.Token);
 
-                var targetListTask = projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames);
+                IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetsPerNode = projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames);
 
-                DumpGraph(projectGraph, targetListTask);
+                DumpGraph(projectGraph, targetsPerNode);
 
-                resultsPerNode = BuildGraph(projectGraph, targetListTask, submission.BuildRequestData);
+                // Non-graph builds verify this in RequestBuilder, but for graph builds we need to disambiguate
+                // between entry nodes and other nodes in the graph since only entry nodes should error. Just do
+                // the verification expicitly before the build even starts.
+                foreach (ProjectGraphNode entryPointNode in projectGraph.EntryPointNodes)
+                {
+                    ImmutableList<string> targetList = targetsPerNode[entryPointNode];
+                    ProjectErrorUtilities.VerifyThrowInvalidProject(targetList.Count > 0, entryPointNode.ProjectInstance.ProjectFileLocation, "NoTargetSpecified");
+                }
+
+                resultsPerNode = BuildGraph(projectGraph, targetsPerNode, submission.BuildRequestData);
             }
             else
             {

--- a/src/UnitTests.Shared/ObjectModelHelpers.cs
+++ b/src/UnitTests.Shared/ObjectModelHelpers.cs
@@ -1699,6 +1699,8 @@ namespace Microsoft.Build.UnitTests
 
             sb.Append("</ItemGroup>");
 
+            // Ensure there is at least one valid target in the project
+            sb.Append("<Target Name='Build'/>");
 
             foreach (var defaultTarget in (defaultTargets ?? string.Empty).Split(MSBuildConstants.SemicolonChar, StringSplitOptions.RemoveEmptyEntries))
             {


### PR DESCRIPTION
Fixes #9502

This change checks the entry point nodes in a graph to see if any targets are specified. This will error similarly to non-graph builds when the project has no targets.

Tested using a project with the content: `<Project />`.

Non-graph behavior:

![image](https://github.com/dotnet/msbuild/assets/6445614/1429a486-d199-47d4-92de-47667111b51b)

Current graph behavior (incorrect):

![image](https://github.com/dotnet/msbuild/assets/6445614/b11b8033-0166-412b-82e2-d8f0402ce23e)

New graph behavior (corrected):

![image](https://github.com/dotnet/msbuild/assets/6445614/baf2406f-0293-45ef-9758-7dd299003e87)

Note: Non-entry points without targets actually are not a problem. In the non-graph scenario, the (valid) referencing project will execute `_GetProjectReferenceTargetFrameworkProperties` which calls `GetTargetFrameworks` on the referenced project. If the target doesn't exist (or in this case, *no* targets exist), then the call no-ops (due to `SkipNonexistentTargets="true"` being set) and the `ProjectReference` is essentially filtered out.