### PR TITLE
ToolTask process start separated to another function

### DIFF
--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -659,9 +659,11 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Starts the process during task execution
+        /// Expect task to override this method if they need information about the process or process events during task execution.
+        /// Implementation should make sure that the task is started in this method.
+        /// Starts the process during task execution. 
         /// </summary>
-        /// <param name="proc"></param>
+        /// <param name="proc">Process that will be executed by ToolTask</param>
         /// <returns></returns>
         protected virtual Process StartToolProcess(Process proc)
         {

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -658,7 +658,12 @@ namespace Microsoft.Build.Utilities
             return startInfo;
         }
 
-        public virtual Process StartTask (Process proc)
+        /// <summary>
+        /// Starts the process during task execution
+        /// </summary>
+        /// <param name="proc"></param>
+        /// <returns></returns>
+        protected virtual Process StartToolProcess(Process proc)
         {
             proc.Start();
             return proc;
@@ -720,7 +725,7 @@ namespace Microsoft.Build.Utilities
                 ExitCode = -1;
 
                 // Start the process
-                StartTask(proc);
+                proc = StartToolProcess(proc);
 
                 // Close the input stream. This is done to prevent commands from
                 // blocking the build waiting for input from the user.

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -659,12 +659,12 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Expect task to override this method if they need information about the process or process events during task execution.
+        /// We expect tasks to override this method if they need information about the tool process or its process events during task execution.
         /// Implementation should make sure that the task is started in this method.
         /// Starts the process during task execution. 
         /// </summary>
-        /// <param name="proc">Process that will be executed by ToolTask</param>
-        /// <returns></returns>
+        /// <param name="proc">Fully populated <see cref="Process"/> instance representing the tool process to be started.</param>
+        /// <returns>A started process. This could be <paramref name="proc"/> or another <see cref="Process"/> instance.</returns>
         protected virtual Process StartToolProcess(Process proc)
         {
             proc.Start();

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -658,6 +658,12 @@ namespace Microsoft.Build.Utilities
             return startInfo;
         }
 
+        public virtual Process StartTask (Process proc)
+        {
+            proc.Start();
+            return proc;
+        }
+
         /// <summary>
         /// Writes out a temporary response file and shell-executes the tool requested.  Enables concurrent
         /// logging of the output of the tool.
@@ -714,7 +720,7 @@ namespace Microsoft.Build.Utilities
                 ExitCode = -1;
 
                 // Start the process
-                proc.Start();
+                StartTask(proc);
 
                 // Close the input stream. This is done to prevent commands from
                 // blocking the build waiting for input from the user.


### PR DESCRIPTION
Fix for https://github.com/dotnet/msbuild/issues/9404

### Context
We currently do not send the cancelation event to tasks being run by `ToolTask`, as such, many children task take a long time to cancel, and sometimes they finish executing before said cancelation. 
This change makes it possible for inherited classes to access the process and check the cancelation event during execution.

### Changes Made
Separated the start of the process to another function that is overridable, as well as exposing the process information.

### Notes

Issue will only be closed once C++ team has incorporated this change into the `CustomBuild` task.

