### PR TITLE
Bugfix forwarding logger

### DIFF
--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -202,8 +202,6 @@ namespace Microsoft.Build.Logging
 
             ParseParameters(eventSource);
 
-            ResetLoggerState();
-
             if (!_forwardingSetFromParameters)
             {
                 SetForwardingBasedOnVerbosity(eventSource);
@@ -312,15 +310,6 @@ namespace Microsoft.Build.Logging
             }
             // The logger does not log messages of any importance.
             return MessageImportance.High - 1;
-        }
-
-        /// <summary>
-        /// Reset the states of per-build member variables.
-        /// Used when a build is finished, but the logger might be needed for the next build.
-        /// </summary>
-        private void ResetLoggerState()
-        {
-            // No state needs resetting
         }
 
         /// <summary>

--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -289,10 +289,12 @@ namespace Microsoft.Build.Logging
 
         /// <summary>
         /// Returns the minimum importance of messages logged by this logger.
+        /// Forwarding logger might be configured to forward messages of particular importance regardless of the verbosity level of said logger.
+        /// This method properly reflects that.
         /// </summary>
         /// <returns>
-        /// The minimum message importance corresponding to this logger's verbosity or (MessageImportance.High - 1)
-        /// if this logger does not log messages of any importance.
+        /// The minimum message importance corresponding to this logger's verbosity or configuration of forwarding of messages of particular importance level.
+        /// If this logger is not configured to forward messages of any importance and verbosity is not explicitly set, then (MessageImportance.High - 1) is returned.
         /// </returns>
         internal MessageImportance GetMinimumMessageImportance()
         {

--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -298,17 +298,20 @@ namespace Microsoft.Build.Logging
         /// </returns>
         internal MessageImportance GetMinimumMessageImportance()
         {
-            return _verbosity switch
+            if (_forwardLowImportanceMessages)
             {
-                LoggerVerbosity.Minimal => MessageImportance.High,
-                LoggerVerbosity.Normal => MessageImportance.Normal,
-                LoggerVerbosity.Detailed => MessageImportance.Low,
-                LoggerVerbosity.Diagnostic => MessageImportance.Low,
-
-                // The logger does not log messages of any importance.
-                LoggerVerbosity.Quiet => MessageImportance.High - 1,
-                _ => MessageImportance.High - 1,
-            };
+                return MessageImportance.Low;
+            }
+            if (_forwardNormalImportanceMessages)
+            {
+                return MessageImportance.Normal;
+            }
+            if (_forwardHighImportanceMessages)
+            {
+                return MessageImportance.High;
+            }
+            // The logger does not log messages of any importance.
+            return MessageImportance.High - 1;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/pull/9578#issuecomment-1893514072

### Context
Forwarding logger might be configured to forward messages of particular importance regardless of the verbosity level of said logger.
`GetMinimumMessageImportance` should properly reflect that


### Testing
Manual testing with the repro case (building msbuild with terminal logger)
