### PR TITLE
Add LangVersion to `_GenerateCompileDependencyCache`

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3799,6 +3799,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CoreCompileCache Include="@(Compile)" />
       <CoreCompileCache Include="@(ReferencePath)" />
       <CoreCompileCache Include="$(DefineConstants)" />
+      <CoreCompileCache Include="$(LangVersion)" />
     </ItemGroup>
 
     <Hash


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/71678

### Context

Building with `dotnet build -p:langversion=X` then with `dotnet build -p:langversion=Y` considers the build up to date.

### Changes Made

Include LangVersion as `CoreCompileCache`

### Testing

-

### Notes
