### PR TITLE
Optimize SDK resolution in dotnet build

### DIFF
--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -24,7 +24,7 @@ using SdkResultImpl = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
 
 namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
-    public class SdkResolverService_Tests
+    public class SdkResolverService_Tests : IDisposable
     {
         private readonly MockLogger _logger;
         private readonly LoggingContext _loggingContext;
@@ -38,6 +38,11 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             _loggingContext = new MockLoggingContext(
                 loggingService,
                 new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0, 0));
+        }
+
+        public void Dispose()
+        {
+            SdkResolverService.Instance.InitializeForTests();
         }
 
         [Fact]
@@ -250,6 +255,29 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             // Second call should have received state
             SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true).Path.ShouldBe("resolverpath");
+        }
+
+        [Fact]
+        public void AssertResolversLoadedIfDefaultResolverSucceeds()
+        {
+            const int submissionId = BuildEventContext.InvalidSubmissionId;
+
+            MockLoaderStrategy mockLoaderStrategy = new MockLoaderStrategy(includeDefaultResolver: true);
+            SdkResolverService.Instance.InitializeForTests(mockLoaderStrategy);
+
+            SdkReference sdk = new SdkReference("notfound", "1.0", "minimumVersion");
+
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true).Path.ShouldBe("defaultpath");
+
+#if NETCOREAPP
+            // On Core, we check the default resolver *first*, so regular resolvers are not loaded.
+            mockLoaderStrategy.ResolversHaveBeenLoaded.ShouldBeFalse();
+            mockLoaderStrategy.ManifestsHaveBeenLoaded.ShouldBeFalse();
+#else
+            // On Framework, the default resolver is a fallback, so regular resolvers will have been loaded.
+            mockLoaderStrategy.ResolversHaveBeenLoaded.ShouldBeTrue();
+            mockLoaderStrategy.ManifestsHaveBeenLoaded.ShouldBeTrue();
+#endif
         }
 
         [Theory]
@@ -622,10 +650,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         private sealed class MockLoaderStrategy : SdkResolverLoader
         {
             private List<SdkResolver> _resolvers;
+            private List<SdkResolver> _defaultResolvers;
             private List<(string ResolvableSdkPattern, SdkResolver Resolver)> _resolversWithPatterns;
 
+            public bool ResolversHaveBeenLoaded { get; private set; } = false;
+            public bool ManifestsHaveBeenLoaded { get; private set; } = false;
 
-            public MockLoaderStrategy(bool includeErrorResolver = false, bool includeResolversWithPatterns = false) : this()
+            public MockLoaderStrategy(bool includeErrorResolver = false, bool includeResolversWithPatterns = false, bool includeDefaultResolver = false) : this()
             {
                 if (includeErrorResolver)
                 {
@@ -636,6 +667,11 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 {
                     _resolversWithPatterns.Add(("1.*", new MockSdkResolverWithResolvableSdkPattern1()));
                     _resolversWithPatterns.Add((".*", new MockSdkResolverWithResolvableSdkPattern2()));
+                }
+
+                if (includeDefaultResolver)
+                {
+                    _defaultResolvers.Add(new MockSdkResolverDefault());
                 }
             }
 
@@ -649,16 +685,22 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     new MockSdkResolverWithState()
                 };
 
+                _defaultResolvers = new List<SdkResolver>();
+
                 _resolversWithPatterns = new List<(string ResolvableSdkPattern, SdkResolver Resolver)>();
             }
 
             internal override IReadOnlyList<SdkResolver> LoadAllResolvers(ElementLocation location)
             {
+                ResolversHaveBeenLoaded = true;
+
                 return _resolvers.OrderBy(i => i.Priority).ToList();
             }
 
             internal override IReadOnlyList<SdkResolverManifest> GetResolversManifests(ElementLocation location)
             {
+                ManifestsHaveBeenLoaded = true;
+
                 var manifests = new List<SdkResolverManifest>();
                 foreach (SdkResolver resolver in _resolvers)
                 {
@@ -678,6 +720,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             protected internal override IReadOnlyList<SdkResolver> LoadResolversFromManifest(SdkResolverManifest manifest, ElementLocation location)
             {
+                ResolversHaveBeenLoaded = true;
+
                 var resolvers = new List<SdkResolver>();
                 foreach (var resolver in _resolvers)
                 {
@@ -698,7 +742,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             internal override IReadOnlyList<SdkResolver> GetDefaultResolvers()
             {
-                return new List<SdkResolver>();
+                return _defaultResolvers;
             }
         }
 
@@ -822,6 +866,19 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 resolverContext.Logger.LogMessage("MockSdkResolverThrows running", MessageImportance.Normal);
 
                 throw new ArithmeticException("EXMESSAGE");
+            }
+        }
+
+        private sealed class MockSdkResolverDefault : SdkResolver
+        {
+            public override string Name => nameof(MockSdkResolverDefault);
+            public override int Priority => 9999;
+
+            public override SdkResultBase Resolve(SdkReference sdk, SdkResolverContextBase resolverContext, SdkResultFactoryBase factory)
+            {
+                resolverContext.Logger.LogMessage("MockSdkResolverDefault running", MessageImportance.Normal);
+
+                return factory.IndicateSuccess("defaultpath", string.Empty);
             }
         }
     }

--- a/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
@@ -624,6 +624,9 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             _env.SetEnvironmentVariable("MSBuildSDKsPath", _testSdkRoot);
             _env.SetEnvironmentVariable("MSBUILD_SDKREFERENCE_PROPERTY_EXPANSION_MODE", data.Mode.ToString());
+            _env.SetEnvironmentVariable("MSBUILDINCLUDEDEFAULTSDKRESOLVER", "false");
+
+            Build.BackEnd.SdkResolution.CachingSdkResolverLoader.ResetStateForTests();
 
             File.WriteAllText(_sdkPropsPath, _sdkPropsContent);
             File.WriteAllText(_sdkTargetsPath, _sdkTargetsContent);
@@ -804,6 +807,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         public void Dispose()
         {
             _env.Dispose();
+            Build.BackEnd.SdkResolution.CachingSdkResolverLoader.ResetStateForTests();
         }
 
         private void VerifyPropertyFromImplicitImport(Project project, string propertyName, string expectedContainingProjectPath, string expectedValue)

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverLoader.cs
@@ -57,6 +57,15 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _defaultResolvers = base.GetDefaultResolvers();
         }
 
+        /// <summary>
+        /// Resets the cached state, intended for tests only.
+        /// </summary>
+        internal static void ResetStateForTests()
+        {
+            // Re-create the singleton to pick up environmental changes.
+            Instance = new CachingSdkResolverLoader();
+        }
+
         #region SdkResolverLoader overrides
 
         /// <inheritdoc />
@@ -87,5 +96,6 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         #endregion
+
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             // 1. DefaultSdkResolver checks the Sdks subdirectory of our SDK installation. Note that the work of resolving the
             //    SDK version using machine-wide state and global.json (step 1.1. in `MSBuild.exe` above) has already been done
             //    by the `dotnet` muxer. We know which SDK (capital letters) we are in, so the in-box Sdk lookup is trivial.
-            // 2. If no match, Microsoft.DotNet.MSBuildSdkResolver is loaded and asked to resolve the Sdk required by the project.
+            // 2. If no match, Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver is loaded and asked to resolve the Sdk required by the project.
             //    2.1. It checks installed workloads.
             // 3. If no match still, Microsoft.Build.NuGetSdkResolver is loaded and asked to resolve the Sdk.
             //

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -118,6 +118,53 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
         public virtual SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk)
         {
+            // If we are running in .NET core, we ask the built-in default resolver first.
+            // - It is a perf optimization (no need to discover and load any of the plug-in assemblies to resolve an "in-box" Sdk).
+            // - It brings `dotnet build` to parity with `MSBuild.exe` functionally, as the Framework build of Microsoft.DotNet.MSBuildSdkResolver
+            //   contains the same logic and it is the first resolver in priority order.
+            //
+            // In an attempt to avoid confusion, this text uses "SDK" to refer to the installation unit, e.g. "C:\Program Files\dotnet\sdk\8.0.100",
+            // and "Sdk" to refer to the set of imports for targeting a specific project type, e.g. "Microsoft.NET.Sdk.Web".
+            //
+            // Here's the flow on Framework (`MSBuild.exe`):
+            // 1. Microsoft.DotNet.MSBuildSdkResolver is loaded and asked to resolve the Sdk required by the project.
+            //    1.1. It resolves the SDK (as in installation directory) using machine-wide state and global.json.
+            //    1.2. It checks the Sdks subdirectory of the SDK installation directory for a matching in-box Sdk.
+            //    1.3. If no match, checks installed workloads.
+            // 2. If no match so far, Microsoft.Build.NuGetSdkResolver is loaded and asked to resolve the Sdk.
+            // 3. If no match still, DefaultSdkResolver checks the Sdks subdirectory of the Visual Studio\MSBuild directory.
+            //
+            // Here's the flow on Core (`dotnet build`):
+            // 1. DefaultSdkResolver checks the Sdks subdirectory of our SDK installation. Note that the work of resolving the
+            //    SDK version using machine-wide state and global.json (step 1.1. in `MSBuild.exe` above) has already been done
+            //    by the `dotnet` muxer. We know which SDK (capital letters) we are in, so the in-box Sdk lookup is trivial.
+            // 2. If no match, Microsoft.DotNet.MSBuildSdkResolver is loaded and asked to resolve the Sdk required by the project.
+            //    2.1. It checks installed workloads.
+            // 3. If no match still, Microsoft.Build.NuGetSdkResolver is loaded and asked to resolve the Sdk.
+            //
+            // Overall, while Sdk resolvers look like a general plug-in system, there are good reasons why some of the logic is hard-coded.
+            // It's not really meant to be modified outside of very special/internal scenarios.
+#if NETCOREAPP
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+            {
+                if (TryResolveSdkUsingSpecifiedResolvers(
+                    _sdkResolverLoader.GetDefaultResolvers(),
+                    BuildEventContext.InvalidSubmissionId, // disables GetResolverState/SetResolverState
+                    sdk,
+                    loggingContext,
+                    sdkReferenceLocation,
+                    solutionPath,
+                    projectPath,
+                    interactive,
+                    isRunningInVisualStudio,
+                    out SdkResult sdkResult,
+                    out _,
+                    out _))
+                {
+                    return sdkResult;
+                }
+            }
+#endif
             if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_4))
             {
                 return ResolveSdkUsingResolversWithPatternsFirst(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, failOnUnresolvedSdk);
@@ -486,15 +533,20 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
                 _manifestToResolvers = new Dictionary<SdkResolverManifest, IReadOnlyList<SdkResolver>>();
 
-                // Load and add the manifest for the default resolvers, located directly in this dll.
-                IReadOnlyList<SdkResolver> defaultResolvers = _sdkResolverLoader.GetDefaultResolvers();
                 SdkResolverManifest sdkDefaultResolversManifest = null;
-                if (defaultResolvers.Count > 0)
+#if NETCOREAPP
+                if (!ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+#endif
                 {
-                    MSBuildEventSource.Log.SdkResolverServiceLoadResolversStart();
-                    sdkDefaultResolversManifest = new SdkResolverManifest(DisplayName: "DefaultResolversManifest", Path: null, ResolvableSdkRegex: null);
-                    _manifestToResolvers[sdkDefaultResolversManifest] = defaultResolvers;
-                    MSBuildEventSource.Log.SdkResolverServiceLoadResolversStop(sdkDefaultResolversManifest.DisplayName ?? string.Empty, defaultResolvers.Count);
+                    // Load and add the manifest for the default resolvers, located directly in this dll.
+                    IReadOnlyList<SdkResolver> defaultResolvers = _sdkResolverLoader.GetDefaultResolvers();
+                    if (defaultResolvers.Count > 0)
+                    {
+                        MSBuildEventSource.Log.SdkResolverServiceLoadResolversStart();
+                        sdkDefaultResolversManifest = new SdkResolverManifest(DisplayName: "DefaultResolversManifest", Path: null, ResolvableSdkRegex: null);
+                        _manifestToResolvers[sdkDefaultResolversManifest] = defaultResolvers;
+                        MSBuildEventSource.Log.SdkResolverServiceLoadResolversStop(sdkDefaultResolversManifest.DisplayName ?? string.Empty, defaultResolvers.Count);
+                    }
                 }
 
                 MSBuildEventSource.Log.SdkResolverServiceFindResolversManifestsStop(allResolversManifests.Count);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -445,6 +445,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             {
                 _sdkResolverLoader = resolverLoader;
             }
+            else
+            {
+                _sdkResolverLoader = CachingSdkResolverLoader.Instance;
+            }
 
             _specificResolversManifestsRegistry = null;
             _generalResolversManifestsRegistry = null;

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -317,11 +317,6 @@ namespace Microsoft.Build.Framework
         public readonly bool DisableSdkResolutionCache = Environment.GetEnvironmentVariable("MSBUILDDISABLESDKCACHE") == "1";
 
         /// <summary>
-        /// Disable the NuGet-based SDK resolver.
-        /// </summary>
-        public readonly bool DisableNuGetSdkResolver = Environment.GetEnvironmentVariable("MSBUILDDISABLENUGETSDKRESOLVER") == "1";
-
-        /// <summary>
         /// Don't delete TargetPath metadata from associated files found by RAR.
         /// </summary>
         public readonly bool TargetPathForRelatedFiles = Environment.GetEnvironmentVariable("MSBUILDTARGETPATHFORRELATEDFILES") == "1";


### PR DESCRIPTION
Fixes #9506

### Context

In `dotnet build`, resolving in-box Sdk's has suboptimal performance. Resolver assemblies are loaded into the process even in cases where the project asks for Sdk's like `Microsoft.NET.Sdk`, which can be looked up trivially. And in fact, they are looked up trivially but only after resolver assemblies have been loaded and invoked.

The inefficiency is shown by the recently added logging:

![image](https://github.com/dotnet/msbuild/assets/12206368/bc3fb867-df4a-46cd-81b4-07e33b2992a2)

There is also a subtle and confusing functional difference between `MSBuild.exe` and `dotnet build` where a NuGet package may take precedence over an in-box Sdk in `dotnet build`, but the same is not possible in `MSBuild.exe`.

### Changes Made

Made the default resolver handle the Sdk resolution first, before external resolvers are consulted. This is better perf-wise and aligns with `MSBuild.exe`, please see the large code comment for details.

This eliminates all but the last log event: `The SDK "Microsoft.NET.Sdk" was successfully resolved by the "DefaultSdkResolver" resolver to location "C:\Program Files\dotnet\sdk\9.0.100-alpha.1.24067.2\Sdks\Microsoft.NET.Sdk\Sdk" and version "".`

### Testing

Existing and new unit tests, manual testing of various builds.

Perf testing: `dotnet build` that builds a project depending on in-box Sdks is ~10 ms faster and loads 5 fewer assemblies, as long as it's built with `MSBuildEnableWorkloadResolver=false` (see below).

### Notes

While we don't have to ask the `MSBuildWorkloadSdkResolver` and `NuGetSdkResolver` to resolve in-box Sdk's anymore, this change is unfortunately not avoiding these resolvers in most builds. They are still loaded to resolve the special `Microsoft.NET.SDK.WorkloadAutoImportPropsLocator` Sdk, unless workloads are disabled.