### PR TITLE
[17.9] Bump version after recent vs17.9 merges

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.9.3</VersionPrefix>
+    <VersionPrefix>17.9.4</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.8.3</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Fixes - broken VS 17.9 insertion due to forgotten version bump

### Context
I forgot to add a version bump for the following merges
* https://github.com/dotnet/msbuild/pull/9615
* https://github.com/dotnet/msbuild/pull/9486
