### PR TITLE
[17.9] Formatting changes to prevent unnoticed version merges into main

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,8 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.9.4</VersionPrefix>
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.9.4</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.8.3</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>


### PR DESCRIPTION

### Context

We intentionally have `DotNetFinalVersionKind` on aa same line as `VersionPrefix` so that codeflow to main causes conflict that needs to be manually resolved and hence we do not end up with unnoticed uninteded version prefix revert in main due to merged codeflow.

Recent arcade update reformatted our Version.props: https://github.com/dotnet/msbuild/pull/9574 - so fixing it back