### PR TITLE
Feature Query API

### DIFF
--- a/src/Framework/FeatureAvailabilityChecker.cs
+++ b/src/Framework/FeatureAvailabilityChecker.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// The status of a feature.
+    /// </summary>
+    public enum FeatureStatus
+    {
+        /// <summary>
+        /// The feature is available.
+        /// </summary>
+        Available,
+
+        /// <summary>
+        /// The feature is not available.
+        /// </summary>
+        NotAvailable,
+
+        /// <summary>
+        /// The feature is not found.
+        /// </summary>
+        NotFound,
+
+        // TODO: Add more status if needed
+        // Preview,
+        // Deprecated,
+    }
+
+    /// <summary>
+    /// This class is used to check if a feature is available or not.
+    /// </summary>
+    public static class FeatureAvailabilityChecker
+    {
+        private static Dictionary<string, FeatureStatus> _featureStatusMap = new Dictionary<string, FeatureStatus>
+        {
+            // TODO: Fill in the dictionary with the features and their status
+            { "Feature1", FeatureStatus.Available },
+            { "Feature2", FeatureStatus.NotAvailable },
+        };
+
+        /// <summary>
+        /// Checks if a feature is available or not.
+        /// </summary>
+        /// <param name="featureName">The name of the feature.</param>
+        /// <returns>A feature status <see cref="FeatureStatus"/>.</returns>
+        public static FeatureStatus CheckFeatureAvailability(string featureName)
+        {
+            return _featureStatusMap.ContainsKey(featureName) ?
+                _featureStatusMap[featureName] : FeatureStatus.NotFound;
+        }
+    }
+}

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Build.CommandLine
 #if DEBUG
             WaitForDebugger,
 #endif
-            NumberOfParameterlessSwitches
+            NumberOfParameterlessSwitches,
+            FeautureAvailability
         }
 
         /// <summary>
@@ -115,6 +116,7 @@ namespace Microsoft.Build.CommandLine
             GetProperty,
             GetItem,
             GetTargetResult,
+            FeatureAvailability,
             NumberOfParameterizedSwitches,
         }
 
@@ -280,6 +282,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "getProperty" },                       ParameterizedSwitch.GetProperty,                null,                           true,           "MissingGetPropertyError",             true,   false),
             new ParameterizedSwitchInfo(  new string[] { "getItem" },                           ParameterizedSwitch.GetItem,                    null,                           true,           "MissingGetItemError",                 true,   false),
             new ParameterizedSwitchInfo(  new string[] { "getTargetResult" },                   ParameterizedSwitch.GetTargetResult,            null,                           true,           "MissingGetTargetResultError",         true,   false),
+            new ParameterizedSwitchInfo(  new string[] { "featureavailability", "fa" },         ParameterizedSwitch.FeatureAvailability,        "DuplicateFeatureAvailability", false,          "MissingFeatureAvailabilityError",     true,   false),
         };
 
         /// <summary>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1053,6 +1053,14 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </comment>
   </data>
+  <data name="MissingFeatureAvailabilityError" UESanitized="true" Visibility="Public">
+    <value>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</value>
+    <comment>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </comment>
+  </data>
   <data name="MissingGetItemError" UESanitized="true" Visibility="Public">
     <value>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</value>
     <comment>
@@ -1397,6 +1405,10 @@
     <value>MSBUILD : error MSB1058: Only one output results cache can be specified.</value>
     <comment>{StrBegin="MSBUILD : error MSB1058: "}</comment>
   </data>
+  <data name="DuplicateFeatureAvailability" UESanitized="true" Visibility="Public">
+    <value>MSBUILD : error MSB1068: Only one feature availability can be specified.</value>
+    <comment>{StrBegin="MSBUILD : error MSB1068: "}</comment>
+  </data>
   <data name="OptionalLoggerCreationMessage" UESanitized="true" Visibility="Public">
     <value>The specified logger "{0}" could not be created and will not be used. {1}</value>
     <comment>
@@ -1559,7 +1571,7 @@
     <!--
         The command line message bucket is: MSB1001 - MSB1999
 
-        Next error code should be MSB1067.
+        Next error code should be MSB1069.
 
         Don't forget to update this comment after using the new code.
   -->

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: Přepínač -noAutoResponse nelze zadat v souboru automatických odpovědí MSBuild.rsp ani v žádném jiném souboru odpovědí, na který se v souboru automatických odpovědí odkazuje.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1} s)</target>
@@ -1333,6 +1338,15 @@ Když se nastaví na MessageUponIsolationViolation (nebo jeho krátký
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">Protokoly MSBuild a informace o ladění budou dostupné v „{0}“</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: Der Schalter "-noAutoResponse" kann weder in der automatischen Antwortdatei "MSBuild.rsp" noch in einer anderen Antwortdatei verwendet werden, auf die die automatische Antwortdatei verweist.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1321,6 +1326,15 @@ Dieses Protokollierungsformat ist standardmäßig aktiviert.
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">MSBuild-Protokolle und Debuginformationen befinden sich auf "{0}"</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: El modificador -noAutoResponse no puede especificarse en el archivo de respuesta automática MSBuild.rsp ni en ningún archivo de respuesta al que el archivo de respuesta automática haga referencia.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1327,6 +1332,15 @@ Esta marca es experimental y puede que no funcione según lo previsto.
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">Los registros de MSBuild y la información de depuración estarán en "{0}"</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: Impossible de spécifier le commutateur -noAutoResponse dans le fichier réponse automatique MSBuild.rsp, ni dans aucun autre fichier réponse référencé par le fichier réponse automatique.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1320,6 +1325,15 @@ Remarque : verbosité des enregistreurs d’événements de fichiers
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">Les journaux MSBuild et les informations de débogage seront au "{0}"</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: non è possibile specificare l'opzione -noAutoResponse nel file di risposta automatica MSBuild.rsp o in file di risposta a cui il file di risposta automatica fa riferimento.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1331,6 +1336,15 @@ Nota: livello di dettaglio dei logger di file
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">I log e le informazioni di debug di MSBuild sono contenuti in "{0}"</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: MSBuild.rsp 自動応答ファイルや、自動応答ファイルによって参照される応答ファイルに -noAutoResponse スイッチを指定することはできません。</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1320,6 +1325,15 @@
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">MSBuild のログとデバッグ情報は、"{0}" にあります。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: MSBuild.rsp 자동 지시 파일과 자동 지시 파일에서 참조하는 모든 지시 파일에는 -noAutoResponse 스위치를 지정할 수 없습니다.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1320,6 +1325,15 @@
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">MSBuild 로그 및 디버그 정보는 "{0}"에 있습니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: przełącznika -noAutoResponse nie można określić w pliku autoodpowiedzi MSBuild.rsp ani w żadnym pliku odpowiedzi, do którego odwołuje się plik autoodpowiedzi.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1331,6 +1336,15 @@ Ta flaga jest eksperymentalna i może nie działać zgodnie z oczekiwaniami.
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">Dzienniki i informacje debugowania programu MSBuild będą znajdować się w lokalizacji „{0}”</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: A opção /noAutoResponse não pode ser especificada no arquivo de resposta automática MSBuild.rsp nem em qualquer arquivo de resposta usado como referência para o arquivo de resposta automática.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1321,6 +1326,15 @@ arquivo de resposta.
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">Os logs e as informações de depuração do MSBuild estarão no "{0}"</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: ключ noAutoResponse не может быть указан в файле автоответа MSBuild.rsp или в любом другом файле ответа, на который файл автоответа ссылается.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1319,6 +1324,15 @@
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">Журналы MSBuild и отладочные сведения будут доступны по адресу "{0}"</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: -noAutoResponse anahtarı, MSBuild.rsp otomatik yanıt dosyasında ve bu dosyanın başvuruda bulunduğu herhangi bir yanıt dosyasında belirtilemez.</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1324,6 +1329,15 @@
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">MSBuild günlükleri ve hata ayıklama bilgileri "{0}" yolunda olacak</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: 不能在 MSBuild.rsp 自动响应文件中或由该自动响应文件引用的任何响应文件中指定 -noAutoResponse 开关。</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1}s)</target>
@@ -1320,6 +1325,15 @@
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">MSBuild 日志和调试信息将位于"{0}"</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -77,6 +77,11 @@
         <target state="translated">MSBUILD : error MSB1027: -noAutoResponse 參數不能在 MSBuild.rsp 自動回應檔中指定，也不能在自動回應檔所參考的任何回應檔中指定。</target>
         <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "-noAutoResponse" and "MSBuild.rsp" should not be localized.</note>
       </trans-unit>
+      <trans-unit id="DuplicateFeatureAvailability">
+        <source>MSBUILD : error MSB1068: Only one feature availability can be specified.</source>
+        <target state="new">MSBUILD : error MSB1068: Only one feature availability can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1068: "}</note>
+      </trans-unit>
       <trans-unit id="DurationDisplay">
         <source>({0:F1}s)</source>
         <target state="translated">({0:F1} 秒)</target>
@@ -1320,6 +1325,15 @@
         <source>MSBuild logs and debug information will be at "{0}"</source>
         <target state="translated">MSBuild 記錄和偵錯工具資訊將位於 "{0}"</target>
         <note />
+      </trans-unit>
+      <trans-unit id="MissingFeatureAvailabilityError">
+        <source>MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</source>
+        <target state="new">MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1067: "}UE: This happens if the user does something like "msbuild.exe -featureavailability". The user must pass in an actual property name
+      following the switch, as in "msbuild.exe -featureavailability:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
       </trans-unit>
       <trans-unit id="MissingGetItemError">
         <source>MSBUILD : error MSB1014: Must provide an item name for the getItem switch.</source>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2501,6 +2501,11 @@ namespace Microsoft.Build.CommandLine
                 {
                     ShowVersion();
                 }
+                // if featureavailability switch is set, just show the feature availability and quit (ignore the other switches)
+                else if (commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.FeatureAvailability))
+                {
+                    ShowFeatureAvailability(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.FeatureAvailability]);
+                }
                 else
                 {
                     bool foundProjectAutoResponseFile = CheckAndGatherProjectAutoResponseFile(switchesFromAutoResponseFile, commandLineSwitches, recursing, commandLine, out projectFile);
@@ -4501,6 +4506,13 @@ namespace Microsoft.Build.CommandLine
             {
                 Console.Write(ProjectCollection.Version.ToString());
             }
+        }
+
+        private static void ShowFeatureAvailability(string[] parameters)
+        {
+            string featureName = parameters[0];
+            var availability = FeatureAvailabilityChecker.CheckFeatureAvailability(featureName);
+            Console.WriteLine(availability);
         }
     }
 }


### PR DESCRIPTION
Fixes #9653

### Context
We need an API that can tell us whether a specific feature is available or not.

### Changes Made
Added a new API
```csharp
namespace Microsoft.Build.Framework
{
    public static class FeatureAvailabilityChecker
    {
        public static FeatureStatus CheckFeatureAvailability(string featureName) 
        {
        }
    }

    public enum FeatureStatus
    {
        Available,
        NotAvailable,
        NotFound,
        // TODO: Add more status if needed
        // Preview,
        // Deprecated,
    }
}
```

And command line support for switch `/featureavailability` and "/fa"

### Use Case
API:
```csharp
var availability = FeatureAvailabilityChecker.CheckFeatureAvailability("Feauture1");
```

Command line:
```powershell
PS>msbuild /fa:Feature1
Available
PS>msbuild /featureavailability:Feauture2
NotAvailable
PS>msbuild /featureavailability:Feauture1,Feature2
NotFound
PS>msbuild /fa:
MSBUILD : error MSB1067: Must provide a property name for the featureavailability switch.
    Full command line: '"C:\msbuild\artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe" /fa'
  Switches appended by response files:
Switch: /fa

For switch syntax, type "MSBuild -help"
PS>msbuild /fa:Feature1 /fa:Feature2
MSBUILD : error MSB1068: Only one feature availability can be specified.
    Full command line: '"C:\msbuild\artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe" /fa:Feature1 /fa:Feature2'
  Switches appended by response files:
Switch: /fa:Feature2

For switch syntax, type "MSBuild -help"
```



### Testing
Only manual testing so far, since it is draft

### Notes
This is not final. **Command line support might be reverted**
