### PR TITLE
[vs17.9] [ClickOnce] [GB18030] Workaround for incorrect encoding of chars in the PUA range of file paths

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.9.4</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.9.5</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.8.3</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Tasks/ManifestUtil/PathUtil.cs
+++ b/src/Tasks/ManifestUtil/PathUtil.cs
@@ -45,6 +45,23 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
             string resolvedPath = Resolve(path);
             Uri u = new Uri(resolvedPath);
+            //
+            // GB18030: Uri class does not correctly encode chars in the PUA range for file paths:
+            // https://github.com/dotnet/runtime/issues/89538
+            // Workaround is to use UriBuilder with the file scheme specified explicitly to 
+            // correctly encode the PUA chars.
+            //
+            if (Uri.UriSchemeFile.Equals(u.Scheme, StringComparison.OrdinalIgnoreCase) &&
+                !IsAsciiString(resolvedPath))
+            {
+                UriBuilder builder = new UriBuilder()
+                {
+                    Scheme = Uri.UriSchemeFile,
+                    Host = string.Empty,
+                    Path = resolvedPath,
+                };
+                u = builder.Uri;
+            }
             return u.AbsoluteUri;
         }
 
@@ -208,6 +225,16 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
             // if not unc or url then it must be a local disk path...
             return Path.GetFullPath(path); // make sure it's a full path
+        }
+
+        private static bool IsAsciiString(string str)
+        {
+            foreach (char c in str)
+            {
+                if (c > 127)
+                {  return false; }
+            }
+            return true;
         }
     }
 }

--- a/src/Tasks/ManifestUtil/PathUtil.cs
+++ b/src/Tasks/ManifestUtil/PathUtil.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             string resolvedPath = Resolve(path);
             Uri u = new Uri(resolvedPath);
             //
-            // GB18030: Uri class does not correctly encode chars in the PUA range for file paths:
+            // GB18030: Uri class does not correctly encode chars in the PUA range for implicit 
+            // file paths (paths without explicit scheme):
             // https://github.com/dotnet/runtime/issues/89538
             // Workaround is to use UriBuilder with the file scheme specified explicitly to 
             // correctly encode the PUA chars.


### PR DESCRIPTION
Fixes #
AB#1939151

### Summary

Uri class when passed a GB18030 string with chars in the PUA range incorrectly encodes the PUA chars.
For e.g. if the PUA char is u+e038, Uri encodes it in UTF-8 as %25EE%2580%25B8 instead of %EE%80%B8 by double encoding the %.

The ClickOnce scenario that is failing is when an app's Installation Uri is set to a UNC path that has PUA chars. In this case, the UNC path is written to the Clickonce manifest. When the app is being installed, ClickOnce Runtime will attempt to download the deployment manifest from the UNC path. Since the Uri is incorrectly encoded, this download will fail.

### Changes Made
The FormatUrl function is being updated to resolve this issue. This function takes input path as string and return a canonicalized path by constructing a Uri class with the input path and then returning it's AbsoluteUri property.

In the case where the Uri's Scheme is File (file://), the function will now check if there are non-ascii characters in it and if so, create a new Uri with the UriBuilder class. The Uri created by UriBuilder correctly handles PUA range in GB18030.

### Customer Impact
ClickOnce apps published with Installation path set to a UNC path containing GB18030 + PUA chars will be installed correctly after this change.

### Testing
Failing scenario has been validated and CTI team has run regression tests on affected scenarios (scenarios where Uri are used for publishing).

### Notes
