### PR TITLE
Add Microsoft.BuildXL.Processes PackageReference in Bootstrap project

### DIFF
--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -31,7 +31,7 @@
          causing it to be downloaded and flagged by component governance -->
     <PackageReference Include="Newtonsoft.Json" />
 
-    <!-- Add this explicitly since it's marked as Private in MSBuild.csproj, but we need these at runtime. -->
+    <!-- Add this explicitly since it's marked as Private in MSBuild.csproj, but we need these at runtime to be like VS. -->
     <PackageReference Include="Microsoft.BuildXL.Processes" Condition="'$(FeatureReportFileAccesses)' == 'true'" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -30,6 +30,9 @@
     <!-- As of 17.5, NuGet.Build.Tasks and Microsoft.Build.NuGetSdkResolver depends on Newtonsoft.Json version 13.0.1,
          causing it to be downloaded and flagged by component governance -->
     <PackageReference Include="Newtonsoft.Json" />
+
+    <!-- Add this explicitly since it's marked as Private in MSBuild.csproj, but we need these at runtime. -->
+    <PackageReference Include="Microsoft.BuildXL.Processes" Condition="'$(FeatureReportFileAccesses)' == 'true'" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MonoBuild)' == 'true'">


### PR DESCRIPTION
Add Microsoft.BuildXL.Processes PackageReference in Bootstrap project

This an existing issue exposed (somehow) by #9634. In particular, `System.Threading.Channels.dll`, an indirect dependency, is missing from the bootstrap output.