### PR TITLE
Respect response files (ignoreProjectExtensions) property

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1530,36 +1530,15 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ResponseFileInProjectDirectoryWithSolutionProjectDifferentNamesShouldBeRespected()
         {
-            string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            string projectPath = Path.Combine(directory, "projectFile.proj");
-            string solutionPath = Path.Combine(directory, "solutionFile.sln");
-            string rspPath = Path.Combine(directory, "Directory.Build.rsp");
+            var directory = _env.CreateFolder();
+            var content = ObjectModelHelpers.CleanupFileContents("<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'><Target Name='t'><Message Text='Completed'/></Target></Project>");
+            directory.CreateFile("projectFile.proj", content);
+            directory.CreateFile("solutionFile.sln", string.Empty);
+            directory.CreateFile("Directory.Build.rsp", "-ignoreProjectExtensions:.sln");
 
-            try
-            {
-                Directory.CreateDirectory(directory);
-
-                string content = ObjectModelHelpers.CleanupFileContents("<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'><Target Name='t'><Message Text='Completed'/></Target></Project>");
-                File.WriteAllText(projectPath, content);
-
-                string rspContent = "-ignoreProjectExtensions:.sln";
-                File.WriteAllText(rspPath, rspContent);
-
-                // Incorrect sln file format, which will result fail if picked by msbuild for building
-                File.WriteAllText(solutionPath, string.Empty);
-
-                var msbuildParameters = "\"" + directory + "\"";
-
-                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit, _output);
-                successfulExit.ShouldBeTrue();
-            }
-            finally
-            {
-                File.Delete(projectPath);
-                File.Delete(solutionPath);
-                File.Delete(rspPath);
-                FileUtilities.DeleteWithoutTrailingBackslash(directory);
-            }
+            var msbuildParameters = "\"" + directory.Path + "\"";
+            RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit, _output);
+            successfulExit.ShouldBeTrue();
         }
 
         /// <summary>

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1449,7 +1449,7 @@ namespace Microsoft.Build.UnitTests
         public void ResponseFileInProjectDirectoryWithSolutionProjectDifferentNamesShouldBeRespected()
         {
             var directory = _env.CreateFolder();
-            var content = ObjectModelHelpers.CleanupFileContents("<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'><Target Name='t'><Message Text='Completed'/></Target></Project>");
+            var content = ObjectModelHelpers.CleanupFileContents("<Project><Target Name='t'><Message Text='Completed'/></Target></Project>");
             directory.CreateFile("projectFile.proj", content);
             directory.CreateFile("solutionFile.sln", string.Empty);
             directory.CreateFile("Directory.Build.rsp", "-ignoreProjectExtensions:.sln");

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2556,7 +2556,6 @@ namespace Microsoft.Build.CommandLine
                                                            commandLine);
                     }
 
-                    // why not process the project parameter here?
                     projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);
 
                     // figure out which targets we are building

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2917,7 +2917,7 @@ namespace Microsoft.Build.CommandLine
         private static string GetProjectDirectory(string[] projectSwitchParameters)
         {
             string projectDirectory = ".";
-            ErrorUtilities.VerifyThrow(projectSwitchParameters.Length <= 1, "It should not be possible to specify more than 1 project at a time.");
+            ErrorUtilities.VerifyThrow(projectSwitchParameters.Length <= 1, "Expect exactly one project at a time.");
 
             if (projectSwitchParameters.Length == 1)
             {
@@ -3404,7 +3404,7 @@ namespace Microsoft.Build.CommandLine
                                  string[] projectsExtensionsToIgnore,
                                  DirectoryGetFiles getFiles)
         {
-            ErrorUtilities.VerifyThrow(parameters.Length <= 1, "It should not be possible to specify more than 1 project at a time.");
+            ErrorUtilities.VerifyThrow(parameters.Length <= 1, "Expect exactly one project at a time.");
             string projectFile = null;
 
             string projectDirectory = null;

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -307,11 +307,11 @@ namespace Microsoft.Build.CommandLine
             {
                 GatherAllSwitches(commandLine, out var switchesFromAutoResponseFile, out var switchesNotFromAutoResponseFile, out string fullCommandLine);
                 CommandLineSwitches commandLineSwitches = CombineSwitchesRespectingPriority(switchesFromAutoResponseFile, switchesNotFromAutoResponseFile, fullCommandLine);
-                if (CheckAndGatherProjectAutoResponseFile(switchesFromAutoResponseFile, commandLineSwitches, false, fullCommandLine, out string projectFile))
+                if (CheckAndGatherProjectAutoResponseFile(switchesFromAutoResponseFile, commandLineSwitches, false, fullCommandLine))
                 {
                     commandLineSwitches = CombineSwitchesRespectingPriority(switchesFromAutoResponseFile, switchesNotFromAutoResponseFile, fullCommandLine);
                 }
-
+                string projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);
                 if (commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.Help] ||
                     commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.NodeMode) ||
                     commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.Version] ||
@@ -2503,7 +2503,7 @@ namespace Microsoft.Build.CommandLine
                 }
                 else
                 {
-                    bool foundProjectAutoResponseFile = CheckAndGatherProjectAutoResponseFile(switchesFromAutoResponseFile, commandLineSwitches, recursing, commandLine, out projectFile);
+                    bool foundProjectAutoResponseFile = CheckAndGatherProjectAutoResponseFile(switchesFromAutoResponseFile, commandLineSwitches, recursing, commandLine);
 
                     if (foundProjectAutoResponseFile)
                     {
@@ -2555,6 +2555,9 @@ namespace Microsoft.Build.CommandLine
                                                            recursing: true,
                                                            commandLine);
                     }
+
+                    // why not process the project parameter here?
+                    projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);
 
                     // figure out which targets we are building
                     targets = ProcessTargetSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Target]);
@@ -2912,18 +2915,43 @@ namespace Microsoft.Build.CommandLine
             return commandLineSwitches;
         }
 
-        private static bool CheckAndGatherProjectAutoResponseFile(CommandLineSwitches switchesFromAutoResponseFile, CommandLineSwitches commandLineSwitches, bool recursing, string commandLine, out string projectFile)
+        private static string GetProjectDirectory(string[] projectSwitchParameters)
+        {
+            string projectDirectory = ".";
+            ErrorUtilities.VerifyThrow(projectSwitchParameters.Length <= 1, "It should not be possible to specify more than 1 project at a time.");
+
+            if (projectSwitchParameters.Length == 1)
+            {
+                var projectFile = FileUtilities.FixFilePath(projectSwitchParameters[0]);
+
+                if (FileSystems.Default.DirectoryExists(projectFile))
+                {
+                    // the provided argument value is actually the directory
+                    projectDirectory = projectFile;
+                }
+                else
+                {
+                    InitializationException.VerifyThrow(FileSystems.Default.FileExists(projectFile), "ProjectNotFoundError", projectFile);
+                    projectDirectory = Path.GetDirectoryName(Path.GetFullPath(projectFile));
+                }
+            }
+
+            return projectDirectory;
+        }
+
+
+        /// <summary>
+        /// Identifies if there is rsp files near the project file 
+        /// </summary>
+        /// <returns>true if there autoresponse file was found</returns>
+        private static bool CheckAndGatherProjectAutoResponseFile(CommandLineSwitches switchesFromAutoResponseFile, CommandLineSwitches commandLineSwitches, bool recursing, string commandLine)
         {
             bool found = false;
-
-            // figure out what project we are building
-            projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);
+           
+            var projectDirectory = GetProjectDirectory(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project]);
 
             if (!recursing && !commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.NoAutoResponse])
             {
-                // gather any switches from an msbuild.rsp that is next to the project or solution file itself
-                string projectDirectory = Path.GetDirectoryName(Path.GetFullPath(projectFile));
-
                 // gather any switches from the first Directory.Build.rsp found in the project directory or above
                 string directoryResponseFile = FileUtilities.GetPathOfFileAbove(directoryResponseFileName, projectDirectory);
 


### PR DESCRIPTION
Fixes #9507

### Context
The ignoreProjectExtensions are not respected if specidified in response file on project level. 
The exception will be thrown in case there are ambiguous files identified in provided directory. Example:
Directiory contains: 
>     1.sln 
>     2.csproj 

The build fails since there are multiple files identified to build. 
IgnoreProjectExtensions: .sln solves the situation but when specified in response file on project level the error will raise before the usage of the response file. 

### Changes Made
Identifying projectFile was extracted from CheckAndGatherProjectAutoResponseFile, and moved to ProcessCommandLineSwitches. 

### Testing
Added specific to the case test case
All existing tests should pass 