### PR TITLE
Add UseArtifactsOutput and ArtifactsPath to XSD

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1964,12 +1964,12 @@ elementFormDefault="qualified">
     </xs:element>
     <xs:element name="UseArtifactsOutput" type="msb:boolean" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="UseArtifactsOutput" _locComment="" -->Indicate whether to opt into the centralized output path format. All build outputs from all projects are gathered into a common location, separated by project. More info: https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output</xs:documentation>
+            <xs:documentation><!-- _locID_text="UseArtifactsOutput" _locComment="" -->Use a centralized location for all outputs of this project. The location of the centralized outputs is set by the ArtifactsPath property. Project outputs are grouped by kind, then by project. See https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output for complete details.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="ArtifactsPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="ArtifactsPath" _locComment="" -->The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path.</xs:documentation>
+            <xs:documentation><!-- _locID_text="ArtifactsPath" _locComment="" -->The path to use for the centralized outputs - if set, UseArtifactsOutput will be defaulted to true. Project outputs will be placed under this path grouped by kind, then by project. See https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output for complete details.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="PackageOutputPath" substitutionGroup="msb:Property">

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1962,6 +1962,16 @@ elementFormDefault="qualified">
             <xs:documentation><!-- _locID_text="OutputType" _locComment="" -->Type of output to generate (WinExe, Exe, or Library)</xs:documentation>
         </xs:annotation>
     </xs:element>
+    <xs:element name="UseArtifactsOutput" type="msb:boolean" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="UseArtifactsOutput" _locComment="" -->Indicate whether to opt into the centralized output path format. All build outputs from all projects are gathered into a common location, separated by project.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="ArtifactsPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="ArtifactsPath" _locComment="" -->The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="PackageOutputPath" substitutionGroup="msb:Property">
       <xs:annotation>
         <xs:documentation><!-- _locID_text="PackageOutputPath" -->Path to the output folder for the package generated when calling Pack.</xs:documentation>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1964,7 +1964,7 @@ elementFormDefault="qualified">
     </xs:element>
     <xs:element name="UseArtifactsOutput" type="msb:boolean" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="UseArtifactsOutput" _locComment="" -->Indicate whether to opt into the centralized output path format. All build outputs from all projects are gathered into a common location, separated by project.</xs:documentation>
+            <xs:documentation><!-- _locID_text="UseArtifactsOutput" _locComment="" -->Indicate whether to opt into the centralized output path format. All build outputs from all projects are gathered into a common location, separated by project. More info: https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="ArtifactsPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">


### PR DESCRIPTION
Fixes #9676

### Context
Autocomplete list when editing a Directory.Build.props file in VS doesn't include the properties `UseArtifactsOutput` and `ArtifactsPath`.

### Changes Made
Add the properties to XSD file for the autocomplete list.

### Testing
N/A

### Notes
