### PR TITLE
Proper support for multiline messages

### DIFF
--- a/src/Framework/Features.cs
+++ b/src/Framework/Features.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Build.Framework
         private static readonly Dictionary<string, FeatureStatus> _featureStatusMap = new Dictionary<string, FeatureStatus>
         {
             { "EvaluationContext_SharedSDKCachePolicy", FeatureStatus.Available }, // EvaluationContext supports the SharingPolicy.SharedSDKCache flag.
+            { "TerminalLogger_MultiLineHandler", FeatureStatus.Available }, // TerminalLogger has better explicit support for rendering multi-line messages
             // Add more features here.
         };
 

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
@@ -1,5 +1,8 @@
 ﻿]9;4;3;\  project [33;1msucceeded with warnings[m (0.2s)
-    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: A 
+       Multi 
+       Line 
+       Warning!
 [?25l[1F
 [?25h
 Build [33;1msucceeded with warnings[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
@@ -1,8 +1,9 @@
 ﻿]9;4;3;\  project [33;1msucceeded with warnings[m (0.2s)
-    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: A 
-       Multi 
-       Line 
-       Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
 [?25l[1F
 [?25h
 Build [33;1msucceeded with warnings[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.OSX.verified.txt
@@ -1,5 +1,9 @@
 ﻿  project [33;1msucceeded with warnings[m (0.2s)
-    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
 [?25l[1F
 [?25h
 Build [33;1msucceeded with warnings[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Windows.verified.txt
@@ -1,5 +1,8 @@
 ﻿]9;4;3;\  project [33;1msucceeded with warnings[m (0.2s)
-    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: A 
+       Multi 
+       Line 
+       Warning!
 [?25l[1F
 [?25h
 Build [33;1msucceeded with warnings[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Windows.verified.txt
@@ -1,8 +1,9 @@
 ﻿]9;4;3;\  project [33;1msucceeded with warnings[m (0.2s)
-    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: A 
-       Multi 
-       Line 
-       Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
 [?25l[1F
 [?25h
 Build [33;1msucceeded with warnings[m in 5.0s

--- a/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
@@ -99,7 +99,6 @@ namespace Microsoft.Build.UnitTests
         {
             _terminallogger.Shutdown();
             Thread.CurrentThread.CurrentCulture = _originalCulture;
-
         }
 
         #endregion
@@ -227,7 +226,7 @@ namespace Microsoft.Build.UnitTests
         {
             InvokeLoggerCallbacksForSimpleProject(succeeded: true, () =>
             {
-                WarningRaised?.Invoke(_eventSender, MakeWarningEventArgs("A \n Multi \r\n Line \n Warning!"));
+                WarningRaised?.Invoke(_eventSender, MakeWarningEventArgs("A\nMulti\r\nLine\nWarning!"));
             });
 
             return Verify(_outputWriter.ToString(), _settings).UniqueForOSPlatform();

--- a/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Build.UnitTests
 
         private VerifySettings _settings = new();
 
+        private readonly CultureInfo _originalCulture = Thread.CurrentThread.CurrentCulture;
+
         public TerminalLogger_Tests()
         {
             _mockTerminal = new Terminal(_outputWriter);
@@ -96,6 +98,8 @@ namespace Microsoft.Build.UnitTests
         public void Dispose()
         {
             _terminallogger.Shutdown();
+            Thread.CurrentThread.CurrentCulture = _originalCulture;
+
         }
 
         #endregion

--- a/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Build.UnitTests
         {
             _terminallogger.Shutdown();
             Thread.CurrentThread.CurrentCulture = _originalCulture;
+
         }
 
         #endregion
@@ -226,7 +227,7 @@ namespace Microsoft.Build.UnitTests
         {
             InvokeLoggerCallbacksForSimpleProject(succeeded: true, () =>
             {
-                WarningRaised?.Invoke(_eventSender, MakeWarningEventArgs("A\nMulti\r\nLine\nWarning!"));
+                WarningRaised?.Invoke(_eventSender, MakeWarningEventArgs("A \n Multi \r\n Line \n Warning!"));
             });
 
             return Verify(_outputWriter.ToString(), _settings).UniqueForOSPlatform();

--- a/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
@@ -52,6 +52,9 @@ namespace Microsoft.Build.UnitTests
             _terminallogger.CreateStopwatch = () => new MockStopwatch();
 
             UseProjectRelativeDirectory("Snapshots");
+
+            // Avoids issues with different cultures on different machines
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
         }
 
         #region IEventSource implementation
@@ -220,7 +223,7 @@ namespace Microsoft.Build.UnitTests
         {
             InvokeLoggerCallbacksForSimpleProject(succeeded: true, () =>
             {
-                WarningRaised?.Invoke(_eventSender, MakeWarningEventArgs("Warning!"));
+                WarningRaised?.Invoke(_eventSender, MakeWarningEventArgs("A \n Multi \r\n Line \n Warning!"));
             });
 
             return Verify(_outputWriter.ToString(), _settings).UniqueForOSPlatform();

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -474,11 +474,11 @@ internal sealed partial class TerminalLogger : INodeLogger
                             else
                             {
                                 Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_WithTF",
-                                    Indentation, Indentation,
-                                    projectFile, projectFile,
+                                    Indentation,
+                                    projectFile,
                                     AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor), AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
-                                    buildResult, buildResult,
-                                    duration)); duration));
+                                    buildResult,
+                                    duration));
                             }
                         }
                     }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -463,12 +463,23 @@ internal sealed partial class TerminalLogger : INodeLogger
                         // Show project build complete and its output
                         if (project.IsTestProject)
                         {
-                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_WithTF",
+                            if (string.IsNullOrEmpty(project.TargetFramework))
+                            {
+                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_NoTF",
                                     Indentation,
                                     projectFile,
-                                    AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
                                     buildResult,
                                     duration));
+                            }
+                            else
+                            {
+                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_WithTF",
+                                    Indentation, Indentation,
+                                    projectFile, projectFile,
+                                    AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor), AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
+                                    buildResult, buildResult,
+                                    duration)); duration));
+                            }
                         }
                     }
                     else

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -549,7 +549,21 @@ internal sealed partial class TerminalLogger : INodeLogger
                     {
                         foreach (BuildMessage buildMessage in project.BuildMessages)
                         {
-                            Terminal.WriteLine($"{Indentation}{Indentation}{buildMessage.Message}");
+                            if (buildMessage.Message.IndexOf('\n') == -1) // Check for multi-line message
+                            {
+                                Terminal.WriteLine($"{Indentation}{Indentation}{buildMessage.Message}");
+                            }
+                            else
+                            {
+                                string[] lines = buildMessage.Message.Split(newLineStrings, StringSplitOptions.None);
+
+                                Terminal.WriteLine($"{Indentation}{Indentation}{lines[0]}");
+
+                                for (int i = 1; i < lines.Length; i++)
+                                {
+                                    Terminal.WriteLine($"{Indentation}{Indentation}{Indentation}{lines[i]}");
+                                }
+                            }
                         }
                     }
 

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -904,7 +904,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             int length = Math.Min(maxLength - indent.Length, text.Length - start);
             sb.AppendLine();
             sb.Append(indent);
-            sb.Append(text.Substring(start, length));
+            sb.Append(text.AsSpan().Slice(start, length));
 
             start += length;
         }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -178,6 +178,26 @@ internal sealed partial class TerminalLogger : INodeLogger
     private static readonly char[] PathSeparators = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
     /// <summary>
+    /// One summary per finished project test run.
+    /// </summary>
+    private List<TestSummary> _testRunSummaries = new();
+
+    /// <summary>
+    /// Name of target that identifies a project that has tests, and that they just started.
+    /// </summary>
+    private static string _testStartTarget = "_TestRunStart";
+
+    /// <summary>
+    /// Time of the oldest observed test target start.
+    /// </summary>
+    private DateTime? _testStartTime;
+
+    /// <summary>
+    /// Time of the most recently observed test target finished.
+    /// </summary>
+    private DateTime? _testEndTime;
+
+    /// <summary>
     /// Default constructor, used by the MSBuild logger infra.
     /// </summary>
     public TerminalLogger()
@@ -296,6 +316,27 @@ internal sealed partial class TerminalLogger : INodeLogger
                     buildResult,
                     duration));
             }
+
+            if (_testRunSummaries.Any())
+            {
+                var total = _testRunSummaries.Sum(t => t.Total);
+                var failed = _testRunSummaries.Sum(t => t.Failed);
+                var passed = _testRunSummaries.Sum(t => t.Passed);
+                var skipped = _testRunSummaries.Sum(t => t.Skipped);
+                var testDuration = (_testStartTime != null && _testEndTime != null ? (_testEndTime - _testStartTime).Value.TotalSeconds : 0).ToString("F1");
+
+                var colorizedResult = _testRunSummaries.Any(t => t.Failed > 0) || _buildHasErrors
+                    ? AnsiCodes.Colorize(ResourceUtilities.GetResourceString("BuildResult_Failed"), TerminalColor.Red)
+                    : AnsiCodes.Colorize(ResourceUtilities.GetResourceString("BuildResult_Succeeded"), TerminalColor.Green);
+
+                Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestSummary",
+                    colorizedResult,
+                    total,
+                    failed,
+                    passed,
+                    skipped,
+                    testDuration));
+            }
         }
         finally
         {
@@ -307,9 +348,12 @@ internal sealed partial class TerminalLogger : INodeLogger
             Terminal.EndUpdate();
         }
 
+        _testRunSummaries.Clear();
         _buildHasErrors = false;
         _buildHasWarnings = false;
         _restoreFailed = false;
+        _testStartTime = null;
+        _testEndTime = null;
     }
 
     /// <summary>
@@ -412,26 +456,41 @@ internal sealed partial class TerminalLogger : INodeLogger
                         _restoreFinished = true;
                     }
                     // If this was a notable project build, we print it as completed only if it's produced an output or warnings/error.
-                    else if (project.OutputPath is not null || project.BuildMessages is not null)
+                    // If this is a test project, print it always, so user can see either a success or failure, otherwise success is hidden
+                    // and it is hard to see if project finished, or did not run at all.
+                    else if (project.OutputPath is not null || project.BuildMessages is not null || project.IsTestProject)
                     {
                         // Show project build complete and its output
-
-                        if (string.IsNullOrEmpty(project.TargetFramework))
+                        if (project.IsTestProject)
                         {
-                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_NoTF",
-                                Indentation,
-                                projectFile,
-                                buildResult,
-                                duration));
-                        }
-                        else
-                        {
-                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
-                                Indentation,
-                                projectFile,
-                                AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
-                                buildResult,
-                                duration));
+                            if (string.IsNullOrEmpty(project.TargetFramework))
+                            {
+                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_NoTF",
+                                    Indentation,
+                                    projectFile,
+                                    buildResult,
+                                    duration));
+                            }
+                            else
+                            {
+                                if (string.IsNullOrEmpty(project.TargetFramework))
+                                {
+                                    Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_NoTF",
+                                        Indentation,
+                                        projectFile,
+                                        buildResult,
+                                        duration));
+                                }
+                                else
+                                {
+                                    Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
+                                        Indentation,
+                                        projectFile,
+                                        AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
+                                        buildResult,
+                                        duration));
+                                }
+                            }
                         }
 
                         // Print the output path as a link if we have it.
@@ -509,7 +568,23 @@ internal sealed partial class TerminalLogger : INodeLogger
             project.Stopwatch.Start();
 
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
-            NodeStatus nodeStatus = new(projectFile, project.TargetFramework, e.TargetName, project.Stopwatch);
+
+
+            var isTestTarget = e.TargetName == _testStartTarget;
+
+            var targetName = isTestTarget ? "Testing" : e.TargetName;
+            if (isTestTarget)
+            {
+                // Use the minimal start time, so if we run tests in parallel, we can calculate duration
+                // as this start time, minus time when tests finished.
+                _testStartTime = _testStartTime == null
+                    ? e.Timestamp
+                    : e.Timestamp < _testStartTime
+                        ? e.Timestamp : _testStartTime;
+                project.IsTestProject = true;
+            }
+
+            NodeStatus nodeStatus = new(projectFile, project.TargetFramework, targetName, project.Stopwatch);
             UpdateNodeStatus(buildEventContext, nodeStatus);
         }
     }
@@ -562,6 +637,7 @@ internal sealed partial class TerminalLogger : INodeLogger
         string? message = e.Message;
         if (message is not null && e.Importance == MessageImportance.High)
         {
+            var hasProject = _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project);
             // Detect project output path by matching high-importance messages against the "$(MSBuildProjectName) -> ..."
             // pattern used by the CopyFilesToOutputDirectory target.
             int index = message.IndexOf(FilePathPattern, StringComparison.Ordinal);
@@ -569,17 +645,63 @@ internal sealed partial class TerminalLogger : INodeLogger
             {
                 var projectFileName = Path.GetFileName(e.ProjectFile.AsSpan());
                 if (!projectFileName.IsEmpty &&
-                    message.AsSpan().StartsWith(Path.GetFileNameWithoutExtension(projectFileName)) &&
-                    _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project))
+                    message.AsSpan().StartsWith(Path.GetFileNameWithoutExtension(projectFileName)) && hasProject)
                 {
                     ReadOnlyMemory<char> outputPath = e.Message.AsMemory().Slice(index + 4);
-                    project.OutputPath = outputPath;
+                    project!.OutputPath = outputPath;
                 }
             }
 
             if (IsImmediateMessage(message))
             {
                 RenderImmediateMessage(message);
+            }
+            else if (hasProject && project!.IsTestProject)
+            {
+                var node = _nodes[NodeIndexForContext(buildEventContext)];
+
+                // Consumes test update messages produced by VSTest and MSTest runner.
+                if (node != null && e is IExtendedBuildEventArgs extendedMessage)
+                {
+                    switch (extendedMessage.ExtendedType)
+                    {
+                        case "TLTESTPASSED":
+                            {
+                                var indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
+                                var displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
+
+                                var status = new NodeStatus(node.Project, node.TargetFramework, TerminalColor.Green, indicator, displayName, project.Stopwatch);
+                                UpdateNodeStatus(buildEventContext, status);
+                                break;
+                            }
+
+                        case "TLTESTSKIPPED":
+                            {
+                                var indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
+                                var displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
+
+                                var status = new NodeStatus(node.Project, node.TargetFramework, TerminalColor.Yellow, indicator, displayName, project.Stopwatch);
+                                UpdateNodeStatus(buildEventContext, status);
+                                break;
+                            }
+
+                        case "TLTESTFINISH":
+                            {
+                                _ = int.TryParse(extendedMessage.ExtendedMetadata!["total"]!, out int total);
+                                _ = int.TryParse(extendedMessage.ExtendedMetadata!["passed"]!, out int passed);
+                                _ = int.TryParse(extendedMessage.ExtendedMetadata!["skipped"]!, out int skipped);
+                                _ = int.TryParse(extendedMessage.ExtendedMetadata!["failed"]!, out int failed);
+
+                                _testRunSummaries.Add(new TestSummary(total, passed, skipped, failed));
+
+                                _testEndTime = _testEndTime == null
+                                        ? e.Timestamp
+                                        : e.Timestamp > _testEndTime
+                                            ? e.Timestamp : _testEndTime;
+                                break;
+                            }
+                    }
+                }
             }
             else if (e.Code == "NETSDK1057" && !_loggedPreviewMessage)
             {

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -840,8 +840,6 @@ internal sealed partial class TerminalLogger : INodeLogger
         Terminal.Write(AnsiCodes.HideCursor);
         try
         {
-            // Move cursor back to 1st line of nodes.
-            Terminal.WriteLine($"{AnsiCodes.CSI}{_currentFrame.NodesCount + 1}{AnsiCodes.MoveUpToLineStart}");
             Terminal.Write(rendered);
         }
         finally

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -847,7 +847,7 @@ internal sealed partial class TerminalLogger : INodeLogger
                     if (endLineNumber == 0)
                     {
                         builder.Append(endColumnNumber == 0 ?
-                            $"({lineNumber},{endColumnNumber}): " :
+                            $"({lineNumber},{columnNumber}): " :
                             $"({lineNumber},{columnNumber}-{endColumnNumber}): ");
                     }
                     else

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -463,34 +463,32 @@ internal sealed partial class TerminalLogger : INodeLogger
                         // Show project build complete and its output
                         if (project.IsTestProject)
                         {
-                            if (string.IsNullOrEmpty(project.TargetFramework))
-                            {
-                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_NoTF",
+                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_WithTF",
                                     Indentation,
                                     projectFile,
+                                    AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
                                     buildResult,
                                     duration));
-                            }
-                            else
-                            {
-                                if (string.IsNullOrEmpty(project.TargetFramework))
-                                {
-                                    Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_NoTF",
-                                        Indentation,
-                                        projectFile,
-                                        buildResult,
-                                        duration));
-                                }
-                                else
-                                {
-                                    Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
-                                        Indentation,
-                                        projectFile,
-                                        AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
-                                        buildResult,
-                                        duration));
-                                }
-                            }
+                        }
+                    }
+                    else
+                    {
+                        if (string.IsNullOrEmpty(project.TargetFramework))
+                        {
+                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_NoTF",
+                                Indentation,
+                                projectFile,
+                                buildResult,
+                                duration));
+                        }
+                        else
+                        {
+                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
+                                Indentation,
+                                projectFile,
+                                AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
+                                buildResult,
+                                duration));
                         }
 
                         // Print the output path as a link if we have it.

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -476,7 +476,7 @@ internal sealed partial class TerminalLogger : INodeLogger
                                 Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_WithTF",
                                     Indentation,
                                     projectFile,
-                                    AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor), AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
+                                    AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
                                     buildResult,
                                     duration));
                             }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -937,7 +937,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             : path;
     }
 
-    internal static string FormatEventMessage(
+    private string FormatEventMessage(
             string category,
             string subcategory,
             string? message,
@@ -949,7 +949,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             int endColumnNumber)
     {
         message ??= string.Empty;
-        using SpanBasedStringBuilder builder = new(128);
+        StringBuilder builder = new(128);
 
         if (string.IsNullOrEmpty(file))
         {
@@ -992,7 +992,7 @@ internal sealed partial class TerminalLogger : INodeLogger
         if (!string.IsNullOrEmpty(subcategory))
         {
             builder.Append(subcategory);
-            builder.Append(" ");
+            builder.Append(' ');
         }
 
         builder.Append($"{category} {code}: ");
@@ -1000,11 +1000,20 @@ internal sealed partial class TerminalLogger : INodeLogger
         // render multi-line message in a special way
         if (message.IndexOf('\n') >= 0)
         {
+            const string indent = $"{Indentation}{Indentation}{Indentation}";
             string[] lines = message.Split(newLineStrings, StringSplitOptions.None);
 
-            for (int i = 0; i < lines.Length; i++)
+            foreach (string line in lines)
             {
-                builder.Append($"{Environment.NewLine}{Indentation}{Indentation}{Indentation}{lines[i]}");
+                if (indent.Length + line.Length > Terminal.Width) // custom wrapping with indentation
+                {
+                    WrapText(builder, line, Terminal.Width, indent);
+                }
+                else
+                {
+                    builder.Append(indent);
+                    builder.AppendLine(line);
+                }
             }
         }
         else
@@ -1013,6 +1022,19 @@ internal sealed partial class TerminalLogger : INodeLogger
         }
 
         return builder.ToString();
+    }
+
+    private static void WrapText(StringBuilder sb, string text, int maxLength, string indent)
+    {
+        int start = 0;
+        while (start < text.Length)
+        {
+            int length = Math.Min(maxLength - indent.Length, text.Length - start);
+            sb.Append(indent);
+            sb.AppendLine(text.Substring(start, length));
+
+            start += length;
+        }
     }
 
     #endregion

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using System.Text.RegularExpressions;
+using System.Diagnostics;
 
 #if NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -481,25 +481,25 @@ internal sealed partial class TerminalLogger : INodeLogger
                                     duration));
                             }
                         }
-                    }
-                    else
-                    {
-                        if (string.IsNullOrEmpty(project.TargetFramework))
-                        {
-                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_NoTF",
-                                Indentation,
-                                projectFile,
-                                buildResult,
-                                duration));
-                        }
                         else
                         {
-                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
-                                Indentation,
-                                projectFile,
-                                AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
-                                buildResult,
-                                duration));
+                            if (string.IsNullOrEmpty(project.TargetFramework))
+                            {
+                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_NoTF",
+                                    Indentation,
+                                    projectFile,
+                                    buildResult,
+                                    duration));
+                            }
+                            else
+                            {
+                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
+                                    Indentation,
+                                    projectFile,
+                                    AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
+                                    buildResult,
+                                    duration));
+                            }
                         }
 
                         // Print the output path as a link if we have it.

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -882,8 +882,9 @@ internal sealed partial class TerminalLogger : INodeLogger
                 }
                 else
                 {
+                    builder.AppendLine();
                     builder.Append(indent);
-                    builder.AppendLine(line);
+                    builder.Append(line);
                 }
             }
         }
@@ -901,8 +902,9 @@ internal sealed partial class TerminalLogger : INodeLogger
         while (start < text.Length)
         {
             int length = Math.Min(maxLength - indent.Length, text.Length - start);
+            sb.AppendLine();
             sb.Append(indent);
-            sb.AppendLine(text.Substring(start, length));
+            sb.Append(text.Substring(start, length));
 
             start += length;
         }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -1032,7 +1032,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             int length = Math.Min(maxLength - indent.Length, text.Length - start);
             sb.AppendLine();
             sb.Append(indent);
-            sb.Append(text.Substring(start, length));
+            sb.Append(text.AsSpan().Slice(start, length));
 
             start += length;
         }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -1011,8 +1011,9 @@ internal sealed partial class TerminalLogger : INodeLogger
                 }
                 else
                 {
+                    builder.AppendLine();
                     builder.Append(indent);
-                    builder.AppendLine(line);
+                    builder.Append(line);
                 }
             }
         }
@@ -1030,8 +1031,9 @@ internal sealed partial class TerminalLogger : INodeLogger
         while (start < text.Length)
         {
             int length = Math.Min(maxLength - indent.Length, text.Length - start);
+            sb.AppendLine();
             sb.Append(indent);
-            sb.AppendLine(text.Substring(start, length));
+            sb.Append(text.Substring(start, length));
 
             start += length;
         }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -975,7 +975,7 @@ internal sealed partial class TerminalLogger : INodeLogger
                     if (endLineNumber == 0)
                     {
                         builder.Append(endColumnNumber == 0 ?
-                            $"({lineNumber},{endColumnNumber}): " :
+                            $"({lineNumber},{columnNumber}): " :
                             $"({lineNumber},{columnNumber}-{endColumnNumber}): ");
                     }
                     else

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -808,7 +808,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             : path;
     }
 
-    internal static string FormatEventMessage(
+    private string FormatEventMessage(
             string category,
             string subcategory,
             string? message,
@@ -820,7 +820,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             int endColumnNumber)
     {
         message ??= string.Empty;
-        using SpanBasedStringBuilder builder = new(128);
+        StringBuilder builder = new(128);
 
         if (string.IsNullOrEmpty(file))
         {
@@ -863,7 +863,7 @@ internal sealed partial class TerminalLogger : INodeLogger
         if (!string.IsNullOrEmpty(subcategory))
         {
             builder.Append(subcategory);
-            builder.Append(" ");
+            builder.Append(' ');
         }
 
         builder.Append($"{category} {code}: ");
@@ -871,11 +871,20 @@ internal sealed partial class TerminalLogger : INodeLogger
         // render multi-line message in a special way
         if (message.IndexOf('\n') >= 0)
         {
+            const string indent = $"{Indentation}{Indentation}{Indentation}";
             string[] lines = message.Split(newLineStrings, StringSplitOptions.None);
 
-            for (int i = 0; i < lines.Length; i++)
+            foreach (string line in lines)
             {
-                builder.Append($"{Environment.NewLine}{Indentation}{Indentation}{Indentation}{lines[i]}");
+                if (indent.Length + line.Length > Terminal.Width) // custom wrapping with indentation
+                {
+                    WrapText(builder, line, Terminal.Width, indent);
+                }
+                else
+                {
+                    builder.Append(indent);
+                    builder.AppendLine(line);
+                }
             }
         }
         else
@@ -884,6 +893,19 @@ internal sealed partial class TerminalLogger : INodeLogger
         }
 
         return builder.ToString();
+    }
+
+    private static void WrapText(StringBuilder sb, string text, int maxLength, string indent)
+    {
+        int start = 0;
+        while (start < text.Length)
+        {
+            int length = Math.Min(maxLength - indent.Length, text.Length - start);
+            sb.Append(indent);
+            sb.AppendLine(text.Substring(start, length));
+
+            start += length;
+        }
     }
 
     #endregion

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -5,11 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-using Microsoft.NET.StringTools;
+using System.Text.RegularExpressions;
 
 #if NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -550,21 +550,7 @@ internal sealed partial class TerminalLogger : INodeLogger
                     {
                         foreach (BuildMessage buildMessage in project.BuildMessages)
                         {
-                            if (buildMessage.Message.IndexOf('\n') == -1) // Check for multi-line message
-                            {
-                                Terminal.WriteLine($"{Indentation}{Indentation}{buildMessage.Message}");
-                            }
-                            else
-                            {
-                                string[] lines = buildMessage.Message.Split(newLineStrings, StringSplitOptions.None);
-
-                                Terminal.WriteLine($"{Indentation}{Indentation}{lines[0]}");
-
-                                for (int i = 1; i < lines.Length; i++)
-                                {
-                                    Terminal.WriteLine($"{Indentation}{Indentation}{Indentation}{lines[i]}");
-                                }
-                            }
+                            Terminal.WriteLine($"{Indentation}{Indentation}{buildMessage.Message}");
                         }
                     }
 
@@ -962,6 +948,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             int columnNumber,
             int endColumnNumber)
     {
+        message ??= string.Empty;
         using SpanBasedStringBuilder builder = new(128);
 
         if (string.IsNullOrEmpty(file))
@@ -1008,7 +995,22 @@ internal sealed partial class TerminalLogger : INodeLogger
             builder.Append(" ");
         }
 
-        builder.Append($"{category} {code}: {message}");
+        builder.Append($"{category} {code}: ");
+
+        // render multi-line message in a special way
+        if (message.IndexOf('\n') >= 0)
+        {
+            string[] lines = message.Split(newLineStrings, StringSplitOptions.None);
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                builder.Append($"{Environment.NewLine}{Indentation}{Indentation}{Indentation}{lines[i]}");
+            }
+        }
+        else
+        {
+            builder.Append(message);
+        }
 
         return builder.ToString();
     }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-using System.Text.RegularExpressions;
-using System.Diagnostics;
+using Microsoft.NET.StringTools;
 
 #if NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -178,26 +178,6 @@ internal sealed partial class TerminalLogger : INodeLogger
     private static readonly char[] PathSeparators = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
     /// <summary>
-    /// One summary per finished project test run.
-    /// </summary>
-    private List<TestSummary> _testRunSummaries = new();
-
-    /// <summary>
-    /// Name of target that identifies a project that has tests, and that they just started.
-    /// </summary>
-    private static string _testStartTarget = "_TestRunStart";
-
-    /// <summary>
-    /// Time of the oldest observed test target start.
-    /// </summary>
-    private DateTime? _testStartTime;
-
-    /// <summary>
-    /// Time of the most recently observed test target finished.
-    /// </summary>
-    private DateTime? _testEndTime;
-
-    /// <summary>
     /// Default constructor, used by the MSBuild logger infra.
     /// </summary>
     public TerminalLogger()
@@ -316,27 +296,6 @@ internal sealed partial class TerminalLogger : INodeLogger
                     buildResult,
                     duration));
             }
-
-            if (_testRunSummaries.Any())
-            {
-                var total = _testRunSummaries.Sum(t => t.Total);
-                var failed = _testRunSummaries.Sum(t => t.Failed);
-                var passed = _testRunSummaries.Sum(t => t.Passed);
-                var skipped = _testRunSummaries.Sum(t => t.Skipped);
-                var testDuration = (_testStartTime != null && _testEndTime != null ? (_testEndTime - _testStartTime).Value.TotalSeconds : 0).ToString("F1");
-
-                var colorizedResult = _testRunSummaries.Any(t => t.Failed > 0) || _buildHasErrors
-                    ? AnsiCodes.Colorize(ResourceUtilities.GetResourceString("BuildResult_Failed"), TerminalColor.Red)
-                    : AnsiCodes.Colorize(ResourceUtilities.GetResourceString("BuildResult_Succeeded"), TerminalColor.Green);
-
-                Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestSummary",
-                    colorizedResult,
-                    total,
-                    failed,
-                    passed,
-                    skipped,
-                    testDuration));
-            }
         }
         finally
         {
@@ -348,12 +307,9 @@ internal sealed partial class TerminalLogger : INodeLogger
             Terminal.EndUpdate();
         }
 
-        _testRunSummaries.Clear();
         _buildHasErrors = false;
         _buildHasWarnings = false;
         _restoreFailed = false;
-        _testStartTime = null;
-        _testEndTime = null;
     }
 
     /// <summary>
@@ -456,50 +412,26 @@ internal sealed partial class TerminalLogger : INodeLogger
                         _restoreFinished = true;
                     }
                     // If this was a notable project build, we print it as completed only if it's produced an output or warnings/error.
-                    // If this is a test project, print it always, so user can see either a success or failure, otherwise success is hidden
-                    // and it is hard to see if project finished, or did not run at all.
-                    else if (project.OutputPath is not null || project.BuildMessages is not null || project.IsTestProject)
+                    else if (project.OutputPath is not null || project.BuildMessages is not null)
                     {
                         // Show project build complete and its output
-                        if (project.IsTestProject)
+
+                        if (string.IsNullOrEmpty(project.TargetFramework))
                         {
-                            if (string.IsNullOrEmpty(project.TargetFramework))
-                            {
-                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_NoTF",
-                                    Indentation,
-                                    projectFile,
-                                    buildResult,
-                                    duration));
-                            }
-                            else
-                            {
-                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestProjectFinished_WithTF",
-                                    Indentation,
-                                    projectFile,
-                                    AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
-                                    buildResult,
-                                    duration));
-                            }
+                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_NoTF",
+                                Indentation,
+                                projectFile,
+                                buildResult,
+                                duration));
                         }
                         else
                         {
-                            if (string.IsNullOrEmpty(project.TargetFramework))
-                            {
-                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_NoTF",
-                                    Indentation,
-                                    projectFile,
-                                    buildResult,
-                                    duration));
-                            }
-                            else
-                            {
-                                Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
-                                    Indentation,
-                                    projectFile,
-                                    AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
-                                    buildResult,
-                                    duration));
-                            }
+                            Terminal.Write(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_WithTF",
+                                Indentation,
+                                projectFile,
+                                AnsiCodes.Colorize(project.TargetFramework, TargetFrameworkColor),
+                                buildResult,
+                                duration));
                         }
 
                         // Print the output path as a link if we have it.
@@ -549,21 +481,7 @@ internal sealed partial class TerminalLogger : INodeLogger
                     {
                         foreach (BuildMessage buildMessage in project.BuildMessages)
                         {
-                            if (buildMessage.Message.IndexOf('\n') == -1) // Check for multi-line message
-                            {
-                                Terminal.WriteLine($"{Indentation}{Indentation}{buildMessage.Message}");
-                            }
-                            else
-                            {
-                                string[] lines = buildMessage.Message.Split(newLineStrings, StringSplitOptions.None);
-
-                                Terminal.WriteLine($"{Indentation}{Indentation}{lines[0]}");
-
-                                for (int i = 1; i < lines.Length; i++)
-                                {
-                                    Terminal.WriteLine($"{Indentation}{Indentation}{Indentation}{lines[i]}");
-                                }
-                            }
+                            Terminal.WriteLine($"{Indentation}{Indentation}{buildMessage.Message}");
                         }
                     }
 
@@ -591,22 +509,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             project.Stopwatch.Start();
 
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
-
-            var isTestTarget = e.TargetName == _testStartTarget;
-
-            var targetName = isTestTarget ? "Testing" : e.TargetName;
-            if (isTestTarget)
-            {
-                // Use the minimal start time, so if we run tests in parallel, we can calculate duration
-                // as this start time, minus time when tests finished.
-                _testStartTime = _testStartTime == null
-                    ? e.Timestamp
-                    : e.Timestamp < _testStartTime
-                        ? e.Timestamp : _testStartTime;
-                project.IsTestProject = true;
-            }
-
-            NodeStatus nodeStatus = new(projectFile, project.TargetFramework, targetName, project.Stopwatch);
+            NodeStatus nodeStatus = new(projectFile, project.TargetFramework, e.TargetName, project.Stopwatch);
             UpdateNodeStatus(buildEventContext, nodeStatus);
         }
     }
@@ -659,7 +562,6 @@ internal sealed partial class TerminalLogger : INodeLogger
         string? message = e.Message;
         if (message is not null && e.Importance == MessageImportance.High)
         {
-            var hasProject = _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project);
             // Detect project output path by matching high-importance messages against the "$(MSBuildProjectName) -> ..."
             // pattern used by the CopyFilesToOutputDirectory target.
             int index = message.IndexOf(FilePathPattern, StringComparison.Ordinal);
@@ -667,63 +569,17 @@ internal sealed partial class TerminalLogger : INodeLogger
             {
                 var projectFileName = Path.GetFileName(e.ProjectFile.AsSpan());
                 if (!projectFileName.IsEmpty &&
-                    message.AsSpan().StartsWith(Path.GetFileNameWithoutExtension(projectFileName)) && hasProject)
+                    message.AsSpan().StartsWith(Path.GetFileNameWithoutExtension(projectFileName)) &&
+                    _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project))
                 {
                     ReadOnlyMemory<char> outputPath = e.Message.AsMemory().Slice(index + 4);
-                    project!.OutputPath = outputPath;
+                    project.OutputPath = outputPath;
                 }
             }
 
             if (IsImmediateMessage(message))
             {
                 RenderImmediateMessage(message);
-            }
-            else if (hasProject && project!.IsTestProject)
-            {
-                var node = _nodes[NodeIndexForContext(buildEventContext)];
-
-                // Consumes test update messages produced by VSTest and MSTest runner.
-                if (node != null && e is IExtendedBuildEventArgs extendedMessage)
-                {
-                    switch (extendedMessage.ExtendedType)
-                    {
-                        case "TLTESTPASSED":
-                            {
-                                var indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
-                                var displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
-
-                                var status = new NodeStatus(node.Project, node.TargetFramework, TerminalColor.Green, indicator, displayName, project.Stopwatch);
-                                UpdateNodeStatus(buildEventContext, status);
-                                break;
-                            }
-
-                        case "TLTESTSKIPPED":
-                            {
-                                var indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
-                                var displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
-
-                                var status = new NodeStatus(node.Project, node.TargetFramework, TerminalColor.Yellow, indicator, displayName, project.Stopwatch);
-                                UpdateNodeStatus(buildEventContext, status);
-                                break;
-                            }
-
-                        case "TLTESTFINISH":
-                            {
-                                _ = int.TryParse(extendedMessage.ExtendedMetadata!["total"]!, out int total);
-                                _ = int.TryParse(extendedMessage.ExtendedMetadata!["passed"]!, out int passed);
-                                _ = int.TryParse(extendedMessage.ExtendedMetadata!["skipped"]!, out int skipped);
-                                _ = int.TryParse(extendedMessage.ExtendedMetadata!["failed"]!, out int failed);
-
-                                _testRunSummaries.Add(new TestSummary(total, passed, skipped, failed));
-
-                                _testEndTime = _testEndTime == null
-                                        ? e.Timestamp
-                                        : e.Timestamp > _testEndTime
-                                            ? e.Timestamp : _testEndTime;
-                                break;
-                            }
-                    }
-                }
             }
             else if (e.Code == "NETSDK1057" && !_loggedPreviewMessage)
             {
@@ -853,6 +709,8 @@ internal sealed partial class TerminalLogger : INodeLogger
         Terminal.Write(AnsiCodes.HideCursor);
         try
         {
+            // Move cursor back to 1st line of nodes.
+            Terminal.WriteLine($"{AnsiCodes.CSI}{_currentFrame.NodesCount + 1}{AnsiCodes.MoveUpToLineStart}");
             Terminal.Write(rendered);
         }
         finally
@@ -950,7 +808,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             : path;
     }
 
-    private string FormatEventMessage(
+    internal static string FormatEventMessage(
             string category,
             string subcategory,
             string? message,
@@ -962,7 +820,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             int endColumnNumber)
     {
         message ??= string.Empty;
-        StringBuilder builder = new(128);
+        using SpanBasedStringBuilder builder = new(128);
 
         if (string.IsNullOrEmpty(file))
         {
@@ -989,7 +847,7 @@ internal sealed partial class TerminalLogger : INodeLogger
                     if (endLineNumber == 0)
                     {
                         builder.Append(endColumnNumber == 0 ?
-                            $"({lineNumber},{columnNumber}): " :
+                            $"({lineNumber},{endColumnNumber}): " :
                             $"({lineNumber},{columnNumber}-{endColumnNumber}): ");
                     }
                     else
@@ -1005,7 +863,7 @@ internal sealed partial class TerminalLogger : INodeLogger
         if (!string.IsNullOrEmpty(subcategory))
         {
             builder.Append(subcategory);
-            builder.Append(' ');
+            builder.Append(" ");
         }
 
         builder.Append($"{category} {code}: ");
@@ -1013,21 +871,11 @@ internal sealed partial class TerminalLogger : INodeLogger
         // render multi-line message in a special way
         if (message.IndexOf('\n') >= 0)
         {
-            const string indent = $"{Indentation}{Indentation}{Indentation}";
             string[] lines = message.Split(newLineStrings, StringSplitOptions.None);
 
-            foreach (string line in lines)
+            for (int i = 0; i < lines.Length; i++)
             {
-                if (indent.Length + line.Length > Terminal.Width) // custom wrapping with indentation
-                {
-                    WrapText(builder, line, Terminal.Width, indent);
-                }
-                else
-                {
-                    builder.AppendLine();
-                    builder.Append(indent);
-                    builder.Append(line);
-                }
+                builder.Append($"{Environment.NewLine}{Indentation}{Indentation}{Indentation}{lines[i]}");
             }
         }
         else
@@ -1036,20 +884,6 @@ internal sealed partial class TerminalLogger : INodeLogger
         }
 
         return builder.ToString();
-    }
-
-    private static void WrapText(StringBuilder sb, string text, int maxLength, string indent)
-    {
-        int start = 0;
-        while (start < text.Length)
-        {
-            int length = Math.Min(maxLength - indent.Length, text.Length - start);
-            sb.AppendLine();
-            sb.Append(indent);
-            sb.Append(text.AsSpan().Slice(start, length));
-
-            start += length;
-        }
     }
 
     #endregion

--- a/src/StringTools/SpanBasedStringBuilder.cs
+++ b/src/StringTools/SpanBasedStringBuilder.cs
@@ -154,12 +154,12 @@ namespace Microsoft.NET.StringTools
         /// Appends a string.
         /// </summary>
         /// <param name="value">The string to append.</param>
-        public void Append(string value)
+        public void Append(string? value)
         {
             if (!string.IsNullOrEmpty(value))
             {
-                _spans.Add(value.AsMemory());
-                Length += value.Length;
+                _spans.Add(value!.AsMemory());
+                Length += value!.Length;
             }
         }
 


### PR DESCRIPTION
Fixes #9666

### Context
Adding proper support for multiline messages (with indentation). 
Removed project name from message line.

### Changes Made
Terminal logger uses different parsing and rendering.

### Testing
Unit tests were updated + manual testing (Windows)

### Notes
New output:
```console
MSBuild version 17.10.0-dev-24101-01+36ab632fa for .NET Framework
  XUnitTestProject succeeded with warnings (0,2s)
    C:\TestProjects\XUnitTestProject\XUnitTestProject\XUnitTestProject.csproj(26,0): warning : 
      A
      Multi
      Line
      Warning.
```