### PR TITLE
Annotate RAR SearchPaths added because they're "next to a reference"

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -8631,8 +8631,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             rar.Assemblies = new ITaskItem[]
             {
-                new TaskItem(@"C:\Program Files\dotnet\sdk\8.0.101\Microsoft.Build.dll"),
-                new TaskItem(@"Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"),
+                new TaskItem(@"C:\DirectoryTest\A.dll"),
+                new TaskItem("B"),
             };
 
             rar.SearchPaths = new string[]
@@ -8640,11 +8640,11 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 "{RawFileName}",
             };
 
-            rar.Execute().ShouldBeTrue();
+            Execute(rar).ShouldBeTrue();
 
             mockEngine.AssertLogContains(rar.Log.FormatResourceString("ResolveAssemblyReference.SearchPathAddedByParentAssembly",
-                @"C:\Program Files\dotnet\sdk\8.0.101",
-                @"C:\Program Files\dotnet\sdk\8.0.101\Microsoft.Build.dll"));
+                @"C:\DirectoryTest",
+                @"C:\DirectoryTest\A.dll"));
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -19,7 +19,6 @@ using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.NetCore.Extensions;
-using Xunit.Sdk;
 using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3237,7 +3237,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void ParentAssemblyResolvedFromAForGac()
         {
-            var parentReferenceFolders = new List<string>();
+            var parentReferenceFolders = new List<(string, string)>();
             var referenceList = new List<Reference>();
 
             var taskItem = new TaskItem("Microsoft.VisualStudio.Interopt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
@@ -3266,7 +3266,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
 
             Assert.Single(parentReferenceFolders);
-            Assert.Equal(reference2.ResolvedSearchPath, parentReferenceFolders[0]);
+            Assert.Equal(reference2.ResolvedSearchPath, parentReferenceFolders[0].Item2);
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -8637,9 +8637,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             rar.SearchPaths = new string[]
             {
-                "{CandidateAssemblyFiles}",
-                "{HintPathFromItem}",
-                "{TargetFrameworkDirectory}",
                 "{RawFileName}",
             };
 

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3237,7 +3237,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void ParentAssemblyResolvedFromAForGac()
         {
-            var parentReferenceFolders = new List<(string, string)>();
+            var parentReferenceFolders = new List<DirectoryWithParentAssembly>();
             var referenceList = new List<Reference>();
 
             var taskItem = new TaskItem("Microsoft.VisualStudio.Interopt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
@@ -3266,7 +3266,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
 
             Assert.Single(parentReferenceFolders);
-            Assert.Equal(reference2.ResolvedSearchPath, parentReferenceFolders[0].Item2);
+            Assert.Equal(reference2.ResolvedSearchPath, parentReferenceFolders[0].Directory);
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -613,7 +613,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             s_netstandardDllPath,
             @"C:\SystemRuntime\Regular.dll",
             s_dependsOnNuGet_ADllPath,
-            s_nugetCache_N_Lib_NDllPath
+            s_nugetCache_N_Lib_NDllPath,
+            @"C:\DirectoryTest\A.dll",
+            @"C:\DirectoryTest\B.dll",
         };
 
         /// <summary>
@@ -2480,6 +2482,19 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 {
                     new AssemblyNameExtension("N, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null")
                 };
+            }
+
+            if (String.Equals(path, @"C:\DirectoryTest\A.dll", StringComparison.OrdinalIgnoreCase))
+            {
+                return new AssemblyNameExtension[]
+                {
+                    GetAssemblyName(@"C:\DirectoryTest\B.dll")
+                };
+            }
+
+            if (path.StartsWith(@"C:\DirectoryTest\B.dll", StringComparison.OrdinalIgnoreCase))
+            {
+                return Array.Empty<AssemblyNameExtension>();
             }
 
             // Use a default list.

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -2492,7 +2492,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (path.StartsWith(@"C:\DirectoryTest\B.dll", StringComparison.OrdinalIgnoreCase))
+            if (String.Equals(path, @"C:\DirectoryTest\B.dll", StringComparison.OrdinalIgnoreCase))
             {
                 return Array.Empty<AssemblyNameExtension>();
             }

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -228,8 +228,10 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (var directory in parentReferenceDirectories.Value)
                 {
-                    resolvers[index] = new DirectoryResolver(directory, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
-                    resolvers[index].ParentAssembly = parentReferenceDirectories.Key;
+                    resolvers[index] = new DirectoryResolver(directory, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion)
+                    {
+                        ParentAssembly = parentReferenceDirectories.Key
+                    };
                     index++;
                 }
             }

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks.AssemblyFoldersFromConfig;

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -12,6 +12,8 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
+    internal readonly record struct DirectoryWithParentAssembly(string Directory, string ParentAssembly);
+
     /// <summary>
     /// Utility class encapsulates steps to resolve assembly references.
     /// For example, this class has the code that will take:
@@ -213,7 +215,7 @@ namespace Microsoft.Build.Tasks
         /// Build a resolver array from a set of directories to resolve directly from.
         /// </summary>
         internal static Resolver[] CompileDirectories(
-            List<(string, string)> parentReferenceDirectories,
+            List<DirectoryWithParentAssembly> parentReferenceDirectories,
             FileExists fileExists,
             GetAssemblyName getAssemblyName,
             GetAssemblyRuntimeVersion getRuntimeVersion,
@@ -222,7 +224,7 @@ namespace Microsoft.Build.Tasks
             var resolvers = new Resolver[parentReferenceDirectories.Count];
             for (int i = 0; i < parentReferenceDirectories.Count; i++)
             {
-                resolvers[i] = new DirectoryResolver(parentReferenceDirectories[i].Item2, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, parentReferenceDirectories[i].Item1);
+                resolvers[i] = new DirectoryResolver(parentReferenceDirectories[i].Directory, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, parentReferenceDirectories[i].ParentAssembly);
             }
 
             return resolvers;

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -214,26 +214,19 @@ namespace Microsoft.Build.Tasks
         /// Build a resolver array from a set of directories to resolve directly from.
         /// </summary>
         internal static Resolver[] CompileDirectories(
-            Dictionary<string, List<string>> parentReferenceDirectoriesMap,
+            List<(string, string)> parentReferenceDirectories,
             FileExists fileExists,
             GetAssemblyName getAssemblyName,
             GetAssemblyRuntimeVersion getRuntimeVersion,
             Version targetedRuntimeVersion)
         {
-            int totalResolversCount = parentReferenceDirectoriesMap.Values.Sum(list => list.Count);
-            var resolvers = new Resolver[totalResolversCount];
-            int index = 0;
-
-            foreach (var parentReferenceDirectories in parentReferenceDirectoriesMap)
+            var resolvers = new Resolver[parentReferenceDirectories.Count];
+            for (int i = 0; i < parentReferenceDirectories.Count; i++)
             {
-                foreach (var directory in parentReferenceDirectories.Value)
+                resolvers[i] = new DirectoryResolver(parentReferenceDirectories[i].Item2, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion)
                 {
-                    resolvers[index] = new DirectoryResolver(directory, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion)
-                    {
-                        ParentAssembly = parentReferenceDirectories.Key
-                    };
-                    index++;
-                }
+                    ParentAssembly = parentReferenceDirectories[i].Item1
+                };
             }
 
             return resolvers;

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
-                    resolvers[p] = new DirectoryResolver(searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
+                    resolvers[p] = new DirectoryResolver(searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, null);
                 }
             }
             return resolvers;
@@ -222,10 +222,7 @@ namespace Microsoft.Build.Tasks
             var resolvers = new Resolver[parentReferenceDirectories.Count];
             for (int i = 0; i < parentReferenceDirectories.Count; i++)
             {
-                resolvers[i] = new DirectoryResolver(parentReferenceDirectories[i].Item2, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion)
-                {
-                    ParentAssembly = parentReferenceDirectories[i].Item1
-                };
+                resolvers[i] = new DirectoryResolver(parentReferenceDirectories[i].Item2, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, parentReferenceDirectories[i].Item1);
             }
 
             return resolvers;

--- a/src/Tasks/AssemblyDependency/DirectoryResolver.cs
+++ b/src/Tasks/AssemblyDependency/DirectoryResolver.cs
@@ -46,14 +46,27 @@ namespace Microsoft.Build.Tasks
             foundPath = null;
             userRequestedSpecificFile = false;
 
-            // Resolve to the given path.
-            string resolvedPath = ResolveFromDirectory(assemblyName, isPrimaryProjectReference, wantSpecificVersion, executableExtensions, searchPathElement, assembliesConsideredAndRejected);
+            string resolvedPath;
 
-            foreach (var searchLocation in assembliesConsideredAndRejected)
+            if (parentAssembly != null)
             {
-                searchLocation.ParentAssembly = parentAssembly;
-            }
+                var searchLocationsWithParentAssembly = new List<ResolutionSearchLocation>();
 
+                // Resolve to the given path.
+                resolvedPath = ResolveFromDirectory(assemblyName, isPrimaryProjectReference, wantSpecificVersion, executableExtensions, searchPathElement, searchLocationsWithParentAssembly);
+
+                foreach (var searchLocation in searchLocationsWithParentAssembly)
+                {
+                    searchLocation.ParentAssembly = parentAssembly;
+                }
+
+                assembliesConsideredAndRejected.AddRange(searchLocationsWithParentAssembly);
+            }
+            else
+            {
+                resolvedPath = ResolveFromDirectory(assemblyName, isPrimaryProjectReference, wantSpecificVersion, executableExtensions, searchPathElement, assembliesConsideredAndRejected);
+            }
+     
             if (resolvedPath != null)
             {
                 foundPath = resolvedPath;

--- a/src/Tasks/AssemblyDependency/DirectoryResolver.cs
+++ b/src/Tasks/AssemblyDependency/DirectoryResolver.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        public DirectoryResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
+        public DirectoryResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion, string parentAssembly)
+            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false, parentAssembly)
         {
         }
 

--- a/src/Tasks/AssemblyDependency/DirectoryResolver.cs
+++ b/src/Tasks/AssemblyDependency/DirectoryResolver.cs
@@ -15,11 +15,17 @@ namespace Microsoft.Build.Tasks
     internal class DirectoryResolver : Resolver
     {
         /// <summary>
+        /// The parent assembly that was used for the SearchPath.
+        /// </summary>
+        public readonly string parentAssembly;
+
+        /// <summary>
         /// Construct.
         /// </summary>
         public DirectoryResolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVesion, string parentAssembly)
-            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false, parentAssembly)
+            : base(searchPathElement, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVesion, System.Reflection.ProcessorArchitecture.None, false)
         {
+            this.parentAssembly = parentAssembly;
         }
 
         /// <inheritdoc/>
@@ -42,6 +48,12 @@ namespace Microsoft.Build.Tasks
 
             // Resolve to the given path.
             string resolvedPath = ResolveFromDirectory(assemblyName, isPrimaryProjectReference, wantSpecificVersion, executableExtensions, searchPathElement, assembliesConsideredAndRejected);
+
+            foreach (var searchLocation in assembliesConsideredAndRejected)
+            {
+                searchLocation.ParentAssembly = parentAssembly;
+            }
+
             if (resolvedPath != null)
             {
                 foundPath = resolvedPath;

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1220,7 +1220,7 @@ namespace Microsoft.Build.Tasks
         /// The only time we do not want to do this is if the parent assembly came from the GAC or AssemblyFoldersEx then we want the assembly
         /// to be found using those resolvers so that our GAC and AssemblyFolders checks later on will work on those assemblies.
         /// </summary>
-        internal static void CalculateParentAssemblyDirectories(List<string> parentReferenceFolders, Reference parentReference)
+        internal static void CalculateParentAssemblyDirectories(List<(string, string)> parentReferenceFolders, Reference parentReference)
         {
             string parentReferenceFolder = parentReference.DirectoryName;
             string parentReferenceResolvedSearchPath = parentReference.ResolvedSearchPath;
@@ -1240,7 +1240,7 @@ namespace Microsoft.Build.Tasks
             if (!parentReferencesAdded.Contains(parentReferenceFolder) && !parentReferenceResolvedFromGAC && !parentReferenceResolvedFromAssemblyFolders)
             {
                 parentReferencesAdded.Add(parentReferenceFolder);
-                parentReferenceFolders.Add(parentReferenceFolder);
+                parentReferenceFolders.Add(new (parentReference.FullPath, parentReferenceFolder));
             }
         }
 
@@ -1279,16 +1279,10 @@ namespace Microsoft.Build.Tasks
             // First, look for the dependency in the parents' directories. Unless they are resolved from the GAC or assemblyFoldersEx then
             // we should make sure we use the GAC and assemblyFolders resolvers themserves rather than a directory resolver to find the reference.
             // This way we dont get assemblies pulled from the GAC or AssemblyFolders but dont have the marking that they were pulled form there.
-            var parentReferenceDirectoriesMap = new Dictionary<string, List<string>>();
+            var parentReferenceFolders = new List<(string, string)>();
             foreach (Reference parentReference in reference.GetDependees())
             {
-                if (!parentReferenceDirectoriesMap.TryGetValue(parentReference.FullPath, out List<string> value))
-                {
-                    value = new List<string>();
-                    parentReferenceDirectoriesMap[parentReference.FullPath] = value;
-                }
-
-                CalculateParentAssemblyDirectories(value, parentReference);
+                CalculateParentAssemblyDirectories(parentReferenceFolders, parentReference);
             }
 
             // Build the set of resolvers.
@@ -1304,9 +1298,9 @@ namespace Microsoft.Build.Tasks
             else
             {
                 // Do not probe near dependees if the reference is primary and resolved externally. If resolved externally, the search paths should have been specified in such a way to point to the assembly file.
-                if (parentReferenceDirectoriesMap.Count > 0 && (assemblyName == null || !_externallyResolvedPrimaryReferences.Contains(assemblyName.Name)))
+                if (parentReferenceFolders.Count > 0 && (assemblyName == null || !_externallyResolvedPrimaryReferences.Contains(assemblyName.Name)))
                 {
-                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceDirectoriesMap, _fileExists, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion));
+                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceFolders, _fileExists, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion));
                 }
 
                 jaggedResolvers.Add(Resolvers);

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1279,10 +1279,11 @@ namespace Microsoft.Build.Tasks
             // First, look for the dependency in the parents' directories. Unless they are resolved from the GAC or assemblyFoldersEx then
             // we should make sure we use the GAC and assemblyFolders resolvers themserves rather than a directory resolver to find the reference.
             // This way we dont get assemblies pulled from the GAC or AssemblyFolders but dont have the marking that they were pulled form there.
-            var parentReferenceFolders = new List<string>();
+            var parentReferenceDirectoriesMap = new Dictionary<string, List<string>>();
             foreach (Reference parentReference in reference.GetDependees())
             {
-                CalculateParentAssemblyDirectories(parentReferenceFolders, parentReference);
+                parentReferenceDirectoriesMap[parentReference.FullPath] = new List<string>();
+                CalculateParentAssemblyDirectories(parentReferenceDirectoriesMap[parentReference.FullPath], parentReference);
             }
 
             // Build the set of resolvers.
@@ -1298,9 +1299,9 @@ namespace Microsoft.Build.Tasks
             else
             {
                 // Do not probe near dependees if the reference is primary and resolved externally. If resolved externally, the search paths should have been specified in such a way to point to the assembly file.
-                if (assemblyName == null || !_externallyResolvedPrimaryReferences.Contains(assemblyName.Name))
+                if (parentReferenceDirectoriesMap.Count > 0 && (assemblyName == null || !_externallyResolvedPrimaryReferences.Contains(assemblyName.Name)))
                 {
-                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceFolders, _fileExists, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion));
+                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceDirectoriesMap, _fileExists, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion));
                 }
 
                 jaggedResolvers.Add(Resolvers);

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1220,7 +1220,7 @@ namespace Microsoft.Build.Tasks
         /// The only time we do not want to do this is if the parent assembly came from the GAC or AssemblyFoldersEx then we want the assembly
         /// to be found using those resolvers so that our GAC and AssemblyFolders checks later on will work on those assemblies.
         /// </summary>
-        internal static void CalculateParentAssemblyDirectories(List<(string, string)> parentReferenceFolders, Reference parentReference)
+        internal static void CalculateParentAssemblyDirectories(List<DirectoryWithParentAssembly> parentReferenceFolders, Reference parentReference)
         {
             string parentReferenceFolder = parentReference.DirectoryName;
             string parentReferenceResolvedSearchPath = parentReference.ResolvedSearchPath;
@@ -1240,7 +1240,7 @@ namespace Microsoft.Build.Tasks
             if (!parentReferencesAdded.Contains(parentReferenceFolder) && !parentReferenceResolvedFromGAC && !parentReferenceResolvedFromAssemblyFolders)
             {
                 parentReferencesAdded.Add(parentReferenceFolder);
-                parentReferenceFolders.Add(new (parentReference.FullPath, parentReferenceFolder));
+                parentReferenceFolders.Add(new (Directory: parentReferenceFolder, ParentAssembly: parentReference.FullPath));
             }
         }
 
@@ -1279,7 +1279,7 @@ namespace Microsoft.Build.Tasks
             // First, look for the dependency in the parents' directories. Unless they are resolved from the GAC or assemblyFoldersEx then
             // we should make sure we use the GAC and assemblyFolders resolvers themserves rather than a directory resolver to find the reference.
             // This way we dont get assemblies pulled from the GAC or AssemblyFolders but dont have the marking that they were pulled form there.
-            var parentReferenceFolders = new List<(string, string)>();
+            var parentReferenceFolders = new List<DirectoryWithParentAssembly>();
             foreach (Reference parentReference in reference.GetDependees())
             {
                 CalculateParentAssemblyDirectories(parentReferenceFolders, parentReference);

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1282,8 +1282,13 @@ namespace Microsoft.Build.Tasks
             var parentReferenceDirectoriesMap = new Dictionary<string, List<string>>();
             foreach (Reference parentReference in reference.GetDependees())
             {
-                parentReferenceDirectoriesMap[parentReference.FullPath] = new List<string>();
-                CalculateParentAssemblyDirectories(parentReferenceDirectoriesMap[parentReference.FullPath], parentReference);
+                if (!parentReferenceDirectoriesMap.TryGetValue(parentReference.FullPath, out List<string> value))
+                {
+                    value = new List<string>();
+                    parentReferenceDirectoriesMap[parentReference.FullPath] = value;
+                }
+
+                CalculateParentAssemblyDirectories(value, parentReference);
             }
 
             // Build the set of resolvers.

--- a/src/Tasks/AssemblyDependency/ResolutionSearchLocation.cs
+++ b/src/Tasks/AssemblyDependency/ResolutionSearchLocation.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Build.Tasks
         internal string SearchPath { get; set; }
 
         /// <summary>
+        /// The parent assembly that was used for the SearchPath.
+        /// </summary>
+        internal string ParentAssembly { get; set; }
+
+        /// <summary>
         /// The name of the assembly found at that location. Will be null if there was no assembly there.
         /// </summary>
         internal AssemblyNameExtension AssemblyName { get; set; }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -153,8 +153,8 @@ namespace Microsoft.Build.Tasks
                 Resolved = GetResourceFourSpaces("ResolveAssemblyReference.Resolved");
                 ResolvedFrom = GetResourceFourSpaces("ResolveAssemblyReference.ResolvedFrom");
                 SearchedAssemblyFoldersEx = GetResourceEightSpaces("ResolveAssemblyReference.SearchedAssemblyFoldersEx");
-                SearchPath = EightSpaces + GetResource("ResolveAssemblyReference.SearchPath");
-                SearchPathAddedByParentAssembly = EightSpaces + GetResource("ResolveAssemblyReference.SearchPathAddedByParentAssembly");
+                SearchPath = GetResourceEightSpaces("ResolveAssemblyReference.SearchPath");
+                SearchPathAddedByParentAssembly = GetResourceEightSpaces("ResolveAssemblyReference.SearchPathAddedByParentAssembly");
                 TargetedProcessorArchitectureDoesNotMatch = GetResourceEightSpaces("ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch");
                 UnificationByAppConfig = GetResourceFourSpaces("ResolveAssemblyReference.UnificationByAppConfig");
                 UnificationByAutoUnify = GetResourceFourSpaces("ResolveAssemblyReference.UnificationByAutoUnify");

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Build.Tasks
             public static string ResolvedFrom;
             public static string SearchedAssemblyFoldersEx;
             public static string SearchPath;
+            public static string SearchPathAddedByParentAssembly;
             public static string TargetedProcessorArchitectureDoesNotMatch;
             public static string UnificationByAppConfig;
             public static string UnificationByAutoUnify;
@@ -153,6 +154,7 @@ namespace Microsoft.Build.Tasks
                 ResolvedFrom = GetResourceFourSpaces("ResolveAssemblyReference.ResolvedFrom");
                 SearchedAssemblyFoldersEx = GetResourceEightSpaces("ResolveAssemblyReference.SearchedAssemblyFoldersEx");
                 SearchPath = EightSpaces + GetResource("ResolveAssemblyReference.SearchPath");
+                SearchPathAddedByParentAssembly = EightSpaces + GetResource("ResolveAssemblyReference.SearchPathAddedByParentAssembly");
                 TargetedProcessorArchitectureDoesNotMatch = GetResourceEightSpaces("ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch");
                 UnificationByAppConfig = GetResourceFourSpaces("ResolveAssemblyReference.UnificationByAppConfig");
                 UnificationByAutoUnify = GetResourceFourSpaces("ResolveAssemblyReference.UnificationByAutoUnify");
@@ -1791,7 +1793,14 @@ namespace Microsoft.Build.Tasks
                     if (lastSearchPath != location.SearchPath)
                     {
                         lastSearchPath = location.SearchPath;
-                        Log.LogMessage(importance, Strings.SearchPath, lastSearchPath);
+                        if (location.ParentAssembly != null)
+                        {
+                            Log.LogMessage(importance, Strings.SearchPathAddedByParentAssembly, lastSearchPath, location.ParentAssembly);
+                        }
+                        else
+                        {
+                            Log.LogMessage(importance, Strings.SearchPath, lastSearchPath);
+                        }                 
                         if (logAssemblyFoldersMinimal)
                         {
                             Log.LogMessage(importance, Strings.SearchedAssemblyFoldersEx);

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -52,14 +52,9 @@ namespace Microsoft.Build.Tasks
         protected bool compareProcessorArchitecture;
 
         /// <summary>
-        /// The parent assembly that was used for the SearchPath.
-        /// </summary>
-        internal readonly string parentAssembly;
-
-        /// <summary>
         /// Construct.
         /// </summary>
-        protected Resolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVersion, ProcessorArchitecture targetedProcessorArchitecture, bool compareProcessorArchitecture, string parentAssembly = null)
+        protected Resolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVersion, ProcessorArchitecture targetedProcessorArchitecture, bool compareProcessorArchitecture)
         {
             this.searchPathElement = searchPathElement;
             this.getAssemblyName = getAssemblyName;
@@ -68,7 +63,6 @@ namespace Microsoft.Build.Tasks
             this.targetedRuntimeVersion = targetedRuntimeVersion;
             this.targetProcessorArchitecture = targetedProcessorArchitecture;
             this.compareProcessorArchitecture = compareProcessorArchitecture;
-            this.parentAssembly = parentAssembly;
         }
 
         /// <summary>
@@ -124,8 +118,7 @@ namespace Microsoft.Build.Tasks
                 considered = new ResolutionSearchLocation
                 {
                     FileNameAttempted = fullPath,
-                    SearchPath = searchPathElement,
-                    ParentAssembly = parentAssembly
+                    SearchPath = searchPathElement
                 };
             }
 

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -96,6 +96,11 @@ namespace Microsoft.Build.Tasks
             out bool userRequestedSpecificFile);
 
         /// <summary>
+        /// The parent assembly that was used for the SearchPath.
+        /// </summary>
+        internal string ParentAssembly { get; set; }
+
+        /// <summary>
         /// The search path element that this resolver is based on.
         /// </summary>
         public string SearchPath => searchPathElement;
@@ -118,7 +123,8 @@ namespace Microsoft.Build.Tasks
                 considered = new ResolutionSearchLocation
                 {
                     FileNameAttempted = fullPath,
-                    SearchPath = searchPathElement
+                    SearchPath = searchPathElement,
+                    ParentAssembly = this.ParentAssembly
                 };
             }
 

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -52,9 +52,14 @@ namespace Microsoft.Build.Tasks
         protected bool compareProcessorArchitecture;
 
         /// <summary>
+        /// The parent assembly that was used for the SearchPath.
+        /// </summary>
+        internal readonly string parentAssembly;
+
+        /// <summary>
         /// Construct.
         /// </summary>
-        protected Resolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVersion, ProcessorArchitecture targetedProcessorArchitecture, bool compareProcessorArchitecture)
+        protected Resolver(string searchPathElement, GetAssemblyName getAssemblyName, FileExists fileExists, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVersion, ProcessorArchitecture targetedProcessorArchitecture, bool compareProcessorArchitecture, string parentAssembly = null)
         {
             this.searchPathElement = searchPathElement;
             this.getAssemblyName = getAssemblyName;
@@ -63,6 +68,7 @@ namespace Microsoft.Build.Tasks
             this.targetedRuntimeVersion = targetedRuntimeVersion;
             this.targetProcessorArchitecture = targetedProcessorArchitecture;
             this.compareProcessorArchitecture = compareProcessorArchitecture;
+            this.parentAssembly = parentAssembly;
         }
 
         /// <summary>
@@ -96,11 +102,6 @@ namespace Microsoft.Build.Tasks
             out bool userRequestedSpecificFile);
 
         /// <summary>
-        /// The parent assembly that was used for the SearchPath.
-        /// </summary>
-        internal string ParentAssembly { get; set; }
-
-        /// <summary>
         /// The search path element that this resolver is based on.
         /// </summary>
         public string SearchPath => searchPathElement;
@@ -124,7 +125,7 @@ namespace Microsoft.Build.Tasks
                 {
                     FileNameAttempted = fullPath,
                     SearchPath = searchPathElement,
-                    ParentAssembly = this.ParentAssembly
+                    ParentAssembly = parentAssembly
                 };
             }
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1713,6 +1713,10 @@
   <data name="ResolveAssemblyReference.SearchPath">
     <value>For SearchPath "{0}".</value>
   </data>
+  <data name="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+    <value>For SearchPath "{0}" (added by referencing assembly "{1}").</value>
+    <comment> {1} is the name of the parent assembly for which SearchPath was used.</comment>
+  </data>
   <data name="ResolveAssemblyReference.UnificationByAppConfig">
     <value>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</value>
   </data>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Byla uvažována umístění AssemblyFoldersEx.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Berücksichtigte Speicherorte von AssemblyFoldersEx.</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Ubicaciones de AssemblyFoldersEx consideradas.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Emplacements d'AssemblyFoldersEx envisagés.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Percorsi AssemblyFoldersEx considerati.</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">AssemblyFoldersEx の場所が考慮されました。</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">AssemblyFoldersEx 위치로 간주했습니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Wybrano lokalizacje klucza rejestru AssemblyFoldersEx.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Localizações de AssemblyFoldersEx consideradas.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">Рассмотрены расположения AssemblyFoldersEx.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">AssemblyFoldersEx konumları dikkate alındı.</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">已考虑 AssemblyFoldersEx 位置。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1686,6 +1686,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
+        <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
+        <target state="new">For SearchPath "{0}" (added by referencing assembly "{1}").</target>
+        <note> {1} is the name of the parent assembly for which SearchPath was used.</note>
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
         <source>Considered AssemblyFoldersEx locations.</source>
         <target state="translated">已考慮 AssemblyFoldersEx 位置。</target>


### PR DESCRIPTION
Fixes #9408

### Context

When building this project from a Developer Command Prompt:

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net472</TargetFramework>
  </PropertyGroup>

  <ItemGroup>
    <Reference Include="$(DevEnvDir)\..\..\MSBuild\Current\Bin\Microsoft.Build.dll" />
    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
  </ItemGroup>

</Project>
```

That produces this RAR snippet for Framework:

```
Primary reference "Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a". (TaskId:59)
    Resolved file path is "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\Microsoft.Build.Framework.dll". (TaskId:59)
    Reference found at search path location "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin". (TaskId:59)
        For SearchPath "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin". (TaskId:59)
        Considered "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\Microsoft.Build.Framework.winmd", but it didn't exist. (TaskId:59)
```

### Changes Made
When calculating resolvers to resolve a reference we currently adding `DirectoryResolver`s for each directories of the reference's dependees:
https://github.com/dotnet/msbuild/blob/07fd5d51f25134ea3ab3620c66f6501a74df2921/src/Tasks/AssemblyDependency/ReferenceTable.cs#L1282-L1286

Added `ParentAssembly` property to the `Resolver` to save that info to log it later for searchpath.
Added new type of log message for this specific case:
```
For SearchPath {searchPath}" (added by referencing assembly {parentAssemly}).

```
Now same example produces:
```
Primary reference "Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a". (TaskId:21)
      Resolved file path is "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\Microsoft.Build.Framework.dll". (TaskId:21)
      Reference found at search path location "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin". (TaskId:21)
          For SearchPath "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" (added by referencing assembly "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\Microsoft.Build.dll"). (TaskId:21)
          Considered "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\Microsoft.Build.Framework.winmd", but it didn't exist. (TaskId:21)
```

### Testing
Unit test for new log message and manual test

### Notes
