### PR TITLE
Allow users to influence the value of CreateSatelliteAssembliesDependsOn

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3949,6 +3949,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <PropertyGroup>
     <CreateSatelliteAssembliesDependsOn>
+      $(CreateSatelliteAssembliesDependsOn);
       _GenerateSatelliteAssemblyInputs;
       ComputeIntermediateSatelliteAssemblies;
       GenerateSatelliteAssemblies


### PR DESCRIPTION
Fixes #9703

### Context

@jaredpar hit this while investigating a Roslyn build process optimization, and it made him sad. We don't want sad @jaredpar.

### Changes Made

The property's existing value is prepended to the default dependency target names, like in #4922.

### Testing

None

### Notes
