### PR TITLE
Bump some System.* deps to 8.0.0

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -5,13 +5,17 @@
   <IgnorePatterns>
     <!-- Baseline 7.0 dependencies until msbuild targets net8 and uses a net8 arcade, SBRP, etc.
          These cannot be added to 7.0 SBRP, because they would are produced in the 7.0 build. -->
+    <UsagePattern IdentityGlob="System.CodeDom/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Collections.Immutable/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Diagnostics.EventLog/*8.0.0*" />
+    <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Reflection.Metadata/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Resources.Extensions/*8.0.0*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/*8.0.0*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Text.Json/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*8.0.0*" />
   </IgnorePatterns>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -3,8 +3,7 @@
 
 <UsageData>
   <IgnorePatterns>
-    <!-- Baseline 7.0 dependencies until msbuild targets net8 and uses a net8 arcade, SBRP, etc.
-         These cannot be added to 7.0 SBRP, because they would are produced in the 7.0 build. -->
+    <!-- 8.0 packages are not allowed in the 8.0 build, because they're not "current", so baseline them. -->
     <UsagePattern IdentityGlob="System.CodeDom/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Collections.Immutable/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/*8.0.0*" />

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Update="Shouldly" Condition="'$(ShouldlyVersion)' != ''" Version="$(ShouldlyVersion)" />
 
-    <PackageVersion Include="System.CodeDom" Version="7.0.0" />
+    <PackageVersion Include="System.CodeDom" Version="8.0.0" />
     <PackageVersion Update="System.CodeDom" Condition="'$(SystemCodeDomVersion)' != ''" Version="$(SystemCodeDomVersion)" />
 
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
@@ -46,10 +46,10 @@
     <PackageVersion Include="System.Runtime" Version="4.3.1" />
     <PackageVersion Update="System.Runtime" Condition="'$(SystemRuntimeVersion)' != ''" Version="$(SystemRuntimeVersion)" />
 
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
     <PackageVersion Update="System.Security.Cryptography.Pkcs" Condition="'$(SystemSecurityCryptographyPkcsVersion)' != ''" Version="$(SystemSecurityCryptographyPkcsVersion)" />
 
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.0" />
     <PackageVersion Update="System.Security.Cryptography.Xml" Condition="'$(SystemSecurityCryptographyXmlVersion)' != ''" Version="$(SystemSecurityCryptographyXmlVersion)" />
 
     <PackageVersion Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />


### PR DESCRIPTION
While looking at something else, I noticed that these references were stale.

(This should be automated but https://github.com/dependabot/dependabot-core/issues/7206.)