### PR TITLE
Add encoding option to consolelogger parameters

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -108,11 +108,11 @@ namespace Microsoft.Build.UnitTests
             var mockLogFromBuild = new MockLogger();
 
             var serialFromBuildText = new StringBuilder();
-            var serialFromBuild = new SerialConsoleLogger(Framework.LoggerVerbosity.Diagnostic, t => serialFromBuildText.Append(t), colorSet: null, colorReset: null);
+            var serialFromBuild = new SerialConsoleLogger(Framework.LoggerVerbosity.Diagnostic, t => serialFromBuildText.Append(t), colorSet: null, colorReset: null, encoding: null);
             serialFromBuild.Parameters = "NOPERFORMANCESUMMARY";
 
             var parallelFromBuildText = new StringBuilder();
-            var parallelFromBuild = new ParallelConsoleLogger(Framework.LoggerVerbosity.Diagnostic, t => parallelFromBuildText.Append(t), colorSet: null, colorReset: null);
+            var parallelFromBuild = new ParallelConsoleLogger(Framework.LoggerVerbosity.Diagnostic, t => parallelFromBuildText.Append(t), colorSet: null, colorReset: null, encoding: null);
             parallelFromBuild.Parameters = "NOPERFORMANCESUMMARY";
 
             // build and log into binary logger, mock logger, serial and parallel console loggers
@@ -156,11 +156,11 @@ namespace Microsoft.Build.UnitTests
             var mockLogFromPlayback = new MockLogger();
 
             var serialFromPlaybackText = new StringBuilder();
-            var serialFromPlayback = new SerialConsoleLogger(Framework.LoggerVerbosity.Diagnostic, t => serialFromPlaybackText.Append(t), colorSet: null, colorReset: null);
+            var serialFromPlayback = new SerialConsoleLogger(Framework.LoggerVerbosity.Diagnostic, t => serialFromPlaybackText.Append(t), colorSet: null, colorReset: null, encoding: null);
             serialFromPlayback.Parameters = "NOPERFORMANCESUMMARY";
 
             var parallelFromPlaybackText = new StringBuilder();
-            var parallelFromPlayback = new ParallelConsoleLogger(Framework.LoggerVerbosity.Diagnostic, t => parallelFromPlaybackText.Append(t), colorSet: null, colorReset: null);
+            var parallelFromPlayback = new ParallelConsoleLogger(Framework.LoggerVerbosity.Diagnostic, t => parallelFromPlaybackText.Append(t), colorSet: null, colorReset: null, encoding: null);
             parallelFromPlayback.Parameters = "NOPERFORMANCESUMMARY";
 
             var binaryLogReader = new BinaryLogReplayEventSource();

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -1927,6 +1927,30 @@ namespace Microsoft.Build.UnitTests
             ((bool)L.ShowSummary).ShouldBeFalse();
         }
 
+        [Fact]
+        public void TestInvalidEncoding()
+        {
+            // To verify it could set the encoding through the parameter, set non-default encoding.
+            Console.OutputEncoding = Encoding.ASCII;
+            ConsoleLogger logger = new ConsoleLogger(LoggerVerbosity.Normal, Console.Write, null, null);
+            logger.Parameters = "encoding=foo";
+            ObjectModelHelpers.BuildProjectExpectSuccess(s_dummyProjectContents, logger);
+            // If invalid encoding is inputted use default encoding UTF-8.
+            Console.OutputEncoding.ShouldBe(Encoding.UTF8);
+        }
+
+        [Fact]
+        public void TestValidEncoding()
+        {
+            // To verify it could set the encoding through the parameter, set non-default encoding.
+            Console.OutputEncoding = Encoding.ASCII;
+            ConsoleLogger logger = new ConsoleLogger(LoggerVerbosity.Normal, Console.Write, null, null);
+            var encodingName = "UTF-16";
+            logger.Parameters = $"encoding={encodingName}";
+            ObjectModelHelpers.BuildProjectExpectSuccess(s_dummyProjectContents, logger);
+            Console.OutputEncoding.ShouldBe(Encoding.GetEncoding(encodingName));
+        }
+
         /// <summary>
         /// ResetConsoleLoggerState should reset the state of the console logger
         /// </summary>

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -1470,12 +1470,12 @@ namespace Microsoft.Build.UnitTests
         public void DisplayPropertiesList()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
 
             WriteAndValidateProperties(cl, sc, true);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
             EventSourceSink es = new EventSourceSink();
             cl2.Initialize(es);
 
@@ -1489,12 +1489,12 @@ namespace Microsoft.Build.UnitTests
         public void DoNotDisplayPropertiesListInDetailed()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null, null);
 
             WriteAndValidateProperties(cl, sc, false);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null, null);
 
             WriteAndValidateProperties(cl2, sc, false);
         }
@@ -1507,12 +1507,12 @@ namespace Microsoft.Build.UnitTests
         public void DoNotDisplayEnvironmentInDetailed()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null, null);
 
             WriteEnvironment(cl, sc, false);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null, null);
 
             WriteEnvironment(cl2, sc, false);
         }
@@ -1526,13 +1526,13 @@ namespace Microsoft.Build.UnitTests
         public void DisplayEnvironmentInDetailed()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null, null);
             cl.Parameters = "ShowEnvironment";
             cl.ParseParameters();
             WriteEnvironment(cl, sc, true);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null, null);
             EventSourceSink es = new EventSourceSink();
             cl2.Initialize(es);
             cl2.Parameters = "ShowEnvironment";
@@ -1548,11 +1548,11 @@ namespace Microsoft.Build.UnitTests
         public void DisplayEnvironmentInDiagnostic()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
             WriteEnvironment(cl, sc, true);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
             EventSourceSink es = new EventSourceSink();
             cl2.Initialize(es);
             WriteEnvironment(cl2, sc, true);
@@ -1565,12 +1565,12 @@ namespace Microsoft.Build.UnitTests
         public void DoNotDisplayEnvironmentInMinimal()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Minimal, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Minimal, sc.Write, null, null, null);
 
             WriteEnvironment(cl, sc, false);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Minimal, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Minimal, sc.Write, null, null, null);
 
             WriteEnvironment(cl2, sc, false);
         }
@@ -1584,13 +1584,13 @@ namespace Microsoft.Build.UnitTests
         public void DisplayEnvironmentInMinimal()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Minimal, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Minimal, sc.Write, null, null, null);
             cl.Parameters = "ShowEnvironment";
             cl.ParseParameters();
             WriteEnvironment(cl, sc, true);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Minimal, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Minimal, sc.Write, null, null, null);
             EventSourceSink es = new EventSourceSink();
             cl2.Initialize(es);
             cl2.Parameters = "ShowEnvironment";
@@ -1606,14 +1606,14 @@ namespace Microsoft.Build.UnitTests
         public void DoNotDisplayPropertiesListIfDisabled()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
             cl.Parameters = "noitemandpropertylist";
             cl.ParseParameters();
 
             WriteAndValidateProperties(cl, sc, false);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
             cl2.Parameters = "noitemandpropertylist";
             cl2.ParseParameters();
 
@@ -1757,11 +1757,11 @@ namespace Microsoft.Build.UnitTests
                 SimulatedConsole sc = new SimulatedConsole();
                 if (i == 0)
                 {
-                    cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+                    cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
                 }
                 else
                 {
-                    cl = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+                    cl = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
                 }
 
                 if (cl is SerialConsoleLogger scl)
@@ -1798,13 +1798,13 @@ namespace Microsoft.Build.UnitTests
                 SimulatedConsole sc = new SimulatedConsole();
                 if (i == 0)
                 {
-                    var cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+                    var cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
                     var propertyList = cl.ExtractPropertyList(properties);
                     cl.WriteProperties(propertyList);
                 }
                 else
                 {
-                    var cl = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+                    var cl = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
                     BuildEventArgs buildEvent = new BuildErrorEventArgs("", "", "", 0, 0, 0, 0, "", "", "");
                     buildEvent.BuildEventContext = new BuildEventContext(1, 2, 3, 4);
                     cl.WriteProperties(buildEvent, properties);
@@ -1825,12 +1825,12 @@ namespace Microsoft.Build.UnitTests
         public void DisplayItemsList()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
 
             WriteAndValidateItems(cl, sc, true);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
             EventSourceSink es = new EventSourceSink();
             cl2.Initialize(es);
 
@@ -1844,12 +1844,12 @@ namespace Microsoft.Build.UnitTests
         public void DoNotDisplayItemListInDetailed()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null, null);
 
             WriteAndValidateItems(cl, sc, false);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Detailed, sc.Write, null, null, null);
 
             WriteAndValidateItems(cl2, sc, false);
         }
@@ -1861,14 +1861,14 @@ namespace Microsoft.Build.UnitTests
         public void DoNotDisplayItemListIfDisabled()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            SerialConsoleLogger cl = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
             cl.Parameters = "noitemandpropertylist";
             cl.ParseParameters();
 
             WriteAndValidateItems(cl, sc, false);
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
             cl2.Parameters = "noitemandpropertylist";
             cl2.ParseParameters();
 
@@ -1879,7 +1879,7 @@ namespace Microsoft.Build.UnitTests
         public void ParametersEmptyTests()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger L = new SerialConsoleLogger(LoggerVerbosity.Normal, sc.Write, null, null);
+            SerialConsoleLogger L = new SerialConsoleLogger(LoggerVerbosity.Normal, sc.Write, null, null, null);
 
             L.Parameters = "";
             L.ParseParameters();
@@ -1890,7 +1890,7 @@ namespace Microsoft.Build.UnitTests
             L.ShowSummary.ShouldBeNull();
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null, null);
             cl2.Parameters = "noitemandpropertylist";
             cl2.ParseParameters();
 
@@ -1901,7 +1901,7 @@ namespace Microsoft.Build.UnitTests
         public void ParametersParsingTests()
         {
             SimulatedConsole sc = new SimulatedConsole();
-            SerialConsoleLogger L = new SerialConsoleLogger(LoggerVerbosity.Normal, sc.Write, null, null);
+            SerialConsoleLogger L = new SerialConsoleLogger(LoggerVerbosity.Normal, sc.Write, null, null, null);
 
             L.Parameters = "NoSuMmaRy";
             L.ParseParameters();
@@ -1914,7 +1914,7 @@ namespace Microsoft.Build.UnitTests
             ((bool)L.ShowSummary).ShouldBeFalse();
 
             sc = new SimulatedConsole();
-            ParallelConsoleLogger L2 = new ParallelConsoleLogger(LoggerVerbosity.Normal, sc.Write, null, null);
+            ParallelConsoleLogger L2 = new ParallelConsoleLogger(LoggerVerbosity.Normal, sc.Write, null, null, null);
 
             L2.Parameters = "NoSuMmaRy";
             L2.ParseParameters();

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     continue;
                 }
 
-                string[] parameterAndValue = parameter.Split(s_parameterValueSplitCharacter);
+                string[] parameterAndValue = parameter.Split(parameterValueSplitCharacter);
                 ApplyParameter(parameterAndValue[0], parameterAndValue.Length > 1 ? parameterAndValue[1] : null);
             }
         }
@@ -423,7 +423,16 @@ namespace Microsoft.Build.BackEnd.Logging
             IsRunningWithCharacterFileType();
             if (encoding != null)
             {
-                Console.OutputEncoding = encoding;
+                // Some encoding is not supported by Console class, such as UTF-32 encoding.
+                // In that case, use UTF-8 encoding by default.
+                try
+                {
+                    Console.OutputEncoding = encoding;
+                }
+                catch (IOException)
+                {
+                    Console.OutputEncoding = Encoding.UTF8;
+                }
             }
             // This is a workaround, because the Console class provides no way to check that a color
             // can actually be set or not. Color cannot be set if the console has been redirected
@@ -1147,7 +1156,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Console logger parameter value split character.
         /// </summary>
-        private static readonly char[] s_parameterValueSplitCharacter = MSBuildConstants.EqualsChar;
+        internal static readonly char[] parameterValueSplitCharacter = MSBuildConstants.EqualsChar;
 
         /// <summary>
         /// When true, accumulate performance numbers.

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -416,11 +416,15 @@ namespace Microsoft.Build.BackEnd.Logging
             // do nothing...
         }
 
-        internal void InitializeConsoleMethods(LoggerVerbosity logverbosity, WriteHandler logwriter, ColorSetter colorSet, ColorResetter colorReset)
+        internal void InitializeConsoleMethods(LoggerVerbosity logverbosity, WriteHandler logwriter, ColorSetter colorSet, ColorResetter colorReset, Encoding encoding)
         {
             Verbosity = logverbosity;
             WriteHandler = logwriter;
             IsRunningWithCharacterFileType();
+            if (encoding != null)
+            {
+                Console.OutputEncoding = encoding;
+            }
             // This is a workaround, because the Console class provides no way to check that a color
             // can actually be set or not. Color cannot be set if the console has been redirected
             // in certain ways (e.g. how BUILD.EXE does it)

--- a/src/Build/Logging/ConsoleLogger.cs
+++ b/src/Build/Logging/ConsoleLogger.cs
@@ -158,11 +158,12 @@ namespace Microsoft.Build.Logging
                         // Use ansi color codes if current target console do support it
                         preferConsoleColor = ConsoleConfiguration.AcceptAnsiColorCodes;
                     }
-                    if (string.Equals(param, "ENCODING", StringComparison.OrdinalIgnoreCase))
+                    var parameterAndValue = param.Split(BaseConsoleLogger.parameterValueSplitCharacter);
+                    if (parameterAndValue.Length == 2 && string.Equals(parameterAndValue[0], "ENCODING", StringComparison.OrdinalIgnoreCase))
                     {
                         try
                         {
-                            _encoding = Encoding.GetEncoding(param);
+                            _encoding = Encoding.GetEncoding(parameterAndValue[1]);
                         }
                         catch (ArgumentException ex)
                         {

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -50,7 +51,8 @@ namespace Microsoft.Build.BackEnd.Logging
                 verbosity,
                 new WriteHandler(Console.Out.Write),
                 new ColorSetter(SetColor),
-                new ColorResetter(ResetColor))
+                new ColorResetter(ResetColor),
+                Encoding.UTF8)
         {
             // do nothing
         }
@@ -62,9 +64,10 @@ namespace Microsoft.Build.BackEnd.Logging
             LoggerVerbosity verbosity,
             WriteHandler write,
             ColorSetter colorSet,
-            ColorResetter colorReset)
+            ColorResetter colorReset,
+            Encoding encoding)
         {
-            InitializeConsoleMethods(verbosity, write, colorSet, colorReset);
+            InitializeConsoleMethods(verbosity, write, colorSet, colorReset, encoding);
             _deferredMessages = new Dictionary<BuildEventContext, List<BuildMessageEventArgs>>(s_compareContextNodeId);
             _buildEventManager = new BuildEventManager();
         }

--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using ColorResetter = Microsoft.Build.Logging.ColorResetter;
@@ -40,7 +41,8 @@ namespace Microsoft.Build.BackEnd.Logging
                 verbosity,
                 new WriteHandler(Console.Out.Write),
                 new ColorSetter(SetColor),
-                new ColorResetter(ResetColor))
+                new ColorResetter(ResetColor),
+                Encoding.UTF8)
         {
             // do nothing
         }
@@ -56,9 +58,10 @@ namespace Microsoft.Build.BackEnd.Logging
             LoggerVerbosity verbosity,
             WriteHandler write,
             ColorSetter colorSet,
-            ColorResetter colorReset)
+            ColorResetter colorReset,
+            Encoding encoding)
         {
-            InitializeConsoleMethods(verbosity, write, colorSet, colorReset);
+            InitializeConsoleMethods(verbosity, write, colorSet, colorReset, encoding);
         }
 
         #endregion

--- a/src/Shared/UnitTests/EngineTestEnvironment.cs
+++ b/src/Shared/UnitTests/EngineTestEnvironment.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Build.UnitTests
         private (ILogger, Func<string>) GetSerialLogger()
         {
             var sb = new StringBuilder();
-            var serialFromBuild = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, t => sb.Append(t), colorSet: null, colorReset: null);
+            var serialFromBuild = new SerialConsoleLogger(LoggerVerbosity.Diagnostic, t => sb.Append(t), colorSet: null, colorReset: null, encoding: null);
             serialFromBuild.Parameters = "NOPERFORMANCESUMMARY";
             return (serialFromBuild, () => sb.ToString());
         }
@@ -184,7 +184,7 @@ namespace Microsoft.Build.UnitTests
         private (ILogger, Func<string>) GetParallelLogger()
         {
             var sb = new StringBuilder();
-            var parallelFromBuild = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, t => sb.Append(t), colorSet: null, colorReset: null);
+            var parallelFromBuild = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, t => sb.Append(t), colorSet: null, colorReset: null, encoding: null);
             parallelFromBuild.Parameters = "NOPERFORMANCESUMMARY";
             return (parallelFromBuild, () => sb.ToString());
         }


### PR DESCRIPTION
Fixes #9694

### Context
For console logger, the message is not readable for some languages such as Korean if the system code page is not UTF-8.

### Changes Made
Add encoding option to console logger to set the encoding.

### Testing
Added test to verify the encoding setting.
It seems there is not a good way to verify the console output with expected encoding. 

### Notes
