### PR TITLE
Add Determinism/SourceLink related Properties to Corecompile dependency checks

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3800,6 +3800,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CoreCompileCache Include="@(ReferencePath)" />
       <CoreCompileCache Include="$(DefineConstants)" />
       <CoreCompileCache Include="$(LangVersion)" />
+      <CoreCompileCache Include="$(Deterministic)" />
+      <CoreCompileCache Include="$(PathMap)" />
     </ItemGroup>
 
     <Hash


### PR DESCRIPTION
### Context

This is one part of https://github.com/dotnet/sdk/issues/16325, identifying two areas where inputs to the CoreCompile Target (via the Csc/Fsc/etc Tasks) aren't tracked consistently.

Fixes part of https://github.com/dotnet/sdk/issues/16325


### Changes Made

Adds Deterministic and PathMap properties, neither of which are Paths and so cannot be coerced into an Item for use in the Target Inputs, to the tracking cache property file.

### Testing


### Notes
