### PR TITLE
Change the priority order of lazyloading

### DIFF
--- a/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
@@ -562,8 +562,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
 <Project>
    <Import Project=`foo/*.props`/>
    <ItemGroup>
-      <i Include=`**/foo/**/*.cs`/>
-      <i2 Include=`**/bar/**/*.cs`/>
+      <i Include=`**/foo/**/*.cs` />
+      <i2 Include=`**/bar/**/*.cs` />
+      <i3 Include=`**/yyy/**/*.cs` Exclude=`mock-value` />
    </ItemGroup>
 
    <ItemGroup>
@@ -584,11 +585,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
 ".Cleanup();
             using (var env = TestEnvironment.Create())
             {
-                var projectFiles = env.CreateTestProjectWithFiles(content, new[] { "foo/extra.props", "foo/a.cs", "foo/b.cs", "bar/c.cs", "bar/d.cs" });
+                var projectFiles = env.CreateTestProjectWithFiles(content, new[] { "foo/extra.props", "foo/a.cs", "foo/b.cs", "bar/c.cs", "bar/d.cs", "yyy/d.cs" });
 
                 File.WriteAllText(projectFiles.CreatedFiles[0], import);
 
-                env.SetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes", ".*foo.*");
+                env.SetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes", ".*foo.*;.*yyy*.");
 
                 EngineFileUtilities.CaptureLazyWildcardRegexes();
 
@@ -596,6 +597,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 Assert.Equal("true", project.GetPropertyValue("FromImport"));
                 Assert.Equal("**/foo/**/*.cs", project.GetConcatenatedItemsOfType("i"));
+                Assert.Equal("**/yyy/**/*.cs", project.GetConcatenatedItemsOfType("i3"));
 
                 var expectedItems = "bar\\c.cs;bar\\d.cs";
 

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -191,10 +191,12 @@ namespace Microsoft.Build.Internal
             FileMatcher.SearchAction action = FileMatcher.SearchAction.None;
             string excludeFileSpec = string.Empty;
 
-            var noWildcards = !FilespecHasWildcards(filespecEscaped) || FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
-
+            var filespecHasNoWildCards = !FilespecHasWildcards(filespecEscaped);
+            var filespecMatchesLazyWildcard = FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
+            var excludeSpecsAreEmpty = excludeSpecsEscaped?.Any() != true;
+            
             // It is possible to return original string if no wildcard matches and no entries in Exclude set.
-            if (noWildcards && excludeSpecsEscaped?.Any() != true)
+            if ( filespecMatchesLazyWildcard || (filespecHasNoWildCards && excludeSpecsAreEmpty) )
             {
                 // Just return the original string.
                 fileList = new string[] { returnEscaped ? filespecEscaped : EscapingUtilities.UnescapeAll(filespecEscaped) };

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -195,7 +195,9 @@ namespace Microsoft.Build.Internal
             var filespecMatchesLazyWildcard = FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards);
             var excludeSpecsAreEmpty = excludeSpecsEscaped?.Any() != true;
             
-            // It is possible to return original string if no wildcard matches and no entries in Exclude set.
+            // Return original value if:
+            //      FileSpec matches lazyloading regex or
+            //      file has no wildcard and excludeSpecs are empty
             if ( filespecMatchesLazyWildcard || (filespecHasNoWildCards && excludeSpecsAreEmpty) )
             {
                 // Just return the original string.


### PR DESCRIPTION
Fixes #9736

### Context
During the improvement of item evalution #9047, the MsBuildSkipEagerWildCardEvaluationRegexes  variable was skipped for some cases: When the exclude was defined with MsBuildSkipEagerWildCardEvaluationRegexes. It resulted the listing of the non needed file (according to lazyload)

### Changes Made
Changed the priority of the lazyLoading regex. Firstly it will compare it and then will check if it is nowildcard file with no exclusions 

### Testing
Added failed scenario to existing test: LazyWildcardExpansionDoesNotEvaluateWildCardsIfNotReferenced. 

### Notes
