### PR TITLE
Do not import project extensions during restore

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1774,7 +1774,10 @@ namespace Microsoft.Build.CommandLine
             // Add/set a property with a random value to ensure that restore happens under a different evaluation context
             // If the evaluation context is not different, then projects won't be re-evaluated after restore
             // The initializer syntax can't be used just in case a user set this property to a value
-            restoreGlobalProperties["MSBuildRestoreSessionId"] = Guid.NewGuid().ToString("D");
+            restoreGlobalProperties[MSBuildConstants.MSBuildRestoreSessionId] = Guid.NewGuid().ToString("D");
+
+            // Add a property to indicate that a Restore is executing
+            restoreGlobalProperties[MSBuildConstants.MSBuildIsRestoring] = bool.TrueString;
 
             // Create a new request with a Restore target only and specify:
             //  - BuildRequestDataFlags.ClearCachesAfterBuild to ensure the projects will be reloaded from disk for subsequent builds

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -70,6 +70,17 @@ namespace Microsoft.Build.Shared
         internal const string MSBuildDummyGlobalPropertyHeader = "MSBuildProjectInstance";
 
         /// <summary>
+        /// A property set during a in implicit restore (/restore) or explicit restore (/t:restore) to ensure that the evaluations are not re-used during build
+        /// </summary>
+        internal const string MSBuildRestoreSessionId = nameof(MSBuildRestoreSessionId);
+
+        /// <summary>
+        /// A property set during a in implicit restore (/restore) or explicit restore (/t:restore) to indicate that a restore is executing.
+        /// </summary>
+        internal const string MSBuildIsRestoring = nameof(MSBuildIsRestoring);
+
+
+        /// <summary>
         /// The most current VSGeneralAssemblyVersion known to this version of MSBuild.
         /// </summary>
         internal const string CurrentAssemblyVersion = "15.1.0.0";

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Shared
         internal const string MSBuildRestoreSessionId = nameof(MSBuildRestoreSessionId);
 
         /// <summary>
-        /// A property set during a in implicit restore (/restore) or explicit restore (/t:restore) to indicate that a restore is executing.
+        /// A property set during an implicit restore (/restore) or explicit restore (/t:restore) to indicate that a restore is executing.
         /// </summary>
         internal const string MSBuildIsRestoring = nameof(MSBuildIsRestoring);
 

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Build.Shared
         internal const string MSBuildDummyGlobalPropertyHeader = "MSBuildProjectInstance";
 
         /// <summary>
-        /// A property set during a in implicit restore (/restore) or explicit restore (/t:restore) to ensure that the evaluations are not re-used during build
+        /// A property set during an implicit restore (/restore) or explicit restore (/t:restore) to ensure that the evaluations are not re-used during build
         /// </summary>
         internal const string MSBuildRestoreSessionId = nameof(MSBuildRestoreSessionId);
 

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -227,6 +227,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     build.
   -->
   <PropertyGroup>
+    <!--
+        Don't import project extensions during restore because NuGet restore generates them.  Importing them during restore will embed
+        the pre-restore files in the binary log and then NuGet won't be able to embed the generated one after restore.  If some other
+        project extension mechanism wants to import project extensions during restore, they need to explicitly set ImportProjectExtensionTargets
+    -->
+    <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
+    
     <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -232,7 +232,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         the pre-restore files in the binary log and then NuGet won't be able to embed the generated one after restore.  If some other
         project extension mechanism wants to import project extensions during restore, they need to explicitly set ImportProjectExtensionTargets
     -->
-    <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
+    <ImportProjectExtensionTargets Condition="$([MSBuild]::AreFeaturesEnabled('17.10')) And '$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
     
     <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -59,6 +59,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
     <MSBuildProjectExtensionsPath Condition="'$([System.IO.Path]::IsPathRooted($(MSBuildProjectExtensionsPath)))' == 'false'">$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(MSBuildProjectExtensionsPath)'))</MSBuildProjectExtensionsPath>
     <MSBuildProjectExtensionsPath Condition="!HasTrailingSlash('$(MSBuildProjectExtensionsPath)')">$(MSBuildProjectExtensionsPath)\</MSBuildProjectExtensionsPath>
+
+    <!--
+        Don't import project extensions during restore because NuGet restore generates them.  Importing them during restore will embed
+        the pre-restore files in the binary log and then NuGet won't be able to embed the generated one after restore.  If some other
+        project extension mechanism wants to import project extensions during restore, they need to explicitly set ImportProjectExtensionProps
+    -->
+    <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionProps>
+    
     <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == ''">true</ImportProjectExtensionProps>
     <_InitialMSBuildProjectExtensionsPath Condition=" '$(ImportProjectExtensionProps)' == 'true' ">$(MSBuildProjectExtensionsPath)</_InitialMSBuildProjectExtensionsPath>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -65,7 +65,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         the pre-restore files in the binary log and then NuGet won't be able to embed the generated one after restore.  If some other
         project extension mechanism wants to import project extensions during restore, they need to explicitly set ImportProjectExtensionProps
     -->
-    <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionProps>
+    <ImportProjectExtensionProps Condition="$([MSBuild]::AreFeaturesEnabled('17.10')) And '$(ImportProjectExtensionProps)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionProps>
     
     <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == ''">true</ImportProjectExtensionProps>
     <_InitialMSBuildProjectExtensionsPath Condition=" '$(ImportProjectExtensionProps)' == 'true' ">$(MSBuildProjectExtensionsPath)</_InitialMSBuildProjectExtensionsPath>

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -29,6 +29,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
   -->
   <PropertyGroup>
+    <!--
+        Don't import project extensions during restore because NuGet restore generates them.  Importing them during restore will embed
+        the pre-restore files in the binary log and then NuGet won't be able to embed the generated one after restore.  If some other
+        project extension mechanism wants to import project extensions during restore, they need to explicitly set ImportProjectExtensionTargets
+    -->
+    <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
+    
     <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -34,7 +34,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         the pre-restore files in the binary log and then NuGet won't be able to embed the generated one after restore.  If some other
         project extension mechanism wants to import project extensions during restore, they need to explicitly set ImportProjectExtensionTargets
     -->
-    <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
+    <ImportProjectExtensionTargets Condition="$([MSBuild]::AreFeaturesEnabled('17.10')) And '$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
     
     <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #9512

### Context
During restore, MSBuild needs to evaluate the entry project and during this evaluation if any of the project extension files that NuGet generates (`project.nuget.g.props` and `project.nuget.g.targets`) they are used during the next restore.  Another side effect is the files that exist on disk at the beginning of restore are embedded in the binary log and not the ones that are generated by NuGet.

### Changes Made
Introduced a new property `MSBuildIsRestoring` which is set during an implicit restore (`/restore`) or an explicit restore (`/Target:restore`) so that we don't need to take a dependency on `MSBuildRestoreSessionId`.  This is now a property users can key off of to detect if a command-line based restore is running.  

Default `ImportProjectExtensionProps` and `ImportProjectExtensionTargets` to `false` if `MSBuildIsRestoring` is `true` unless a users has explicitly set `ImportProjectExtensionProps` or `ImportProjectExtensionTargets` to `true`.  This allows users to bring back the old behavior if desired.

I also added `MSBuildRestoreSessionId` and `MSBuildIsRestoring` to `MSBuildConstants` so their names can be defined in a single place.

### Testing
Added to existing unit tests to verify
1. `ImportProjectExtensionProps` and `ImportProjectExtensionTargets` default to `false` if `MSBuildIsRestoring` is `true`
2. When `ImportProjectExtensionProps` and `ImportProjectExtensionTargets` are set to `true`, their values are not set even if `MSBuildIsRestoring` is `true`

### Notes
