### PR TITLE
[vs17.8] Workaround for incorrect encoding of PUA range in GB18030 Uri string

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.8.5</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.8.6</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.7.0</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>


### PR DESCRIPTION
Fixes [AB#1957157](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1957157)

### Summary
Uri class when passed a GB18030 string with chars in the PUA range incorrectly encodes the PUA chars.
For e.g. if the PUA char is u+e038, Uri encodes it in UTF-8 as %25EE%2580%25B8 instead of %EE%80%B8 by double encoding the %.

The ClickOnce scenario that is failing is when an app's Installation Uri is set to a UNC path that has PUA chars. In this case, the UNC path is written to the Clickonce manifest. When the app is being installed, ClickOnce Runtime will attempt to download the deployment manifest from the UNC path. Since the Uri is incorrectly encoded, this download will fail.

### Changes Made
The FormatUrl function is being updated to resolve this issue. This function takes input path as string and return a canonicalized path by constructing a Uri class with the input path and then returning it's AbsoluteUri property.

In the case where the Uri's Scheme is File (file://), the function will now check if there are non-ascii characters in it and if so, create a new Uri with the UriBuilder class. The Uri created by UriBuilder correctly handles PUA range in GB18030.

### Regression?
Yes

### Customer Impact
ClickOnce apps published with Installation path set to a UNC path containing GB18030 + PUA chars will be installed correctly after this change.

### Testing
Failing scenario has been validated and CTI team has run regression tests on affected scenarios (scenarios where Uri are used for publishing).

### Risk
Low (Already deployed with 17.9/8.0.2xx)
