### PR TITLE
Init of msbuild env variables document

### DIFF
--- a/documentation/wiki/MSBuild-Environment-Variables.md
+++ b/documentation/wiki/MSBuild-Environment-Variables.md
@@ -1,0 +1,12 @@
+# MSBuild environment variables
+
+- [MsBuildSkipEagerWildCardEvaluationRegexes](#msbuildskipeagerwildcardevaluationregexes)
+
+
+### MsBuildSkipEagerWildCardEvaluationRegexes
+
+If specified, overrides the default behavior of glob expansion. 
+
+During glob expansion, if the path with wildcards that is being processed matches one of the regular expressions provided in the [environment variable](#msbuildskipeagerwildcardevaluationregexes), the path is not processed (expanded). 
+
+The value of the envvironment variable is a list of regular expressions, separated by semilcon (;).


### PR DESCRIPTION
Fixes #9739

### Context
Please see the description in attached issue

### Changes Made
Added the new file in wiki, which will describe the behavior and usage of different environment variables that are being respected and used  in MSBuild. 

### Testing
Nothing to test

### Notes
Next steps would be to transfer all environment variables from https://github.com/dotnet/msbuild/blob/main/documentation/wiki/MSBuild-Tips-%26-Tricks.md to have a separate well indexed file for easy search. 