### PR TITLE
Make sdk resolvers list immutable

### DIFF
--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     "1.0.0",
                     Enumerable.Empty<string>()));
 
-            var service = new CachingSdkResolverService();
+            var service = CachingSdkResolverService.Instance;
             service.InitializeForTests(
                 null,
                 new List<SdkResolver>
@@ -532,7 +532,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     "1.0.0",
                     Enumerable.Empty<string>()));
 
-            var service = new CachingSdkResolverService();
+            var service = CachingSdkResolverService.Instance;
             service.InitializeForTests(
                 null,
                 new List<SdkResolver>
@@ -560,7 +560,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             // Start with interactive false
             bool interactive = false;
 
-            var service = new CachingSdkResolverService();
+            var service = CachingSdkResolverService.Instance;
 
             service.InitializeForTests(
                 resolvers: new List<SdkResolver>
@@ -593,7 +593,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
             bool isRunningInVisualStudio = false;
 
-            var service = new CachingSdkResolverService();
+            var service = CachingSdkResolverService.Instance;
             service.InitializeForTests(
                 resolvers: new List<SdkResolver>
                 {

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -21,6 +21,20 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// </summary>
         private readonly ConcurrentDictionary<int, ConcurrentDictionary<string, Lazy<SdkResult>>> _cache = new ConcurrentDictionary<int, ConcurrentDictionary<string, Lazy<SdkResult>>>();
 
+        /// <summary>
+        /// Stores the singleton instance for a particular process.
+        /// </summary>
+        private static readonly Lazy<CachingSdkResolverService> InstanceLazy = new Lazy<CachingSdkResolverService>(() => new CachingSdkResolverService(), isThreadSafe: true);
+
+        private CachingSdkResolverService()
+        {
+        }
+
+        /// <summary>
+        /// Gets the current instance of <see cref="CachingSdkResolverService"/> for this process.
+        /// </summary>
+        public static new CachingSdkResolverService Instance => InstanceLazy.Value;
+
         public override void ClearCache(int submissionId)
         {
             base.ClearCache(submissionId);

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
@@ -97,5 +98,17 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
             return result;
         }
+
+        /// <summary>
+        /// Used for unit tests only.
+        /// </summary>
+        /// <param name="resolverLoader">An <see cref="SdkResolverLoader"/> to use for loading SDK resolvers.</param>
+        /// <param name="resolvers">Explicit set of SdkResolvers to use for all SDK resolution.</param>
+        internal new void InitializeForTests(SdkResolverLoader resolverLoader = null, IReadOnlyList<SdkResolver> resolvers = null)
+        {
+            _cache.Clear();
+            base.InitializeForTests(resolverLoader, resolvers);
+        }
+
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -109,6 +109,5 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _cache.Clear();
             base.InitializeForTests(resolverLoader, resolvers);
         }
-
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
     /// </summary>
     internal sealed class MainNodeSdkResolverService : HostedSdkResolverServiceBase
     {
-        private readonly ISdkResolverService _cachedSdkResolver = new CachingSdkResolverService();
+        private readonly ISdkResolverService _cachedSdkResolver = CachingSdkResolverService.Instance;
 
         /// <summary>
         /// A factory which is registered to create an instance of this class.

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -74,7 +75,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             ? CachingSdkResolverLoader.Instance
             : new SdkResolverLoader();
 
-        public SdkResolverService()
+        protected SdkResolverService()
         {
         }
 

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Evaluation.Context
         {
             Policy = policy;
 
-            SdkResolverService = sdkResolverService ?? new CachingSdkResolverService();
+            SdkResolverService = sdkResolverService ?? CachingSdkResolverService.Instance;
             FileEntryExpansionCache = fileEntryExpansionCache ?? new ConcurrentDictionary<string, IReadOnlyList<string>>();
             FileSystem = fileSystem ?? new CachingFileSystemWrapper(FileSystems.Default);
             FileMatcher = new FileMatcher(FileSystem, FileEntryExpansionCache);


### PR DESCRIPTION
Fixes #9679

### Context
Under certain circumstances MSBuild will create and use multiple `SdkResolverService` classes, which leads to multiple read of sdk resolvers manifests files and re-loading of the resolvers. As stated in the issue, we should identify resolvers at most once in a process lifetime. 

### Changes Made
`SdkResolverService` is supposed to be a singleton and is supposed to be instantiated only once. However, a derived class with caching `CachingSdkResolverService` was introduced. `CachingSdkResolverService` is not a singleton, thus allowing multiple loads of the resolvers. This PR makes `CachingSdkResolverService` a singleton, thus fixing multiple re-loads.

### Testing
Unit tests, local testing and experimental insertion
