### PR TITLE
Determine ProjectGraphNode ProjectType once

### DIFF
--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -2133,7 +2133,7 @@ $@"
 
             graph.ProjectNodes.Count.ShouldBe(4);
 
-            var outerBuild = graph.GraphRoots.First(IsOuterBuild);
+            var outerBuild = graph.GraphRoots.First(i => i.ProjectType == ProjectInterpretation.ProjectType.OuterBuild);
 
             AssertOuterBuild(outerBuild, graph, additionalGlobalProperties);
             AssertNonMultitargetingNode(GetFirstNodeWithProjectNumber(graph, 2), additionalGlobalProperties);
@@ -2215,7 +2215,7 @@ $@"
 
             AssertOuterBuild(outerBuild1, graph, additionalGlobalProperties);
 
-            var innerBuild1WithReferenceToInnerBuild2 = outerBuild1.ProjectReferences.FirstOrDefault(n => IsInnerBuild(n) && n.ProjectInstance.GlobalProperties[InnerBuildPropertyName] == "a");
+            var innerBuild1WithReferenceToInnerBuild2 = outerBuild1.ProjectReferences.FirstOrDefault(n => n.ProjectType == ProjectInterpretation.ProjectType.InnerBuild && n.ProjectInstance.GlobalProperties[InnerBuildPropertyName] == "a");
             innerBuild1WithReferenceToInnerBuild2.ShouldNotBeNull();
 
             var outerBuild2 = GetOuterBuild(graph, 2);

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Build.Graph
             {
                 var currentNode = parsedProject.Value.GraphNode;
 
-                var requiresTransitiveProjectReferences = _projectInterpretation.RequiresTransitiveProjectReferences(currentNode.ProjectInstance);
+                var requiresTransitiveProjectReferences = _projectInterpretation.RequiresTransitiveProjectReferences(currentNode);
 
                 foreach (var referenceInfo in parsedProject.Value.ReferenceInfos)
                 {
@@ -572,7 +572,7 @@ namespace Microsoft.Build.Graph
         {
             var referenceInfos = new List<ProjectInterpretation.ReferenceInfo>();
 
-            foreach (var referenceInfo in _projectInterpretation.GetReferences(parsedProject.ProjectInstance, _projectCollection, GetInstanceForPlatformNegotiationWithCaching))
+            foreach (var referenceInfo in _projectInterpretation.GetReferences(parsedProject, _projectCollection, GetInstanceForPlatformNegotiationWithCaching))
             {
                 if (FileUtilities.IsSolutionFilename(referenceInfo.ReferenceConfiguration.ProjectFullPath))
                 {

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -635,7 +635,7 @@ namespace Microsoft.Build.Graph
                 // Queue the project references for visitation, if the edge hasn't already been traversed.
                 foreach (var referenceNode in node.ProjectReferences)
                 {
-                    var applicableTargets = targetsToPropagate.GetApplicableTargetsForReference(referenceNode.ProjectInstance);
+                    var applicableTargets = targetsToPropagate.GetApplicableTargetsForReference(referenceNode);
 
                     if (applicableTargets.IsEmpty)
                     {

--- a/src/Build/Graph/ProjectGraphNode.cs
+++ b/src/Build/Graph/ProjectGraphNode.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Build.BackEnd;
@@ -21,11 +22,15 @@ namespace Microsoft.Build.Graph
         private readonly HashSet<ProjectGraphNode> _projectReferences = new HashSet<ProjectGraphNode>();
         private readonly HashSet<ProjectGraphNode> _referencingProjects = new HashSet<ProjectGraphNode>();
 
+        internal ProjectInterpretation.ProjectType ProjectType { get; }
+
         // No public creation.
         internal ProjectGraphNode(ProjectInstance projectInstance)
         {
             ErrorUtilities.VerifyThrowInternalNull(projectInstance, nameof(projectInstance));
             ProjectInstance = projectInstance;
+
+            ProjectType = ProjectInterpretation.GetProjectType(projectInstance);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/9769

### Context
The calculation of project type during Project Graph construction happens four times per project instance when instead it could be calculated once and the value re-used.

### Changes Made
The `ProjectGraphNode` constructor now calculates the value for "project type" and stores it with an internal property that is read when constructing the graph.

### Testing
Updated unit tests which were checking this value.

### Notes
I got rid of all the helper methods and replaced them with simple checks like `ProjectType == ProjectType.OuterBuild` because these helpers aren't really necessary for simple checks like the value of an enum.