### PR TITLE
Safe access to event wait handle

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1353,7 +1353,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
                         _emptyQueueEvent?.Reset();
                     }
-                } while (_eventQueue?.IsEmpty == false || !completeAdding.IsCancellationRequested);
+                } while (!completeAdding.IsCancellationRequested || _eventQueue?.IsEmpty == false);
 
                 _emptyQueueEvent?.Set();
             }

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1343,19 +1343,19 @@ namespace Microsoft.Build.BackEnd.Logging
                     }
                     else
                     {
-                        _emptyQueueEvent.Set();
+                        _emptyQueueEvent?.Set();
 
                         // Wait for next event, or finish.
-                        if (!completeAdding.IsCancellationRequested && _eventQueue.IsEmpty)
+                        if (!completeAdding.IsCancellationRequested && _eventQueue?.IsEmpty == true)
                         {
                             WaitHandle.WaitAny(waitHandlesForNextEvent);
                         }
 
-                        _emptyQueueEvent.Reset();
+                        _emptyQueueEvent?.Reset();
                     }
-                } while (!_eventQueue.IsEmpty || !completeAdding.IsCancellationRequested);
+                } while (_eventQueue?.IsEmpty != false|| !completeAdding.IsCancellationRequested);
 
-                _emptyQueueEvent.Set();
+                _emptyQueueEvent?.Set();
             }
         }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1353,7 +1353,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
                         _emptyQueueEvent?.Reset();
                     }
-                } while (_eventQueue?.IsEmpty != false|| !completeAdding.IsCancellationRequested);
+                } while (_eventQueue?.IsEmpty == false || !completeAdding.IsCancellationRequested);
 
                 _emptyQueueEvent?.Set();
             }


### PR DESCRIPTION
### Context
There is a possibility that the variable emptyQueueEvent could be null. 
Unfortunatelly I was not able to reproduce the exact scenario, but accessing the variables that could be null safely should not do harm overall.

### Changes Made

1. Change the way to access the EventWaitHandle objects inside LoggingEventProc. 
2. Change the order of checking if the thread should stop or not with putting the check of cancelled token first in the while condition

### Testing
All existing tests should pass. 