### PR TITLE
Make console output encoding support all languages

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1833,6 +1833,26 @@ namespace Microsoft.Build.CommandLine
             CultureInfo.CurrentUICulture = desiredCulture;
             CultureInfo.DefaultThreadCurrentUICulture = desiredCulture;
 
+#if RUNTIME_TYPE_NETCORE
+            if (EncodingUtilities.CurrentPlatformIsWindowsAndOfficiallySupportsUTF8Encoding())
+#else
+            if (EncodingUtilities.CurrentPlatformIsWindowsAndOfficiallySupportsUTF8Encoding()
+                && !CultureInfo.CurrentUICulture.TwoLetterISOLanguageName.Equals("en", StringComparison.InvariantCultureIgnoreCase))
+#endif
+            {
+                try
+                {
+                    // Setting both encodings causes a change in the CHCP, making it so we don't need to P-Invoke CHCP ourselves.
+                    Console.OutputEncoding = Encoding.UTF8;
+                    // If the InputEncoding is not set, the encoding will work in CMD but not in PowerShell, as the raw CHCP page won't be changed.
+                    Console.InputEncoding = Encoding.UTF8;
+                }
+                catch (Exception ex) when (ex is IOException || ex is SecurityException)
+                {
+                    // The encoding is unavailable. Do nothing.
+                }
+            }
+
             // Determine if the language can be displayed in the current console codepage, otherwise set to US English
             int codepage;
 


### PR DESCRIPTION
Fixes #9694

### Context
For console logger, the message is not readable for some languages such as Korean if the system code page is not UTF-8.

### Changes Made
Set console output encoding to UTF-8 to support all languages on OSes that support UTF-8.
- On Core unconditionally set the encoding
- On Full framework set the encoding if the OS system locale is non-English. 

### Testing
Test the fix with msbuild task `Message`/`Warning` that contains Chinese/Korean/Japanese using the following cases.
- `dotnet build` on OS with English locale
-  msbuild.exe on OS with English locale (this requires set the env var `DOTNET_CLI_UI_LANGUAGE`)
- `dotnet build` on OS with Chinese locale
-  msbuild.exe on OS with Chinese locale

### Notes
