### PR TITLE
Update xcopy-msbuild

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
     "vs": {
       "version": "17.8.0"
     },
-    "xcopy-msbuild": "17.8.1-2"
+    "xcopy-msbuild": "17.8.5"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24060.4"


### PR DESCRIPTION
Fixes #

### Context
Version 8.0.201 of the .NET SDK requires at least version 17.8.3 of MSBuild. The current available version of MSBuild is 17.8.1.47607. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.

### Changes Made
Update "xcopy-msbuild" from "17.8.1-2" to "17.8.5"