### PR TITLE
Remove api compat workaround

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,12 +38,4 @@
                Condition="Exists('$(_PackageFolderInGlobalPackages)')" />
   </Target>
 
-  <!-- Make APICompat use roslyn from the toolset SDK instead of from the toolset package. This avoids unification issues on desktop msbuild.
-       TODO: Remove when a 8.0.200 or 9.0 SDK is consumed. -->
-  <Target Name="FixAPICompatWorkAroundRoslynMove" AfterTargets="CollectApiCompatInputs">
-    <PropertyGroup>
-      <RoslynAssembliesPath>$(RoslynTargetsPath)</RoslynAssembliesPath>
-    </PropertyGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
Fixes #9720

MSBuild is now using the 201 SDK. This also breaks usage of the dotnet msbuild engine in VMR builds.