### PR TITLE
Revert "Remove api compat workaround"

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,4 +38,12 @@
                Condition="Exists('$(_PackageFolderInGlobalPackages)')" />
   </Target>
 
+  <!-- Make APICompat use roslyn from the toolset SDK instead of from the toolset package. This avoids unification issues on desktop msbuild.
+       TODO: Remove when a 8.0.200 or 9.0 SDK is consumed. -->
+  <Target Name="FixAPICompatWorkAroundRoslynMove" AfterTargets="CollectApiCompatInputs">
+    <PropertyGroup>
+      <RoslynAssembliesPath>$(RoslynTargetsPath)</RoslynAssembliesPath>
+    </PropertyGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
Reverts dotnet/msbuild#9791

Fixes the failing build (https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9155329&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=94418e61-6648-5751-f7d4-a14f4e5e2bb7&l=157)