### PR TITLE
Support environments with long variable values

### DIFF
--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\UnitTests\CommunicationUtilities_Tests.cs" />
     <Compile Include="..\Shared\UnitTests\EscapingUtilities_Tests.cs" />
     <Compile Include="..\Shared\UnitTests\ErrorUtilities_Tests.cs" />
     <Compile Include="..\Shared\UnitTests\PrintLineDebugger_Tests.cs" />

--- a/src/Build.UnitTests/Utilities_Tests.cs
+++ b/src/Build.UnitTests/Utilities_Tests.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Build.Shared;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
-using CommunicationsUtilities = Microsoft.Build.Internal.CommunicationsUtilities;
 using InternalUtilities = Microsoft.Build.Internal.Utilities;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using MSBuildApp = Microsoft.Build.CommandLine.MSBuildApp;
@@ -320,24 +317,6 @@ namespace Microsoft.Build.UnitTests
             string result = InternalUtilities.CreateToolsVersionListString(toolsets);
 
             Assert.Equal("\"66\", \"44\"", result);
-        }
-
-        /// <summary>
-        /// Verify our custom way of getting env vars gives the same results as the BCL.
-        /// </summary>
-        [Fact]
-        public void GetEnvVars()
-        {
-            IDictionary<string, string> envVars = CommunicationsUtilities.GetEnvironmentVariables();
-            IDictionary referenceVars = Environment.GetEnvironmentVariables();
-            IDictionary<string, string> referenceVars2 = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (DictionaryEntry item in referenceVars)
-            {
-                referenceVars2.Add((string)item.Key, (string)item.Value);
-            }
-
-            Helpers.AssertCollectionsValueEqual(envVars, referenceVars2);
         }
 
         protected string GetXmlContents(string xmlText)

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -472,11 +472,18 @@ namespace Microsoft.Build.Execution
             // so reset it away from a user-requested folder that may get deleted.
             NativeMethodsShared.SetCurrentDirectory(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
 
-            // Restore the original environment.
+            // Restore the original environment, best effort.
             // If the node was never configured, this will be null.
             if (_savedEnvironment != null)
             {
-                CommunicationsUtilities.SetEnvironment(_savedEnvironment);
+                try
+                {
+                    CommunicationsUtilities.SetEnvironment(_savedEnvironment);
+                }
+                catch (Exception ex)
+                {
+                    CommunicationsUtilities.Trace("Failed to restore the original environment: {0}.", ex);
+                }
                 Traits.UpdateFromEnvironment();
             }
             try

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -240,23 +240,48 @@ namespace Microsoft.Build.Internal
             get { return GetIntegerVariableOrDefault("MSBUILDNODECONNECTIONTIMEOUT", DefaultNodeConnectionTimeout); }
         }
 
+#if NETFRAMEWORK
         /// <summary>
-        /// Get environment block
+        /// Get environment block.
         /// </summary>
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern unsafe char* GetEnvironmentStrings();
 
         /// <summary>
-        /// Free environment block
+        /// Free environment block.
         /// </summary>
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern unsafe bool FreeEnvironmentStrings(char* pStrings);
 
         /// <summary>
-        /// Copied from the BCL implementation to eliminate some expensive security asserts.
+        /// Set environment variable P/Invoke.
+        /// </summary>
+        [DllImport("kernel32.dll", EntryPoint = "SetEnvironmentVariable", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetEnvironmentVariableNative(string name, string value);
+
+        /// <summary>
+        /// Sets an environment variable using P/Invoke to workaround the .NET Framework BCL implementation.
+        /// </summary>
+        /// <remarks>
+        /// .NET Framework implementation of SetEnvironmentVariable checks the length of the value and throws an exception if
+        /// it's greater than or equal to 32,767 characters. This limitation does not exist on modern Windows.
+        /// </remarks>
+        internal static void SetEnvironmentVariable(string name, string value)
+        {
+            if (!SetEnvironmentVariableNative(name, value))
+            {
+                throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+            }
+        }
+
+        /// <summary>
         /// Returns key value pairs of environment variables in a new dictionary
         /// with a case-insensitive key comparer.
         /// </summary>
+        /// <remarks>
+        /// Copied from the BCL implementation to eliminate some expensive security asserts on .NET Framework.
+        /// </remarks>
         internal static Dictionary<string, string> GetEnvironmentVariables()
         {
 #if !CLR2COMPATIBILITY
@@ -268,107 +293,121 @@ namespace Microsoft.Build.Internal
 
             Dictionary<string, string> table = new Dictionary<string, string>(200, StringComparer.OrdinalIgnoreCase); // Razzle has 150 environment variables
 
-            if (NativeMethodsShared.IsWindows)
+            unsafe
             {
-                unsafe
+                char* pEnvironmentBlock = null;
+
+                try
                 {
-                    char* pEnvironmentBlock = null;
-
-                    try
+                    pEnvironmentBlock = GetEnvironmentStrings();
+                    if (pEnvironmentBlock == null)
                     {
-                        pEnvironmentBlock = GetEnvironmentStrings();
-                        if (pEnvironmentBlock == null)
+                        throw new OutOfMemoryException();
+                    }
+
+                    // Search for terminating \0\0 (two unicode \0's).
+                    char* pEnvironmentBlockEnd = pEnvironmentBlock;
+                    while (!(*pEnvironmentBlockEnd == '\0' && *(pEnvironmentBlockEnd + 1) == '\0'))
+                    {
+                        pEnvironmentBlockEnd++;
+                    }
+                    long stringBlockLength = pEnvironmentBlockEnd - pEnvironmentBlock;
+
+                    // Copy strings out, parsing into pairs and inserting into the table.
+                    // The first few environment variable entries start with an '='!
+                    // The current working directory of every drive (except for those drives
+                    // you haven't cd'ed into in your DOS window) are stored in the
+                    // environment block (as =C:=pwd) and the program's exit code is
+                    // as well (=ExitCode=00000000)  Skip all that start with =.
+                    // Read docs about Environment Blocks on MSDN's CreateProcess page.
+
+                    // Format for GetEnvironmentStrings is:
+                    // (=HiddenVar=value\0 | Variable=value\0)* \0
+                    // See the description of Environment Blocks in MSDN's
+                    // CreateProcess page (null-terminated array of null-terminated strings).
+                    // Note the =HiddenVar's aren't always at the beginning.
+                    for (int i = 0; i < stringBlockLength; i++)
+                    {
+                        int startKey = i;
+
+                        // Skip to key
+                        // On some old OS, the environment block can be corrupted.
+                        // Some lines will not have '=', so we need to check for '\0'.
+                        while (*(pEnvironmentBlock + i) != '=' && *(pEnvironmentBlock + i) != '\0')
                         {
-                            throw new OutOfMemoryException();
-                        }
-
-                        // Search for terminating \0\0 (two unicode \0's).
-                        char* pEnvironmentBlockEnd = pEnvironmentBlock;
-                        while (!(*pEnvironmentBlockEnd == '\0' && *(pEnvironmentBlockEnd + 1) == '\0'))
-                        {
-                            pEnvironmentBlockEnd++;
-                        }
-                        long stringBlockLength = pEnvironmentBlockEnd - pEnvironmentBlock;
-
-                        // Copy strings out, parsing into pairs and inserting into the table.
-                        // The first few environment variable entries start with an '='!
-                        // The current working directory of every drive (except for those drives
-                        // you haven't cd'ed into in your DOS window) are stored in the
-                        // environment block (as =C:=pwd) and the program's exit code is
-                        // as well (=ExitCode=00000000)  Skip all that start with =.
-                        // Read docs about Environment Blocks on MSDN's CreateProcess page.
-
-                        // Format for GetEnvironmentStrings is:
-                        // (=HiddenVar=value\0 | Variable=value\0)* \0
-                        // See the description of Environment Blocks in MSDN's
-                        // CreateProcess page (null-terminated array of null-terminated strings).
-                        // Note the =HiddenVar's aren't always at the beginning.
-                        for (int i = 0; i < stringBlockLength; i++)
-                        {
-                            int startKey = i;
-
-                            // Skip to key
-                            // On some old OS, the environment block can be corrupted.
-                            // Some lines will not have '=', so we need to check for '\0'.
-                            while (*(pEnvironmentBlock + i) != '=' && *(pEnvironmentBlock + i) != '\0')
-                            {
-                                i++;
-                            }
-
-                            if (*(pEnvironmentBlock + i) == '\0')
-                            {
-                                continue;
-                            }
-
-                            // Skip over environment variables starting with '='
-                            if (i - startKey == 0)
-                            {
-                                while (*(pEnvironmentBlock + i) != 0)
-                                {
-                                    i++;
-                                }
-
-                                continue;
-                            }
-
-                            string key = new string(pEnvironmentBlock, startKey, i - startKey);
                             i++;
+                        }
 
-                            // skip over '='
-                            int startValue = i;
+                        if (*(pEnvironmentBlock + i) == '\0')
+                        {
+                            continue;
+                        }
 
+                        // Skip over environment variables starting with '='
+                        if (i - startKey == 0)
+                        {
                             while (*(pEnvironmentBlock + i) != 0)
                             {
-                                // Read to end of this entry
                                 i++;
                             }
 
-                            string value = new string(pEnvironmentBlock, startValue, i - startValue);
+                            continue;
+                        }
 
-                            // skip over 0 handled by for loop's i++
-                            table[key] = value;
-                        }
-                    }
-                    finally
-                    {
-                        if (pEnvironmentBlock != null)
+                        string key = new string(pEnvironmentBlock, startKey, i - startKey);
+                        i++;
+
+                        // skip over '='
+                        int startValue = i;
+
+                        while (*(pEnvironmentBlock + i) != 0)
                         {
-                            FreeEnvironmentStrings(pEnvironmentBlock);
+                            // Read to end of this entry
+                            i++;
                         }
+
+                        string value = new string(pEnvironmentBlock, startValue, i - startValue);
+
+                        // skip over 0 handled by for loop's i++
+                        table[key] = value;
                     }
                 }
-            }
-            else
-            {
-                var vars = Environment.GetEnvironmentVariables();
-                foreach (var key in vars.Keys)
+                finally
                 {
-                    table[(string)key] = (string)vars[key];
+                    if (pEnvironmentBlock != null)
+                    {
+                        FreeEnvironmentStrings(pEnvironmentBlock);
+                    }
                 }
             }
 
             return table;
         }
+
+#else // NETFRAMEWORK
+
+        /// <summary>
+        /// Sets an environment variable using <see cref="Environment.SetEnvironmentVariable(string,string)" />.
+        /// </summary>
+        internal static void SetEnvironmentVariable(string name, string value)
+            => Environment.SetEnvironmentVariable(name, value);
+
+        /// <summary>
+        /// Returns key value pairs of environment variables in a new dictionary
+        /// with a case-insensitive key comparer.
+        /// </summary>
+        internal static Dictionary<string, string> GetEnvironmentVariables()
+        {
+            var vars = Environment.GetEnvironmentVariables();
+
+            Dictionary<string, string> table = new Dictionary<string, string>(vars.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (var key in vars.Keys)
+            {
+                table[(string)key] = (string)vars[key];
+            }
+            return table;
+        }
+#endif // NETFRAMEWORK
 
         /// <summary>
         /// Updates the environment to match the provided dictionary.
@@ -378,18 +417,22 @@ namespace Microsoft.Build.Internal
             if (newEnvironment != null)
             {
                 // First, delete all no longer set variables
-                foreach (KeyValuePair<string, string> entry in CommunicationsUtilities.GetEnvironmentVariables())
+                Dictionary<string, string> currentEnvironment = GetEnvironmentVariables();
+                foreach (KeyValuePair<string, string> entry in currentEnvironment)
                 {
                     if (!newEnvironment.ContainsKey(entry.Key))
                     {
-                        Environment.SetEnvironmentVariable(entry.Key, null);
+                        SetEnvironmentVariable(entry.Key, null);
                     }
                 }
 
                 // Then, make sure the new ones have their new values.
                 foreach (KeyValuePair<string, string> entry in newEnvironment)
                 {
-                    Environment.SetEnvironmentVariable(entry.Key, entry.Value);
+                    if (!currentEnvironment.TryGetValue(entry.Key, out string currentValue) || currentValue != entry.Value)
+                    {
+                        SetEnvironmentVariable(entry.Key, entry.Value);
+                    }
                 }
             }
         }

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Build.Internal
         /// </summary>
         /// <remarks>
         /// .NET Framework implementation of SetEnvironmentVariable checks the length of the value and throws an exception if
-        /// it's greater than or equal to 32,767 characters. This limitation does not exist on modern Windows.
+        /// it's greater than or equal to 32,767 characters. This limitation does not exist on modern Windows or .NET.
         /// </remarks>
         internal static void SetEnvironmentVariable(string name, string value)
         {

--- a/src/Shared/UnitTests/CommunicationUtilities_Tests.cs
+++ b/src/Shared/UnitTests/CommunicationUtilities_Tests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using CommunicationsUtilities = Microsoft.Build.Internal.CommunicationsUtilities;
+
+namespace Microsoft.Build.UnitTests
+{
+    public class CommunicationUtilitiesTests
+    {
+        /// <summary>
+        /// Verify our custom way of getting env vars gives the same results as the BCL.
+        /// </summary>
+        [Fact]
+        public void GetEnvVars()
+        {
+            IDictionary<string, string> envVars = CommunicationsUtilities.GetEnvironmentVariables();
+            IDictionary referenceVars = Environment.GetEnvironmentVariables();
+            IDictionary<string, string> referenceVars2 = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (DictionaryEntry item in referenceVars)
+            {
+                referenceVars2.Add((string)item.Key!, (string)item.Value!);
+            }
+
+            Helpers.AssertCollectionsValueEqual(envVars, referenceVars2);
+        }
+
+        /// <summary>
+        /// Verify that we correctly restore environment variables.
+        /// </summary>
+        [Fact]
+        public void RestoreEnvVars()
+        {
+            string testName1 = "_MSBUILD_TEST_ENV_VAR1";
+            string testName2 = "_MSBUILD_TEST_ENV_VAR2";
+
+            // A long value exceeding the former limit of 32,767 characters.
+            string testValue = new string('a', 1_000_000);
+
+            CommunicationsUtilities.SetEnvironmentVariable(testName1, testValue);
+            try
+            {
+                IDictionary<string, string> envVars = CommunicationsUtilities.GetEnvironmentVariables();
+
+                CommunicationsUtilities.SetEnvironmentVariable(testName1, null);
+                CommunicationsUtilities.SetEnvironmentVariable(testName2, testValue);
+
+                CommunicationsUtilities.SetEnvironment(envVars);
+
+                Environment.GetEnvironmentVariable(testName1).ShouldBe(testValue);
+                Environment.GetEnvironmentVariable(testName2).ShouldBe(null);
+            }
+            finally
+            {
+                CommunicationsUtilities.SetEnvironmentVariable(testName1, null);
+                CommunicationsUtilities.SetEnvironmentVariable(testName2, null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes [AB#1527557](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1527557)

### Context

The .NET Framework implementation of `Environment.SetEnvironmentVariable` has a hard-coded check for the 32,767 character limit and exceeding it fails the call with `ArgumentException`. The limit does not exist anymore on modern Windows and we've started seeing users run MSBuild in environments with very long variables. This is problematic because MSBuild contains logic to restore the environment, so even if the particular variable is not really used, we may end up trying to set it to an excessively long value.

### Changes Made

- Made `CommunicationUtilities.SetEnvironment` use a P/Invoke to `kernel32!SetEnvironmentVariable` on .NET Framework, to work around the problematic BCL implementation.
- Optimized `CommunicationUtilities.SetEnvironment` to call `SetEnvironmentVariable` only if it doesn't already have the desired value.
- Made `CommunicationUtilities.SetEnvironment` calls to restore the environment _best-effort_ in places where the process is anyways shutting done.
- Changed `CommunicationUtilities.GetEnvironmentVariables` to use the custom implementation only on .NET Framework where it provides the perf benefit. On .NET Core it is actually slower than the BCL implementation.

### Testing

Added a new unit test class and also pulled one existing test to it because it was unnecessarily running twice in its previous location.

### Notes
