### PR TITLE
Condition APICompat workaround on desktop msbuild only

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -39,8 +39,10 @@
   </Target>
 
   <!-- Make APICompat use roslyn from the toolset SDK instead of from the toolset package. This avoids unification issues on desktop msbuild.
-       TODO: Remove when a 8.0.200 or 9.0 SDK is consumed. -->
-  <Target Name="FixAPICompatWorkAroundRoslynMove" AfterTargets="CollectApiCompatInputs">
+       TODO: Remove when Visual Studio with an 8.0.200 or 9.0 SDK is consumed. -->
+  <Target Name="FixAPICompatWorkAroundRoslynMove"
+          AfterTargets="CollectApiCompatInputs"
+          Condition="'$(MSBuildRuntimeType)' != 'Core'">
     <PropertyGroup>
       <RoslynAssembliesPath>$(RoslynTargetsPath)</RoslynAssembliesPath>
     </PropertyGroup>


### PR DESCRIPTION
This is another attempt of https://github.com/dotnet/msbuild/commit/cf75831988b054c9a852fab995235b4b7b495b11

We need to keep this workaround in msbuild until the .NET Framework legs build with a VS that either uses a 8.0.2xx or a 9.0 SDK. To unblock building msbuild for unified-build in the VMR, condition this target on desktop msbuild only.