### PR TITLE
Test for eventsource logs

### DIFF
--- a/src/Build.UnitTests/BackEnd/EventSourceTestHelper.cs
+++ b/src/Build.UnitTests/BackEnd/EventSourceTestHelper.cs
@@ -10,6 +10,24 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
+    /// <summary>
+    /// This class provides the ability to fetch events emitted from the "Microsoft-Build" EventSource.
+    /// The instance listens and saves emitted events in-memory.
+    /// To fetch the events, use the <see cref="GetEvents"/> method.
+    /// Note that the current implementation of this class does not have protection against concurrent usage in tests.
+    /// If used in tests, ensure to rely on unique variables, names, or IDs. For example usage: <see cref="SdkResolverService_Tests.AssertSdkResolutionMessagesAreLoggedInEventSource"/>.
+    /// 
+    /// Reference: <see href="https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventlistener"/>
+    /// <example>
+    /// <code>
+    /// // ...
+    /// using var eventSourceTestListener = new EventSourceTestHelper();
+    /// // ...
+    /// var events = eventSourceTestListener.GetEvents();
+    /// // verification
+    /// </code>
+    /// </example>
+    /// </summary>
     internal sealed class EventSourceTestHelper : EventListener
     {
         private readonly string eventSourceName = "Microsoft-Build";

--- a/src/Build.UnitTests/BackEnd/EventSourceTestHelper.cs
+++ b/src/Build.UnitTests/BackEnd/EventSourceTestHelper.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
-    internal class EventSourceTestHelper : EventListener
+    internal sealed class EventSourceTestHelper : EventListener
     {
         private readonly string eventSourceName = "Microsoft-Build";
         private readonly List<EventWrittenEventArgs> emittedEvents;

--- a/src/Build.UnitTests/BackEnd/EventSourceTestHelper.cs
+++ b/src/Build.UnitTests/BackEnd/EventSourceTestHelper.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Engine.UnitTests.BackEnd
+{
+    internal class EventSourceTestHelper : EventListener
+    {
+        private readonly string eventSourceName = "Microsoft-Build";
+        private readonly List<EventWrittenEventArgs> emittedEvents;
+        private object _eventListLock = new object();
+        private EventSource? _eventSources = null;
+
+        public EventSourceTestHelper()
+        {
+            emittedEvents = new List<EventWrittenEventArgs>();
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == eventSourceName)
+            {
+                EnableEvents(eventSource, EventLevel.LogAlways);
+                _eventSources = eventSource;
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            lock (_eventListLock)
+            {
+                emittedEvents.Add(eventData);
+            }
+        }
+
+        public override void Dispose() {
+            DisableEvents(_eventSources);
+            base.Dispose();
+        }
+
+        /// <summary>
+        /// Returns the events that were emitted till invocation of this method.
+        /// The events are cleared from the in-memory store and are populated again. 
+        /// </summary>
+        /// <returns>List of the events that were emitted for eventSource</returns>
+        internal List<EventWrittenEventArgs> GetEvents()
+        {
+            var resultList = new List<EventWrittenEventArgs>();
+            lock (_eventListLock)
+            {
+                resultList = new List<EventWrittenEventArgs>(emittedEvents);
+                emittedEvents.Clear();
+            }
+            
+            return resultList;
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/EventSourceTestHelper.cs
+++ b/src/Build.UnitTests/BackEnd/EventSourceTestHelper.cs
@@ -40,13 +40,17 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         public override void Dispose() {
-            DisableEvents(_eventSources);
+            if (_eventSources  != null)
+            {
+                DisableEvents(_eventSources);
+            }
+            
             base.Dispose();
         }
 
         /// <summary>
         /// Returns the events that were emitted till invocation of this method.
-        /// The events are cleared from the in-memory store and are populated again. 
+        /// The events are cleared from the in-memory store and are populated again in <see cref="OnEventWritten"/>. 
         /// </summary>
         /// <returns>List of the events that were emitted for eventSource</returns>
         internal List<EventWrittenEventArgs> GetEvents()

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -212,16 +212,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public void AssertSdkResolutionMessagesAreLoggedInEventSource()
         {
             SdkResolverService.Instance.InitializeForTests(new MockLoaderStrategy(false, false, true));
-            SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
+            var sdkName = Guid.NewGuid().ToString();
+            SdkReference sdk = new SdkReference(sdkName, "referencedVersion", "minimumVersion");
 
             SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false, failOnUnresolvedSdk: true);
             var eventsLogged = _eventSourceTestListener.GetEvents();
-            eventsLogged.Count.ShouldBe(2);
             eventsLogged.ShouldContain(x => x.EventId == 64); // Start of the sdk resolve
-
-            var sdkStopEvent = eventsLogged.FirstOrDefault(x => x.EventId == 65); // End sdk resolve
-            sdkStopEvent.ShouldNotBeNull();
-            sdkStopEvent.Payload[1].ShouldBe("1sdkName");
+            eventsLogged.ShouldContain(x => x.EventId == 65 && x.Payload[1].ToString() == sdkName);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -81,7 +81,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 "notfound"
             })));
             _logger.Warnings.Select(i => i.Message).ShouldBe(new[] { "WARNING4", "WARNING2" });
-            
         }
 
         [Fact]


### PR DESCRIPTION
Related #9793

### Context
In case there are logical changes in usage of eventsource logs which is one of the logging part of the application the coverage by tests of the changed code is missing.
In order to cover this part with minimum testing against braking by accident adding the eventListener for the "Microsoft-Build" event source with an example test. 

EventSourceTestHelper will subscribe to the events from "Microsoft-Build". 
will save the events in-memory store and once GetEvents is called, the in-momory store cleared. 

### Testing
Testing functionality added and test using newly introduced class
