### PR TITLE
Use repository root for output path calculation when the output isn't a child of the working directory

### DIFF
--- a/src/MSBuild/TerminalLogger/EvaluationData.cs
+++ b/src/MSBuild/TerminalLogger/EvaluationData.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+internal sealed class EvaluationData
+{
+    /// <summary>
+    /// Captures data that comes from project evaluation, is assumed to not change through execution,
+    /// and is referenced for rendering purposes throughout the execution of the build.
+    /// </summary>
+    /// <param name="targetFramework"></param>
+    public EvaluationData(string? targetFramework)
+    {
+        TargetFramework = targetFramework;
+    }
+
+    /// <summary>
+    /// The target framework of the project or null if not multi-targeting.
+    /// </summary>
+    public string? TargetFramework { get; }
+
+    /// <summary>
+    /// This property is true when the project would prefer to have full paths in the logs and/or for processing tasks.
+    /// </summary>
+    /// <remarks>
+    /// There's an MSBuild property called GenerateFullPaths that would be a great knob to use for this, but the Common
+    /// Targets set it to true if not set, and setting it to false completely destroys the terminal logger output.
+    /// That's why this value is hardcoded to false for now, until we define a better mechanism.
+    /// </remarks>
+    public bool GenerateFullPaths { get; } = false;
+}

--- a/src/MSBuild/TerminalLogger/Project.cs
+++ b/src/MSBuild/TerminalLogger/Project.cs
@@ -1,6 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NETFRAMEWORK
+using Microsoft.IO;
+#else
+using System.IO;
+#endif
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -39,12 +44,12 @@ internal sealed class Project
     /// <summary>
     /// Full path to the primary output of the project, if known.
     /// </summary>
-    public ReadOnlyMemory<char>? OutputPath { get; set; }
+    public FileInfo? OutputPath { get; set; }
 
     /// <summary>
     /// Full path to the 'root' of this project's source control repository, if known.
     /// </summary>
-    public string? SourceRoot { get; set; }
+    public DirectoryInfo? SourceRoot { get; set; }
 
     /// <summary>
     /// The target framework of the project or null if not multi-targeting.

--- a/src/MSBuild/TerminalLogger/Project.cs
+++ b/src/MSBuild/TerminalLogger/Project.cs
@@ -44,7 +44,7 @@ internal sealed class Project
     /// <summary>
     /// Full path to the 'root' of this project's source control repository, if known.
     /// </summary>
-    public ReadOnlyMemory<char>? SourceRoot { get; set; }
+    public string? SourceRoot { get; set; }
 
     /// <summary>
     /// The target framework of the project or null if not multi-targeting.

--- a/src/MSBuild/TerminalLogger/Project.cs
+++ b/src/MSBuild/TerminalLogger/Project.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Build.Logging.TerminalLogger;
 /// <summary>
 /// Represents a project being built.
 /// </summary>
+[DebuggerDisplay("{OutputPath}({TargetFramework})")]
 internal sealed class Project
 {
     /// <summary>

--- a/src/MSBuild/TerminalLogger/Project.cs
+++ b/src/MSBuild/TerminalLogger/Project.cs
@@ -22,10 +22,8 @@ internal sealed class Project
     /// Initialized a new <see cref="Project"/> with the given <paramref name="targetFramework"/>.
     /// </summary>
     /// <param name="targetFramework">The target framework of the project or null if not multi-targeting.</param>
-    public Project(string? targetFramework, StopwatchAbstraction? stopwatch)
+    public Project(StopwatchAbstraction? stopwatch)
     {
-        TargetFramework = targetFramework;
-
         if (stopwatch is not null)
         {
             stopwatch.Start();
@@ -51,11 +49,6 @@ internal sealed class Project
     /// Full path to the 'root' of this project's source control repository, if known.
     /// </summary>
     public DirectoryInfo? SourceRoot { get; set; }
-
-    /// <summary>
-    /// The target framework of the project or null if not multi-targeting.
-    /// </summary>
-    public string? TargetFramework { get; }
 
     /// <summary>
     /// True when the project has run target with name "_TestRunStart" defined in <see cref="TerminalLogger._testStartTarget"/>.

--- a/src/MSBuild/TerminalLogger/Project.cs
+++ b/src/MSBuild/TerminalLogger/Project.cs
@@ -62,6 +62,11 @@ internal sealed class Project
     public bool IsCachePluginProject { get; set; }
 
     /// <summary>
+    /// This property is true when the project would prefer to have full paths in the logs and/or for processing tasks.
+    /// </summary>
+    public bool GenerateFullPaths { get; set; }
+
+    /// <summary>
     /// A lazily initialized list of build messages/warnings/errors raised during the build.
     /// </summary>
     public List<BuildMessage>? BuildMessages { get; private set; }

--- a/src/MSBuild/TerminalLogger/Project.cs
+++ b/src/MSBuild/TerminalLogger/Project.cs
@@ -42,6 +42,11 @@ internal sealed class Project
     public ReadOnlyMemory<char>? OutputPath { get; set; }
 
     /// <summary>
+    /// Full path to the 'root' of this project's source control repository, if known.
+    /// </summary>
+    public ReadOnlyMemory<char>? SourceRoot { get; set; }
+
+    /// <summary>
     /// The target framework of the project or null if not multi-targeting.
     /// </summary>
     public string? TargetFramework { get; }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -678,10 +678,11 @@ internal sealed partial class TerminalLogger : INodeLogger
                                 if (outputPathSpan.StartsWith(sourceRootSpan, FileUtilities.PathComparison))
                                 {
                                     if (outputPathSpan.Length > sourceRootSpan.Length
-                                        && (outputPathSpan[sourceRootSpan.Length] == Path.DirectorySeparatorChar
-                                            || outputPathSpan[sourceRootSpan.Length] == Path.AltDirectorySeparatorChar))
+                                        // offsets are -1 here compared to above for reasons
+                                        && (outputPathSpan[sourceRootSpan.Length - 1 ] == Path.DirectorySeparatorChar
+                                            || outputPathSpan[sourceRootSpan.Length - 1] == Path.AltDirectorySeparatorChar))
                                     {
-                                        relativeDisplayPathSpan = outputPathSpan.Slice(sourceRootSpan.Length + 1);
+                                        relativeDisplayPathSpan = outputPathSpan.Slice(sourceRootSpan.Length);
                                     }
                                 }
                             }
@@ -795,9 +796,17 @@ internal sealed partial class TerminalLogger : INodeLogger
         var projectContext = new ProjectContext(context);
         if (_projects.TryGetValue(projectContext, out Project? project))
         {
+            if (project.SourceRoot is not null)
+            {
+                return;
+            }
             var sourceControlSourceRoot = sourceRoots.FirstOrDefault(root => !string.IsNullOrEmpty(root.GetMetadata("SourceControl")));
             if (sourceControlSourceRoot is not null)
             {
+                // This takes the first root from source control the first time it's added to the build.
+                // This seems to be the Target InitializeSourceControlInformationFromSourceControlManager.
+                // So far this has been acceptable, but if a SourceRoot would be modified by a task later on
+                // (e.g. TranslateGitHubUrlsInSourceControlInformation) we would lose that modification.
                 project.SourceRoot = sourceControlSourceRoot.ItemSpec.AsMemory();
             }
         }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -675,14 +675,15 @@ internal sealed partial class TerminalLogger : INodeLogger
                             else if (project.SourceRoot is not null)
                             {
                                 var sourceRootSpan = project.SourceRoot.Value.Span;
+                                var relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectorySpan.ToString(), sourceRootSpan.ToString()).AsSpan();
                                 if (outputPathSpan.StartsWith(sourceRootSpan, FileUtilities.PathComparison))
                                 {
                                     if (outputPathSpan.Length > sourceRootSpan.Length
                                         // offsets are -1 here compared to above for reasons
-                                        && (outputPathSpan[sourceRootSpan.Length - 1 ] == Path.DirectorySeparatorChar
+                                        && (outputPathSpan[sourceRootSpan.Length - 1] == Path.DirectorySeparatorChar
                                             || outputPathSpan[sourceRootSpan.Length - 1] == Path.AltDirectorySeparatorChar))
                                     {
-                                        relativeDisplayPathSpan = outputPathSpan.Slice(sourceRootSpan.Length);
+                                        relativeDisplayPathSpan = Path.Combine(relativePathFromWorkingDirToSourceRoot.ToString(), outputPathSpan.Slice(sourceRootSpan.Length).ToString()).AsSpan();
                                     }
                                 }
                             }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -659,37 +659,31 @@ internal sealed partial class TerminalLogger : INodeLogger
                                 urlString = uri.ToString();
                             }
 
-                            var relativeDisplayPathSpan = outputPathSpan;
-                            var workingDirectorySpan = _initialWorkingDirectory.AsSpan();
+                            var outputPathString = outputPathSpan.ToString();
+                            var relativeDisplayPath = outputPathString;
+                            var workingDirectory = _initialWorkingDirectory;
+
                             // If the output path is under the initial working directory, make the console output relative to that to save space.
-                            if (outputPathSpan.StartsWith(workingDirectorySpan, FileUtilities.PathComparison))
+                            if (outputPathString.StartsWith(workingDirectory, FileUtilities.PathComparison))
                             {
-                                if (outputPathSpan.Length > workingDirectorySpan.Length
-                                    && (outputPathSpan[workingDirectorySpan.Length] == Path.DirectorySeparatorChar
-                                        || outputPathSpan[workingDirectorySpan.Length] == Path.AltDirectorySeparatorChar))
-                                {
-                                    relativeDisplayPathSpan = outputPathSpan.Slice(workingDirectorySpan.Length + 1);
-                                }
+                                relativeDisplayPath = Path.GetRelativePath(workingDirectory, outputPathString);
                             }
+
                             // if the output path isn't under the working directory, but is under the source root, make the output relative to that to save space
-                            else if (project.SourceRoot is not null)
+                            else if (project.SourceRoot is ReadOnlyMemory<char> sourceRoot)
                             {
-                                var sourceRootSpan = project.SourceRoot.Value.Span;
-                                var relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectorySpan.ToString(), sourceRootSpan.ToString()).AsSpan();
-                                if (outputPathSpan.StartsWith(sourceRootSpan, FileUtilities.PathComparison))
+                                var sourceRootString = sourceRoot.Span.ToString();
+                                if (outputPathString.StartsWith(sourceRootString, FileUtilities.PathComparison))
                                 {
-                                    if (outputPathSpan.Length > sourceRootSpan.Length
-                                        // offsets are -1 here compared to above for reasons
-                                        && (outputPathSpan[sourceRootSpan.Length - 1] == Path.DirectorySeparatorChar
-                                            || outputPathSpan[sourceRootSpan.Length - 1] == Path.AltDirectorySeparatorChar))
-                                    {
-                                        relativeDisplayPathSpan = Path.Combine(relativePathFromWorkingDirToSourceRoot.ToString(), outputPathSpan.Slice(sourceRootSpan.Length).ToString()).AsSpan();
-                                    }
+                                    var relativePathFromOutputToRoot = Path.GetRelativePath(sourceRootString, outputPathString);
+                                    // we have the portion from sourceRoot to outputPath, now we need to get the portion from workingDirectory to sourceRoot
+                                    var relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectory, sourceRootString);
+                                    relativeDisplayPath = Path.Join(relativePathFromWorkingDirToSourceRoot, relativePathFromOutputToRoot);
                                 }
                             }
 
                             Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath",
-                                $"{AnsiCodes.LinkPrefix}{urlString}{AnsiCodes.LinkInfix}{relativeDisplayPathSpan.ToString()}{AnsiCodes.LinkSuffix}"));
+                                $"{AnsiCodes.LinkPrefix}{urlString}{AnsiCodes.LinkInfix}{relativeDisplayPath}{AnsiCodes.LinkSuffix}"));
                         }
                         else
                         {
@@ -845,7 +839,6 @@ internal sealed partial class TerminalLogger : INodeLogger
         string? message = e.Message;
         if (e is TaskParameterEventArgs taskArgs)
         {
-            Debug.WriteLine(taskArgs.BuildEventContext?.TaskId);
             if (taskArgs.Kind == TaskParameterMessageKind.AddItem)
             {
                 if (taskArgs.ItemType.Equals("SourceRoot", StringComparison.OrdinalIgnoreCase))

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -670,14 +670,13 @@ internal sealed partial class TerminalLogger : INodeLogger
                             }
 
                             // if the output path isn't under the working directory, but is under the source root, make the output relative to that to save space
-                            else if (project.SourceRoot is ReadOnlyMemory<char> sourceRoot)
+                            else if (project.SourceRoot is string sourceRoot)
                             {
-                                var sourceRootString = sourceRoot.Span.ToString();
-                                if (outputPathString.StartsWith(sourceRootString, FileUtilities.PathComparison))
+                                if (outputPathString.StartsWith(sourceRoot, FileUtilities.PathComparison))
                                 {
-                                    var relativePathFromOutputToRoot = Path.GetRelativePath(sourceRootString, outputPathString);
+                                    var relativePathFromOutputToRoot = Path.GetRelativePath(sourceRoot, outputPathString);
                                     // we have the portion from sourceRoot to outputPath, now we need to get the portion from workingDirectory to sourceRoot
-                                    var relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectory, sourceRootString);
+                                    var relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectory, sourceRoot);
                                     relativeDisplayPath = Path.Join(relativePathFromWorkingDirToSourceRoot, relativePathFromOutputToRoot);
                                 }
                             }
@@ -802,7 +801,7 @@ internal sealed partial class TerminalLogger : INodeLogger
                 // This seems to be the Target InitializeSourceControlInformationFromSourceControlManager.
                 // So far this has been acceptable, but if a SourceRoot would be modified by a task later on
                 // (e.g. TranslateGitHubUrlsInSourceControlInformation) we would lose that modification.
-                project.SourceRoot = sourceControlSourceRoot.ItemSpec.AsMemory();
+                project.SourceRoot = sourceControlSourceRoot.ItemSpec;
             }
         }
     }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -14,7 +14,7 @@ using Microsoft.Build.Framework.Logging;
 using System.Globalization;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Utilities;
-
+using DictionaryEntry = System.Collections.DictionaryEntry;
 
 
 #if NET7_0_OR_GREATER
@@ -499,7 +499,8 @@ internal sealed partial class TerminalLogger : INodeLogger
             {
                 targetFramework = null;
             }
-            _projects[c] = new(targetFramework, CreateStopwatch?.Invoke());
+            Project project = new(targetFramework, CreateStopwatch?.Invoke());
+            _projects[c] = project;
 
             // First ever restore in the build is starting.
             if (e.TargetNames == "Restore" && !_restoreFinished)
@@ -507,6 +508,30 @@ internal sealed partial class TerminalLogger : INodeLogger
                 _restoreContext = c;
                 int nodeIndex = NodeIndexForContext(buildEventContext);
                 _nodes[nodeIndex] = new NodeStatus(e.ProjectFile!, null, "Restore", _projects[c].Stopwatch);
+            }
+
+            TryDetectGenerateFullPaths(e, project);
+        }
+    }
+
+    private void TryDetectGenerateFullPaths(ProjectStartedEventArgs e, Project project)
+    {
+        if (e.GlobalProperties is not null
+            && e.GlobalProperties.TryGetValue("GenerateFullPaths", out string? generateFullPaths)
+            && bool.TryParse(generateFullPaths, out bool generateFullPathsValue))
+        {
+            project.GenerateFullPaths = generateFullPathsValue;
+        }
+        else if (e.Properties is not null)
+        {
+            foreach (DictionaryEntry property in e.Properties)
+            {
+                if (property.Key is "GenerateFullPaths" &&
+                    property.Value is string generateFullPathsString
+                    && bool.TryParse(generateFullPathsString, out bool generateFullPathsPropertyValue))
+                {
+                    project.GenerateFullPaths = generateFullPathsPropertyValue;
+                }
             }
         }
     }
@@ -659,30 +684,37 @@ internal sealed partial class TerminalLogger : INodeLogger
                                 urlString = uri.ToString();
                             }
 
-                            var outputPathString = outputPathSpan.ToString();
-                            var relativeDisplayPath = outputPathString;
-                            var workingDirectory = _initialWorkingDirectory;
-
-                            // If the output path is under the initial working directory, make the console output relative to that to save space.
-                            if (outputPathString.StartsWith(workingDirectory, FileUtilities.PathComparison))
+                            string? resolvedPathToOutput = null;
+                            if (project.GenerateFullPaths)
                             {
-                                relativeDisplayPath = Path.GetRelativePath(workingDirectory, outputPathString);
+                                resolvedPathToOutput = outputPathSpan.ToString();
                             }
-
-                            // if the output path isn't under the working directory, but is under the source root, make the output relative to that to save space
-                            else if (project.SourceRoot is string sourceRoot)
+                            else
                             {
-                                if (outputPathString.StartsWith(sourceRoot, FileUtilities.PathComparison))
+                                var outputPathString = outputPathSpan.ToString();
+                                var workingDirectory = _initialWorkingDirectory;
+
+                                // If the output path is under the initial working directory, make the console output relative to that to save space.
+                                if (outputPathString.StartsWith(workingDirectory, FileUtilities.PathComparison))
                                 {
-                                    var relativePathFromOutputToRoot = Path.GetRelativePath(sourceRoot, outputPathString);
-                                    // we have the portion from sourceRoot to outputPath, now we need to get the portion from workingDirectory to sourceRoot
-                                    var relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectory, sourceRoot);
-                                    relativeDisplayPath = Path.Join(relativePathFromWorkingDirToSourceRoot, relativePathFromOutputToRoot);
+                                    resolvedPathToOutput = Path.GetRelativePath(workingDirectory, outputPathString);
+                                }
+
+                                // if the output path isn't under the working directory, but is under the source root, make the output relative to that to save space
+                                else if (project.SourceRoot is string sourceRoot)
+                                {
+                                    if (outputPathString.StartsWith(sourceRoot, FileUtilities.PathComparison))
+                                    {
+                                        var relativePathFromOutputToRoot = Path.GetRelativePath(sourceRoot, outputPathString);
+                                        // we have the portion from sourceRoot to outputPath, now we need to get the portion from workingDirectory to sourceRoot
+                                        var relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectory, sourceRoot);
+                                        resolvedPathToOutput = Path.Join(relativePathFromWorkingDirToSourceRoot, relativePathFromOutputToRoot);
+                                    }
                                 }
                             }
 
                             Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath",
-                                $"{AnsiCodes.LinkPrefix}{urlString}{AnsiCodes.LinkInfix}{relativeDisplayPath}{AnsiCodes.LinkSuffix}"));
+                                $"{AnsiCodes.LinkPrefix}{urlString}{AnsiCodes.LinkInfix}{resolvedPathToOutput}{AnsiCodes.LinkSuffix}"));
                         }
                         else
                         {

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -12,6 +12,8 @@ using System.Text.RegularExpressions;
 using System.Diagnostics;
 using Microsoft.Build.Framework.Logging;
 using System.Globalization;
+using Microsoft.Build.Execution;
+
 
 #if NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -217,7 +219,7 @@ internal sealed partial class TerminalLogger : INodeLogger
     private bool _hasUsedCache = false;
 
     /// <summary>
-    /// Whether to show TaskCommandLineEventArgs high-priority messages. 
+    /// Whether to show TaskCommandLineEventArgs high-priority messages.
     /// </summary>
     private bool _showCommandLine = false;
 
@@ -650,19 +652,35 @@ internal sealed partial class TerminalLogger : INodeLogger
                                 urlString = uri.ToString();
                             }
 
+                            var relativeDisplayPathSpan = outputPathSpan;
+                            var workingDirectorySpan = _initialWorkingDirectory.AsSpan();
                             // If the output path is under the initial working directory, make the console output relative to that to save space.
-                            if (outputPathSpan.StartsWith(_initialWorkingDirectory.AsSpan(), FileUtilities.PathComparison))
+                            if (outputPathSpan.StartsWith(workingDirectorySpan, FileUtilities.PathComparison))
                             {
-                                if (outputPathSpan.Length > _initialWorkingDirectory.Length
-                                    && (outputPathSpan[_initialWorkingDirectory.Length] == Path.DirectorySeparatorChar
-                                        || outputPathSpan[_initialWorkingDirectory.Length] == Path.AltDirectorySeparatorChar))
+                                if (outputPathSpan.Length > workingDirectorySpan.Length
+                                    && (outputPathSpan[workingDirectorySpan.Length] == Path.DirectorySeparatorChar
+                                        || outputPathSpan[workingDirectorySpan.Length] == Path.AltDirectorySeparatorChar))
                                 {
-                                    outputPathSpan = outputPathSpan.Slice(_initialWorkingDirectory.Length + 1);
+                                    relativeDisplayPathSpan = outputPathSpan.Slice(workingDirectorySpan.Length + 1);
+                                }
+                            }
+                            // if the output path isn't under the working directory, but is under the source root, make the output relative to that to save space
+                            else if (project.SourceRoot is not null)
+                            {
+                                var sourceRootSpan = project.SourceRoot.Value.Span;
+                                if (outputPathSpan.StartsWith(sourceRootSpan, FileUtilities.PathComparison))
+                                {
+                                    if (outputPathSpan.Length > sourceRootSpan.Length
+                                        && (outputPathSpan[sourceRootSpan.Length] == Path.DirectorySeparatorChar
+                                            || outputPathSpan[sourceRootSpan.Length] == Path.AltDirectorySeparatorChar))
+                                    {
+                                        relativeDisplayPathSpan = outputPathSpan.Slice(sourceRootSpan.Length + 1);
+                                    }
                                 }
                             }
 
                             Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath",
-                                $"{AnsiCodes.LinkPrefix}{urlString}{AnsiCodes.LinkInfix}{outputPathSpan.ToString()}{AnsiCodes.LinkSuffix}"));
+                                $"{AnsiCodes.LinkPrefix}{urlString}{AnsiCodes.LinkInfix}{relativeDisplayPathSpan.ToString()}{AnsiCodes.LinkSuffix}"));
                         }
                         else
                         {
@@ -760,6 +778,24 @@ internal sealed partial class TerminalLogger : INodeLogger
         }
     }
 
+    private void TryReadSourceControlInformationForProject(BuildEventContext? context, IList<ProjectItemInstance> sourceRoots)
+    {
+        if (context is null)
+        {
+            return;
+        }
+
+        var projectContext = new ProjectContext(context);
+        if (_projects.TryGetValue(projectContext, out Project? project))
+        {
+            var sourceControlSourceRoot = sourceRoots.FirstOrDefault(root => root.HasMetadata("SourceControl"));
+            if (sourceControlSourceRoot is not null)
+            {
+                project.SourceRoot = sourceControlSourceRoot.EvaluatedInclude.AsMemory();
+            }
+        }
+    }
+
     /// <summary>
     /// The <see cref="IEventSource.TaskStarted"/> callback.
     /// </summary>
@@ -790,6 +826,10 @@ internal sealed partial class TerminalLogger : INodeLogger
         }
 
         string? message = e.Message;
+        if (e is TaskParameterEventArgs taskArgs && taskArgs.ItemType.Equals("SourceRoot", StringComparison.OrdinalIgnoreCase))
+        {
+            TryReadSourceControlInformationForProject(taskArgs.BuildEventContext, taskArgs.Items as IList<ProjectItemInstance>);
+        }
         if (message is not null && e.Importance == MessageImportance.High)
         {
             var hasProject = _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project);

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -4023,7 +4023,7 @@ namespace Microsoft.Build.CommandLine
                 else
                 {
                     // For performance, register this logger using the forwarding logger mechanism.
-                    DistributedLoggerRecord forwardingLoggerRecord = CreateForwardingLoggerRecord(logger, string.Join(";", TerminalLogger.ConfigurableForwardingLoggerParameters), LoggerVerbosity.Quiet);
+                    DistributedLoggerRecord forwardingLoggerRecord = CreateForwardingLoggerRecord(logger, string.Join(";", [.. TerminalLogger.ConfigurableForwardingLoggerParameters, "verbosity=diagnostic"]), LoggerVerbosity.Quiet);
                     distributedLoggerRecords.Add(forwardingLoggerRecord);
                 }
             }


### PR DESCRIPTION
Fixes #9800

### Context
This PR teaches Terminal Logger to look for a specific kind of MSBuild Item for a project during the build. This kind of item (SourceRoot) points to the computed source code repository of the build, which we can use to calculate the output path to render for a project when that project doesn't build to location that's a child of the current directory. Here's what it looks like when building a child project in a repository using the SDK Artifacts path layout: 

![image](https://github.com/dotnet/msbuild/assets/573979/4131cb51-65be-458e-a6fb-4fe68327a106)

### Changes Made

Terminal Logger Projects now keep track of a SourceRoot span. This span is calculated by looking for the first `SourceRoot` item that has `SourceControl` metadata on it. This data is filled in by Sourcelink, which is part of the .NET SDK.

Terminal Logger is opted into TaskParameterEventArgs messages via the `IEventSource3.IncludeTaskInputs()` method.

During output rendering, if the output path isn't a child of the working directory, the SourceRoot is checked as a fallback,  if it exists. If so, the relative path between the working directory and the SourceRoot is computed and combined with the portion of the output path that maps to the SourceRoot.

### Testing

I need to add testing for this scenario.

### Notes

This will only work when /m:1 currently because the messages that contain task inputs are not `High` importance.  To fix this, we will need to make TerminalLogger a proper forwarding logger, not using the ConfigurableForwardingLogger infrastructure. I logged https://github.com/dotnet/msbuild/issues/9806 to capture this need.
