### PR TITLE
Remove needs-triage label from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/01_bugreport.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
 description: Report a bug to help us improve MSBuild.
 title: "[Bug]: "
-labels: ["bug", "needs-triage"]
+labels: ["bug"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_performanceissue.yml
+++ b/.github/ISSUE_TEMPLATE/02_performanceissue.yml
@@ -1,7 +1,7 @@
 name: 📉 Performance Issue
 description: Report a performance issue or regression.
 title: "[Performance]: "
-labels: ["performance", "needs-triage"]
+labels: ["performance"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/03_mybuildisbroken.yml
+++ b/.github/ISSUE_TEMPLATE/03_mybuildisbroken.yml
@@ -1,7 +1,6 @@
 name: 😵 My Build is Broken
 description: Use this template for helping figure out what's wrong with your build.
 title: "[Broken Build]: "
-labels: ["needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/05_unhandledexception.yml
+++ b/.github/ISSUE_TEMPLATE/05_unhandledexception.yml
@@ -1,7 +1,7 @@
 name: 😱 Unhandled Exception
 description: Reporting holes in our bug reporting system
 title: "[Unhandled Exception]: "
-labels: ["bug", "needs-triage"]
+labels: ["bug"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/06_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/06_feature_request.yml
@@ -1,7 +1,7 @@
 name: 💡 Feature  Request
 description: Suggest an idea for this project.
 title: "[Feature Request]: "
-labels: ["Feature Request", "needs-triage"]
+labels: ["Feature Request"]
 body:
   - type: textarea
     attributes:

--- a/documentation/wiki/Labels.md
+++ b/documentation/wiki/Labels.md
@@ -3,10 +3,10 @@ Here's a brief explanation on the labels most often used by the MSBuild team exc
 
 | Label             | Applied When | Notes |
 |-------------------|--------------|-------|
-| `needs-triage`    | Team has yet to determine what area/prioritization applies to the issue. | This is the primary label queried during a regular bug triage meeting. Automatically removed when `needs-more-info` is applied. |
+| `triaged`    | Team has determined what area/prioritization applies to the issue. | This is the primary label absence of which is queried during a regular bug triage meeting. Automatically added when `needs-more-info` is applied. |
 | `needs-attention` | An issue requires the team look at it during bug triage. | Automatically applied when a stale issue receives a comment. |
 | `needs-more-info` | Team asked for info needed to continue an investigation. | If no response is given within 7 days, the `stale` label is applied. |
-| `initial-investigation` | A member of the team does a "first pass" investigation. | `needs-triage` is applied and team member and unassigns themselves after the initial investigation is complete. |
+| `initial-investigation` | A member of the team does a "first pass" investigation. | `triaged` label is removed and team member unassigns themselves after the initial investigation is complete. |
 | `stale` | An issue marked with `needs-more-info` is inactive for 7 days. | The issue will be closed after 30 days of inactivity while the `stale` label is applied. |
 | `For consideration` | An issue should get higher prioritization when planning the next set of features. | |
 | `help wanted` | Anyone can take ownership over this issue. | If a contributor wants to take the issue on, they should ask that it be assigned to them BEFORE doing development work.  |


### PR DESCRIPTION
We do not use `needs-triage` label anymore. Instead, we started to use label `triaged` during the triage meetings.
