### PR TITLE
Use templates-official for production pipeline + @self

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -18,6 +18,7 @@ parameters:
   default: 'default'
 
 variables:
+  - group: DotNet-MSBuild-SDLValidation-Params
   # if OptProfDrop is not set, string '$(OptProfDrop)' will be passed to the build script.
   - name: OptProfDrop
     value: ''
@@ -37,20 +38,17 @@ variables:
     value: true
   - name: Codeql.Enabled
     value: true
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-MSBuild-SDLValidation-Params
 
 stages:
 - stage: build
   displayName: Build
 
   jobs:
-  - ${{ if and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    # The localization setup for release/ branches. Note difference in LclPackageId. main branch is handled separately below.
-    # Used for vs17.2, vs17.4, vs17.6 etc. branches only.
-    # When the branch is setup for localization (the localization ticket needs to be created - https://aka.ms/ceChangeLocConfig, requesting change from one release branch to another),
-    #  set 'EnableReleaseOneLocBuild' to true.
-    - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/vs') }}:
+  # The localization setup for release/ branches. Note difference in LclPackageId. main branch is handled separately below.
+  # Used for vs17.2, vs17.4, vs17.6 etc. branches only.
+  # When the branch is setup for localization (the localization ticket needs to be created - https://aka.ms/ceChangeLocConfig, requesting change from one release branch to another),
+  #  set 'EnableReleaseOneLocBuild' to true.
+  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/vs') }}:
       - template: /eng/common/templates-official/job/onelocbuild.yml@self
         parameters:
           MirrorRepo: 'msbuild'
@@ -59,8 +57,8 @@ stages:
           MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
           JobNameSuffix: '_release'
           condition: ${{ variables.EnableReleaseOneLocBuild }}
-    # The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
-    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  # The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
       - template: /eng/common/templates-official/job/onelocbuild.yml@self
         parameters:
           MirrorRepo: 'msbuild'
@@ -259,7 +257,7 @@ stages:
 
     - template: /eng/common/templates-official/steps/component-governance.yml@self
       parameters:
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
+        ${{ if or(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
           disableComponentGovernance: false
         ${{ else }}:
           disableComponentGovernance: true
@@ -276,7 +274,6 @@ stages:
       pool:
         vmImage: windows-latest
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates-official\post-build\post-build.yml@self
     parameters:
       publishingInfraVersion: 3

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -281,7 +281,7 @@ extends:
             - name: Managed
               pool:
                 name: AzurePipelines-EO
-                image: 1ESPT-Ubuntu20.04
+                image: 1ESPT-Ubuntu22.04
                 os: linux
 
       - template: /eng/common/templates-official/job/publish-build-assets.yml@self

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -51,7 +51,7 @@ stages:
     # When the branch is setup for localization (the localization ticket needs to be created - https://aka.ms/ceChangeLocConfig, requesting change from one release branch to another),
     #  set 'EnableReleaseOneLocBuild' to true.
     - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/vs') }}:
-      - template: /eng/common/templates/job/onelocbuild.yml
+      - template: /eng/common/templates-official/job/onelocbuild.yml@self
         parameters:
           MirrorRepo: 'msbuild'
           LclSource: lclFilesfromPackage
@@ -61,7 +61,7 @@ stages:
           condition: ${{ variables.EnableReleaseOneLocBuild }}
     # The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
     - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-      - template: /eng/common/templates/job/onelocbuild.yml
+      - template: /eng/common/templates-official/job/onelocbuild.yml@self
         parameters:
           MirrorRepo: 'msbuild'
           LclSource: lclFilesfromPackage
@@ -138,7 +138,7 @@ stages:
       condition: succeeded()
 
     # Required by Microsoft policy
-    - template: eng\common\templates\steps\generate-sbom.yml
+    - template: eng\common\templates-official\steps\generate-sbom.yml@self
 
     # Publish OptProf configuration files
     - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
@@ -257,16 +257,16 @@ stages:
       displayName: Execute cleanup tasks
       condition: succeededOrFailed()
 
-    - template: /eng/common/templates/steps/component-governance.yml
+    - template: /eng/common/templates-official/steps/component-governance.yml@self
       parameters:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
           disableComponentGovernance: false
         ${{ else }}:
           disableComponentGovernance: true
 
-  - template: /eng/common/templates/jobs/source-build.yml
+  - template: /eng/common/templates-official/jobs/source-build.yml@self
 
-  - template: /eng/common/templates/job/publish-build-assets.yml
+  - template: /eng/common/templates-official/job/publish-build-assets.yml@self
     parameters:
       enablePublishBuildArtifacts: true
       publishUsingPipelines: true
@@ -277,7 +277,7 @@ stages:
         vmImage: windows-latest
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates\post-build\post-build.yml
+  - template: eng\common\templates-official\post-build\post-build.yml@self
     parameters:
       publishingInfraVersion: 3
       # Symbol validation is not entirely reliable as of yet, so should be turned off until


### PR DESCRIPTION
## Context
We need to adapt official templates for production pipelines

## Note
There is a warning on sbom generation - it will be resolved on the servicing side in scope of 
https://github.com/dotnet/arcade/issues/14560

## Testing 
Yes, by using exp branch: https://tfsprodwus2su6.visualstudio.com/A011b8bdf-6d56-4f87-be0d-0092136884d9/DevDiv/_build/results?buildId=9236625&view=results