### PR TITLE
Fix LingeringProcessCollector pipeline failure

### DIFF
--- a/eng/config/OptProf.runsettings
+++ b/eng/config/OptProf.runsettings
@@ -21,6 +21,20 @@
   </SessionConfiguration>
   <DataCollectionRunSettings>
     <DataCollectors>
+      <DataCollector uri="datacollector://microsoft/DevDiv/TestExtensions/LingeringProcessCollector/v1" friendlyName="Lingering Process Collector" enabled="True">
+        <Configuration>
+          <KillLingeringProcesses>false</KillLingeringProcesses>
+          <LoggingBehavior>Warning</LoggingBehavior>
+          <CollectDumps>true</CollectDumps>
+          <RootDumpDirectory>%SystemDrive%\dumps</RootDumpDirectory>
+          <WhiteList>
+            <ProcessName>devenv</ProcessName>
+          </WhiteList>
+          <ShutdownCommands>
+            <ShutdownCommand Process="VBCSCompiler" Command="%ProcessPath%" Arguments="-shutdown" Timeout="60000" />
+          </ShutdownCommands>
+        </Configuration>
+      </DataCollector>
       <DataCollector uri="datacollector://microsoft/DevDiv/TestExtensions/ProcDumpCollector/v1" friendlyName="ProcDump Collector" enabled="True">
         <Configuration>
           <RootDumpDirectory>C:\Test\Dumps</RootDumpDirectory>


### PR DESCRIPTION
## Fixes

Pipeline failures when `Data collector 'Lingering Process Collector' message: [2024-03-08T14:24:03] The shutdown command 'C:\Test\VisualStudio\MSBuild\Current\bin\Roslyn\VBCSCompiler.exe' for 'VBCSCompiler' failed to close the process. StdOut: , StdError: , Exit code: 0.` occures.

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9211811&view=results


## Solution

According to guideline https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/890/LingeringProcessCollector ,
handling for LingeringProcessCollector was extended.
