### PR TITLE
Add production tags for OptProf CI

### DIFF
--- a/.opt-prof.yml
+++ b/.opt-prof.yml
@@ -21,18 +21,22 @@ resources:
     project: DevDiv
     source: DartLab
     branch: main
+    tags:
+    - production
   - pipeline: DartLab.OptProf
     source: DartLab.OptProf
     branch: main
+    tags:
+    - production
   repositories:
   - repository: DartLabTemplates
     type: git
     name: DartLab.Templates
-    ref: refs/heads/main
+    ref: refs/tags/Production
   - repository: DartLabOptProfTemplates
     type: git
     name: DartLab.OptProf
-    ref: refs/heads/main
+    ref: refs/tags/Production
 
 parameters:
   # Whether or not to delete the test machines after the run completes


### PR DESCRIPTION
Adding Production tags for OptProf CI pipeline to force pipeline to pick the build/commits marked as 'production' for improved reliability.

## Fixes
Existing optprof failures.
Inspired by @mtylerMSFT work for VS.