### PR TITLE
Fix api doc warning

### DIFF
--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1649,7 +1649,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Reload the existing project root element from the given <paramref name="reader"/>
         /// A reload operation completely replaces the state of this <see cref="ProjectRootElement"/> object. This operation marks the
-        /// object as dirty (see <see cref="ProjectRootElement.MarkDirty"/> for side effects).
+        /// object as dirty (see <see cref="ProjectRootElementLink.MarkDirty"/> for side effects) .
         ///
         /// If the new state has invalid XML or MSBuild syntax, then this method throws an <see cref="InvalidProjectFileException"/>.
         /// When this happens, the state of this object does not change.

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1649,7 +1649,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Reload the existing project root element from the given <paramref name="reader"/>
         /// A reload operation completely replaces the state of this <see cref="ProjectRootElement"/> object. This operation marks the
-        /// object as dirty for side effects) .
+        /// object as dirty.
         ///
         /// If the new state has invalid XML or MSBuild syntax, then this method throws an <see cref="InvalidProjectFileException"/>.
         /// When this happens, the state of this object does not change.

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1649,7 +1649,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Reload the existing project root element from the given <paramref name="reader"/>
         /// A reload operation completely replaces the state of this <see cref="ProjectRootElement"/> object. This operation marks the
-        /// object as dirty (see <see cref="ProjectRootElementLink.MarkDirty"/> for side effects) .
+        /// object as dirty for side effects) .
         ///
         /// If the new state has invalid XML or MSBuild syntax, then this method throws an <see cref="InvalidProjectFileException"/>.
         /// When this happens, the state of this object does not change.

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
-        /// Exposes the private <see cref="timestamp"/> field to derived types.
+        /// Exposes the private timestamp field to derived types.
         /// Used for serialization. Avoids the side effects of calling the
         /// <see cref="Timestamp"/> getter.
         /// </summary>

--- a/src/Framework/CustomBuildEventArgs.cs
+++ b/src/Framework/CustomBuildEventArgs.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Build.Framework
     /// <format type="text/markdown"><![CDATA[
     /// ## Remarks
     /// > [!CAUTION]
-    /// In .NET 8 and later and Visual Studio 17.8 and later, this type is deprecated; instead use <see cref="ExtendedCustomBuildEventArgs"/>.
-    /// For more information, see <see href="https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs"/>
-    /// For recommended replacement, see <see href="https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs#recommended-action" />.
+    /// In .NET 8 and later and Visual Studio 17.8 and later, this type is deprecated; instead use <xref:Microsoft.Build.Framework.ExtendedCustomBuildEventArgs>.
+    /// For more information, [this link](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs).
+    /// For recommended replacement, see [this link](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs#recommended-action).
     /// ]]></format>
     /// </remarks>
     [Serializable]

--- a/src/Framework/XamlTypes/BaseProperty.cs
+++ b/src/Framework/XamlTypes/BaseProperty.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Build.Framework.XamlTypes
         /// The help file to use when the user hits F1. Must specify <see cref="HelpContext"/> along with this.
         /// </summary>
         /// <remarks>
-        /// This property goes along with <see cref="HelpContext"/>. <seealso cref="HelpContext"/>. This
+        /// This property goes along with <see cref="HelpContext"/>. This
         /// form of specifying the help page for a property takes lower precedence than both <see cref="F1Keyword"/>
         /// and <see cref="HelpUrl"/>.
         /// This field is optional and is culture insensitive.


### PR DESCRIPTION
Fixes [#9766](https://github.com/dotnet/msbuild/issues/9766)

### Context
There are some documentation issues we should fix: https://github.com/dotnet/msbuild-api-docs/pull/39#issuecomment-1953148132

[msbuild-api-docs/xml/Microsoft.Build.Construction/ProjectRootElement.xml](https://github.com/dotnet/msbuild-api-docs/blob/smoke-test/msbuild-api-docs/xml/Microsoft.Build.Construction/ProjectRootElement.xml)
Line 0, Column 0: [Warning: xref-not-found - [See documentation](https://review.learn.microsoft.com/en-us/help/platform/validation-ref/xref-not-found?branch=main)] Cross reference not found: 'Microsoft.Build.Construction.ProjectRootElement.MarkDirty(System.String,System.String)'.

[msbuild-api-docs/xml/Microsoft.Build.Framework.XamlTypes/BaseProperty.xml](https://github.com/dotnet/msbuild-api-docs/blob/smoke-test/msbuild-api-docs/xml/Microsoft.Build.Framework.XamlTypes/BaseProperty.xml)
Line 0, Column 0: [Warning: disallowed-html-tag - [See documentation](https://review.learn.microsoft.com/help/contribute/validation-ref/disallowed-html-tag?branch=main)] HTML tag 'seealso' isn't allowed.  Replace it with approved Markdown or escape the brackets if the content is a placeholder.

[msbuild-api-docs/xml/Microsoft.Build.Framework/BuildEventArgs.xml](https://github.com/dotnet/msbuild-api-docs/blob/smoke-test/msbuild-api-docs/xml/Microsoft.Build.Framework/BuildEventArgs.xml)
Line 0, Column 0: [Warning: xref-not-found - [See documentation](https://review.learn.microsoft.com/en-us/help/platform/validation-ref/xref-not-found?branch=main)] Cross reference not found: 'Microsoft.Build.Framework.BuildEventArgs.timestamp'.

[msbuild-api-docs/xml/Microsoft.Build.Framework/CustomBuildEventArgs.xml](https://github.com/dotnet/msbuild-api-docs/blob/smoke-test/msbuild-api-docs/xml/Microsoft.Build.Framework/CustomBuildEventArgs.xml)
Line 0, Column 0: [Warning: disallowed-html-tag - [See documentation](https://review.learn.microsoft.com/help/contribute/validation-ref/disallowed-html-tag?branch=main)] HTML tag 'see' isn't allowed.  Replace it with approved Markdown or escape the brackets if the content is a placeholder.
Line 0, Column 0: [Warning: disallowed-html-tag - [See documentation](https://review.learn.microsoft.com/help/contribute/validation-ref/disallowed-html-tag?branch=main)] HTML tag 'see' isn't allowed.  Replace it with approved Markdown or escape the brackets if the content is a placeholder.
Line 0, Column 0: [Warning: disallowed-html-tag - [See documentation](https://review.learn.microsoft.com/help/contribute/validation-ref/disallowed-html-tag?branch=main)] HTML tag 'see' isn't allowed.  Replace it with approved Markdown or escape the brackets if the content is a placeholder.

### Changes Made
Update the link