### PR TITLE
Add the reminder to run VS Perf DDRITs when deployed assemblies change

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -159,11 +159,14 @@ configuration:
             action: Opened
         - isAction:
             action: Reopened
-      - filesMatchPattern:
-          pattern: ^.+\.swr$
+      - or:
+        - filesMatchPattern:
+            pattern: ^.+\.swr$
+        - filesMatchPattern:
+            pattern: src/Package/MSBuild.VSSetup.*/.*
       then:
       - addReply:
-          reply: Hello @${issueAuthor}, I noticed that you’re changing *.swr file. Please make sure to run VS Perf DDRITs using exp/* insertion before merging the change.
+          reply: Hello @${issueAuthor}, I noticed that you’re changing an *.swr file. Please make sure to validate this change by an experimental VS insertion. This is accomplished by pushing to an exp/* branch, which requires write permissions to this repo.
       description: Remind to run VS Perf DDRITs when deployed assemblies change
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -152,5 +152,18 @@ configuration:
       - addReply:
           reply: Hello! I noticed that you're targeting one of our servicing branches. Please consider updating the version.
       description: Comment on vs* branches
+    - if:
+      - payloadType: Pull_Request
+      - or:
+        - isAction:
+            action: Opened
+        - isAction:
+            action: Reopened
+      - filesMatchPattern:
+          pattern: ^.+\.swr$
+      then:
+      - addReply:
+          reply: Hello @${issueAuthor}, I noticed that you’re changing *.swr file. Please make sure to run VS Perf DDRITs using exp/* insertion before merging the change.
+      description: Remind to run VS Perf DDRITs when deployed assemblies change
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -166,7 +166,7 @@ configuration:
             pattern: src/Package/MSBuild.VSSetup.*/.*
       then:
       - addReply:
-          reply: Hello @${issueAuthor}, I noticed that you’re changing an *.swr file. Please make sure to validate this change by an experimental VS insertion. This is accomplished by pushing to an exp/* branch, which requires write permissions to this repo.
+          reply: Hello @${issueAuthor}, I noticed that you’re changing an *.swr file or any file under src/Package/MSBuild.VSSetup.*. Please make sure to validate this change by an experimental VS insertion. This is accomplished by pushing to an exp/* branch, which requires write permissions to this repo.
       description: Remind to run VS Perf DDRITs when deployed assemblies change
 onFailure: 
 onSuccess: 


### PR DESCRIPTION
Fixes #9425

### Context
Add a reminder feature to run VS Perf DDRITs when deployed assemblies change. Double-check that we run perf ddrits early when we change the assemblies we ship with (or the .swr in general).

### Changes Made
Use resourceManagement policy to add a comment to remind the author of pull request that has the change to *.swr file.

### Testing


### Notes
