### PR TITLE
Null annotate ILogger.cs

### DIFF
--- a/src/Build/Logging/SimpleErrorLogger.cs
+++ b/src/Build/Logging/SimpleErrorLogger.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Logging.SimpleErrorLogger
             set { }
         }
 
-        public string Parameters
+        public string? Parameters
         {
             get => string.Empty;
             set { }

--- a/src/Framework/ILogger.cs
+++ b/src/Framework/ILogger.cs
@@ -3,8 +3,6 @@
 
 using System.Runtime.InteropServices;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -75,7 +73,7 @@ namespace Microsoft.Build.Framework
         /// to defaults. If a logger does not take parameters, it can ignore this property.
         /// </summary>
         /// <value>The parameter string (can be null).</value>
-        string Parameters { get; set; }
+        string? Parameters { get; set; }
 
         /// <summary>
         /// Called by the build engine to allow loggers to subscribe to the events they desire.

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -216,7 +216,7 @@ internal sealed partial class TerminalLogger : INodeLogger
     public LoggerVerbosity Verbosity { get => LoggerVerbosity.Minimal; set { } }
 
     /// <inheritdoc/>
-    public string Parameters
+    public string? Parameters
     {
         get => ""; set { }
     }


### PR DESCRIPTION
`ILogger.Parameters` is documented as allowing a `null` value. This change updates the annotation accordingly.

CPS explicitly returns null from its implementation of this interface.
