### PR TITLE
Proposed rewording for error message when enumerating drive

### DIFF
--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -350,7 +350,7 @@
     <comment>{StrBegin="MSB5028: "}UE: The project filename is provided separately to loggers.</comment>
   </data>
   <data name="WildcardResultsInDriveEnumeration" xml:space="preserve">
-    <value>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</value>
+    <value>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</value>
     <comment>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</comment>
   </data>

--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: Hodnota {0} atributu {1} v elementu &lt;{2}&gt; v souboru {3} je zástupný znak, jehož výsledkem je výčet všech souborů na jednotce, což pravděpodobně nebylo zamýšleno. Zkontrolujte, jestli jsou odkazované vlastnosti vždy definovány.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: Hodnota {0} atributu {1} v elementu &lt;{2}&gt; v souboru {3} je zástupný znak, jehož výsledkem je výčet všech souborů na jednotce, což pravděpodobně nebylo zamýšleno. Zkontrolujte, jestli jsou odkazované vlastnosti vždy definovány.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: Der Wert "{0}" des Attributs "{1}" in Element &lt;{2}&gt; in der Datei "{3}" ist ein Platzhalter, der dazu führt, dass alle Dateien auf dem Laufwerk aufgelistet werden, was wahrscheinlich nicht beabsichtigt war. Überprüfen Sie, ob Eigenschaften, auf die verwiesen wird, immer definiert sind.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: Der Wert "{0}" des Attributs "{1}" in Element &lt;{2}&gt; in der Datei "{3}" ist ein Platzhalter, der dazu führt, dass alle Dateien auf dem Laufwerk aufgelistet werden, was wahrscheinlich nicht beabsichtigt war. Überprüfen Sie, ob Eigenschaften, auf die verwiesen wird, immer definiert sind.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: El valor “{0}” del atributo “{1}” en el elemento &lt;{2}&gt; en el archivo "{3}" es un carácter comodín que da como resultado la enumeración de todos los archivos de la unidad, lo que probablemente no estaba previsto. Compruebe que siempre se definan las propiedades a las que se hace referencia.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: El valor “{0}” del atributo “{1}” en el elemento &lt;{2}&gt; en el archivo "{3}" es un carácter comodín que da como resultado la enumeración de todos los archivos de la unidad, lo que probablemente no estaba previsto. Compruebe que siempre se definan las propiedades a las que se hace referencia.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: La valeur «{0}» de l’attribut «{1}» dans l’élément &lt;{2}&gt; dans le fichier «{3}» est un caractère générique qui entraîne l’énumération de tous les fichiers sur le lecteur, ce qui n’était probablement pas prévu. Vérifiez que les propriétés référencées sont toujours définies.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: La valeur «{0}» de l’attribut «{1}» dans l’élément &lt;{2}&gt; dans le fichier «{3}» est un caractère générique qui entraîne l’énumération de tous les fichiers sur le lecteur, ce qui n’était probablement pas prévu. Vérifiez que les propriétés référencées sont toujours définies.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: il valore "{0}" dell'attributo "{1}" nell'elemento &lt;{2}&gt; nel file "{3}" è un carattere jolly che determina l'enumerazione di tutti i file nell'unità, che probabilmente non era previsto. Verificare che le proprietà di riferimento siano sempre definite.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: il valore "{0}" dell'attributo "{1}" nell'elemento &lt;{2}&gt; nel file "{3}" è un carattere jolly che determina l'enumerazione di tutti i file nell'unità, che probabilmente non era previsto. Verificare che le proprietà di riferimento siano sempre definite.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: ファイル "{3}" 内の要素 &lt;{2}&gt; の "{1}" 属性の値 "{0}" はワイルドカードであり、ドライブ上のすべてのファイルが列挙されます。それは意図されてはいないと思われます。参照されるプロパティが常に定義されていることを確認してください。</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: ファイル "{3}" 内の要素 &lt;{2}&gt; の "{1}" 属性の値 "{0}" はワイルドカードであり、ドライブ上のすべてのファイルが列挙されます。それは意図されてはいないと思われます。参照されるプロパティが常に定義されていることを確認してください。</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: 파일 "{3}"에 있는 요소 &lt;{2}&gt; 요소의 "{1}" 특성의 값 "{0}"은(는) 의도하지 않은 드라이브의 모든 파일을 열거하는 와일드카드입니다. 참조된 속성이 항상 정의되어 있는지 확인하세요.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: 파일 "{3}"에 있는 요소 &lt;{2}&gt; 요소의 "{1}" 특성의 값 "{0}"은(는) 의도하지 않은 드라이브의 모든 파일을 열거하는 와일드카드입니다. 참조된 속성이 항상 정의되어 있는지 확인하세요.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: Wartość „{0}” atrybutu „{1}” w elemencie &lt;{2}&gt; w pliku „{3}” jest symbolem wieloznacznym, który powoduje wyliczenie wszystkich plików na dysku, co prawdopodobnie nie było zamierzone. Sprawdź, aby przywoływane właściwości były zawsze zdefiniowane.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: Wartość „{0}” atrybutu „{1}” w elemencie &lt;{2}&gt; w pliku „{3}” jest symbolem wieloznacznym, który powoduje wyliczenie wszystkich plików na dysku, co prawdopodobnie nie było zamierzone. Sprawdź, aby przywoływane właściwości były zawsze zdefiniowane.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: O valor "{0}" do atributo "{1}" no elemento &lt;{2}&gt; no arquivo "{3}" é um curinga que resulta na enumeração de todos os arquivos na unidade, o que provavelmente não foi planejado. Verifique se as propriedades referenciadas estão sempre definidas.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: O valor "{0}" do atributo "{1}" no elemento &lt;{2}&gt; no arquivo "{3}" é um curinga que resulta na enumeração de todos os arquivos na unidade, o que provavelmente não foi planejado. Verifique se as propriedades referenciadas estão sempre definidas.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: значение "{0}" атрибута "{1}" в элементе &lt;{2}&gt; в файле "{3}" является подстановочным знаком, который приводит к перечислению всех файлов на диске, что, вероятно, не предполагалось. Убедитесь, что ссылочные свойства всегда определены.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: значение "{0}" атрибута "{1}" в элементе &lt;{2}&gt; в файле "{3}" является подстановочным знаком, который приводит к перечислению всех файлов на диске, что, вероятно, не предполагалось. Убедитесь, что ссылочные свойства всегда определены.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: "{3}" dosyasındaki &lt;{2}&gt; öğesinde "{1}" özniteliğinin "{0}" değeri, sürücüdeki tüm dosyaların numaralandırılmasıyla sonuçlanan (büyük olasılıkla bunun olması amaçlanmıyordu) bir joker karakterdir. Başvurulan özelliklerin her zaman tanımlı olduğundan emin olun.</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: "{3}" dosyasındaki &lt;{2}&gt; öğesinde "{1}" özniteliğinin "{0}" değeri, sürücüdeki tüm dosyaların numaralandırılmasıyla sonuçlanan (büyük olasılıkla bunun olması amaçlanmıyordu) bir joker karakterdir. Başvurulan özelliklerin her zaman tanımlı olduğundan emin olun.</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: 文件 "{3}" 中元素 &lt;{2}&gt; 中 "{1}" 属性的值 "{0}" 是通配符，可导致枚举驱动器上的所有文件，这可能不是预期的行为。请检查是否始终定义了所引用的属性。</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: 文件 "{3}" 中元素 &lt;{2}&gt; 中 "{1}" 属性的值 "{0}" 是通配符，可导致枚举驱动器上的所有文件，这可能不是预期的行为。请检查是否始终定义了所引用的属性。</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -324,8 +324,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WildcardResultsInDriveEnumeration">
-        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.</source>
-        <target state="translated">MSB5029: 檔案「{3}」元素 &lt;{2}&gt; 中屬性「{1}」的值「{0}」是萬用字元，導致列舉磁碟機上的所有檔案，這很可能不是預期的結果。檢查是否一直定義參考屬性。</target>
+        <source>MSB5029: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; in file "{3}" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined and that the project and current working directory are not at the drive root.</source>
+        <target state="needs-review-translation">MSB5029: 檔案「{3}」元素 &lt;{2}&gt; 中屬性「{1}」的值「{0}」是萬用字元，導致列舉磁碟機上的所有檔案，這很可能不是預期的結果。檢查是否一直定義參考屬性。</target>
         <note>{StrBegin="MSB5029: "}UE: This is a generic message that is displayed when we find a project element that has a drive enumerating wildcard value for one of its
       attributes e.g. &lt;Compile Include="$(NotAlwaysDefined)\**\*.cs"&gt; -- if the property is undefined, the value of Include should not result in enumerating all files on drive.</note>
       </trans-unit>


### PR DESCRIPTION
I have a PR out to make use of the environment variable that leads to this message when you try to enumerate your drive.

From the SDK's perspective, however, this message is a bit confusing because it talks about some specific ItemGroup, whereas the reality is probably that it came from some MSBuild code you didn't write, and the real problem is that you're building at the root of your drive.

I think this wording is an improvement but not perfect. For instance, it isn't a problem if your current working directory is the drive root as long as you specify a project that isn't there, but I don't just want to say 'that your project isn't at the drive root' because if you try to build without specifying a project while at the drive root (as with `dotnet new`), it'll fail, and you'll be confused.

Thoughts? @baronfel 