### PR TITLE
[release/vs17.9] Return params for CIBuild run

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -147,6 +147,12 @@ extends:
                     /p:VisualStudioDropAccessToken=$(System.AccessToken)
                     /p:VisualStudioDropName=$(VisualStudio.DropName)
                     /p:DotNetSignType=$(SignType)
+                    /p:DotNetPublishToBlobFeed=true
+                    /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                    /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                    /p:PublishToSymbolServer=true
+                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                     /p:TeamName=MSBuild
                     /p:DotNetPublishUsingPipelines=true
                     /p:VisualStudioIbcDrop=$(OptProfDrop)

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -33,6 +33,10 @@ variables:
       value: ${{parameters.OptProfDropName}}
     - name: SourceBranch
       value: ''
+  - name: _DotNetArtifactsCategory
+    value: .NETCore
+  - name: _DotNetValidationArtifactsCategory
+    value: .NETCoreValidation
   - name: EnableReleaseOneLocBuild
     value: true
   - name: Codeql.Enabled
@@ -96,6 +100,8 @@ extends:
         timeoutInMinutes: 180
 
         variables:
+        - group: DotNet-Blob-Feed
+        - group: DotNet-Symbol-Publish
         - group: Publish-Build-Assets
         - name: TeamName
           value: MSBuild


### PR DESCRIPTION
### Context

In scope 1es migration effort, set of required params was missed.
This pr returns the required part.
The comparison is better here: https://tfsprodwus2su6.visualstudio.com/A011b8bdf-6d56-4f87-be0d-0092136884d9/DevDiv/_git/DotNet-msbuild-Trusted/commit/5977c9ba0241aa60751cd92e37c02120a368f3f5?refName=refs%2Fheads%2Fvs17.9&path=%2F.vsts-dotnet.yml&_a=compare
 
Unfortunately, the experimental run didn't catch it in time due to different env variables https://tfsprodwus2su6.visualstudio.com/A011b8bdf-6d56-4f87-be0d-0092136884d9/DevDiv/_build/results?buildId=9281418&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=94418e61-6648-5751-f7d4-a14f4e5e2bb7&l=41