### PR TITLE
Make GeneratedFileUsedEventArgs internal

### DIFF
--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -547,14 +547,6 @@ namespace Microsoft.Build.UnitTests
                 e => e.ResponseFilePath);
         }
 
-        [Fact]
-        public void RoundtripGeneratedFileUsedEventArgs()
-        {
-            var args = new GeneratedFileUsedEventArgs("MSBuild.rsp", "");
-            Roundtrip(args,
-                e => e.FilePath,
-                e => e.Content);
-        }
 
         [Fact]
         public void RoundtripCriticalBuildMessageEventArgs()

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Build.Logging
         String,
         TaskParameter,
         ResponseFileUsed,
-        GeneratedFileUsed,
         AssemblyLoad,
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Build.Logging
         //     between de/serialization roundtrips.
         //   - Adding serialized events lengths - to support forward compatible reading
         // version 19:
-        //   - new record kind: GeneratedFileUsedEventArgs
+        //   - GeneratedFileUsedEventArgs exposed for brief period of time (so let's continue with 20)
 
         // This should be never changed.
         // The minimum version of the binary log reader that can read log of above version.
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Logging
 
         // The current version of the binary log representation.
         // Changes with each update of the binary log format.
-        internal const int FileFormatVersion = 19;
+        internal const int FileFormatVersion = 18;
 
         // The minimum version of the binary log reader that can read log of above version.
         // This should be changed only when the binary log format is changed in a way that would prevent it from being
@@ -335,17 +335,27 @@ namespace Microsoft.Build.Logging
         {
             if (stream != null)
             {
+                if (projectImportsCollector != null)
+                {
+                    CollectImports(e);
+                }
+
+                if (DoNotWriteToBinlog(e))
+                {
+                    return;
+                }
+
                 // TODO: think about queuing to avoid contention
                 lock (eventArgsWriter)
                 {
                     eventArgsWriter.Write(e);
                 }
-
-                if (projectImportsCollector != null)
-                {
-                    CollectImports(e);
-                }
             }
+        }
+
+        private static bool DoNotWriteToBinlog(BuildEventArgs e)
+        {
+            return e is GeneratedFileUsedEventArgs;
         }
 
         private void CollectImports(BuildEventArgs e)

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -315,7 +315,6 @@ namespace Microsoft.Build.Logging
                 BinaryLogRecordKind.TargetSkipped => ReadTargetSkippedEventArgs(),
                 BinaryLogRecordKind.EnvironmentVariableRead => ReadEnvironmentVariableReadEventArgs(),
                 BinaryLogRecordKind.ResponseFileUsed => ReadResponseFileUsedEventArgs(),
-                BinaryLogRecordKind.GeneratedFileUsed => ReadGeneratedFileUsedEventArgs(),
                 BinaryLogRecordKind.PropertyReassignment => ReadPropertyReassignmentEventArgs(),
                 BinaryLogRecordKind.UninitializedPropertyRead => ReadUninitializedPropertyReadEventArgs(),
                 BinaryLogRecordKind.PropertyInitialValueSet => ReadPropertyInitialValueSetEventArgs(),
@@ -1111,23 +1110,6 @@ namespace Microsoft.Build.Logging
             SetCommonFields(e, fields);
 
             return e;
-        }
-
-        private BuildEventArgs ReadGeneratedFileUsedEventArgs()
-        {
-            var fields = ReadBuildEventArgsFields();
-
-            string? filePath = ReadDeduplicatedString();
-            string? content = ReadDeduplicatedString();
-
-            if (filePath != null && content != null)
-            {
-                var e = new GeneratedFileUsedEventArgs(filePath, content);
-                SetCommonFields(e, fields);
-                return e;
-            }
-
-            return new GeneratedFileUsedEventArgs();
         }
 
         private BuildEventArgs ReadPropertyReassignmentEventArgs()

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -460,7 +460,6 @@ namespace Microsoft.Build.Logging
             switch (e)
             {
                 case ResponseFileUsedEventArgs responseFileUsed: return Write(responseFileUsed);
-                case GeneratedFileUsedEventArgs generatedFileUsed: return Write(generatedFileUsed);
                 case TaskParameterEventArgs taskParameter: return Write(taskParameter);
                 case ProjectImportedEventArgs projectImported: return Write(projectImported);
                 case TargetSkippedEventArgs targetSkipped: return Write(targetSkipped);
@@ -556,13 +555,6 @@ namespace Microsoft.Build.Logging
             WriteMessageFields(e);
             WriteDeduplicatedString(e.ResponseFilePath);
             return BinaryLogRecordKind.ResponseFileUsed;
-        }
-        private BinaryLogRecordKind Write(GeneratedFileUsedEventArgs e)
-        {
-            WriteMessageFields(e);
-            WriteDeduplicatedString(e.FilePath);
-            WriteDeduplicatedString(e.Content);
-            return BinaryLogRecordKind.GeneratedFileUsed;
         }
         private BinaryLogRecordKind Write(TaskCommandLineEventArgs e)
         {

--- a/src/Framework/GeneratedFileUsedEventArgs.cs
+++ b/src/Framework/GeneratedFileUsedEventArgs.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// Arguments for the generated file used event
     /// </summary>
-    public class GeneratedFileUsedEventArgs : BuildMessageEventArgs
+    internal class GeneratedFileUsedEventArgs : BuildMessageEventArgs
     {
         public GeneratedFileUsedEventArgs()
         {
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// 
         public GeneratedFileUsedEventArgs(string filePath, string content)
-            : base("", null, null, MessageImportance.Low)
+            : base(nameof(GeneratedFileUsedEventArgs) + ": " + filePath, null, null, MessageImportance.Low)
         {
             FilePath = filePath;
             Content = content;

--- a/src/Framework/GeneratedFileUsedEventArgs.cs
+++ b/src/Framework/GeneratedFileUsedEventArgs.cs
@@ -20,7 +20,9 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// 
         public GeneratedFileUsedEventArgs(string filePath, string content)
-            : base(nameof(GeneratedFileUsedEventArgs) + ": " + filePath, null, null, MessageImportance.Low)
+        // We are not sending the event to binlog (just the file), so we do not want it
+        // to have any stringified representation for other logs either.
+            : base(string.Empty, null, null, MessageImportance.Low)
         {
             FilePath = filePath;
             Content = content;


### PR DESCRIPTION
### Context

`GeneratedFileUsedEventArgs` do not need to be written to binlog. It's important to have the generated file being embedded into the binlog files, other than that the event doesn't bring additional value.

While forward compatibility of binlog allows us to introduce new events (or events additions) without breaking the viewer - there is still a minor impact that can confuse some users:

![image](https://github.com/dotnet/msbuild/assets/3809076/5b302cc6-1d82-4725-8e31-73623c810db2)


So it's safer to not to write the event now.

Mid-term, we should think about generalizing the event - so that it can be used for other scenarios (e.g. response file, .editorconfig file etc.), with the same structured format - https://github.com/dotnet/msbuild/issues/9906

### Changes Made
Made `GeneratedFileUsedEventArgs` internal and dismounting sending it to the binlog (but kept the pushing of the generated file content itself - as that's the main gain brought by the feature).
~~Added `Message` representation of the event - for the verbouse logging via `ConsoleLogger` and `FileLogger`.~~

### Testing
Kept existing tests.
Manual tests with binlog viewer and ConsoleLogger and FileLogger.

FYI @KirillOsenkov 