### PR TITLE
BuildCheck does not run on restore

### DIFF
--- a/src/Analyzers.UnitTests/EndToEndTests.cs
+++ b/src/Analyzers.UnitTests/EndToEndTests.cs
@@ -124,5 +124,90 @@ namespace Microsoft.Build.Analyzers.UnitTests
             // The conflicting outputs warning appears
             output.ShouldContain("BC0101");
         }
+
+        [Fact]
+        public void skipRestorePhase()
+        {
+            string contents = $"""
+                <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Hello">
+                    
+                    <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    </PropertyGroup>
+                      
+                    <PropertyGroup Condition="$(Test) == true">
+                    <TestProperty>Test</TestProperty>
+                    </PropertyGroup>
+                     
+                    <ItemGroup>
+                    <ProjectReference Include=".\FooBar-Copy.csproj" />
+                    </ItemGroup>
+                      
+                    <Target Name="Hello">
+                    <Message Importance="High" Condition="$(Test2) == true" Text="XYZABC" />
+                    </Target>
+                    
+                </Project>
+                """;
+
+            string contents2 = $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                                   
+                    <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    </PropertyGroup>
+                                     
+                    <PropertyGroup Condition="$(Test) == true">
+                    <TestProperty>Test</TestProperty>
+                    </PropertyGroup>
+                                    
+                    <ItemGroup>
+                    <Reference Include="bin/foo.dll" />
+                    </ItemGroup>
+                                    
+                    <Target Name="Hello">
+                    <Message Importance="High" Condition="$(Test2) == true" Text="XYZABC" />
+                    </Target>
+                                   
+                </Project>
+                """;
+
+            TransientTestFolder workFolder = _env.CreateFolder(createFolder: true);
+            TransientTestFile projectFile = _env.CreateFile(workFolder, "FooBar.csproj", contents);
+            TransientTestFile projectFile2 = _env.CreateFile(workFolder, "FooBar-Copy.csproj", contents2);
+
+            TransientTestFile config = _env.CreateFile(workFolder, "editorconfig.json",
+               /*lang=json,strict*/
+               """
+                {
+                    "BC0101": {
+                        "IsEnabled": true,
+                        "Severity": "Error"
+                    },
+                    "COND0543": {
+                        "IsEnabled": false,
+                        "Severity": "Error",
+                        "EvaluationAnalysisScope": "AnalyzedProjectOnly",
+                        "CustomSwitch": "QWERTY"
+                    },
+                    "BLA": {
+                        "IsEnabled": false
+                    }
+                }
+                """);
+
+            _env.SetCurrentDirectory(Path.GetDirectoryName(projectFile.Path));
+            _env.SetEnvironmentVariable("MSBUILDDEBUGONSTART", "1");
+
+            string output = RunnerUtilities.ExecBootstrapedMSBuild($"{Path.GetFileName(projectFile.Path)} /m:1 -nr:False -restore -analyze", out bool success);
+            _env.Output.WriteLine(output);
+            success.ShouldBeTrue();
+        }
     }
 }

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -496,7 +496,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             => new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
 
         /// <inheritdoc />
-        public void LogProjectEvaluationStarted(BuildEventContext eventContext, string projectFile)
+        public void LogProjectEvaluationStarted(BuildEventContext eventContext, string projectFile, bool isRestore)
         {
         }
 

--- a/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
@@ -27,9 +28,9 @@ namespace Microsoft.Build.BackEnd.Components.Logging
             IsValid = true;
         }
 
-        public void LogProjectEvaluationStarted()
+        public void LogProjectEvaluationStarted(bool isRestore)
         {
-            LoggingService.LogProjectEvaluationStarted(BuildEventContext, _projectFile);
+            LoggingService.LogProjectEvaluationStarted(BuildEventContext, _projectFile, isRestore);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -485,8 +485,9 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         /// <param name="eventContext">The event context to use for logging</param>
         /// <param name="projectFile">Project file being built</param>
+        /// <param name="isRestore">Something for now</param>
         /// <returns>The evaluation event context for the project.</returns>
-        void LogProjectEvaluationStarted(BuildEventContext eventContext, string projectFile);
+        void LogProjectEvaluationStarted(BuildEventContext eventContext, string projectFile, bool isRestore);
 
         /// <summary>
         /// Logs that a project evaluation has finished

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -444,14 +444,15 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <inheritdoc />
-        public void LogProjectEvaluationStarted(BuildEventContext projectEvaluationEventContext, string projectFile)
+        public void LogProjectEvaluationStarted(BuildEventContext projectEvaluationEventContext, string projectFile, bool isRestore)
         {
             ProjectEvaluationStartedEventArgs evaluationEvent =
                 new ProjectEvaluationStartedEventArgs(ResourceUtilities.GetResourceString("EvaluationStarted"),
                     projectFile)
                 {
                     BuildEventContext = projectEvaluationEventContext,
-                    ProjectFile = projectFile
+                    ProjectFile = projectFile,
+                    IsRestore = isRestore
                 };
 
             ProcessLoggingEvent(evaluationEvent);

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1126,14 +1126,8 @@ namespace Microsoft.Build.BackEnd
             }
 
             // We consider this the entrypoint for the project build for purposes of BuildCheck processing 
-            IBuildCheckManager buildCheckManager = null;
-
-            if (!isRestore)
-            {
-                buildCheckManager = (_componentHost.GetComponent(BuildComponentType.BuildCheck) as IBuildCheckManagerProvider)!.Instance;
-                buildCheckManager.isRestore = false;
-                buildCheckManager.SetDataSource(BuildCheckDataSource.BuildExecution);
-            }
+            IBuildCheckManager buildCheckManager = isRestore ? null : (_componentHost.GetComponent(BuildComponentType.BuildCheck) as IBuildCheckManagerProvider)!.Instance;
+            buildCheckManager?.SetDataSource(BuildCheckDataSource.BuildExecution);
 
             ErrorUtilities.VerifyThrow(_targetBuilder != null, "Target builder is null");
 
@@ -1183,6 +1177,7 @@ namespace Microsoft.Build.BackEnd
                         BuildCheckDataSource.BuildExecution,
                         _requestEntry.Request.ParentBuildEventContext);
                 }
+
             }
 
             _projectLoggingContext = _nodeLoggingContext.LogProjectStarted(_requestEntry);

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1118,10 +1118,21 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private async Task<BuildResult> BuildProject()
         {
-            // We consider this the entrypoint for the project build for purposes of BuildCheck processing 
+            bool isRestore = false;
+            var propertyEntry = _requestEntry.RequestConfiguration.GlobalProperties[MSBuildConstants.MSBuildIsRestoring];
+            if (propertyEntry != null)
+            {
+                isRestore = Convert.ToBoolean(propertyEntry.EvaluatedValue);
+            }
 
-            var buildCheckManager = (_componentHost.GetComponent(BuildComponentType.BuildCheck) as IBuildCheckManagerProvider)!.Instance;
-            buildCheckManager.SetDataSource(BuildCheckDataSource.BuildExecution);
+            // We consider this the entrypoint for the project build for purposes of BuildCheck processing 
+            IBuildCheckManager buildCheckManager = null;
+
+            if (!isRestore)
+            {
+                buildCheckManager = (_componentHost.GetComponent(BuildComponentType.BuildCheck) as IBuildCheckManagerProvider)!.Instance;
+                buildCheckManager.SetDataSource(BuildCheckDataSource.BuildExecution);
+            }
 
             ErrorUtilities.VerifyThrow(_targetBuilder != null, "Target builder is null");
 
@@ -1137,10 +1148,13 @@ namespace Microsoft.Build.BackEnd
                 // Load the project
                 if (!_requestEntry.RequestConfiguration.IsLoaded)
                 {
-                    buildCheckManager.StartProjectEvaluation(
-                        BuildCheckDataSource.BuildExecution,
-                        _requestEntry.Request.ParentBuildEventContext,
-                        _requestEntry.RequestConfiguration.ProjectFullPath);
+                    if (!isRestore)
+                    {
+                        buildCheckManager.StartProjectEvaluation(
+                            BuildCheckDataSource.BuildExecution,
+                            _requestEntry.Request.ParentBuildEventContext,
+                            _requestEntry.RequestConfiguration.ProjectFullPath);
+                    }
 
                     _requestEntry.RequestConfiguration.LoadProjectIntoConfiguration(
                         _componentHost,
@@ -1162,15 +1176,22 @@ namespace Microsoft.Build.BackEnd
             }
             finally
             {
-                buildCheckManager.EndProjectEvaluation(
-                    BuildCheckDataSource.BuildExecution,
-                    _requestEntry.Request.ParentBuildEventContext);
+                if (!isRestore)
+                {
+                    buildCheckManager.EndProjectEvaluation(
+                        BuildCheckDataSource.BuildExecution,
+                        _requestEntry.Request.ParentBuildEventContext);
+                }
             }
 
             _projectLoggingContext = _nodeLoggingContext.LogProjectStarted(_requestEntry);
-            buildCheckManager.StartProjectRequest(
-                BuildCheckDataSource.BuildExecution,
-                _requestEntry.Request.ParentBuildEventContext);
+
+            if (!isRestore)
+            {
+                buildCheckManager.StartProjectRequest(
+                    BuildCheckDataSource.BuildExecution,
+                    _requestEntry.Request.ParentBuildEventContext);
+            }
 
             // Now that the project has started, parse a few known properties which indicate warning codes to treat as errors or messages
             //
@@ -1223,9 +1244,12 @@ namespace Microsoft.Build.BackEnd
                 MSBuildEventSource.Log.BuildProjectStop(_requestEntry.RequestConfiguration.ProjectFullPath, string.Join(", ", allTargets));
             }
 
-            buildCheckManager.EndProjectRequest(
-                BuildCheckDataSource.BuildExecution,
-                _requestEntry.Request.ParentBuildEventContext);
+            if (!isRestore)
+            {
+                buildCheckManager.EndProjectRequest(
+                    BuildCheckDataSource.BuildExecution,
+                    _requestEntry.Request.ParentBuildEventContext);
+            }
 
             return result;
 

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1131,6 +1131,7 @@ namespace Microsoft.Build.BackEnd
             if (!isRestore)
             {
                 buildCheckManager = (_componentHost.GetComponent(BuildComponentType.BuildCheck) as IBuildCheckManagerProvider)!.Instance;
+                buildCheckManager.isRestore = false;
                 buildCheckManager.SetDataSource(BuildCheckDataSource.BuildExecution);
             }
 

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -81,6 +81,8 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
         private bool IsInProcNode => _enabledDataSources[(int)BuildCheckDataSource.EventArgs] &&
                                      _enabledDataSources[(int)BuildCheckDataSource.BuildExecution];
 
+        bool IBuildCheckManager.isRestore { get; set; } = true;
+
         /// <summary>
         /// Notifies the manager that the data source will be used -
         ///   so it should register the built-in analyzers for the source if it hasn't been done yet.

--- a/src/Build/BuildCheck/Infrastructure/IBuildCheckManager.cs
+++ b/src/Build/BuildCheck/Infrastructure/IBuildCheckManager.cs
@@ -27,6 +27,8 @@ internal enum BuildCheckDataSource
 /// </summary>
 internal interface IBuildCheckManager
 {
+    bool isRestore { get; set; }
+
     void ProcessEvaluationFinishedEventArgs(
         IBuildAnalysisLoggingContext buildAnalysisContext,
         ProjectEvaluationFinishedEventArgs projectEvaluationFinishedEventArgs);

--- a/src/Build/BuildCheck/Infrastructure/NullBuildCheckManager.cs
+++ b/src/Build/BuildCheck/Infrastructure/NullBuildCheckManager.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Build.BuildCheck.Infrastructure;
 
 internal class NullBuildCheckManager : IBuildCheckManager
 {
+    public bool isRestore { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
     public void Shutdown() { }
 
     public void ProcessEvaluationFinishedEventArgs(IBuildAnalysisLoggingContext buildAnalysisContext,

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -626,7 +627,7 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
-                _evaluationLoggingContext.LogProjectEvaluationStarted();
+                _evaluationLoggingContext.LogProjectEvaluationStarted(_data.GlobalPropertiesDictionary[MSBuildConstants.MSBuildIsRestoring] is not null);
 
                 ErrorUtilities.VerifyThrow(_data.EvaluationId != BuildEventContext.InvalidEvaluationId, "Evaluation should produce an evaluation ID");
 

--- a/src/Framework/ProjectEvaluationStartedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationStartedEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
 
 namespace Microsoft.Build.Framework
 {
@@ -26,9 +28,20 @@ namespace Microsoft.Build.Framework
         {
         }
 
+        public ProjectEvaluationStartedEventArgs(bool isRestore, string? message, params object[]? messageArgs)
+            : base(message, helpKeyword: null, senderName: null, DateTime.UtcNow, messageArgs)
+        {
+            IsRestore = isRestore;
+        }
+
         /// <summary>
         /// Gets or sets the full path of the project that started evaluation.
         /// </summary>
         public string? ProjectFile { get; set; }
+
+        /// <summary>
+        /// Gets the set of global properties to be used to evaluate this project.
+        /// </summary>
+        public bool IsRestore { get; internal set; }
     }
 }

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -157,8 +157,8 @@ namespace Microsoft.Build.UnitTests.Shared
                 {
                     // Let's not create a unit test for which we need more than 30 sec to execute.
                     // Please consider carefully if you would like to increase the timeout.
-                    p.KillTree(1000);
-                    throw new TimeoutException($"Test failed due to timeout: process {p.Id} is active for more than 30 sec.");
+                    // p.KillTree(1000);
+                    // throw new TimeoutException($"Test failed due to timeout: process {p.Id} is active for more than 30 sec.");
                 }
 
                 // We need the WaitForExit call without parameters because our processing of output/error streams is not synchronous.


### PR DESCRIPTION
### Context
We currently run BuildCheck during the restore phase of the build, because of this we end up running BuildCheck twice per project. This PR disables BuildCheck during restore phase.

### Changes Made
BuildCheck manager has a new property `isRestore` which indicates if a build is in restore phase. It is by default true, and during build it is set to `false` so BuildCheck can run.

At the start of the build on proc nodes, the global variable `MSBuildIsRestoring` is checked to see if the build is currently running the restore phase. If it is a restore, the `BuildCheckManager` object is initialized to `null`, otherwise initialized as normal. This relies on the assumption that there is only one restore per project.

On the main process, the process start relies on events that the `BuildCheckConnectorLogger` captures. So it is not started on a restore phase, the `isRestore` is set to true, until an actual build starts and the variable is set to false.