### PR TITLE
Log TaskParameterEvent for scalar parameters

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -23,6 +23,9 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 
 ## Current Rotation of Change Waves
 
+### 17.12
+- [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)
+
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`
 - [Warning on serialization custom events by default in .NET framework](https://github.com/dotnet/msbuild/pull/9318)
@@ -36,13 +39,11 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Introduce [MSBuild]::StableStringHash overloads](https://github.com/dotnet/msbuild/issues/9519)
 - [Keep the encoding of standard output & error consistent with the console code page for ToolTask](https://github.com/dotnet/msbuild/pull/9539)
 
-
 ### 17.8
 - [[RAR] Don't do I/O on SDK-provided references](https://github.com/dotnet/msbuild/pull/8688)
 - [Delete destination file before copy](https://github.com/dotnet/msbuild/pull/8685)
 - [Moving from SHA1 to SHA256 for Hash task](https://github.com/dotnet/msbuild/pull/8812)
 - [Deprecating custom derived BuildEventArgs](https://github.com/dotnet/msbuild/pull/8917) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`
-
 
 ### 17.6
 - [Parse invalid property under target](https://github.com/dotnet/msbuild/pull/8190)

--- a/src/Build.UnitTests/BackEnd/TaskThatReturnsDictionaryTaskItem.cs
+++ b/src/Build.UnitTests/BackEnd/TaskThatReturnsDictionaryTaskItem.cs
@@ -17,6 +17,8 @@ public sealed class TaskThatReturnsDictionaryTaskItem : Utilities.Task
     public string Key { get; set; }
     public string Value { get; set; }
 
+    public ITaskItem[] AdditionalParameters { get; set; }
+
     public override bool Execute()
     {
         var metaValue = new MinimalDictionary<string, string>

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1280,7 +1280,7 @@ namespace Microsoft.Build.BackEnd
             if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents)
             {
                 IList parameterValueAsList = parameterValue as IList;
-                bool legacyBehavior = !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10);
+                bool legacyBehavior = !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12);
 
                 // Legacy textual logging for parameters that are not lists.
                 if (legacyBehavior && parameterValueAsList == null)

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1266,30 +1266,6 @@ namespace Microsoft.Build.BackEnd
             return success;
         }
 
-        /// <summary>
-        /// Variation to handle arrays, to help with logging the parameters.
-        /// </summary>
-        /// <remarks>
-        /// Logging currently enabled only by an env var.
-        /// </remarks>
-        private bool InternalSetTaskParameter(TaskPropertyInfo parameter, IList parameterValue)
-        {
-            if (LogTaskInputs &&
-                !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents &&
-                parameterValue.Count > 0 &&
-                parameter.Log)
-            {
-                ItemGroupLoggingHelper.LogTaskParameter(
-                    _taskLoggingContext,
-                    TaskParameterMessageKind.TaskInput,
-                    parameter.Name,
-                    parameterValue,
-                    parameter.LogItemMetadata);
-            }
-
-            return InternalSetTaskParameter(parameter, (object)parameterValue);
-        }
-
         private static readonly string TaskParameterFormatString = ItemGroupLoggingHelper.TaskParameterPrefix + "{0}={1}";
 
         /// <summary>
@@ -1303,14 +1279,31 @@ namespace Microsoft.Build.BackEnd
 
             if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents)
             {
-                // If the type is a list, we already logged the parameters
-                if (!(parameterValue is IList))
+                IList parameterValueAsList = parameterValue as IList;
+                bool legacyBehavior = !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10);
+
+                // Legacy textual logging for parameters that are not lists.
+                if (legacyBehavior && parameterValueAsList == null)
                 {
                     _taskLoggingContext.LogCommentFromText(
-                        MessageImportance.Low,
-                        TaskParameterFormatString,
-                        parameter.Name,
-                        ItemGroupLoggingHelper.GetStringFromParameterValue(parameterValue));
+                       MessageImportance.Low,
+                       TaskParameterFormatString,
+                       parameter.Name,
+                       ItemGroupLoggingHelper.GetStringFromParameterValue(parameterValue));
+                }
+
+                if (parameter.Log)
+                {
+                    // Structured logging for all parameters that have logging enabled and are not empty lists.
+                    if (parameterValueAsList?.Count > 0 || (parameterValueAsList == null && !legacyBehavior))
+                    {
+                        ItemGroupLoggingHelper.LogTaskParameter(
+                            _taskLoggingContext,
+                            TaskParameterMessageKind.TaskInput,
+                            parameter.Name,
+                            parameterValueAsList ?? new object[] { parameterValue },
+                            parameter.LogItemMetadata);
+                    }
                 }
             }
 

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave17_6 = new Version(17, 6);
         internal static readonly Version Wave17_8 = new Version(17, 8);
         internal static readonly Version Wave17_10 = new Version(17, 10);
-        internal static readonly Version[] AllWaves = { Wave17_4, Wave17_6, Wave17_8, Wave17_10 };
+        internal static readonly Version Wave17_12 = new Version(17, 12);
+        internal static readonly Version[] AllWaves = { Wave17_4, Wave17_6, Wave17_8, Wave17_10, Wave17_12 };
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/UnitTests.Shared/MockLogger.cs
+++ b/src/UnitTests.Shared/MockLogger.cs
@@ -124,6 +124,11 @@ namespace Microsoft.Build.UnitTests
         public List<TaskFinishedEventArgs> TaskFinishedEvents { get; } = new List<TaskFinishedEventArgs>();
 
         /// <summary>
+        /// List of TaskParameter events
+        /// </summary>
+        public List<TaskParameterEventArgs> TaskParameterEvents { get; } = new List<TaskParameterEventArgs>();
+
+        /// <summary>
         /// List of BuildMessage events
         /// </summary>
         public List<BuildMessageEventArgs> BuildMessageEvents { get; } = new List<BuildMessageEventArgs>();
@@ -360,6 +365,11 @@ namespace Microsoft.Build.UnitTests
                     case TaskFinishedEventArgs taskFinishedEventArgs:
                         {
                             TaskFinishedEvents.Add(taskFinishedEventArgs);
+                            break;
+                        }
+                    case TaskParameterEventArgs taskParameterEventArgs:
+                        {
+                            TaskParameterEvents.Add(taskParameterEventArgs);
                             break;
                         }
                     case BuildMessageEventArgs buildMessageEventArgs:


### PR DESCRIPTION
Fixes #9827

### Context

`TaskParameterEvent` with `TaskParameterMessageKind.TaskInput` is currently used only for parameters that are lists. Parameters that are simple strings are logged as a specially formatted low-importance message.

The binlog viewer contains logic to recognize this special message and recover the Name and Value to be rendered in the viewer UI. Since we will use this event for analyzers, it would be unfortunate to add one more place with this suboptimal processing.

### Changes Made

Unified the logic in `TaskExecutionHost` to log all parameters as `TaskParameterEvent` with `TaskParameterMessageKind.TaskInput`. The change is under a change wave check.

### Testing

- Added a new unit test.
- Compared diagnostic-level output with task parameter logging enabled with and without the change. No differences were found when passing null, empty, false, true, numeric, string, or stringified item list parameters.
- Compared the appearance in binlog for the same sample values as above. No differences were observed.
- Compared OrchardCore binlogs with and without the change. They're the same size and the only difference I found was in rendering the `SolutionConfigurationContents` parameter which is a string but the content _looks_ formatted so it was rendered incorrectly as a list of items.

### Notes

As @KirillOsenkov pointed out in the issue, we don't really depend on the textual messages so we don't have to do any double-logging. The viewer can remove parsing the textual messages on its own schedule.