### PR TITLE
Change the SourceBranch to IbcSourceBranchName

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -22,7 +22,7 @@ variables:
   - name: OptProfDrop
     value: ''
   - name: SourceBranch
-    value: $(IbcBranchName)
+    value: $(IbcSourceBranchName)
   # If we're not on a vs* branch, use main as our optprof collection branch
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
     - name: SourceBranch


### PR DESCRIPTION
### Context
Pipeline fails due to  SourceBranch value. 
IbcBranchName seems to be applicable for main only, get back to IbcSourceBranchName

Build log:
https://tfsprodwus2su6.visualstudio.com/A011b8bdf-6d56-4f87-be0d-0092136884d9/DevDiv/_build/results?buildId=9290067&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=94418e61-6648-5751-f7d4-a14f4e5e2bb7&l=41