### PR TITLE
Change the SourceBranch to IbcSourceBranchName

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -22,7 +22,7 @@ variables:
   - name: OptProfDrop
     value: ''
   - name: SourceBranch
-    value: $(IbcBranchName)
+    value: $(IbcSourceBranchName)
   # If we're not on a vs* branch, use main as our optprof collection branch
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
     - name: SourceBranch


### PR DESCRIPTION
### Context
The wrong env variable name was taken from example.
It was unnoticeable on main branch, but revealed itself on service branches.