### PR TITLE
Include error/warning count in Terminal Logger summaries

### DIFF
--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_2Projects_FailedWithErrorsAndWarnings.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_2Projects_FailedWithErrorsAndWarnings.Linux.verified.txt
@@ -1,0 +1,15 @@
+﻿]9;4;3;\  project [31;1mfailed with 2 error(s) and 2 warning(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning1!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning2!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error1!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error2!
+[?25l[1F
+[?25h  project2 [31;1mfailed with 2 error(s) and 2 warning(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning3!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning4!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error3!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error4!
+[?25l[1F
+[?25h
+Build [31;1mfailed with 4 error(s) and 4 warning(s)[m in 5.0s
+]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_2Projects_FailedWithErrorsAndWarnings.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_2Projects_FailedWithErrorsAndWarnings.OSX.verified.txt
@@ -1,0 +1,14 @@
+﻿  project [31;1mfailed with 2 error(s) and 2 warning(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning1!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning2!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error1!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error2!
+[?25l[1F
+[?25h  project2 [31;1mfailed with 2 error(s) and 2 warning(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning3!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning4!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error3!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error4!
+[?25l[1F
+[?25h
+Build [31;1mfailed with 4 error(s) and 4 warning(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_2Projects_FailedWithErrorsAndWarnings.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_2Projects_FailedWithErrorsAndWarnings.Windows.verified.txt
@@ -1,0 +1,15 @@
+﻿]9;4;3;\  project [31;1mfailed with 2 error(s) and 2 warning(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning1!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning2!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error1!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error2!
+[?25l[1F
+[?25h  project2 [31;1mfailed with 2 error(s) and 2 warning(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning3!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning4!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error3!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error4!
+[?25l[1F
+[?25h
+Build [31;1mfailed with 4 error(s) and 4 warning(s)[m in 5.0s
+]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Linux.verified.txt
@@ -1,6 +1,6 @@
-﻿]9;4;3;\  project [31;1mfailed with errors[m (0.2s)
+﻿]9;4;3;\  project [31;1mfailed with 1 error(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with errors[m in 5.0s
+Build [31;1mfailed with 1 error(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.OSX.verified.txt
@@ -1,5 +1,5 @@
-﻿  project [31;1mfailed with errors[m (0.2s)
+﻿  project [31;1mfailed with 1 error(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with errors[m in 5.0s
+Build [31;1mfailed with 1 error(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrors.Windows.verified.txt
@@ -1,6 +1,6 @@
-﻿]9;4;3;\  project [31;1mfailed with errors[m (0.2s)
+﻿]9;4;3;\  project [31;1mfailed with 1 error(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with errors[m in 5.0s
+Build [31;1mfailed with 1 error(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndWarnings.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndWarnings.Linux.verified.txt
@@ -1,0 +1,9 @@
+﻿]9;4;3;\  project [31;1mfailed with 2 error(s) and 2 warning(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning1!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning2!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error1!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error2!
+[?25l[1F
+[?25h
+Build [31;1mfailed with 2 error(s) and 2 warning(s)[m in 5.0s
+]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndWarnings.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndWarnings.OSX.verified.txt
@@ -1,0 +1,8 @@
+﻿  project [31;1mfailed with 2 error(s) and 2 warning(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning1!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning2!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error1!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error2!
+[?25l[1F
+[?25h
+Build [31;1mfailed with 2 error(s) and 2 warning(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndWarnings.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndWarnings.Windows.verified.txt
@@ -1,0 +1,9 @@
+﻿]9;4;3;\  project [31;1mfailed with 2 error(s) and 2 warning(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning1!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning2!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error1!
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error2!
+[?25l[1F
+[?25h
+Build [31;1mfailed with 2 error(s) and 2 warning(s)[m in 5.0s
+]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Linux.verified.txt
@@ -1,4 +1,4 @@
-﻿]9;4;3;\  project [33;1msucceeded with warnings[m (0.2s)
+﻿]9;4;3;\  project [33;1msucceeded with 1 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
       A
       Multi
@@ -6,5 +6,5 @@
       Warning!
 [?25l[1F
 [?25h
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with 1 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.OSX.verified.txt
@@ -1,4 +1,4 @@
-﻿  project [33;1msucceeded with warnings[m (0.2s)
+﻿  project [33;1msucceeded with 1 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
       A
       Multi
@@ -6,4 +6,5 @@
       Warning!
 [?25l[1F
 [?25h
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with 1 warning(s)[m in 5.0s
+

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_SucceededWithWarnings.Windows.verified.txt
@@ -1,4 +1,4 @@
-﻿]9;4;3;\  project [33;1msucceeded with warnings[m (0.2s)
+﻿]9;4;3;\  project [33;1msucceeded with 1 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
       A
       Multi
@@ -6,5 +6,5 @@
       Warning!
 [?25l[1F
 [?25h
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with 1 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintImmediateWarningMessage_Succeeded.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintImmediateWarningMessage_Succeeded.Linux.verified.txt
@@ -1,9 +1,9 @@
 ﻿]9;4;3;\directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]DeviceFlow: https://testfeed/index.json
 directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]ATTENTION: User interaction required.**********************************************************************To sign in, use a web browser to open the page https://devicelogin and enter the code XXXXXX to authenticate.**********************************************************************
-  project [33;1msucceeded with warnings[m (0.2s)
+  project [33;1msucceeded with 2 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]DeviceFlow: https://testfeed/index.json
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]ATTENTION: User interaction required.**********************************************************************To sign in, use a web browser to open the page https://devicelogin and enter the code XXXXXX to authenticate.**********************************************************************
 [?25l[1F
 [?25h
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintImmediateWarningMessage_Succeeded.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintImmediateWarningMessage_Succeeded.OSX.verified.txt
@@ -1,8 +1,8 @@
 ﻿directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]DeviceFlow: https://testfeed/index.json
 directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]ATTENTION: User interaction required.**********************************************************************To sign in, use a web browser to open the page https://devicelogin and enter the code XXXXXX to authenticate.**********************************************************************
-  project [33;1msucceeded with warnings[m (0.2s)
+  project [33;1msucceeded with 2 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]DeviceFlow: https://testfeed/index.json
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]ATTENTION: User interaction required.**********************************************************************To sign in, use a web browser to open the page https://devicelogin and enter the code XXXXXX to authenticate.**********************************************************************
 [?25l[1F
 [?25h
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with 2 warning(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintImmediateWarningMessage_Succeeded.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintImmediateWarningMessage_Succeeded.Windows.verified.txt
@@ -1,9 +1,9 @@
 ﻿]9;4;3;\directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]DeviceFlow: https://testfeed/index.json
 directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]ATTENTION: User interaction required.**********************************************************************To sign in, use a web browser to open the page https://devicelogin and enter the code XXXXXX to authenticate.**********************************************************************
-  project [33;1msucceeded with warnings[m (0.2s)
+  project [33;1msucceeded with 2 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]DeviceFlow: https://testfeed/index.json
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: [CredentialProvider]ATTENTION: User interaction required.**********************************************************************To sign in, use a web browser to open the page https://devicelogin and enter the code XXXXXX to authenticate.**********************************************************************
 [?25l[1F
 [?25h
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_Failed.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_Failed.Linux.verified.txt
@@ -1,4 +1,4 @@
 ﻿]9;4;3;\directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Restore Failed
 
-Build [31;1mfailed with errors[m in 5.0s
+Build [31;1mfailed with 1 error(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_Failed.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_Failed.OSX.verified.txt
@@ -1,3 +1,3 @@
 ﻿directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Restore Failed
 
-Build [31;1mfailed with errors[m in 5.0s
+Build [31;1mfailed with 1 error(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_Failed.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_Failed.Windows.verified.txt
@@ -1,4 +1,4 @@
 ﻿]9;4;3;\directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Restore Failed
 
-Build [31;1mfailed with errors[m in 5.0s
+Build [31;1mfailed with 1 error(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_SuccessWithWarnings.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_SuccessWithWarnings.Linux.verified.txt
@@ -1,4 +1,4 @@
 ﻿]9;4;3;\directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Restore with Warning
 
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with 1 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_SuccessWithWarnings.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_SuccessWithWarnings.OSX.verified.txt
@@ -1,3 +1,3 @@
 ﻿directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Restore with Warning
 
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with 1 warning(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_SuccessWithWarnings.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintRestore_SuccessWithWarnings.Windows.verified.txt
@@ -1,4 +1,4 @@
 ﻿]9;4;3;\directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Restore with Warning
 
-Build [33;1msucceeded with warnings[m in 5.0s
+Build [33;1msucceeded with 1 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1539,13 +1539,19 @@
     </comment>
   </data>
   <data name="BuildResult_FailedWithErrors" xml:space="preserve">
-    <value>failed with errors</value>
+    <value>failed with {0} error(s)</value>
+    <comment>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </comment>
+  </data>
+  <data name="BuildResult_FailedWithErrorsAndWarnings" xml:space="preserve">
+    <value>failed with {0} error(s) and {1} warning(s)</value>
     <comment>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </comment>
   </data>
   <data name="BuildResult_FailedWithWarnings" xml:space="preserve">
-    <value>failed with warnings</value>
+    <value>failed with {0} warning(s)</value>
     <comment>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </comment>
@@ -1563,7 +1569,7 @@
     </comment>
   </data>
   <data name="BuildResult_SucceededWithWarnings" xml:space="preserve">
-    <value>succeeded with warnings</value>
+    <value>succeeded with {0} warning(s)</value>
     <comment>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </comment>

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">selhalo s chybami</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">selhalo s upozorněními</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">úspěšně dokončeno s upozorněními</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">Fehlgeschlagen mit Fehlern</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">Fehlgeschlagen mit Warnungen</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">Erfolgreich mit Warnungen</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">error con errores</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">error con advertencias</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">correcto con advertencias</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">a échoué avec des erreurs</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">a échoué avec des avertissements</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">a réussi avec des avertissements</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">non riuscito con errori</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">non riuscito con avvisi</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">completato con avvisi</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">エラーで失敗しました</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">失敗し、警告が発生しました</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">警告付きで成功</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">실패(오류 발생)</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">실패(경고 발생)</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">성공(경고 발생)</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">zakończono niepowodzeniem, z błędami</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">zakończono niepowodzeniem, z ostrzeżeniami.</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">zakończono powodzeniem, z ostrzeżeniem</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">falhou com erros</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">falhou com avisos</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">êxito com avisos</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">сбой с ошибками</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">сбой с предупреждениями</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">успешно выполнено с предупреждением</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">hatalarla başarısız oldu</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">uyarılarla başarısız oldu</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">uyarılarla birlikte başarılı</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">失败，出现错误</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">失败，出现警告</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">成功，但出现警告</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -32,15 +32,22 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithErrors">
-        <source>failed with errors</source>
-        <target state="translated">失敗但有錯誤</target>
+        <source>failed with {0} error(s)</source>
+        <target state="new">failed with {0} error(s)</target>
+        <note>
+      Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
+    </note>
+      </trans-unit>
+      <trans-unit id="BuildResult_FailedWithErrorsAndWarnings">
+        <source>failed with {0} error(s) and {1} warning(s)</source>
+        <target state="new">failed with {0} error(s) and {1} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_FailedWithWarnings">
-        <source>failed with warnings</source>
-        <target state="translated">失敗但有警告</target>
+        <source>failed with {0} warning(s)</source>
+        <target state="new">failed with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
@@ -53,8 +60,8 @@
     </note>
       </trans-unit>
       <trans-unit id="BuildResult_SucceededWithWarnings">
-        <source>succeeded with warnings</source>
-        <target state="translated">成功但有警告</target>
+        <source>succeeded with {0} warning(s)</source>
+        <target state="new">succeeded with {0} warning(s)</target>
         <note>
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>


### PR DESCRIPTION
Fixes #9049

### Context
Updated the Terminal Logger summary to include number of errors and warnings.

### Testing
Unit tests & local testing