### PR TITLE
Attribute custom task OOM (and other critical exceptions) to the task

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -1050,21 +1050,20 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ml.AssertLogContains("a=b");
         }
 
-        [Fact]
-        public void TaskExceptionHandlingTest()
-        {
-            // Unfortunately we cannot run those via TheoryAttribute and InlineDataAttribute because
-            //  the MSBuildTestEnvironmentFixture injects the cleanup logic for each testcase and when those
-            //  are run in parallel, within the same process, the two process will conflict with each other (on the error file).
-            TaskExceptionHandlingTestInternal(typeof(OutOfMemoryException), true);
-            TaskExceptionHandlingTestInternal(typeof(ArgumentException), false);
-        }
-
-        private void TaskExceptionHandlingTestInternal(Type exceptionType, bool isCritical)
+        [Theory]
+        [InlineData(typeof(OutOfMemoryException), true)]
+        [InlineData(typeof(ArgumentException), false)]
+        public void TaskExceptionHandlingTest(Type exceptionType, bool isCritical)
         {
             string testExceptionMessage = "Test Message";
             string customTaskPath = Assembly.GetExecutingAssembly().Location;
             MockLogger ml = new MockLogger() { AllowTaskCrashes = true };
+
+            using TestEnvironment env = TestEnvironment.Create();
+            var debugFolder = env.CreateFolder(true);
+            // inject the location for failure logs - not to interact with other tests
+            env.SetEnvironmentVariable("MSBUILDDEBUGPATH", debugFolder.Path);
+
             ObjectModelHelpers.BuildProjectExpectFailure($"""
                      <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                          <UsingTask TaskName=`TaskThatThrows` AssemblyFile=`{customTaskPath}`/>

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -1083,7 +1083,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ml.AssertLogDoesntContain(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("UnhandledMSBuildError", string.Empty));
             ml.AssertLogContains(testExceptionMessage);
 
-            File.Exists(ExceptionHandling.DumpFilePath).ShouldBe(isCritical);
+            File.Exists(ExceptionHandling.DumpFilePath).ShouldBe(isCritical,
+                $"{ExceptionHandling.DumpFilePath} expected to exist: {isCritical}");
             if (isCritical)
             {
                 FileUtilities.DeleteNoThrow(ExceptionHandling.DumpFilePath);

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -18,6 +18,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.Debugging;
 using Shouldly;
 using Xunit;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
@@ -1060,9 +1061,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
             MockLogger ml = new MockLogger() { AllowTaskCrashes = true };
 
             using TestEnvironment env = TestEnvironment.Create();
-            var debugFolder = env.CreateFolder(true);
+            var debugFolder = env.CreateFolder();
             // inject the location for failure logs - not to interact with other tests
             env.SetEnvironmentVariable("MSBUILDDEBUGPATH", debugFolder.Path);
+            // Force initing the DebugPath from the env var - as we need it to be unique for those tests.
+            // The ProjectCacheTests DataMemberAttribute usages (specifically SuccessfulGraphsWithBuildParameters) lead
+            //  to the DebugPath being set before this test runs - and hence the env var is ignored.
+            DebugUtils.SetDebugPath();
 
             ObjectModelHelpers.BuildProjectExpectFailure($"""
                      <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>

--- a/src/Build.UnitTests/BackEnd/TaskThatThrows.cs
+++ b/src/Build.UnitTests/BackEnd/TaskThatThrows.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Engine.UnitTests;
+
+/// <summary>
+/// Task that throws exception based on input parameters.
+/// </summary>
+public sealed class TaskThatThrows : Utilities.Task
+{
+    public string ExceptionType { get; set; }
+
+    public string ExceptionMessage { get; set; }
+
+    public override bool Execute()
+    {
+        if (string.IsNullOrWhiteSpace(ExceptionMessage))
+        {
+            ExceptionMessage = "Default exception message";
+        }
+
+        Type exceptionType = string.IsNullOrWhiteSpace(ExceptionType) ? typeof(Exception) : Type.GetType(ExceptionType);
+
+        ConstructorInfo ctor = exceptionType.GetConstructor(new[] { typeof(string) });
+        Exception exceptionInstance = (Exception)ctor.Invoke(new object[] { ExceptionMessage });
+
+
+        throw exceptionInstance;
+    }
+}

--- a/src/Build.UnitTests/BackEnd/TaskThatThrows.cs
+++ b/src/Build.UnitTests/BackEnd/TaskThatThrows.cs
@@ -15,22 +15,18 @@ namespace Microsoft.Build.Engine.UnitTests;
 /// </summary>
 public sealed class TaskThatThrows : Utilities.Task
 {
-    public string ExceptionType { get; set; }
+    public string? ExceptionType { get; set; }
 
-    public string ExceptionMessage { get; set; }
+    public string? ExceptionMessage { get; set; }
 
     public override bool Execute()
     {
-        if (string.IsNullOrWhiteSpace(ExceptionMessage))
-        {
-            ExceptionMessage = "Default exception message";
-        }
+        string exceptionMessage = string.IsNullOrWhiteSpace(ExceptionMessage) ? "Default exception message" : ExceptionMessage!;
 
-        Type exceptionType = string.IsNullOrWhiteSpace(ExceptionType) ? typeof(Exception) : Type.GetType(ExceptionType);
+        Type exceptionType = string.IsNullOrWhiteSpace(ExceptionType) ? typeof(Exception) : Type.GetType(ExceptionType) ?? typeof(Exception);
 
-        ConstructorInfo ctor = exceptionType.GetConstructor(new[] { typeof(string) });
-        Exception exceptionInstance = (Exception)ctor.Invoke(new object[] { ExceptionMessage });
-
+        ConstructorInfo? ctor = exceptionType.GetConstructor([typeof(string)]);
+        Exception exceptionInstance = (Exception)(ctor?.Invoke([exceptionMessage]) ?? new Exception(exceptionMessage));
 
         throw exceptionInstance;
     }

--- a/src/Build/BackEnd/Components/Communications/SerializationContractInitializer.cs
+++ b/src/Build/BackEnd/Components/Communications/SerializationContractInitializer.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Build.BackEnd
                 new(typeof(SchedulerCircularDependencyException), (msg, inner) => new SchedulerCircularDependencyException(msg, inner)),
                 new(typeof(RegistryException), (msg, inner) => new RegistryException(msg, inner)),
                 new(typeof(HostObjectException), (msg, inner) => new HostObjectException(msg, inner)),
-                new(typeof(UnbuildableProjectTypeException), (msg, inner) => new UnbuildableProjectTypeException(msg, inner)));
+                new(typeof(UnbuildableProjectTypeException), (msg, inner) => new UnbuildableProjectTypeException(msg, inner)),
+                new(typeof(CriticalTaskException), (msg, inner) => new CriticalTaskException(msg, inner)));
         }
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -853,7 +853,7 @@ namespace Microsoft.Build.BackEnd
 
                     loggingContext.LogCommentFromText(MessageImportance.Low, ex.ToString());
                 }
-                else
+                else if (ex is not CriticalTaskException)
                 {
                     (((LoggingContext)_projectLoggingContext) ?? _nodeLoggingContext).LogError(BuildEventFileInfo.Empty, "UnhandledMSBuildError", ex.ToString());
                 }

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -762,9 +762,13 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// The entry point for the request builder thread.
+        /// Launch the project and gather the results, reporting them back to the BuildRequestEngine.
         /// </summary>
         private async Task RequestThreadProc(bool setThreadParameters)
         {
+            Exception thrownException = null;
+            BuildResult result = null;
+
             try
             {
                 if (setThreadParameters)
@@ -772,42 +776,9 @@ namespace Microsoft.Build.BackEnd
                     SetCommonWorkerThreadParameters();
                 }
                 MSBuildEventSource.Log.RequestThreadProcStart();
-                await BuildAndReport();
-                MSBuildEventSource.Log.RequestThreadProcStop();
-            }
-            catch (ThreadAbortException)
-            {
-                // Do nothing.  This will happen when the thread is forcibly terminated because we are shutting down, for example
-                // when the unit test framework terminates.
-                throw;
-            }
-            catch (Exception e)
-            {
-                // Dump all engine exceptions to a temp file
-                // so that we have something to go on in the
-                // event of a failure
-                ExceptionHandling.DumpExceptionToFile(e);
-
-                // This is fatal: process will terminate: make sure the
-                // debugger launches
-                ErrorUtilities.ThrowInternalError(e.Message, e);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Launch the project and gather the results, reporting them back to the BuildRequestEngine.
-        /// </summary>
-        private async Task BuildAndReport()
-        {
-            Exception thrownException = null;
-            BuildResult result = null;
-            VerifyEntryInActiveState();
-
-            // Start the build request
-            try
-            {
+                VerifyEntryInActiveState();
                 result = await BuildProject();
+                MSBuildEventSource.Log.RequestThreadProcStop();
             }
             catch (InvalidProjectFileException ex)
             {
@@ -853,6 +824,12 @@ namespace Microsoft.Build.BackEnd
 
                     loggingContext.LogCommentFromText(MessageImportance.Low, ex.ToString());
                 }
+                else if (ex is ThreadAbortException)
+                {
+                    // Do nothing.  This will happen when the thread is forcibly terminated because we are shutting down, for example
+                    // when the unit test framework terminates.
+                    throw;
+                }
                 else if (ex is not CriticalTaskException)
                 {
                     (((LoggingContext)_projectLoggingContext) ?? _nodeLoggingContext).LogError(BuildEventFileInfo.Empty, "UnhandledMSBuildError", ex.ToString());
@@ -860,10 +837,19 @@ namespace Microsoft.Build.BackEnd
 
                 if (ExceptionHandling.IsCriticalException(ex))
                 {
+                    // Dump all engine exceptions to a temp file
+                    // so that we have something to go on in the
+                    // event of a failure
+                    ExceptionHandling.DumpExceptionToFile(ex);
+
                     // This includes InternalErrorException, which we definitely want a callstack for.
                     // Fortunately the default console UnhandledExceptionHandler will log the callstack even
                     // for unhandled exceptions thrown from threads other than the main thread, like here.
                     // Less fortunately NUnit doesn't.
+
+                    // This is fatal: process will terminate: make sure the
+                    // debugger launches
+                    ErrorUtilities.ThrowInternalError(ex.Message, ex);
                     throw;
                 }
             }
@@ -879,8 +865,6 @@ namespace Microsoft.Build.BackEnd
 
                 ReportResultAndCleanUp(result);
             }
-
-            return;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -814,8 +814,18 @@ namespace Microsoft.Build.BackEnd
                         }
                     }
                 }
-                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex) && Environment.GetEnvironmentVariable("MSBUILDDONOTCATCHTASKEXCEPTIONS") != "1")
+                catch (Exception ex)
                 {
+                    if (ExceptionHandling.IsCriticalException(ex) || Environment.GetEnvironmentVariable("MSBUILDDONOTCATCHTASKEXCEPTIONS") == "1")
+                    {
+                        taskLoggingContext.LogFatalTaskError(
+                            ex,
+                            new BuildEventFileInfo(_targetChildInstance.Location),
+                            _taskNode.Name);
+
+                        throw new CriticalTaskException(ex);
+                    }
+
                     taskException = ex;
                 }
 

--- a/src/Framework/CriticalTaskException.cs
+++ b/src/Framework/CriticalTaskException.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Framework
         { }
 
         // Do not remove - used by BuildExceptionSerializationHelper
-        internal CriticalTaskException(string message, Exception inner)
+        internal CriticalTaskException(string message, Exception? inner)
             : base(message, inner)
         { }
     }

--- a/src/Framework/CriticalTaskException.cs
+++ b/src/Framework/CriticalTaskException.cs
@@ -10,6 +10,9 @@ using Microsoft.Build.Framework.BuildException;
 
 namespace Microsoft.Build.Framework
 {
+    /// <summary>
+    /// A wrapper exception for exceptions thrown by tasks (in TaskBuilder) that are critical to the build process.
+    /// </summary>
     internal sealed class CriticalTaskException : BuildExceptionBase
     {
         public CriticalTaskException(

--- a/src/Framework/CriticalTaskException.cs
+++ b/src/Framework/CriticalTaskException.cs
@@ -11,7 +11,9 @@ using Microsoft.Build.Framework.BuildException;
 namespace Microsoft.Build.Framework
 {
     /// <summary>
-    /// A wrapper exception for exceptions thrown by tasks (in TaskBuilder) that are critical to the build process.
+    /// A wrapper exception for exceptions thrown by MsBuild Tasks (in TaskBuilder) that are critical to the task run and overall to the build process.
+    /// However such exception desn't indicate problem within the MsBuild engine, but rather in the Task itself - for this reason we wrap the exception,
+    ///  so that we can properly log it up the stack (and not assume it is a bug within the build engine)
     /// </summary>
     internal sealed class CriticalTaskException : BuildExceptionBase
     {

--- a/src/Framework/CriticalTaskException.cs
+++ b/src/Framework/CriticalTaskException.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.BuildException;
+
+namespace Microsoft.Build.Framework
+{
+    internal sealed class CriticalTaskException : BuildExceptionBase
+    {
+        public CriticalTaskException(
+            Exception innerException)
+            : base(string.Empty, innerException)
+        { }
+
+        // Do not remove - used by BuildExceptionSerializationHelper
+        internal CriticalTaskException(string message, Exception inner)
+            : base(message, inner)
+        { }
+    }
+}

--- a/src/Shared/Debugging/DebugUtils.cs
+++ b/src/Shared/Debugging/DebugUtils.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Build.Shared.Debugging
 
         static DebugUtils()
         {
+            SetDebugPath();
+        }
+
+        // DebugUtils are initialized early on by the test runner - during preparing data for DataMemeberAttribute of some test,
+        //  for that reason it is not easily possible to inject the DebugPath in tests via env var (unless we want to run expensive exec style test).
+        internal static void SetDebugPath()
+        {
             string environmentDebugPath = FileUtilities.TrimAndStripAnyQuotes(Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH"));
             string debugDirectory = environmentDebugPath;
 
@@ -95,7 +102,7 @@ namespace Microsoft.Build.Shared.Debugging
 
         public static readonly bool ShouldDebugCurrentProcess = CurrentProcessMatchesDebugName();
 
-        public static string DebugPath { get; }
+        public static string DebugPath { get; private set; }
 
         public static string FindNextAvailableDebugFilePath(string fileName)
         {

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -79,6 +79,11 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string DebugDumpPath => s_debugDumpPath;
 
+        /// <summary>
+        /// The file used for diagnostic log files.
+        /// </summary>
+        internal static string DumpFilePath => s_dumpFileName;
+
 #if !BUILDINGAPPXTASKS
         /// <summary>
         /// The filename that exceptions will be dumped to
@@ -99,6 +104,9 @@ namespace Microsoft.Build.Shared
              || e is ThreadAbortException
              || e is ThreadInterruptedException
              || e is AccessViolationException
+#if !TASKHOST
+             || e is CriticalTaskException
+#endif
 #if !BUILDINGAPPXTASKS
              || e is InternalErrorException
 #endif


### PR DESCRIPTION
Fixes #9928

### Context
OOM in custom tasks is rethrown to RequestBuilder, where it is logged as an MSBuild bug.
We might try - on best effort basis - to log an error for the task little more up the stack and then continue in unrolling as before. If we succeed - we get better logging experience for the case; if we fail - we get the same experience as before.


### Changes Made
* The exception is attempted to be logged in `TaskBuilder`
* `RequestThreadProc` and `BuildAndReport` methods merged into single one - so that writing the 'error dump' file (MSBuild***.failure.txt) is deterministically written before reporting the result back
* Exposing an internal option to re-initialize `DebugUtils.DebugPath` - as this was set before any unit test was given chance to start, so injecting altering env var was not possible.

### Testing
Added test with dummy OOM (not a real CLR OOM - in order to have deterministic test outputs)

### Notes
Discussed the OOM handling with @janvorli (for a perspective from the Runtime PoV) - we should not make no expectations that anything can succeed after OOM catching (though this migh get more successful in single threaded processing - which MSBuild currently is), but if we are fine with the handler possibly failing (which basically leads to pre-existing behavior) - than there should not be any security nor corectness concerns.
