### PR TITLE
Move the ConvertToString invariant culture changes under 17.12 changewave

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -25,6 +25,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 
 ### 17.12
 - [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)
+- [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`
@@ -38,7 +39,6 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Exec task does not trim leading whitespaces for ConsoleOutput](https://github.com/dotnet/msbuild/pull/9722)
 - [Introduce [MSBuild]::StableStringHash overloads](https://github.com/dotnet/msbuild/issues/9519)
 - [Keep the encoding of standard output & error consistent with the console code page for ToolTask](https://github.com/dotnet/msbuild/pull/9539)
-- [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
 
 ### 17.8
 - [[RAR] Don't do I/O on SDK-provided references](https://github.com/dotnet/msbuild/pull/8688)

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4950,7 +4950,7 @@ $(
                 var svSECultureInfo = new CultureInfo("sv-SE");
                 using (var env = TestEnvironment.Create())
                 {
-                    env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_10.ToString());
+                    env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_12.ToString());
                     currentThread.CurrentCulture = svSECultureInfo;
                     currentThread.CurrentUICulture = svSECultureInfo;
                     var root = env.CreateFolder();

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1479,7 +1479,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     // The fall back is always to just convert to a string directly.
                     // Issue: https://github.com/dotnet/msbuild/issues/9757
-                    if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+                    if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
                     {
                         convertedString = Convert.ToString(valueToConvert, CultureInfo.InvariantCulture);
                     }


### PR DESCRIPTION
### Context
Change https://github.com/dotnet/msbuild/pull/9874 was put behind the change wave 17.10. 
However the version of the change wave should be 17.12 based on https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves-Dev.md#change-wave-versioning

### Changes Made
Move the fix behind different change wave version

### Testing
Existing test was updated to respect new change wave
