### PR TITLE
[release/vs17.10] Fix issue with assemblies locking

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.10.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.10.1</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.8.3</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Tasks/GetAssembliesMetadata.cs
+++ b/src/Tasks/GetAssembliesMetadata.cs
@@ -50,12 +50,14 @@ namespace Microsoft.Build.Tasks
                 // During DTB the referenced project may not has been built yet, so we need to check if the assembly already exists.
                 if (File.Exists(assemblyPath))
                 {
-                    AssemblyInformation assemblyInformation = new(assemblyPath);
-                    AssemblyAttributes attributes = assemblyInformation.GetAssemblyMetadata();
-
-                    if (attributes != null)
+                    using (AssemblyInformation assemblyInformation = new(assemblyPath))
                     {
-                        assembliesMetadata.Add(CreateItemWithMetadata(attributes));
+                        AssemblyAttributes attributes = assemblyInformation.GetAssemblyMetadata();
+
+                        if (attributes != null)
+                        {
+                            assembliesMetadata.Add(CreateItemWithMetadata(attributes));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
fwdport of https://github.com/dotnet/msbuild/pull/9973

### Summary
The issue is related to the presence of disposable resource that wasn't cleaned up in time.

### Customer Impact
Absence of dispose causes "warning MSB3026: Could not copy "*.dll". Beginning retry 1 in 1000ms. The process cannot access the file '*.dll' because it is being used by another process. The file is locked by: "MSBuild.exe" and it's presence breaks project building.

### Regression?
Yes, was introduced in scope of https://github.com/dotnet/msbuild/pull/9313/files#diff-0c7ff4eddab39e683e61e6f11011eac73dae76d2574999184b3c0e74f9c2fa10

### Testing
Manual -the problem wasn't caught locally, but manual testing doesn't expose any side effects.

### Risk
Low, doesn't contain any changes in logic.
