### PR TITLE
Include Microsoft.Common.Test.targets in Arm64

### DIFF
--- a/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
+++ b/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
@@ -21,6 +21,7 @@ folder InstallDir:\MSBuild\Current\Bin\arm64
   file source=$(Arm64BinPath)Microsoft.Common.overridetasks
   file source=$(Arm64BinPath)Microsoft.Common.targets
   file source=$(Arm64BinPath)Microsoft.Common.tasks
+  file source=$(Arm64BinPath)Microsoft.Common.Test.targets
   file source=$(Arm64BinPath)Microsoft.Managed.targets
   file source=$(Arm64BinPath)Microsoft.Managed.Before.targets
   file source=$(Arm64BinPath)Microsoft.Managed.After.targets


### PR DESCRIPTION
This file is missing, leading to errors in the Arm64 flavor of VS

```
C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\arm64\Microsoft.Common.CurrentVersion.targets
(6824,3): error MSB4019: The imported project "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bi
n\arm64\Microsoft.Common.Test.targets" was not found. Confirm that the expression in the Import declaration "C:\Program
 Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\arm64\Microsoft.Common.Test.targets" is correct, and th
at the file exists on disk.
```

See: https://developercommunity.visualstudio.com/t/Arm64-Unable-to-use-MicrosoftBuildRu/10632924?ref=native&refTime=1712530347328&refUserId=ba1eecbf-9f1b-431b-ba02-0503abd8762c