### PR TITLE
Handle solution traversal targets in graph builds

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2300,6 +2300,50 @@ EndGlobal
         }
 
         /// <summary>
+        /// Verifies that disambiguated target names are used when a project name matches a standard solution entry point.
+        /// </summary>
+        [Fact]
+        public void DisambiguatedTargetNamesAreInInMetaproj()
+        {
+            foreach(string projectName in ProjectInSolution.projectNamesToDisambiguate)
+            {
+                SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(
+                $$"""
+                    Microsoft Visual Studio Solution File, Format Version 14.00
+                    # Visual Studio 2015
+                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{projectName}}", "{{projectName}}.csproj", "{6185CC21-BE89-448A-B3C0-D1C27112E595}"
+                    EndProject
+                    Global
+                        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                            Release|Any CPU = Release|Any CPU
+                        EndGlobalSection
+                        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                            {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                            {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                            {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                            {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
+                        EndGlobalSection
+                    EndGlobal
+                """);
+
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, CreateMockLoggingService(), null);
+
+                foreach (string targetName in ProjectInSolution.projectNamesToDisambiguate)
+                {
+                    // The entry point still exists normally.
+                    Assert.True(instances[0].Targets.ContainsKey(targetName));
+
+                    // The traversal target should be disambiguated with a "Solution:" prefix.
+                    // Note: The default targets are used instead of "Build".
+                    string traversalTargetName = targetName.Equals("Build", StringComparison.OrdinalIgnoreCase)
+                        ? $"Solution:{projectName}"
+                        : $"Solution:{projectName}:{targetName}";
+                    Assert.True(instances[0].Targets.ContainsKey(traversalTargetName));
+                }
+            }
+        }
+
+        /// <summary>
         /// Verifies that illegal user target names (the ones already used internally) don't crash the SolutionProjectGenerator
         /// </summary>
         [Theory]

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -2808,6 +2808,119 @@ $@"
             }
         }
 
+        [Theory]
+        // Built-in targets
+        [InlineData(new string[0], new[] { "Project1Default" }, new[] { "Project2Default" })]
+        [InlineData(new[] { "Build" }, new[] { "Project1Default" }, new[] { "Project2Default" })]
+        [InlineData(new[] { "Rebuild" }, new[] { "Rebuild" }, new[] { "Rebuild" })]
+        [InlineData(new[] { "Clean" }, new[] { "Clean" }, new[] { "Clean" })]
+        [InlineData(new[] { "Publish" }, new[] { "Publish" }, new[] { "Publish" })]
+        // Traversal targets
+        [InlineData(new[] { "Project1" }, new[] { "Project1Default" }, new string[0])]
+        [InlineData(new[] { "Project2" }, new string[0], new[] { "Project2Default" })]
+        [InlineData(new[] { "Project1", "Project2" }, new[] { "Project1Default" }, new[] { "Project2Default" })]
+        [InlineData(new[] { "Project1:Rebuild" }, new[] { "Rebuild" }, new string[0])]
+        [InlineData(new[] { "Project2:Rebuild" }, new string[0], new[] { "Rebuild" })]
+        [InlineData(new[] { "Project1:Rebuild", "Project2:Clean" }, new[] { "Rebuild" }, new[] { "Clean" })]
+        [InlineData(new[] { "CustomTarget" }, new[] { "CustomTarget" }, new[] { "CustomTarget" })]
+        [InlineData(new[] { "Project1:CustomTarget" }, new[] { "CustomTarget" }, new string[0])]
+        [InlineData(new[] { "Project2:CustomTarget" }, new string[0], new[] { "CustomTarget" })]
+        [InlineData(new[] { "Project1:CustomTarget", "Project2:CustomTarget" }, new[] { "CustomTarget" }, new[] { "CustomTarget" })]
+        public void GetTargetListsWithSolution(string[] entryTargets, string[] expectedProject1Targets, string[] expectedProject2Targets)
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                const string ExtraContent = """
+                    <Target Name="CustomTarget" />
+                    """;
+                TransientTestFile project1File = CreateProjectFile(env: env, projectNumber: 1, defaultTargets: "Project1Default", extraContent: ExtraContent);
+                TransientTestFile project2File = CreateProjectFile(env: env, projectNumber: 2, defaultTargets: "Project2Default", extraContent: ExtraContent);
+
+                string solutionFileContents = $$"""
+                    Microsoft Visual Studio Solution File, Format Version 12.00
+                    # Visual Studio Version 17
+                    VisualStudioVersion = 17.0.31903.59
+                    MinimumVisualStudioVersion = 17.0.31903.59
+                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project1", "{{project1File.Path}}", "{8761499A-7280-43C4-A32F-7F41C47CA6DF}"
+                    EndProject
+                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project2", "{{project2File.Path}}", "{2022C11A-1405-4983-BEC2-3A8B0233108F}"
+                    EndProject
+                    Global
+                        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                            Debug|x64 = Debug|x64
+                            Release|x64 = Release|x64
+                        EndGlobalSection
+                        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                            {8761499A-7280-43C4-A32F-7F41C47CA6DF}.Debug|x64.ActiveCfg = Debug|x64
+                            {8761499A-7280-43C4-A32F-7F41C47CA6DF}.Debug|x64.Build.0 = Debug|x64
+                            {8761499A-7280-43C4-A32F-7F41C47CA6DF}.Release|x64.ActiveCfg = Release|x64
+                            {8761499A-7280-43C4-A32F-7F41C47CA6DF}.Release|x64.Build.0 = Release|x64
+                            {2022C11A-1405-4983-BEC2-3A8B0233108F}.Debug|x64.ActiveCfg = Debug|x64
+                            {2022C11A-1405-4983-BEC2-3A8B0233108F}.Debug|x64.Build.0 = Debug|x64
+                            {2022C11A-1405-4983-BEC2-3A8B0233108F}.Release|x64.ActiveCfg = Release|x64
+                            {2022C11A-1405-4983-BEC2-3A8B0233108F}.Release|x64.Build.0 = Release|x64
+                        EndGlobalSection
+                        GlobalSection(SolutionProperties) = preSolution
+                            HideSolutionNode = FALSE
+                        EndGlobalSection
+                    EndGlobal
+                    """;
+                TransientTestFile slnFile = env.CreateFile(@"Solution.sln", solutionFileContents);
+                SolutionFile solutionFile = SolutionFile.Parse(slnFile.Path);
+
+                ProjectGraph projectGraph = new(slnFile.Path);
+                ProjectGraphNode project1Node = GetFirstNodeWithProjectNumber(projectGraph, 1);
+                ProjectGraphNode project2Node = GetFirstNodeWithProjectNumber(projectGraph, 2);
+
+                IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = projectGraph.GetTargetLists(entryTargets);
+                targetLists.Count.ShouldBe(projectGraph.ProjectNodes.Count);
+                targetLists[project1Node].ShouldBe(expectedProject1Targets);
+                targetLists[project2Node].ShouldBe(expectedProject2Targets);
+            }
+        }
+
+        [Theory]
+        [InlineData("Project1:Build")]
+        [InlineData("Project1:")]
+        public void GetTargetListsWithSolutionInvalidTargets(string entryTarget)
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                TransientTestFile project1File = CreateProjectFile(env: env, projectNumber: 1);
+                string solutionFileContents = $$"""
+                    Microsoft Visual Studio Solution File, Format Version 12.00
+                    # Visual Studio Version 17
+                    VisualStudioVersion = 17.0.31903.59
+                    MinimumVisualStudioVersion = 17.0.31903.59
+                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project1", "{{project1File.Path}}", "{8761499A-7280-43C4-A32F-7F41C47CA6DF}"
+                    EndProject
+                    Global
+                        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                            Debug|x64 = Debug|x64
+                            Release|x64 = Release|x64
+                        EndGlobalSection
+                        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                            {8761499A-7280-43C4-A32F-7F41C47CA6DF}.Debug|x64.ActiveCfg = Debug|x64
+                            {8761499A-7280-43C4-A32F-7F41C47CA6DF}.Debug|x64.Build.0 = Debug|x64
+                            {8761499A-7280-43C4-A32F-7F41C47CA6DF}.Release|x64.ActiveCfg = Release|x64
+                            {8761499A-7280-43C4-A32F-7F41C47CA6DF}.Release|x64.Build.0 = Release|x64
+                        EndGlobalSection
+                        GlobalSection(SolutionProperties) = preSolution
+                            HideSolutionNode = FALSE
+                        EndGlobalSection
+                    EndGlobal
+                    """;
+                TransientTestFile slnFile = env.CreateFile(@"Solution.sln", solutionFileContents);
+                SolutionFile solutionFile = SolutionFile.Parse(slnFile.Path);
+
+                ProjectGraph projectGraph = new(slnFile.Path);
+
+                var getTargetListsFunc = (() => projectGraph.GetTargetLists([entryTarget]));
+                InvalidProjectFileException exception = getTargetListsFunc.ShouldThrow<InvalidProjectFileException>();
+                exception.Message.ShouldContain($"The target \"{entryTarget}\" does not exist in the project.");
+            }
+        }
+
         public void Dispose()
         {
             _env.Dispose();

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1962,11 +1962,10 @@ namespace Microsoft.Build.Execution
 
                 // Non-graph builds verify this in RequestBuilder, but for graph builds we need to disambiguate
                 // between entry nodes and other nodes in the graph since only entry nodes should error. Just do
-                // the verification expicitly before the build even starts.
+                // the verification explicitly before the build even starts.
                 foreach (ProjectGraphNode entryPointNode in projectGraph.EntryPointNodes)
                 {
-                    ImmutableList<string> targetList = targetsPerNode[entryPointNode];
-                    ProjectErrorUtilities.VerifyThrowInvalidProject(targetList.Count > 0, entryPointNode.ProjectInstance.ProjectFileLocation, "NoTargetSpecified");
+                    ProjectErrorUtilities.VerifyThrowInvalidProject(entryPointNode.ProjectInstance.Targets.Count > 0, entryPointNode.ProjectInstance.ProjectFileLocation, "NoTargetSpecified");
                 }
 
                 resultsPerNode = BuildGraph(projectGraph, targetsPerNode, submission.BuildRequestData);

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Build.Graph
 
         public GraphEdges Edges { get; private set; }
 
+        public SolutionFile Solution { get; private set; }
+
         private readonly List<ConfigurationMetadata> _entryPointConfigurationMetadata;
 
         private readonly ParallelWorkSet<ConfigurationMetadata, ParsedProject> _graphWorkSet;
@@ -269,43 +271,43 @@ namespace Microsoft.Build.Graph
                 solutionGlobalPropertiesBuilder.AddRange(solutionEntryPoint.GlobalProperties);
             }
 
-            var solution = SolutionFile.Parse(solutionEntryPoint.ProjectFile);
+            Solution = SolutionFile.Parse(solutionEntryPoint.ProjectFile);
 
-            if (solution.SolutionParserWarnings.Count != 0 || solution.SolutionParserErrorCodes.Count != 0)
+            if (Solution.SolutionParserWarnings.Count != 0 || Solution.SolutionParserErrorCodes.Count != 0)
             {
                 throw new InvalidProjectFileException(
                     ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
                         "StaticGraphSolutionLoaderEncounteredSolutionWarningsAndErrors",
                         solutionEntryPoint.ProjectFile,
-                        string.Join(";", solution.SolutionParserWarnings),
-                        string.Join(";", solution.SolutionParserErrorCodes)));
+                        string.Join(";", Solution.SolutionParserWarnings),
+                        string.Join(";", Solution.SolutionParserErrorCodes)));
             }
 
             // Mimic behavior of SolutionProjectGenerator
-            SolutionConfigurationInSolution currentSolutionConfiguration = SelectSolutionConfiguration(solution, solutionEntryPoint.GlobalProperties);
+            SolutionConfigurationInSolution currentSolutionConfiguration = SelectSolutionConfiguration(Solution, solutionEntryPoint.GlobalProperties);
             solutionGlobalPropertiesBuilder["Configuration"] = currentSolutionConfiguration.ConfigurationName;
             solutionGlobalPropertiesBuilder["Platform"] = currentSolutionConfiguration.PlatformName;
 
-            string solutionConfigurationXml = SolutionProjectGenerator.GetSolutionConfiguration(solution, currentSolutionConfiguration);
+            string solutionConfigurationXml = SolutionProjectGenerator.GetSolutionConfiguration(Solution, currentSolutionConfiguration);
             solutionGlobalPropertiesBuilder["CurrentSolutionConfigurationContents"] = solutionConfigurationXml;
             solutionGlobalPropertiesBuilder["BuildingSolutionFile"] = "true";
 
-            string solutionDirectoryName = solution.SolutionFileDirectory;
+            string solutionDirectoryName = Solution.SolutionFileDirectory;
             if (!solutionDirectoryName.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
             {
                 solutionDirectoryName += Path.DirectorySeparatorChar;
             }
 
             solutionGlobalPropertiesBuilder["SolutionDir"] = EscapingUtilities.Escape(solutionDirectoryName);
-            solutionGlobalPropertiesBuilder["SolutionExt"] = EscapingUtilities.Escape(Path.GetExtension(solution.FullPath));
-            solutionGlobalPropertiesBuilder["SolutionFileName"] = EscapingUtilities.Escape(Path.GetFileName(solution.FullPath));
-            solutionGlobalPropertiesBuilder["SolutionName"] = EscapingUtilities.Escape(Path.GetFileNameWithoutExtension(solution.FullPath));
-            solutionGlobalPropertiesBuilder[SolutionProjectGenerator.SolutionPathPropertyName] = EscapingUtilities.Escape(Path.Combine(solution.SolutionFileDirectory, Path.GetFileName(solution.FullPath)));
+            solutionGlobalPropertiesBuilder["SolutionExt"] = EscapingUtilities.Escape(Path.GetExtension(Solution.FullPath));
+            solutionGlobalPropertiesBuilder["SolutionFileName"] = EscapingUtilities.Escape(Path.GetFileName(Solution.FullPath));
+            solutionGlobalPropertiesBuilder["SolutionName"] = EscapingUtilities.Escape(Path.GetFileNameWithoutExtension(Solution.FullPath));
+            solutionGlobalPropertiesBuilder[SolutionProjectGenerator.SolutionPathPropertyName] = EscapingUtilities.Escape(Path.Combine(Solution.SolutionFileDirectory, Path.GetFileName(Solution.FullPath)));
 
             // Project configurations are reused heavily, so cache the global properties for each
             Dictionary<string, ImmutableDictionary<string, string>> globalPropertiesForProjectConfiguration = new(StringComparer.OrdinalIgnoreCase);
 
-            IReadOnlyList<ProjectInSolution> projectsInSolution = solution.ProjectsInOrder;
+            IReadOnlyList<ProjectInSolution> projectsInSolution = Solution.ProjectsInOrder;
             List<ProjectGraphEntryPoint> newEntryPoints = new(projectsInSolution.Count);
             Dictionary<string, IReadOnlyCollection<string>> solutionDependencies = new();
 
@@ -318,7 +320,7 @@ namespace Microsoft.Build.Graph
 
                 ProjectConfigurationInSolution projectConfiguration = SelectProjectConfiguration(currentSolutionConfiguration, project.ProjectConfigurations);
 
-                if (!SolutionProjectGenerator.WouldProjectBuild(solution, currentSolutionConfiguration.FullName, project, projectConfiguration))
+                if (!SolutionProjectGenerator.WouldProjectBuild(Solution, currentSolutionConfiguration.FullName, project, projectConfiguration))
                 {
                     continue;
                 }
@@ -341,11 +343,11 @@ namespace Microsoft.Build.Graph
                     List<string> solutionDependenciesForProject = new(project.Dependencies.Count);
                     foreach (string dependencyProjectGuid in project.Dependencies)
                     {
-                        if (!solution.ProjectsByGuid.TryGetValue(dependencyProjectGuid, out ProjectInSolution dependencyProject))
+                        if (!Solution.ProjectsByGuid.TryGetValue(dependencyProjectGuid, out ProjectInSolution dependencyProject))
                         {
                             ProjectFileErrorUtilities.ThrowInvalidProjectFile(
                                 "SubCategoryForSolutionParsingErrors",
-                                new BuildEventFileInfo(solution.FullPath),
+                                new BuildEventFileInfo(Solution.FullPath),
                                 "SolutionParseProjectDepNotFoundError",
                                 project.ProjectGuid,
                                 dependencyProjectGuid);

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Eventing;
 using Microsoft.Build.Exceptions;
@@ -59,6 +60,8 @@ namespace Microsoft.Build.Graph
         private GraphBuilder.GraphEdges Edges { get; }
 
         internal GraphBuilder.GraphEdges TestOnly_Edges => Edges;
+
+        internal SolutionFile Solution { get; }
 
         public GraphConstructionMetrics ConstructionMetrics { get; private set; }
 
@@ -433,6 +436,7 @@ namespace Microsoft.Build.Graph
             GraphRoots = graphBuilder.RootNodes;
             ProjectNodes = graphBuilder.ProjectNodes;
             Edges = graphBuilder.Edges;
+            Solution = graphBuilder.Solution;
 
             _projectNodesTopologicallySorted = new Lazy<IReadOnlyCollection<ProjectGraphNode>>(() => TopologicalSort(GraphRoots, ProjectNodes));
 
@@ -604,14 +608,92 @@ namespace Microsoft.Build.Graph
             var encounteredEdges = new HashSet<ProjectGraphBuildRequest>();
             var edgesToVisit = new Queue<ProjectGraphBuildRequest>();
 
-            foreach (ProjectGraphNode entryPointNode in EntryPointNodes)
+            if (entryProjectTargets == null || entryProjectTargets.Count == 0)
             {
-                var entryTargets = entryProjectTargets == null || entryProjectTargets.Count == 0
-                    ? ImmutableList.CreateRange(entryPointNode.ProjectInstance.DefaultTargets)
-                    : ImmutableList.CreateRange(entryProjectTargets);
-                var entryEdge = new ProjectGraphBuildRequest(entryPointNode, entryTargets);
-                encounteredEdges.Add(entryEdge);
-                edgesToVisit.Enqueue(entryEdge);
+                // If no targets were specified, use every project's default targets.
+                foreach (ProjectGraphNode entryPointNode in EntryPointNodes)
+                {
+                    var entryTargets = ImmutableList.CreateRange(entryPointNode.ProjectInstance.DefaultTargets);
+                    var entryEdge = new ProjectGraphBuildRequest(entryPointNode, entryTargets);
+                    encounteredEdges.Add(entryEdge);
+                    edgesToVisit.Enqueue(entryEdge);
+                }
+            }
+            else
+            {
+                foreach (string targetName in entryProjectTargets)
+                {
+                    // Special-case the "Build" target. The solution's metaproj invokes each project's default targets
+                    if (targetName.Equals("Build", StringComparison.OrdinalIgnoreCase))
+                    {
+                        foreach (ProjectGraphNode entryPointNode in EntryPointNodes)
+                        {
+                            var entryTargets = ImmutableList.CreateRange(entryPointNode.ProjectInstance.DefaultTargets);
+                            var entryEdge = new ProjectGraphBuildRequest(entryPointNode, entryTargets);
+                            encounteredEdges.Add(entryEdge);
+                            edgesToVisit.Enqueue(entryEdge);
+                        }
+
+                        continue;
+                    }
+
+                    bool isSolutionTraversalTarget = false;
+                    if (Solution != null)
+                    {
+                        foreach (ProjectInSolution project in Solution.ProjectsInOrder)
+                        {
+                            if (!SolutionFile.IsBuildableProject(project))
+                            {
+                                continue;
+                            }
+
+                            string baseProjectName = ProjectInSolution.DisambiguateProjectTargetName(project.GetUniqueProjectName());
+
+                            // Solutions generate target names to build individual projects. Map these to "real" targets on the relevant projects.
+                            // This logic should match SolutionProjectGenerator's behavior
+                            if (targetName.Equals(baseProjectName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                // Build a specific project with its default targets.
+                                ProjectGraphNode node = GetNodeForProject(project);
+                                ProjectGraphBuildRequest entryEdge = new(node, ImmutableList.CreateRange(node.ProjectInstance.DefaultTargets));
+                                encounteredEdges.Add(entryEdge);
+                                edgesToVisit.Enqueue(entryEdge);
+                                isSolutionTraversalTarget = true;
+                            }
+                            else if (targetName.StartsWith($"{baseProjectName}:", StringComparison.OrdinalIgnoreCase))
+                            {
+                                // Build a specific project with the specified target
+                                string projectTargetName = targetName.Substring(baseProjectName.Length + 1);
+
+                                // Special-case "Project:" and "Project:Build". SolutionProjectGenerator does not generate a target for those, so should error with MSB4057
+                                ProjectErrorUtilities.VerifyThrowInvalidProject(
+                                    projectTargetName.Length > 0 && !projectTargetName.Equals("Build", StringComparison.OrdinalIgnoreCase),
+                                    ElementLocation.Create(Solution.FullPath),
+                                    "TargetDoesNotExist",
+                                    targetName);
+
+                                ProjectGraphNode node = GetNodeForProject(project);
+                                ProjectGraphBuildRequest entryEdge = new(node,[projectTargetName]);
+                                encounteredEdges.Add(entryEdge);
+                                edgesToVisit.Enqueue(entryEdge);
+                                isSolutionTraversalTarget = true;
+                            }
+
+                            // For solutions, there should only be exactly one entry node per project file
+                            ProjectGraphNode GetNodeForProject(ProjectInSolution project) => EntryPointNodes.First(node => string.Equals(node.ProjectInstance.FullPath, project.AbsolutePath));
+                        }
+                    }
+
+                    if (!isSolutionTraversalTarget)
+                    {
+                        foreach (ProjectGraphNode entryPointNode in EntryPointNodes)
+                        {
+                            ProjectGraphBuildRequest entryEdge = new(entryPointNode,[targetName]);
+                            encounteredEdges.Add(entryEdge);
+                            edgesToVisit.Enqueue(entryEdge);
+                        }
+                    }
+                }
             }
 
             // Traverse the entire graph, visiting each edge once.

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Eventing;
@@ -650,8 +651,8 @@ namespace Microsoft.Build.Graph
                             string baseProjectName = ProjectInSolution.DisambiguateProjectTargetName(project.GetUniqueProjectName());
 
                             // Solutions generate target names to build individual projects. Map these to "real" targets on the relevant projects.
-                            // This logic should match SolutionProjectGenerator's behavior
-                            if (targetName.Equals(baseProjectName, StringComparison.OrdinalIgnoreCase))
+                            // This logic should match SolutionProjectGenerator's behavior, particularly EvaluateAndAddProjects's calls to AddTraversalTargetForProject.
+                            if (MSBuildNameIgnoreCaseComparer.Default.Equals(targetName, baseProjectName))
                             {
                                 // Build a specific project with its default targets.
                                 ProjectGraphNode node = GetNodeForProject(project);


### PR DESCRIPTION
Fixes #9952

This change adds understanding of "solution traversal" targets to graph builds. The special targets are like "ProjectName" or "ProjectName:TargetName" and can be used to build specific projects in a sln or specific targets on specific projects in a sln.

Also added some missing UTs for `SolutionProjectGenerator` to help my understanding for how these kinds of targets work.