### PR TITLE
Fix oversharing of build results in ResultsCache

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -410,5 +410,5 @@ dotnet_diagnostic.IDE0300.severity = suggestion
 dotnet_diagnostic.IDE0301.severity = suggestion
 dotnet_diagnostic.IDE0305.severity = suggestion
 
-# Temporarily disable SA1010 "Opening square brackets should not be preceded by a space" until https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687 if fixed
+# Temporarily disable SA1010 "Opening square brackets should not be preceded by a space" until https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687 is fixed
 dotnet_diagnostic.SA1010.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -409,3 +409,6 @@ dotnet_diagnostic.IDE0290.severity = suggestion
 dotnet_diagnostic.IDE0300.severity = suggestion
 dotnet_diagnostic.IDE0301.severity = suggestion
 dotnet_diagnostic.IDE0305.severity = suggestion
+
+# Temporarily disable SA1010 "Opening square brackets should not be preceded by a space" until https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687 if fixed
+dotnet_diagnostic.SA1010.severity = none

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -35,6 +35,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Add Link metadata to Resources in AssignLinkMetadata target](https://github.com/dotnet/msbuild/pull/9464)
 - [Change Version switch output to finish with a newline](https://github.com/dotnet/msbuild/pull/9485)
 - [Load NuGet.Frameworks into secondary AppDomain (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/9446)
+- [ResultsCache ignores some of the BuildRequest data, may return incorrect results](https://github.com/dotnet/msbuild/pull/9565)
 - [Update Traits when environment has been changed](https://github.com/dotnet/msbuild/pull/9655)
 - [Exec task does not trim leading whitespaces for ConsoleOutput](https://github.com/dotnet/msbuild/pull/9722)
 - [Introduce [MSBuild]::StableStringHash overloads](https://github.com/dotnet/msbuild/issues/9519)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -26,7 +26,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 ### 17.12
 - [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)
 - [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
-- [ResultsCache ignores some of the BuildRequest data, may return incorrect results](https://github.com/dotnet/msbuild/pull/9987)
+- [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -26,6 +26,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 ### 17.12
 - [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)
 - [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
+- [ResultsCache ignores some of the BuildRequest data, may return incorrect results](https://github.com/dotnet/msbuild/pull/9987)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`
@@ -35,7 +36,6 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Add Link metadata to Resources in AssignLinkMetadata target](https://github.com/dotnet/msbuild/pull/9464)
 - [Change Version switch output to finish with a newline](https://github.com/dotnet/msbuild/pull/9485)
 - [Load NuGet.Frameworks into secondary AppDomain (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/9446)
-- [ResultsCache ignores some of the BuildRequest data, may return incorrect results](https://github.com/dotnet/msbuild/pull/9565)
 - [Update Traits when environment has been changed](https://github.com/dotnet/msbuild/pull/9655)
 - [Exec task does not trim leading whitespaces for ConsoleOutput](https://github.com/dotnet/msbuild/pull/9722)
 - [Introduce [MSBuild]::StableStringHash overloads](https://github.com/dotnet/msbuild/issues/9519)

--- a/src/Build.UnitTests/BackEnd/RequestedProjectState_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/RequestedProjectState_Tests.cs
@@ -80,8 +80,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             clone.ItemFilters.Should().BeEquivalentTo(items);
 
             // Mutating the original instance is not reflected in the clone.
-            items.Add("item3", ["metadatum4"]);
-            clone.ItemFilters.Count.Should().NotBe(items.Count);
+            items["item2"].Add("metadatum4");
+            clone.ItemFilters["item2"].Count.Should().NotBe(items["item2"].Count);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/RequestedProjectState_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/RequestedProjectState_Tests.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Build.Execution;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Build.UnitTests.BackEnd
+{
+    public class RequestedProjectState_Tests
+    {
+        [Fact]
+        public void DeepCloneEmpty()
+        {
+            RequestedProjectState state = new();
+            RequestedProjectState clone = state.DeepClone();
+
+            clone.PropertyFilters.Should().BeNull();
+            clone.ItemFilters.Should().BeNull();
+        }
+
+        [Fact]
+        public void DeepCloneProperties()
+        {
+            List<string> properties = ["prop1", "prop2"];
+            RequestedProjectState state = new()
+            {
+                PropertyFilters = properties,
+            };
+            RequestedProjectState clone = state.DeepClone();
+
+            clone.PropertyFilters.Should().BeEquivalentTo(properties);
+            clone.ItemFilters.Should().BeNull();
+
+            // Mutating the original instance is not reflected in the clone.
+            properties.Add("prop3");
+            clone.PropertyFilters.Count.Should().NotBe(properties.Count);
+        }
+
+        [Fact]
+        public void DeepCloneItemsNoMetadata()
+        {
+            Dictionary<string, List<string>> items = new()
+            {
+                { "item1", null! },
+                { "item2", null! },
+            };
+            RequestedProjectState state = new()
+            {
+                ItemFilters = items,
+            };
+            RequestedProjectState clone = state.DeepClone();
+
+            clone.PropertyFilters.Should().BeNull();
+            clone.ItemFilters.Should().BeEquivalentTo(items);
+
+            // Mutating the original instance is not reflected in the clone.
+            items.Add("item3", null!);
+            clone.ItemFilters.Count.Should().NotBe(items.Count);
+        }
+
+        [Fact]
+        public void DeepCloneItemsWithMetadata()
+        {
+            Dictionary<string, List<string>> items = new()
+            {
+                { "item1", ["metadatum1", "metadatum2"] },
+                { "item2", ["metadatum3"] },
+            };
+            RequestedProjectState state = new()
+            {
+                ItemFilters = items,
+            };
+            RequestedProjectState clone = state.DeepClone();
+
+            clone.PropertyFilters.Should().BeNull();
+            clone.ItemFilters.Should().BeEquivalentTo(items);
+
+            // Mutating the original instance is not reflected in the clone.
+            items.Add("item3", ["metadatum4"]);
+            clone.ItemFilters.Count.Should().NotBe(items.Count);
+        }
+
+        [Fact]
+        public void IsSubsetOfEmpty()
+        {
+            RequestedProjectState state1 = new();
+            RequestedProjectState state2 = new();
+
+            // Empty instances are subsets of each other.
+            state1.IsSubsetOf(state2).Should().BeTrue();
+            state2.IsSubsetOf(state1).Should().BeTrue();
+
+            state1.PropertyFilters = ["prop1"];
+            state1.ItemFilters = new Dictionary<string, List<string>>()
+            {
+                { "item1", null! },
+            };
+
+            // Non-empty instance is a subset of empty instance but not the other way round.
+            state1.IsSubsetOf(state2).Should().BeTrue();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsSubsetOfProperties()
+        {
+            RequestedProjectState state1 = new()
+            {
+                PropertyFilters = ["prop1"],
+            };
+            RequestedProjectState state2 = new()
+            {
+                PropertyFilters = ["prop1", "prop2"],
+            };
+
+            // "prop1" is a subset of "prop1", "prop2".
+            state1.IsSubsetOf(state2).Should().BeTrue();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+
+            state1.PropertyFilters.Add("prop3");
+
+            // Disjoint sets are not subsets of each other.
+            state1.IsSubsetOf(state2).Should().BeFalse();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+
+            state1.PropertyFilters.Clear();
+
+            // Empty props is a subset of anything.
+            state1.IsSubsetOf(state2).Should().BeTrue();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsSubsetOfItemsNoMetadata()
+        {
+            RequestedProjectState state1 = new()
+            {
+                ItemFilters = new Dictionary<string, List<string>>()
+                {
+                    { "item1", null! },
+                },
+            };
+            RequestedProjectState state2 = new()
+            {
+                ItemFilters = new Dictionary<string, List<string>>()
+                {
+                    { "item1", null! },
+                    { "item2", null! },
+                },
+            };
+
+            // "item1" is a subset of "item1", "item2".
+            state1.IsSubsetOf(state2).Should().BeTrue();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+
+            state1.ItemFilters.Add("item3", null!);
+
+            // Disjoint sets are not subsets of each other.
+            state1.IsSubsetOf(state2).Should().BeFalse();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+
+            state1.ItemFilters.Clear();
+
+            // Empty items is a subset of anything.
+            state1.IsSubsetOf(state2).Should().BeTrue();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsSubsetOfItemsWithMetadata()
+        {
+            RequestedProjectState state1 = new()
+            {
+                ItemFilters = new Dictionary<string, List<string>>()
+                {
+                    { "item1", ["metadatum1"] },
+                },
+            };
+            RequestedProjectState state2 = new()
+            {
+                ItemFilters = new Dictionary<string, List<string>>()
+                {
+                    { "item1", null! },
+                },
+            };
+
+            // "item1" with "metadatum1" is a subset of "item1" with no metadata filter.
+            state1.IsSubsetOf(state2).Should().BeTrue();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+
+            state2.ItemFilters["item1"] = ["metadatum2"];
+
+            // Disjoint metadata filters are not subsets of each other.
+            state1.IsSubsetOf(state2).Should().BeFalse();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+
+            state1.ItemFilters["item1"] = [];
+
+            // Empty metadata filter is a subset of any other metadata filter.
+            state1.IsSubsetOf(state2).Should().BeTrue();
+            state2.IsSubsetOf(state1).Should().BeFalse();
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
@@ -304,9 +304,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             // It was agreed not to return cache results if ProvideSubsetOfStateAfterBuild is passed,
             // because RequestedProjectState may have different user filters defined.
-            // It is more reliable to ignore the cached value. 
+            // It is more reliable to ignore the cached value.
             Assert.Equal(ResultsCacheResponseType.NotSatisfied, cachedResponseWithSubsetFlag1.Type);
-            Assert.Equal(ResultsCacheResponseType.NotSatisfied, cachedResponseWithSubsetFlag2.Type);    
+            Assert.Equal(ResultsCacheResponseType.NotSatisfied, cachedResponseWithSubsetFlag2.Type);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
@@ -328,10 +328,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 new List<string>(new string[] { targetName }),
                 skippedResultsDoNotCauseCacheMiss: false);
 
+            // We used the same filter that was used for the ProjectInstance in the cache -> cache hit.
             Assert.Equal(ResultsCacheResponseType.Satisfied, cachedResponseWithSubsetFlag1.Type);
             Assert.Equal("Value1", cachedResponseWithSubsetFlag1.Results.ProjectStateAfterBuild.GetPropertyValue("property1"));
             Assert.Equal("Value2", cachedResponseWithSubsetFlag1.Results.ProjectStateAfterBuild.GetPropertyValue("property2"));
 
+            // We used a filter that's a subset of the one used for the ProjectInstance in the cache -> cache hit.
             Assert.Equal(ResultsCacheResponseType.Satisfied, cachedResponseWithSubsetFlag2.Type);
             Assert.Equal("Value1", cachedResponseWithSubsetFlag2.Results.ProjectStateAfterBuild.GetPropertyValue("property1"));
             Assert.Equal("", cachedResponseWithSubsetFlag2.Results.ProjectStateAfterBuild.GetPropertyValue("property2"));

--- a/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
@@ -189,6 +189,127 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact]
+        public void TestCacheOnDifferentBuildFlagsPerRequest_ProvideProjectStateAfterBuild()
+        {
+            string targetName = "testTarget1";
+            int submissionId = 1;
+            int nodeRequestId = 0;
+            int configurationId = 1;
+
+            BuildRequest requestWithNoBuildDataFlags = new BuildRequest(
+               submissionId,
+               nodeRequestId,
+               configurationId,
+               new string[1] { targetName } /* escapedTargets */,
+               null /* hostServices */,
+               BuildEventContext.Invalid /* parentBuildEventContext */,
+               null /* parentRequest */,
+               BuildRequestDataFlags.None);
+
+            BuildRequest requestWithProjectStateFlag = new BuildRequest(
+               submissionId,
+               nodeRequestId,
+               configurationId,
+               new string[1] { targetName } /* escapedTargets */,
+               null /* hostServices */,
+               BuildEventContext.Invalid /* parentBuildEventContext */,
+               null /* parentRequest */,
+               BuildRequestDataFlags.ProvideProjectStateAfterBuild);
+
+            BuildRequest requestWithNoBuildDataFlags2 = new BuildRequest(
+               submissionId,
+               nodeRequestId,
+               configurationId,
+               new string[1] { targetName } /* escapedTargets */,
+               null /* hostServices */,
+               BuildEventContext.Invalid /* parentBuildEventContext */,
+               null /* parentRequest */,
+               BuildRequestDataFlags.None);
+
+            BuildResult resultForRequestWithNoBuildDataFlags = new(requestWithNoBuildDataFlags);
+            resultForRequestWithNoBuildDataFlags.AddResultsForTarget(targetName, BuildResultUtilities.GetEmptySucceedingTargetResult());
+            ResultsCache cache = new();
+            cache.AddResult(resultForRequestWithNoBuildDataFlags);
+
+            ResultsCacheResponse cacheResponseForRequestWithNoBuildDataFlags = cache.SatisfyRequest(
+               requestWithNoBuildDataFlags,
+               new List<string>(),
+               new List<string>(new string[] { targetName }),
+               skippedResultsDoNotCauseCacheMiss: false);
+
+            ResultsCacheResponse cachedResponseForProjectState = cache.SatisfyRequest(
+               requestWithProjectStateFlag,
+               new List<string>(),
+               new List<string>(new string[] { targetName }),
+               skippedResultsDoNotCauseCacheMiss: false);
+
+            ResultsCacheResponse cacheResponseForNoBuildDataFlags2 = cache.SatisfyRequest(
+               requestWithNoBuildDataFlags2,
+               new List<string>(),
+               new List<string>(new string[] { targetName }),
+               skippedResultsDoNotCauseCacheMiss: false);
+
+            Assert.Equal(ResultsCacheResponseType.Satisfied, cacheResponseForRequestWithNoBuildDataFlags.Type);
+
+            // Because ProvideProjectStateAfterBuildFlag was provided as a part of BuildRequest
+            Assert.Equal(ResultsCacheResponseType.NotSatisfied, cachedResponseForProjectState.Type);
+
+            Assert.Equal(ResultsCacheResponseType.Satisfied, cacheResponseForNoBuildDataFlags2.Type);
+        }
+
+        [Fact]
+        public void TestCacheOnDifferentBuildFlagsPerRequest_ProvideSubsetOfStateAfterBuild()
+        {
+            string targetName = "testTarget1";
+            int submissionId = 1;
+            int nodeRequestId = 0;
+            int configurationId = 1;
+
+            BuildRequest requestWithSubsetFlag1 = new BuildRequest(
+                submissionId,
+                nodeRequestId,
+                configurationId,
+                new string[1] { targetName } /* escapedTargets */,
+                null /* hostServices */,
+                BuildEventContext.Invalid /* parentBuildEventContext */,
+                null /* parentRequest */,
+                BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild);
+
+            BuildRequest requestWithSubsetFlag2 = new BuildRequest(
+                submissionId,
+                nodeRequestId,
+                configurationId,
+                new string[1] { targetName } /* escapedTargets */,
+                null /* hostServices */,
+                BuildEventContext.Invalid /* parentBuildEventContext */,
+                null /* parentRequest */,
+                BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild);
+
+            BuildResult resultForRequestWithSubsetFlag1 = new(requestWithSubsetFlag1);
+            resultForRequestWithSubsetFlag1.AddResultsForTarget(targetName, BuildResultUtilities.GetEmptySucceedingTargetResult());
+            ResultsCache cache = new();
+            cache.AddResult(resultForRequestWithSubsetFlag1);
+
+            ResultsCacheResponse cachedResponseWithSubsetFlag1 = cache.SatisfyRequest(
+            requestWithSubsetFlag1,
+            new List<string>(),
+            new List<string>(new string[] { targetName }),
+            skippedResultsDoNotCauseCacheMiss: false);
+
+            ResultsCacheResponse cachedResponseWithSubsetFlag2 = cache.SatisfyRequest(
+                requestWithSubsetFlag2,
+                new List<string>(),
+                new List<string>(new string[] { targetName }),
+                skippedResultsDoNotCauseCacheMiss: false);
+
+            // It was agreed not to return cache results if ProvideSubsetOfStateAfterBuild is passed,
+            // because RequestedProjectState may have different user filters defined.
+            // It is more reliable to ignore the cached value. 
+            Assert.Equal(ResultsCacheResponseType.NotSatisfied, cachedResponseWithSubsetFlag1.Type);
+            Assert.Equal(ResultsCacheResponseType.NotSatisfied, cachedResponseWithSubsetFlag2.Type);    
+        }
+
+        [Fact]
         public void TestClearResultsCache()
         {
             ResultsCache cache = new ResultsCache();

--- a/src/Build/BackEnd/BuildManager/RequestedProjectState.cs
+++ b/src/Build/BackEnd/BuildManager/RequestedProjectState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Build.BackEnd;
 
 #nullable disable
@@ -33,6 +34,94 @@ namespace Microsoft.Build.Execution
         {
             get => _itemFilters;
             set => _itemFilters = value;
+        }
+
+        /// <summary>
+        /// Creates a deep copy of this instance.
+        /// </summary>
+        internal RequestedProjectState DeepClone()
+        {
+            RequestedProjectState result = new RequestedProjectState();
+            if (PropertyFilters is not null)
+            {
+                result.PropertyFilters = new List<string>(PropertyFilters);
+            }
+            if (ItemFilters is not null)
+            {
+                result.ItemFilters = ItemFilters.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value == null ? null : new List<string>(kvp.Value));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns true if this instance contains all property and item filters present in another instance.
+        /// </summary>
+        /// <param name="another">The instance to compare against.</param>
+        /// <returns>True if this instance is equivalent or a strict subset of <paramref name="another"/>.</returns>
+        internal bool IsSubsetOf(RequestedProjectState another)
+        {
+            if (PropertyFilters is null)
+            {
+                if (another.PropertyFilters is not null)
+                {
+                    // The instance to compare against has filtered props and we need everything -> not a subset.
+                    return false;
+                }
+            }
+            else if (another.PropertyFilters is not null)
+            {
+                HashSet<string> anotherPropertyFilters = new HashSet<string>(another.PropertyFilters);
+                foreach (string propertyFilter in PropertyFilters)
+                {
+                    if (!anotherPropertyFilters.Contains(propertyFilter))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            if (ItemFilters is null)
+            {
+                if (another.ItemFilters is not null)
+                {
+                    // The instance to compare against has filtered items and we need everything -> not a subset.
+                    return false;
+                }
+            }
+            else if (another.ItemFilters is not null)
+            {
+                foreach (KeyValuePair<string, List<string>> kvp in ItemFilters)
+                {
+                    if (!another.ItemFilters.TryGetValue(kvp.Key, out List<string> metadata))
+                    {
+                        // The instance to compare against doesn't have this item -> not a subset.
+                        return false;
+                    }
+                    if (kvp.Value is null)
+                    {
+                        if (metadata is not null)
+                        {
+                            // The instance to compare against has filtered metadata for this item and we need everything - not a subset.
+                            return false;
+                        }
+                    }
+                    else if (metadata is not null)
+                    {
+                        HashSet<string> anotherMetadata = new HashSet<string>(metadata);
+                        foreach (string metadatum in kvp.Value)
+                        {
+                            if (!anotherMetadata.Contains(metadatum))
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return true;
         }
 
         void ITranslatable.Translate(ITranslator translator)

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Build.BackEnd
     internal class ResultsCache : IResultsCache
     {
         /// <summary>
-        /// The presence of any of these flags affects build result for the specified request.
+        /// The presence of any of these flags affects build result for the specified request. Not included are ProvideProjectStateAfterBuild
+        /// and ProvideSubsetOfStateAfterBuild which require additional checks.
         /// </summary>
         private const BuildRequestDataFlags FlagsAffectingBuildResults =
-            BuildRequestDataFlags.ProvideProjectStateAfterBuild
-            | BuildRequestDataFlags.SkipNonexistentTargets
+            BuildRequestDataFlags.SkipNonexistentTargets
             | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports
             | BuildRequestDataFlags.FailOnUnresolvedSdk;
 
@@ -174,7 +174,7 @@ namespace Microsoft.Build.BackEnd
                 if (_resultsByConfiguration.TryGetValue(request.ConfigurationId, out BuildResult allResults))
                 {
                     bool buildDataFlagsSatisfied = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
-                        ? CheckBuildDataFlagsResults(request.BuildRequestDataFlags, allResults.BuildRequestDataFlags) : true;
+                        ? AreBuildResultFlagsCompatible(request, allResults) : true;
 
                     if (buildDataFlagsSatisfied)
                     {
@@ -345,18 +345,45 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Checks results for the specified build flags.
+        /// Returns true if the giveChecks results for the specified build flags.
         /// </summary>
-        /// <param name="buildRequestDataFlags">The current request build flags.</param>
-        /// <param name="buildResultDataFlags">The existing build result data flags.</param>
-        /// <returns>False if there is any difference in the data flags that can cause missed build data, true otherwise.</returns>
-        private static bool CheckBuildDataFlagsResults(BuildRequestDataFlags buildRequestDataFlags, BuildRequestDataFlags buildResultDataFlags) =>
+        /// <param name="buildRequest">The current build request.</param>
+        /// <param name="buildResult">The candidate build result.</param>
+        /// <returns>False if there is any difference in the flags that can cause missed build data, true otherwise.</returns>
+        private static bool AreBuildResultFlagsCompatible(BuildRequest buildRequest, BuildResult buildResult)
+        {
+            BuildRequestDataFlags buildRequestDataFlags = buildRequest.BuildRequestDataFlags;
+            BuildRequestDataFlags buildResultDataFlags = buildResult.BuildRequestDataFlags;
 
-            // Even if both buildRequestDataFlags and buildResultDataFlags have ProvideSubsetOfStateAfterBuild flag,
-            // the underlying RequestedProjectState may have different user filters defined.
-            // It is more reliable to ignore the cached value.
-            !buildRequestDataFlags.HasFlag(BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild)
-            && (buildRequestDataFlags & FlagsAffectingBuildResults) == (buildResultDataFlags & FlagsAffectingBuildResults);
+            if ((buildRequestDataFlags & FlagsAffectingBuildResults) != (buildResultDataFlags & FlagsAffectingBuildResults))
+            {
+                // Mismatch in flags that can affect build results -> not compatible.
+                return false;
+            }
+
+            if (buildRequestDataFlags.HasFlag(BuildRequestDataFlags.ProvideProjectStateAfterBuild))
+            {
+                // If full state is requested, we must have full state in the result.
+                return buildResultDataFlags.HasFlag(BuildRequestDataFlags.ProvideProjectStateAfterBuild);
+            }
+
+            if (buildRequestDataFlags.HasFlag(BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild))
+            {
+                // If partial state is requested, we must have full or partial-and-compatible state in the result.
+                if (buildResultDataFlags.HasFlag(BuildRequestDataFlags.ProvideProjectStateAfterBuild))
+                {
+                    return true;
+                }
+                if (!buildResultDataFlags.HasFlag(BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild))
+                {
+                    return false;
+                }
+
+                // Verify that the requested subset is compatible with the result.
+            }
+
+            return true;
+        }
 
         public IEnumerator<BuildResult> GetEnumerator()
         {

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Returns true if the giveChecks results for the specified build flags.
+        /// Returns true if the flags of the given build request are compatible with the given build result.
         /// </summary>
         /// <param name="buildRequest">The current build request.</param>
         /// <param name="buildResult">The candidate build result.</param>
@@ -380,6 +380,9 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 // Verify that the requested subset is compatible with the result.
+                return buildRequest.RequestedProjectState is not null &&
+                    buildResult.ProjectStateAfterBuild?.RequestedProjectStateFilter is not null &&
+                    buildRequest.RequestedProjectState.IsSubsetOf(buildResult.ProjectStateAfterBuild.RequestedProjectStateFilter);
             }
 
             return true;

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Build.BackEnd
         /// and ProvideSubsetOfStateAfterBuild which require additional checks.
         /// </summary>
         private const BuildRequestDataFlags FlagsAffectingBuildResults =
-            BuildRequestDataFlags.SkipNonexistentTargets
-            | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports
+            BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports
             | BuildRequestDataFlags.FailOnUnresolvedSdk;
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// Attempts to satisfy the request from the cache.  The request can be satisfied only if:
-        /// 1. The passed BuildRequestDataFlags can not affect the result data.
+        /// 1. The passed BuildRequestDataFlags and RequestedProjectStateFilter are compatible with the result data.
         /// 2. All specified targets in the request have successful results in the cache or if the sequence of target results
         ///    includes 0 or more successful targets followed by at least one failed target.
         /// 3. All initial targets in the configuration for the request have non-skipped results in the cache.
@@ -345,11 +345,11 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Returns true if the flags of the given build request are compatible with the given build result.
+        /// Returns true if the flags and project state filter of the given build request are compatible with the given build result.
         /// </summary>
         /// <param name="buildRequest">The current build request.</param>
         /// <param name="buildResult">The candidate build result.</param>
-        /// <returns>False if there is any difference in the flags that can cause missed build data, true otherwise.</returns>
+        /// <returns>True if the flags and project state filter of the build request is compatible with the build result.</returns>
         private static bool AreBuildResultFlagsCompatible(BuildRequest buildRequest, BuildResult buildResult)
         {
             BuildRequestDataFlags buildRequestDataFlags = buildRequest.BuildRequestDataFlags;

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Build.BackEnd
             {
                 if (_resultsByConfiguration.TryGetValue(request.ConfigurationId, out BuildResult allResults))
                 {
-                    bool buildDataFlagsSatisfied = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10)
+                    bool buildDataFlagsSatisfied = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
                         ? CheckBuildDataFlagsResults(request.BuildRequestDataFlags, allResults.BuildRequestDataFlags) : true;
 
                     if (buildDataFlagsSatisfied)
@@ -354,7 +354,7 @@ namespace Microsoft.Build.BackEnd
 
             // Even if both buildRequestDataFlags and buildResultDataFlags have ProvideSubsetOfStateAfterBuild flag,
             // the underlying RequestedProjectState may have different user filters defined.
-            // It is more reliable to ignore the cached value. 
+            // It is more reliable to ignore the cached value.
             !buildRequestDataFlags.HasFlag(BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild)
             && (buildRequestDataFlags & FlagsAffectingBuildResults) == (buildResultDataFlags & FlagsAffectingBuildResults);
 

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -361,20 +361,20 @@ namespace Microsoft.Build.BackEnd
                 return false;
             }
 
-            if (buildRequestDataFlags.HasFlag(BuildRequestDataFlags.ProvideProjectStateAfterBuild))
+            if (HasProvideProjectStateAfterBuild(buildRequestDataFlags))
             {
                 // If full state is requested, we must have full state in the result.
-                return buildResultDataFlags.HasFlag(BuildRequestDataFlags.ProvideProjectStateAfterBuild);
+                return HasProvideProjectStateAfterBuild(buildResultDataFlags);
             }
 
-            if (buildRequestDataFlags.HasFlag(BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild))
+            if (HasProvideSubsetOfStateAfterBuild(buildRequestDataFlags))
             {
                 // If partial state is requested, we must have full or partial-and-compatible state in the result.
-                if (buildResultDataFlags.HasFlag(BuildRequestDataFlags.ProvideProjectStateAfterBuild))
+                if (HasProvideProjectStateAfterBuild(buildResultDataFlags))
                 {
                     return true;
                 }
-                if (!buildResultDataFlags.HasFlag(BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild))
+                if (!HasProvideSubsetOfStateAfterBuild(buildResultDataFlags))
                 {
                     return false;
                 }
@@ -386,6 +386,12 @@ namespace Microsoft.Build.BackEnd
             }
 
             return true;
+
+            static bool HasProvideProjectStateAfterBuild(BuildRequestDataFlags flags)
+                => (flags & BuildRequestDataFlags.ProvideProjectStateAfterBuild) == BuildRequestDataFlags.ProvideProjectStateAfterBuild;
+
+            static bool HasProvideSubsetOfStateAfterBuild(BuildRequestDataFlags flags)
+                => (flags & BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild) == BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild;
         }
 
         public IEnumerator<BuildResult> GetEnumerator()

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -19,6 +19,15 @@ namespace Microsoft.Build.BackEnd
     internal class ResultsCache : IResultsCache
     {
         /// <summary>
+        /// The presence of any of these flags affects build result for the specified request.
+        /// </summary>
+        private const BuildRequestDataFlags FlagsAffectingBuildResults =
+            BuildRequestDataFlags.ProvideProjectStateAfterBuild
+            | BuildRequestDataFlags.SkipNonexistentTargets
+            | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports
+            | BuildRequestDataFlags.FailOnUnresolvedSdk;
+
+        /// <summary>
         /// The table of all build results.  This table is indexed by configuration id and
         /// contains BuildResult objects which have all of the target information.
         /// </summary>
@@ -140,10 +149,11 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// Attempts to satisfy the request from the cache.  The request can be satisfied only if:
-        /// 1. All specified targets in the request have successful results in the cache or if the sequence of target results
+        /// 1. The passed BuildRequestDataFlags can not affect the result data.
+        /// 2. All specified targets in the request have successful results in the cache or if the sequence of target results
         ///    includes 0 or more successful targets followed by at least one failed target.
-        /// 2. All initial targets in the configuration for the request have non-skipped results in the cache.
-        /// 3. If there are no specified targets, then all default targets in the request must have non-skipped results
+        /// 3. All initial targets in the configuration for the request have non-skipped results in the cache.
+        /// 4. If there are no specified targets, then all default targets in the request must have non-skipped results
         ///    in the cache.
         /// </summary>
         /// <param name="request">The request whose results we should return.</param>
@@ -163,47 +173,53 @@ namespace Microsoft.Build.BackEnd
             {
                 if (_resultsByConfiguration.TryGetValue(request.ConfigurationId, out BuildResult allResults))
                 {
-                    // Check for targets explicitly specified.
-                    bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, response.ExplicitTargetsToBuild, skippedResultsDoNotCauseCacheMiss);
+                    bool buildDataFlagsSatisfied = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10)
+                        ? CheckBuildDataFlagsResults(request.BuildRequestDataFlags, allResults.BuildRequestDataFlags) : true;
 
-                    if (explicitTargetsSatisfied)
+                    if (buildDataFlagsSatisfied)
                     {
-                        // All of the explicit targets, if any, have been satisfied
-                        response.Type = ResultsCacheResponseType.Satisfied;
+                        // Check for targets explicitly specified.
+                        bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, response.ExplicitTargetsToBuild, skippedResultsDoNotCauseCacheMiss);
 
-                        // Check for the initial targets.  If we don't know what the initial targets are, we assume they are not satisfied.
-                        if (configInitialTargets == null || !CheckResults(allResults, configInitialTargets, null, skippedResultsDoNotCauseCacheMiss))
+                        if (explicitTargetsSatisfied)
                         {
-                            response.Type = ResultsCacheResponseType.NotSatisfied;
-                        }
+                            // All of the explicit targets, if any, have been satisfied
+                            response.Type = ResultsCacheResponseType.Satisfied;
 
-                        // We could still be missing implicit targets, so check those...
-                        if (request.Targets.Count == 0)
-                        {
-                            // Check for the default target, if necessary.  If we don't know what the default targets are, we
-                            // assume they are not satisfied.
-                            if (configDefaultTargets == null || !CheckResults(allResults, configDefaultTargets, null, skippedResultsDoNotCauseCacheMiss))
+                            // Check for the initial targets.  If we don't know what the initial targets are, we assume they are not satisfied.
+                            if (configInitialTargets == null || !CheckResults(allResults, configInitialTargets, null, skippedResultsDoNotCauseCacheMiss))
                             {
                                 response.Type = ResultsCacheResponseType.NotSatisfied;
                             }
-                        }
 
-                        // Now report those results requested, if they are satisfied.
-                        if (response.Type == ResultsCacheResponseType.Satisfied)
-                        {
-                            List<string> targetsToAddResultsFor = new List<string>(configInitialTargets);
-
-                            // Now report either the explicit targets or the default targets
-                            if (request.Targets.Count > 0)
+                            // We could still be missing implicit targets, so check those...
+                            if (request.Targets.Count == 0)
                             {
-                                targetsToAddResultsFor.AddRange(request.Targets);
-                            }
-                            else
-                            {
-                                targetsToAddResultsFor.AddRange(configDefaultTargets);
+                                // Check for the default target, if necessary.  If we don't know what the default targets are, we
+                                // assume they are not satisfied.
+                                if (configDefaultTargets == null || !CheckResults(allResults, configDefaultTargets, null, skippedResultsDoNotCauseCacheMiss))
+                                {
+                                    response.Type = ResultsCacheResponseType.NotSatisfied;
+                                }
                             }
 
-                            response.Results = new BuildResult(request, allResults, targetsToAddResultsFor.ToArray(), null);
+                            // Now report those results requested, if they are satisfied.
+                            if (response.Type == ResultsCacheResponseType.Satisfied)
+                            {
+                                List<string> targetsToAddResultsFor = new List<string>(configInitialTargets);
+
+                                // Now report either the explicit targets or the default targets
+                                if (request.Targets.Count > 0)
+                                {
+                                    targetsToAddResultsFor.AddRange(request.Targets);
+                                }
+                                else
+                                {
+                                    targetsToAddResultsFor.AddRange(configDefaultTargets);
+                                }
+
+                                response.Results = new BuildResult(request, allResults, targetsToAddResultsFor.ToArray(), null);
+                            }
                         }
                     }
                 }
@@ -327,6 +343,20 @@ namespace Microsoft.Build.BackEnd
 
             return returnValue;
         }
+
+        /// <summary>
+        /// Checks results for the specified build flags.
+        /// </summary>
+        /// <param name="buildRequestDataFlags">The current request build flags.</param>
+        /// <param name="buildResultDataFlags">The existing build result data flags.</param>
+        /// <returns>False if there is any difference in the data flags that can cause missed build data, true otherwise.</returns>
+        private static bool CheckBuildDataFlagsResults(BuildRequestDataFlags buildRequestDataFlags, BuildRequestDataFlags buildResultDataFlags) =>
+
+            // Even if both buildRequestDataFlags and buildResultDataFlags have ProvideSubsetOfStateAfterBuild flag,
+            // the underlying RequestedProjectState may have different user filters defined.
+            // It is more reliable to ignore the cached value. 
+            !buildRequestDataFlags.HasFlag(BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild)
+            && (buildRequestDataFlags & FlagsAffectingBuildResults) == (buildResultDataFlags & FlagsAffectingBuildResults);
 
         public IEnumerator<BuildResult> GetEnumerator()
         {

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -119,6 +119,11 @@ namespace Microsoft.Build.BackEnd
             _nodeRequestId = nodeRequestId;
             _buildRequestDataFlags = buildRequestDataFlags;
             _requestedProjectState = requestedProjectState;
+
+            if (_requestedProjectState != null)
+            {
+                _buildRequestDataFlags |= BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild;
+            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -116,6 +116,11 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private ProjectInstance _projectStateAfterBuild;
 
+        /// <summary>
+        /// The flags provide additional control over the build results and may affect the cached value.
+        /// </summary>
+        private BuildRequestDataFlags _buildRequestDataFlags;
+
         private string _schedulerInducedError;
 
         private HashSet<string> _projectTargets;
@@ -204,6 +209,7 @@ namespace Microsoft.Build.Execution
             _nodeRequestId = request.NodeRequestId;
             _circularDependency = false;
             _baseOverallResult = true;
+            _buildRequestDataFlags = request.BuildRequestDataFlags;
 
             if (existingResults == null)
             {
@@ -379,6 +385,12 @@ namespace Microsoft.Build.Execution
             get => _projectStateAfterBuild;
             set => _projectStateAfterBuild = value;
         }
+
+        /// <summary>
+        /// Gets the flags that were used in the build request to which these results are associated.
+        /// See <see cref="Execution.BuildRequestDataFlags"/> for examples of the available flags.
+        /// </summary>
+        public BuildRequestDataFlags BuildRequestDataFlags => _buildRequestDataFlags;
 
         /// <summary>
         /// Returns the node packet type.
@@ -581,6 +593,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _savedCurrentDirectory);
             translator.Translate(ref _schedulerInducedError);
             translator.TranslateDictionary(ref _savedEnvironmentVariables, StringComparer.OrdinalIgnoreCase);
+            translator.TranslateEnum(ref _buildRequestDataFlags, (int)_buildRequestDataFlags);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -220,6 +220,10 @@ namespace Microsoft.Build.Execution
             {
                 _requestException = exception ?? existingResults._requestException;
                 _resultsByTarget = targetNames == null ? existingResults._resultsByTarget : CreateTargetResultDictionaryWithContents(existingResults, targetNames);
+                if (request.RequestedProjectState != null)
+                {
+                    _projectStateAfterBuild = existingResults._projectStateAfterBuild?.FilteredCopy(request.RequestedProjectState);
+                }
             }
         }
 

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -177,6 +177,8 @@ namespace Microsoft.Build.Execution
             _requestException = existingResults._requestException;
             _resultsByTarget = CreateTargetResultDictionaryWithContents(existingResults, targetNames);
             _baseOverallResult = existingResults.OverallResult == BuildResultCode.Success;
+            _buildRequestDataFlags = existingResults._buildRequestDataFlags;
+            _projectStateAfterBuild = existingResults._projectStateAfterBuild;
 
             _circularDependency = existingResults._circularDependency;
         }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -186,6 +186,12 @@ namespace Microsoft.Build.Execution
         private int _evaluationId = BuildEventContext.InvalidEvaluationId;
 
         /// <summary>
+        /// The property and item filter used when creating this instance, or null if this is not a filtered copy
+        /// of another ProjectInstance. <seealso cref="ProjectInstance(ProjectInstance, bool, RequestedProjectState)"/>
+        /// </summary>
+        private RequestedProjectState _requestedProjectStateFilter;
+
+        /// <summary>
         /// Creates a ProjectInstance directly.
         /// No intermediate Project object is created.
         /// This is ideal if the project is simply going to be built, and not displayed or edited.
@@ -679,6 +685,7 @@ namespace Microsoft.Build.Execution
             _isImmutable = isImmutable;
             _evaluationId = that.EvaluationId;
             _translateEntireState = that._translateEntireState;
+            _requestedProjectStateFilter = filter?.DeepClone();
 
             if (filter == null)
             {
@@ -1114,6 +1121,12 @@ namespace Microsoft.Build.Execution
         {
             get { return _isImmutable; }
         }
+
+        /// <summary>
+        /// The property and item filter used when creating this instance, or null if this is not a filtered copy
+        /// of another ProjectInstance. <seealso cref="ProjectInstance(ProjectInstance, bool, RequestedProjectState)"/>
+        /// </summary>
+        internal RequestedProjectState RequestedProjectStateFilter => _requestedProjectStateFilter;
 
         /// <summary>
         /// Task classes and locations known to this project.
@@ -2228,6 +2241,7 @@ namespace Microsoft.Build.Execution
         {
             translator.TranslateDictionary(ref _globalProperties, ProjectPropertyInstance.FactoryForDeserialization);
             translator.TranslateDictionary(ref _properties, ProjectPropertyInstance.FactoryForDeserialization);
+            translator.Translate(ref _requestedProjectStateFilter);
             translator.Translate(ref _isImmutable);
             TranslateItems(translator);
         }


### PR DESCRIPTION
Fixes #9458

### Context

#9565 had to be reverted because the assumption that results with `BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild` don't have to be cached broke design-time builds in Visual Studio.

### Changes Made

Re-did the change, now with full handling of `BuildRequestDataFlags.ProvideSubsetOfStateAfterBuild`.

### Testing

New and existing unit tests, experimental insertion, manual testing with the problematic design-time build scenario.

### Notes

Compared to #9565, we now:
- Copy the flags from the original `BuildResult` in the `BuildResult` copy constructor.
- Have `ProjectInstance` remember the project state filter it was created from.
- Implement `IsSubsetOf` operator on `RequestedProjectState`.
- Use the `IsSubsetOf` to determine if a request with `ProvideSubsetOfStateAfterBuild` can be satisfied by the cache.
- Don't consider `SkipNonexistentTargets` to be a flag affecting build results.
