### PR TITLE
Adjust tests with terminal logger enabled

### DIFF
--- a/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
+++ b/src/Build.UnitTests/TerminalLoggerConfiguration_Tests.cs
@@ -28,10 +28,6 @@ public class TerminalLoggerConfiguration_Tests : IDisposable
     {
         _env = TestEnvironment.Create(output);
 
-        // Ignore environment variables that may have been set by the environment where the tests are running.
-        _env.SetEnvironmentVariable("MSBUILDLIVELOGGER", null);
-        _env.SetEnvironmentVariable("MSBUILDTERMINALLOGGER", null);
-
         TransientTestFolder logFolder = _env.CreateFolder(createFolder: true);
         TransientTestFile projectFile = _env.CreateFile(logFolder, "myProj.proj", $"""
             <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Hello">

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Build.Engine.UnitTests
         <ProcessIdTask>
             <Output PropertyName=""PID"" TaskParameter=""Pid"" />
         </ProcessIdTask>
-        <Message Text=""Server ID is $(PID)"" Importance=""High"" />
+        <Message Text=""[Work around Github issue #9667 with --interactive]Server ID is $(PID)"" Importance=""High"" />
     </Target>
 </Project>";
         private static string sleepingTaskContentsFormat = @$"
@@ -313,8 +313,8 @@ namespace Microsoft.Build.Engine.UnitTests
         <ProcessIdTask>
             <Output PropertyName=""PID"" TaskParameter=""Pid"" />
         </ProcessIdTask>
-        <Message Text=""Server ID is $(PID)"" Importance=""High"" />
-		<Message Text="":MSBuildStartupDirectory:$(MSBuildStartupDirectory):"" Importance=""high"" />
+        <Message Text=""[Work around Github issue #9667 with --interactive]Server ID is $(PID)"" Importance=""High"" />
+		<Message Text=""[Work around Github issue #9667 with --interactive]:MSBuildStartupDirectory:$(MSBuildStartupDirectory):"" Importance=""high"" />
 	</Target>
 </Project>";
 

--- a/src/UnitTests.Shared/TestEnvironment.cs
+++ b/src/UnitTests.Shared/TestEnvironment.cs
@@ -53,6 +53,10 @@ namespace Microsoft.Build.UnitTests
                 env.WithInvariant(new BuildFailureLogInvariant());
             }
 
+            // Clear these two environment variables first in case pre-setting affects the test.
+            env.SetEnvironmentVariable("MSBUILDLIVELOGGER", null);
+            env.SetEnvironmentVariable("MSBUILDTERMINALLOGGER", null);
+
             return env;
         }
 

--- a/src/UnitTests.Shared/TestEnvironment.cs
+++ b/src/UnitTests.Shared/TestEnvironment.cs
@@ -87,12 +87,10 @@ namespace Microsoft.Build.UnitTests
             {
                 _disposed = true;
 
-                // It should be in reverse order revert to get back to original state.
-                _variants.Reverse();
-                // Reset test variants
-                foreach (var variant in _variants)
+                // Reset test variants in reverse order to get back to original state.
+                for (int i = _variants.Count - 1; i >= 0; i--)
                 {
-                    variant.Revert();
+                    _variants[i].Revert();
                 }
 
                 // Assert invariants

--- a/src/UnitTests.Shared/TestEnvironment.cs
+++ b/src/UnitTests.Shared/TestEnvironment.cs
@@ -87,6 +87,8 @@ namespace Microsoft.Build.UnitTests
             {
                 _disposed = true;
 
+                // It should be in reverse order revert to get back to original state.
+                _variants.Reverse();
                 // Reset test variants
                 foreach (var variant in _variants)
                 {


### PR DESCRIPTION
Fixes #9796

### Context
With terminal logger enabled by `SET MSBUILDLIVELOGGER=auto`, current tests has the following problems.

- `Message` is ignored by terminal logger currently and this causes tests depending on the message fail. Though #9667 could get messages ptinted in terminal logger, it is a way to opt. To make messages output in console logger and terminal logger both, we need the workaround for printing messages in terminal logger. Affected tests: Microsoft.Build.Engine.UnitTests.MSBuildServer_Tests.
- The environment variable `MSBUILDLIVELOGGER`/`MSBUILDTERMINALLOGGER` affects tests for these two environment variables. Affected tests: Microsoft.Build.UnitTests.TerminalLoggerConfiguration_Tests.TerminalLoggerOnByEnv.
- Enabling terminal logger by the environment variable gets extra more build events than other loggers by https://github.com/dotnet/msbuild/blob/bb7846e599da22193f35649bc3cd90073cbf8c8c/src/MSBuild/XMake.cs#L2854-L2855. Affected test: Microsoft.Build.UnitTests.TerminalLogger_Tests.TestTerminalLoggerTogetherWithOtherLoggers.

In addition, cleaning up created TestEnvironment should revert variants in reverse order. 

### Changes Made

- For `Message`, use the workaround adding --interactive for terminal logger to make messages output in console logger and terminal logger both.
- Clear pre-setting environment variables of terminal logger to affect the tests.
- Reverting variants in reverse order while cleaning up created TestEnvironment.

### Testing
Run existing tests locally with setting the environment variable. Also verified in CI through #9957.

### Notes
