### PR TITLE
Fix indentation of multiline messages in Terminal Logger.

### DIFF
--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDetailedVerbosity_FailedWithErrors.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDetailedVerbosity_FailedWithErrors.Linux.verified.txt
@@ -1,9 +1,14 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     High importance message!
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDetailedVerbosity_FailedWithErrors.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDetailedVerbosity_FailedWithErrors.OSX.verified.txt
@@ -1,8 +1,13 @@
 ﻿The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     High importance message!
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDetailedVerbosity_FailedWithErrors.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDetailedVerbosity_FailedWithErrors.Windows.verified.txt
@@ -1,9 +1,14 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     High importance message!
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDiagnosticVerbosity_FailedWithErrors.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDiagnosticVerbosity_FailedWithErrors.Linux.verified.txt
@@ -1,9 +1,14 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     High importance message!
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDiagnosticVerbosity_FailedWithErrors.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDiagnosticVerbosity_FailedWithErrors.OSX.verified.txt
@@ -1,8 +1,13 @@
 ﻿The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     High importance message!
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDiagnosticVerbosity_FailedWithErrors.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryDiagnosticVerbosity_FailedWithErrors.Windows.verified.txt
@@ -1,9 +1,14 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     High importance message!
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryMinimalVerbosity_FailedWithErrors.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryMinimalVerbosity_FailedWithErrors.Linux.verified.txt
@@ -1,8 +1,13 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryMinimalVerbosity_FailedWithErrors.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryMinimalVerbosity_FailedWithErrors.OSX.verified.txt
@@ -1,7 +1,12 @@
 ﻿The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryMinimalVerbosity_FailedWithErrors.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryMinimalVerbosity_FailedWithErrors.Windows.verified.txt
@@ -1,8 +1,13 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryNormalVerbosity_FailedWithErrors.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryNormalVerbosity_FailedWithErrors.Linux.verified.txt
@@ -1,8 +1,13 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryNormalVerbosity_FailedWithErrors.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryNormalVerbosity_FailedWithErrors.OSX.verified.txt
@@ -1,7 +1,12 @@
 ﻿The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryNormalVerbosity_FailedWithErrors.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryNormalVerbosity_FailedWithErrors.Windows.verified.txt
@@ -1,8 +1,13 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryQuietVerbosity_FailedWithErrors.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryQuietVerbosity_FailedWithErrors.Linux.verified.txt
@@ -1,3 +1,8 @@
 ﻿]9;4;3;\directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+  A
+  Multi
+  Line
+  Warning!
 directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryQuietVerbosity_FailedWithErrors.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryQuietVerbosity_FailedWithErrors.OSX.verified.txt
@@ -1,2 +1,7 @@
 ﻿directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+  A
+  Multi
+  Line
+  Warning!
 directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryQuietVerbosity_FailedWithErrors.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummaryQuietVerbosity_FailedWithErrors.Windows.verified.txt
@@ -1,3 +1,8 @@
 ﻿]9;4;3;\directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+  A
+  Multi
+  Line
+  Warning!
 directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintSummaryWithOverwrittenVerbosity_FailedWithErrors.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintSummaryWithOverwrittenVerbosity_FailedWithErrors.Linux.verified.txt
@@ -1,9 +1,14 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     High importance message!
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintSummaryWithOverwrittenVerbosity_FailedWithErrors.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintSummaryWithOverwrittenVerbosity_FailedWithErrors.OSX.verified.txt
@@ -1,8 +1,13 @@
 ﻿The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     High importance message!
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintSummaryWithOverwrittenVerbosity_FailedWithErrors.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintSummaryWithOverwrittenVerbosity_FailedWithErrors.Windows.verified.txt
@@ -1,9 +1,14 @@
 ﻿]9;4;3;\The plugin credential provider could not acquire credentials.Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
-  project [31;1mfailed with 1 error(s) and 1 warning(s)[m (0.2s)
+  project [31;1mfailed with 1 error(s) and 2 warning(s)[m (0.2s)
     High importance message!
     directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: Warning!
+    directory/[1mfile[m(1,2,3,4): [33;1mwarning[m [33;1mAA0000[m: 
+      A
+      Multi
+      Line
+      Warning!
     directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
 [?25l[1F
 [?25h
-Build [31;1mfailed with 1 error(s) and 1 warning(s)[m in 5.0s
+Build [31;1mfailed with 1 error(s) and 2 warning(s)[m in 5.0s
 ]9;4;0;\

--- a/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
@@ -436,6 +436,7 @@ namespace Microsoft.Build.UnitTests
             MessageRaised?.Invoke(_eventSender, MakeMessageEventArgs("Normal importance message!", MessageImportance.Normal));
             MessageRaised?.Invoke(_eventSender, MakeMessageEventArgs("Low importance message!", MessageImportance.Low));
             WarningRaised?.Invoke(_eventSender, MakeWarningEventArgs("Warning!"));
+            WarningRaised?.Invoke(_eventSender, MakeWarningEventArgs("A\nMulti\r\nLine\nWarning!"));
             ErrorRaised?.Invoke(_eventSender, MakeErrorEventArgs("Error!"));
         }
 

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -64,6 +64,10 @@ internal sealed partial class TerminalLogger : INodeLogger
     /// </summary>
     internal const string Indentation = "  ";
 
+    internal const string DoubleIndentation = $"{Indentation}{Indentation}";
+
+    internal const string TripleIndentation = $"{Indentation}{Indentation}{Indentation}";
+
     internal const TerminalColor TargetFrameworkColor = TerminalColor.Cyan;
 
     internal Func<StopwatchAbstraction>? CreateStopwatch = null;
@@ -644,7 +648,7 @@ internal sealed partial class TerminalLogger : INodeLogger
                     {
                         foreach (BuildMessage buildMessage in project.BuildMessages)
                         {
-                            Terminal.WriteLine($"{Indentation}{Indentation}{buildMessage.Message}");
+                            Terminal.WriteLine($"{DoubleIndentation}{buildMessage.Message}");
                         }
                     }
 
@@ -863,12 +867,12 @@ internal sealed partial class TerminalLogger : INodeLogger
             && _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project)
             && Verbosity > LoggerVerbosity.Quiet)
         {
-            if (!String.IsNullOrEmpty(e.Message) && IsImmediateMessage(e.Message))
+            if (!String.IsNullOrEmpty(e.Message) && IsImmediateMessage(e.Message!))
             {
                 RenderImmediateMessage(FormatWarningMessage(e, Indentation));
             }
 
-            project.AddBuildMessage(MessageSeverity.Warning, FormatWarningMessage(e, $"{Indentation}{Indentation}{Indentation}"));
+            project.AddBuildMessage(MessageSeverity.Warning, FormatWarningMessage(e, TripleIndentation));
         }
         else
         {
@@ -901,7 +905,7 @@ internal sealed partial class TerminalLogger : INodeLogger
             && _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project)
             && Verbosity > LoggerVerbosity.Quiet)
         {
-            project.AddBuildMessage(MessageSeverity.Error, FormatErrorMessage(e, $"{Indentation}{Indentation}{Indentation}"));
+            project.AddBuildMessage(MessageSeverity.Error, FormatErrorMessage(e, TripleIndentation));
         }
         else
         {

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -858,32 +858,22 @@ internal sealed partial class TerminalLogger : INodeLogger
     private void WarningRaised(object sender, BuildWarningEventArgs e)
     {
         BuildEventContext? buildEventContext = e.BuildEventContext;
-        string message = FormatEventMessage(
-                category: AnsiCodes.Colorize("warning", TerminalColor.Yellow),
-                subcategory: e.Subcategory,
-                message: e.Message,
-                code: AnsiCodes.Colorize(e.Code, TerminalColor.Yellow),
-                file: HighlightFileName(e.File),
-                lineNumber: e.LineNumber,
-                endLineNumber: e.EndLineNumber,
-                columnNumber: e.ColumnNumber,
-                endColumnNumber: e.EndColumnNumber);
 
         if (buildEventContext is not null
             && _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project)
             && Verbosity > LoggerVerbosity.Quiet)
         {
-            if (IsImmediateMessage(message))
+            if (!String.IsNullOrEmpty(e.Message) && IsImmediateMessage(e.Message))
             {
-                RenderImmediateMessage(message);
+                RenderImmediateMessage(FormatWarningMessage(e, Indentation));
             }
 
-            project.AddBuildMessage(MessageSeverity.Warning, message);
+            project.AddBuildMessage(MessageSeverity.Warning, FormatWarningMessage(e, $"{Indentation}{Indentation}{Indentation}"));
         }
         else
         {
             // It is necessary to display warning messages reported by MSBuild, even if it's not tracked in _projects collection or the verbosity is Quiet.
-            RenderImmediateMessage(message);
+            RenderImmediateMessage(FormatWarningMessage(e, Indentation));
             _buildWarningsCount++;
         }
     }
@@ -906,27 +896,17 @@ internal sealed partial class TerminalLogger : INodeLogger
     private void ErrorRaised(object sender, BuildErrorEventArgs e)
     {
         BuildEventContext? buildEventContext = e.BuildEventContext;
-        string message = FormatEventMessage(
-                category: AnsiCodes.Colorize("error", TerminalColor.Red),
-                subcategory: e.Subcategory,
-                message: e.Message,
-                code: AnsiCodes.Colorize(e.Code, TerminalColor.Red),
-                file: HighlightFileName(e.File),
-                lineNumber: e.LineNumber,
-                endLineNumber: e.EndLineNumber,
-                columnNumber: e.ColumnNumber,
-                endColumnNumber: e.EndColumnNumber);
-
+        
         if (buildEventContext is not null
             && _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project)
             && Verbosity > LoggerVerbosity.Quiet)
         {
-            project.AddBuildMessage(MessageSeverity.Error, message);
+            project.AddBuildMessage(MessageSeverity.Error, FormatErrorMessage(e, $"{Indentation}{Indentation}{Indentation}"));
         }
         else
         {
             // It is necessary to display error messages reported by MSBuild, even if it's not tracked in _projects collection or the verbosity is Quiet.
-            RenderImmediateMessage(message);
+            RenderImmediateMessage(FormatErrorMessage(e, Indentation));
             _buildErrorsCount++;
         }
     }
@@ -1070,6 +1050,36 @@ internal sealed partial class TerminalLogger : INodeLogger
             : path;
     }
 
+    private string FormatWarningMessage(BuildWarningEventArgs e, string indent)
+    {
+        return FormatEventMessage(
+                category: AnsiCodes.Colorize("warning", TerminalColor.Yellow),
+                subcategory: e.Subcategory,
+                message: e.Message,
+                code: AnsiCodes.Colorize(e.Code, TerminalColor.Yellow),
+                file: HighlightFileName(e.File),
+                lineNumber: e.LineNumber,
+                endLineNumber: e.EndLineNumber,
+                columnNumber: e.ColumnNumber,
+                endColumnNumber: e.EndColumnNumber,
+                indent);
+    }
+
+    private string FormatErrorMessage(BuildErrorEventArgs e, string indent)
+    {
+        return FormatEventMessage(
+                category: AnsiCodes.Colorize("error", TerminalColor.Red),
+                subcategory: e.Subcategory,
+                message: e.Message,
+                code: AnsiCodes.Colorize(e.Code, TerminalColor.Red),
+                file: HighlightFileName(e.File),
+                lineNumber: e.LineNumber,
+                endLineNumber: e.EndLineNumber,
+                columnNumber: e.ColumnNumber,
+                endColumnNumber: e.EndColumnNumber,
+                indent);
+    }
+
     private string FormatEventMessage(
             string category,
             string subcategory,
@@ -1079,7 +1089,8 @@ internal sealed partial class TerminalLogger : INodeLogger
             int lineNumber,
             int endLineNumber,
             int columnNumber,
-            int endColumnNumber)
+            int endColumnNumber,
+            string indent)
     {
         message ??= string.Empty;
         StringBuilder builder = new(128);
@@ -1133,7 +1144,7 @@ internal sealed partial class TerminalLogger : INodeLogger
         // render multi-line message in a special way
         if (message.IndexOf('\n') >= 0)
         {
-            const string indent = $"{Indentation}{Indentation}{Indentation}";
+            // Place the multiline message under the project in case of minimal and higher verbosity.
             string[] lines = message.Split(newLineStrings, StringSplitOptions.None);
 
             foreach (string line in lines)


### PR DESCRIPTION
Fixes #9996

### Context
The multiline messages indentation processing implies that the message will appear in the structured view under the related project. That is not correct for the Quiet verbosity and for couple of other places, such as rendering the immediate message and cases when the project is not determined.

### Changes Made
Make the indentation dependent on where the message would be shown.

### Testing
Unit tests
