### PR TITLE
Fix Arm64 VS not localization

### DIFF
--- a/src/Package/GetBinPaths.Arm64.targets
+++ b/src/Package/GetBinPaths.Arm64.targets
@@ -34,7 +34,7 @@
     <PropertyGroup>
       <FrameworkBinPath>@(FrameworkResolvedProjectReferencePath->'%(RootDir)%(Directory)')</FrameworkBinPath>
       <Arm64BinPath>@(MSBuildArm64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</Arm64BinPath>
-      <MSBuildTaskHostX64BinPath>@(MSBuildTaskHostArm64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildTaskHostX64BinPath>
+      <MSBuildTaskHostArm64BinPath>@(MSBuildTaskHostArm64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildTaskHostArm64BinPath>
 
     </PropertyGroup>
   </Target>

--- a/src/Package/GetBinPaths.Arm64.targets
+++ b/src/Package/GetBinPaths.Arm64.targets
@@ -15,7 +15,7 @@
                       ReferenceOutputAssembly="false"
                       OutputItemType="FrameworkResolvedProjectReferencePath" />
 
-    <X64ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuildTaskHost\MSBuildTaskHost.csproj"
+    <Arm64ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuildTaskHost\MSBuildTaskHost.csproj"
                       SetPlatform="Platform=arm64"
                       OutputItemType="MSBuildTaskHostArm64ResolvedProjectReferencePath"
                       GlobalPropertiesToRemove="TargetFramework" />

--- a/src/Package/GetBinPaths.Arm64.targets
+++ b/src/Package/GetBinPaths.Arm64.targets
@@ -14,6 +14,11 @@
                       Private="false"
                       ReferenceOutputAssembly="false"
                       OutputItemType="FrameworkResolvedProjectReferencePath" />
+
+    <X64ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuildTaskHost\MSBuildTaskHost.csproj"
+                      SetPlatform="Platform=arm64"
+                      OutputItemType="MSBuildTaskHostArm64ResolvedProjectReferencePath"
+                      GlobalPropertiesToRemove="TargetFramework" />
   </ItemGroup>
 
   <Target Name="SetBinPathsArm64" DependsOnTargets="ResolveProjectReferences">
@@ -29,6 +34,8 @@
     <PropertyGroup>
       <FrameworkBinPath>@(FrameworkResolvedProjectReferencePath->'%(RootDir)%(Directory)')</FrameworkBinPath>
       <Arm64BinPath>@(MSBuildArm64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</Arm64BinPath>
+      <MSBuildTaskHostX64BinPath>@(MSBuildTaskHostArm64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildTaskHostX64BinPath>
+
     </PropertyGroup>
   </Target>
 

--- a/src/Package/MSBuild.VSSetup.Arm64/MSBuild.VSSetup.Arm64.csproj
+++ b/src/Package/MSBuild.VSSetup.Arm64/MSBuild.VSSetup.Arm64.csproj
@@ -29,6 +29,7 @@
       <SwrProperty Include="Version=$(VsixVersion)" />
       <SwrProperty Include="FrameworkBinPath=$(FrameworkBinPath)" />
       <SwrProperty Include="Arm64BinPath=$(Arm64BinPath)" />
+      <SwrProperty Include="TaskHostBinPath=$(MSBuildTaskHostX64BinPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Package/MSBuild.VSSetup.Arm64/MSBuild.VSSetup.Arm64.csproj
+++ b/src/Package/MSBuild.VSSetup.Arm64/MSBuild.VSSetup.Arm64.csproj
@@ -29,7 +29,7 @@
       <SwrProperty Include="Version=$(VsixVersion)" />
       <SwrProperty Include="FrameworkBinPath=$(FrameworkBinPath)" />
       <SwrProperty Include="Arm64BinPath=$(Arm64BinPath)" />
-      <SwrProperty Include="TaskHostBinPath=$(MSBuildTaskHostX64BinPath)" />
+      <SwrProperty Include="TaskHostArm64BinPath=$(MSBuildTaskHostArm64BinPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
+++ b/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
@@ -54,76 +54,76 @@ folder InstallDir:\MSBuild\Current\Bin\arm64\cs
   file source=$(Arm64BinPath)cs\MSBuild.resources.dll
   file source=$(Arm64BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)cs\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)cs\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\de
   file source=$(Arm64BinPath)de\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)de\MSBuild.resources.dll
   file source=$(Arm64BinPath)de\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)de\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)de\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)de\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\es
   file source=$(Arm64BinPath)es\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)es\MSBuild.resources.dll
   file source=$(Arm64BinPath)es\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)es\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)es\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)es\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\fr
   file source=$(Arm64BinPath)fr\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)fr\MSBuild.resources.dll
   file source=$(Arm64BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)fr\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)fr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\it
   file source=$(Arm64BinPath)it\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)it\MSBuild.resources.dll
   file source=$(Arm64BinPath)it\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)it\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)it\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)it\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ja
   file source=$(Arm64BinPath)ja\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)ja\MSBuild.resources.dll
   file source=$(Arm64BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)ja\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)ja\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ko
   file source=$(Arm64BinPath)ko\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)ko\MSBuild.resources.dll
   file source=$(Arm64BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)ko\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)ko\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\pl
   file source=$(Arm64BinPath)pl\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)pl\MSBuild.resources.dll
   file source=$(Arm64BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)pl\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)pl\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\pt-BR
   file source=$(Arm64BinPath)pt-BR\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)pt-BR\MSBuild.resources.dll
   file source=$(Arm64BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)pt-BR\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)pt-BR\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ru
   file source=$(Arm64BinPath)ru\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)ru\MSBuild.resources.dll
   file source=$(Arm64BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)ru\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)ru\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\tr
   file source=$(Arm64BinPath)tr\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)tr\MSBuild.resources.dll
   file source=$(Arm64BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)tr\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)tr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\zh-Hans
   file source=$(Arm64BinPath)zh-Hans\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)zh-Hans\MSBuild.resources.dll
   file source=$(Arm64BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)zh-Hans\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)zh-Hans\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\zh-Hant
   file source=$(Arm64BinPath)zh-Hant\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)zh-Hant\MSBuild.resources.dll
   file source=$(Arm64BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostBinPath)zh-Hant\MSBuildTaskHost.resources.dll
+  file source=$(TaskHostArm64BinPath)zh-Hant\MSBuildTaskHost.resources.dll

--- a/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
+++ b/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
@@ -50,28 +50,80 @@ folder InstallDir:\MSBuild\Current\Bin\arm64\MSBuild
   file source=$(Arm64BinPath)\MSBuild\Microsoft.Build.CommonTypes.xsd
 
 folder InstallDir:\MSBuild\Current\Bin\arm64\cs
+  file source=$(Arm64BinPath)cs\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)cs\MSBuild.resources.dll
+  file source=$(Arm64BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)cs\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\de
+  file source=$(Arm64BinPath)de\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)de\MSBuild.resources.dll
+  file source=$(Arm64BinPath)de\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)de\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)de\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\es
+  file source=$(Arm64BinPath)es\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)es\MSBuild.resources.dll
+  file source=$(Arm64BinPath)es\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)es\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)es\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\fr
+  file source=$(Arm64BinPath)fr\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)fr\MSBuild.resources.dll
+  file source=$(Arm64BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)fr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\it
+  file source=$(Arm64BinPath)it\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)it\MSBuild.resources.dll
+  file source=$(Arm64BinPath)it\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)it\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)it\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ja
+  file source=$(Arm64BinPath)ja\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)ja\MSBuild.resources.dll
+  file source=$(Arm64BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)ja\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ko
+  file source=$(Arm64BinPath)ko\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)ko\MSBuild.resources.dll
+  file source=$(Arm64BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)ko\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\pl
+  file source=$(Arm64BinPath)pl\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)pl\MSBuild.resources.dll
+  file source=$(Arm64BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)pl\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\pt-BR
+  file source=$(Arm64BinPath)pt-BR\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)pt-BR\MSBuild.resources.dll
+  file source=$(Arm64BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)pt-BR\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ru
+  file source=$(Arm64BinPath)ru\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)ru\MSBuild.resources.dll
+  file source=$(Arm64BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)ru\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\tr
+  file source=$(Arm64BinPath)tr\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)tr\MSBuild.resources.dll
+  file source=$(Arm64BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)tr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\zh-Hans
+  file source=$(Arm64BinPath)zh-Hans\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)zh-Hans\MSBuild.resources.dll
+  file source=$(Arm64BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)zh-Hans\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\zh-Hant
+  file source=$(Arm64BinPath)zh-Hant\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)zh-Hant\MSBuild.resources.dll
+  file source=$(Arm64BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(Arm64BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(TaskHostBinPath)zh-Hant\MSBuildTaskHost.resources.dll


### PR DESCRIPTION
Fixes [#1806513](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1806513)

### Context
On the arm64, the build output is not localized as amd64 results.
amd64
![image](https://github.com/dotnet/msbuild/assets/26814373/ca09a655-7fb3-41ed-a2dd-dc04ebd88f02)
arm64
![image](https://github.com/dotnet/msbuild/assets/26814373/859c77ef-9c5c-460e-a585-538dab3a9026)


### Changes Made
copy all of our loc .resources assemblies to the arm64 .swr file. Same with amd64

### Testing


### Notes
