### PR TITLE
Check version bump on release branches' update

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -16,6 +16,7 @@ jobs:
       if ($changedVersionsFile -ne $null) {
         $difference = git diff HEAD~1 $versionsFile
         $changedContent = $difference -join " "
+        # 'DotNetFinalVersionKind' is expected to be added only during the initial setup of the release branch
         $initialCommitPattern = '-\s*<VersionPrefix>\d+\.\d+\.\d+<\/VersionPrefix> \+\s*<VersionPrefix>\d+\.\d+\.\d+<\/VersionPrefix>.*<DotNetFinalVersionKind>release<\/DotNetFinalVersionKind>'
         $isInitialCommit = $changedContent -match $initialCommitPattern
         $pattern = '-\s*<VersionPrefix>\d+\.\d+\.(?<previous>\d+)<\/VersionPrefix>.* \+\s*<VersionPrefix>\d+\.\d+\.(?<current>\d+)<\/VersionPrefix>'
@@ -32,13 +33,8 @@ jobs:
         }
       }
 
-      $url = "https://api.github.com/repos/dotnet/msbuild/pulls/$(System.PullRequest.PullRequestNumber)"
-      Write-Host "Get PR information from $url"
-      $response = Invoke-RestMethod -Uri $url -Method Get
-      $isDotnetBot = $response.user.login -eq "dotnet-maestro[bot]"
-
-      if (!($isInitialCommit -or $isDotnetBot -or $isVersionBumped)) {
-        throw "Hello! I noticed that you're targeting one of our servicing branches. Please consider updating the version."
+      if (!($isInitialCommit -or $isVersionBumped)) {
+        throw "Hello! I noticed that you're targeting one of our servicing branches. You need to increase the revision version number (the last part) of 'VersionPrefix' in eng/Versions.props."
       }
     condition: startsWith(variables['System.PullRequest.TargetBranch'], 'vs')
     displayName: "Check if patch version is bumped up"

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -11,12 +11,15 @@ jobs:
       $versionsFile = "eng/Versions.props"
       $changedFiles = git diff --name-only HEAD HEAD~1
       $changedVersionsFile = $changedFiles | Where-Object { $_ -eq $versionsFile }
+      $isInitialCommit = $false
       $isVersionBumped = $false
       if ($changedVersionsFile -ne $null) {
         $difference = git diff HEAD~1 $versionsFile
         $changedContent = $difference -join " "
+        $initialCommitPattern = '-\s*<VersionPrefix>\d+\.\d+\.\d+<\/VersionPrefix> \+\s*<VersionPrefix>\d+\.\d+\.\d+<\/VersionPrefix>.*<DotNetFinalVersionKind>release<\/DotNetFinalVersionKind>'
+        $isInitialCommit = $changedContent -match $initialCommitPattern
         $pattern = '-\s*<VersionPrefix>\d+\.\d+\.(?<previous>\d+)<\/VersionPrefix>.* \+\s*<VersionPrefix>\d+\.\d+\.(?<current>\d+)<\/VersionPrefix>'
-        if ($changedContent -match $pattern) {
+        if (!($isInitialCommit) -and ($changedContent -match $pattern)) {
           try {
             $previousPatch = [Convert]::ToInt32($Matches.previous)
             $currentPatch = [Convert]::ToInt32($Matches.current)
@@ -24,11 +27,17 @@ jobs:
               $isVersionBumped = $true
             }
           } catch {
-            Write-Output "An error occurred during conversion: $_"
+            Write-Host "An error occurred during conversion: $_"
           }
         }
       }
-      if (-not $isVersionBumped) {
+
+      $url = "https://api.github.com/repos/dotnet/msbuild/pulls/$(System.PullRequest.PullRequestNumber)"
+      Write-Host "Get PR information from $url"
+      $response = Invoke-RestMethod -Uri $url -Method Get
+      $isDotnetBot = $response.user.login -eq "dotnet-maestro[bot]"
+
+      if (!($isInitialCommit -or $isDotnetBot -or $isVersionBumped)) {
         throw "Hello! I noticed that you're targeting one of our servicing branches. Please consider updating the version."
       }
     condition: startsWith(variables['System.PullRequest.TargetBranch'], 'vs')

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -4,7 +4,38 @@ trigger:
 - vs*
 
 jobs:
+- job: CheckVersionBumpOnReleaseBranches
+  displayName: "Check Version Bump On Release Branches"
+  steps:
+  - powershell: |
+      $versionsFile = "eng/Versions.props"
+      $changedFiles = git diff --name-only HEAD HEAD~1
+      $changedVersionsFile = $changedFiles | Where-Object { $_ -eq $versionsFile }
+      $isVersionBumped = $false
+      if ($changedVersionsFile -ne $null) {
+        $difference = git diff HEAD~1 $versionsFile
+        $changedContent = $difference -join " "
+        $pattern = '-\s*<VersionPrefix>\d+\.\d+\.(?<previous>\d+)<\/VersionPrefix>.* \+\s*<VersionPrefix>\d+\.\d+\.(?<current>\d+)<\/VersionPrefix>'
+        if ($changedContent -match $pattern) {
+          try {
+            $previousPatch = [Convert]::ToInt32($Matches.previous)
+            $currentPatch = [Convert]::ToInt32($Matches.current)
+            if ($currentPatch -gt $previousPatch) {
+              $isVersionBumped = $true
+            }
+          } catch {
+            Write-Output "An error occurred during conversion: $_"
+          }
+        }
+      }
+      if (-not $isVersionBumped) {
+        throw "Hello! I noticed that you're targeting one of our servicing branches. Please consider updating the version."
+      }
+    condition: startsWith(variables['System.PullRequest.TargetBranch'], 'vs')
+    displayName: "Check if patch version is bumped up"
+
 - job: IfOnlyDocumentionChanged
+  dependsOn: CheckVersionBumpOnReleaseBranches
   displayName: "Check whether Test Results need to be executed"
   steps:
   - powershell: |


### PR DESCRIPTION
Fixes #9960

### Context
`VersionPrefix` should be updated on each commit to our service branches (vsXX.YY) to prevent clashes of the produced packages with same version that would cause issues later down the VS insertion pipeline.

Though currently we use GH polices to inform us about this, it still requires user action and can be prone to errors.

### Changes Made
Add a build step checking version bump on release branches' update. If it's not updated, fail the run with the message asking to update the version.

Need to backport to active release branches.

### Testing
Tested with test PR #10017.

### Notes
